### PR TITLE
Setup includes a seeded user to allow us to sign in locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This service enables the Department for Business, Energy and Industrial Strategy
   bundle exec rails server
   ```
 
+1. log in using the generic development user roda@dxw.com. Find the credentials in the team 1Password vault.
+
 ## Running the tests
 
 To run all the tests, and linters we use `rake`:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Generic development user
+if Rails.env.development?
+  User.find_or_create_by(
+    name: "Generic development user",
+    email: "roda@dxw.com",
+    identifier: "auth0|5dc53e4b85758e0e95b062f0"
+  )
+end


### PR DESCRIPTION
## Changes in this PR

* A user is required to add more users. Use the Seed file to create a local copy of the information stored in Auth0 for our generic team user roda@dxw.com.
* This user is only in the development tenant and is isolated from staging and production. Sharing the identifier in plain text should be safe to do.
