### PR TITLE
Ensure that when there is a problem with creating the user, no welcom…

### DIFF
--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -8,11 +8,13 @@ class CreateUser
 
   def call
     result = Result.new(true)
+
     User.transaction do
       user.organisations = organisations
       user.save
       begin
         CreateUserInAuth0.new(user: user).call
+        SendWelcomeEmail.new(user: user).call
       rescue Auth0::Exception => e
         result.success = false
         Rails.logger.error("Error adding user #{user.email} to Auth0 during CreateUser with #{e.message}.")
@@ -20,7 +22,6 @@ class CreateUser
       end
     end
 
-    SendWelcomeEmail.new(user: user).call
     result
   end
 end

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe CreateUser do
       end
 
       it "does not email the user" do
-        described_class.new(user: user).call
         expect(SendWelcomeEmail).not_to receive(:new)
+        described_class.new(user: user).call
       end
     end
   end


### PR DESCRIPTION
…e email is sent

* This happens in Auth0 when you use the same email address in the name field as the email field. It fails, and the mailer tries to send an email to a user object that was rolled back.
* Moving it into the ensure block allows us to only send if no Auth0 error is raised, ensuring there will be a user persisted.