### PR TITLE
(fix) Prevent test suite 'reloading is disabled' error

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,6 +9,10 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  # Prevent 'reloading is disabled' errors from Spring
+  # https://github.com/rails/spring/issues/598
+  config.autoloader = :classic
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.


### PR DESCRIPTION
There's a bug with the way Spring interacts with Rails 6. The original workaround was to set `cache_classes = false` which causes the test suite to run a *lot* slower, particularly when using Capybara.

An alternative workaround is to use the classic autoloader rather than Zeitwerk (default in Rails 6), which allows the faster `cache_classes = true` whilst preventing the annoying reloading errors.

The issue is documented here: https://github.com/rails/spring/issues/598