### PR TITLE
Add navigation to Organisations page(s) to the dashboard

### DIFF
--- a/app/views/staff/dashboards/show.html.haml
+++ b/app/views/staff/dashboards/show.html.haml
@@ -18,5 +18,9 @@
     .govuk-grid-column-two-thirds
       %hr
       %h3.govuk-heading-m
-        = t('page_content.dashboard.header.manage_users')
+        = t("page_content.dashboard.header.manage_users")
       = link_to t("page_content.dashboard.button.manage_users"), users_path, class: "govuk-button"
+      %hr
+      %h3.govuk-heading-m
+        = t("page_content.dashboard.header.manage_organisations")
+      = link_to t("page_content.dashboard.button.manage_organisations"), organisations_path, class: "govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,8 +43,10 @@ en:
   page_content:
     dashboard:
       button:
+        manage_organisations: Manage organisations
         manage_users: Manage users
       header:
+        manage_organisations: Organisations
         manage_users: Users
     errors:
       not_authorised:

--- a/spec/features/staff/users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_create_an_organisation_spec.rb
@@ -11,13 +11,43 @@ RSpec.feature "Users can create organisations" do
     end
   end
 
-  context "when the user is not allowed to add a new user" do
+  context "when the user is allowed to add a new organisation" do
+    scenario "successfully creating an organisation" do
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link I18n.t("page_content.organisations.button.create")
+
+      expect(page).to have_content(I18n.t("page_title.organisation.new"))
+      fill_in "organisation[name]", with: "My New Organisation"
+      select "Government", from: "organisation[organisation_type]"
+      select "Czech", from: "organisation[language_code]"
+      select "Zloty", from: "organisation[default_currency]"
+      click_button I18n.t("form.organisation.submit")
+      expect(page).to have_content I18n.t("form.organisation.create.success")
+    end
+
+    scenario "presence validation works as expected" do
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link I18n.t("page_content.organisations.button.create")
+
+      expect(page).to have_content(I18n.t("page_title.organisation.new"))
+      fill_in "organisation[name]", with: "My New Organisation"
+
+      click_button I18n.t("form.organisation.submit")
+      expect(page).to_not have_content I18n.t("form.organisation.create.success")
+      expect(page).to have_content "can't be blank"
+    end
+  end
+
+  context "when the user is not allowed to add a new organisation" do
     before do
       authenticate!(user: build_stubbed(:user))
     end
 
     scenario "hides the 'Create organisation' button" do
-      visit organisations_path
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
 
       expect(page).to have_no_content(I18n.t("page_content.organisations.button.create"))
     end
@@ -28,30 +58,5 @@ RSpec.feature "Users can create organisations" do
       expect(page).to have_content(I18n.t("pundit.default"))
       expect(page).to have_http_status(:unauthorized)
     end
-  end
-
-  scenario "successfully creating an organisation" do
-    visit new_organisation_path
-
-    expect(page).to have_content(I18n.t("page_title.organisation.new"))
-    fill_in "organisation[name]", with: "My New Organisation"
-    select "Government", from: "organisation[organisation_type]"
-    select "Czech", from: "organisation[language_code]"
-    select "Zloty", from: "organisation[default_currency]"
-    click_button I18n.t("form.organisation.submit")
-    expect(page).to have_content I18n.t("form.organisation.create.success")
-  end
-
-  scenario "presence validation works as expected" do
-    mock_successful_authentication(name: "Alex Smith")
-
-    visit new_organisation_path
-
-    expect(page).to have_content(I18n.t("page_title.organisation.new"))
-    fill_in "organisation[name]", with: "My New Organisation"
-
-    click_button I18n.t("form.organisation.submit")
-    expect(page).to_not have_content I18n.t("form.organisation.create.success")
-    expect(page).to have_content "can't be blank"
   end
 end

--- a/spec/features/staff/users_can_view_all_organisations_spec.rb
+++ b/spec/features/staff/users_can_view_all_organisations_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Users can view all organisations" do
 
   scenario "organisation index page" do
     organisation = FactoryBot.create(:organisation)
-
-    visit organisations_path
+    visit dashboard_path
+    click_link I18n.t("page_content.dashboard.button.manage_organisations")
 
     expect(page).to have_content(I18n.t("page_title.organisation.index"))
     expect(page).to have_content organisation.name

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -14,8 +14,9 @@ RSpec.feature "Users can view an individual organisation" do
 
   scenario "organisation show page" do
     organisation = FactoryBot.create(:organisation)
-
-    visit organisation_path(organisation)
+    visit dashboard_path
+    click_link I18n.t("page_content.dashboard.button.manage_organisations")
+    click_link organisation.name
 
     expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
   end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/mrW7IAqI/93-users-can-navigate-to-organisation-pages-without-changing-the-url

Add navigation to the Organisation pages without having to change the URL. Also amend the Organisation-related feature tests to use the new navigation steps.

## Screenshots of UI changes

<img width="1005" alt="Screenshot 2019-11-26 at 11 15 33" src="https://user-images.githubusercontent.com/1089521/69625420-7084f580-103e-11ea-8d87-111eaefcc211.png">

