### PR TITLE
IATI locale fallback is used in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  # config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
## Changes in this PR

When viewing an activity, the locale lookups are failing with key not found. This works as intended in development and test but it turns out that this configuration overrides that made by us in application.rb. 

This configuration is not overridden in the development or test environment files, so we remove this production specific config to allow the application.rb version to take affect across all envs.

