### PR TITLE
(97) Add crown copyright logo to the footer

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -57,6 +57,8 @@
               All content is available under the
               = succeed "," do
                 %a.govuk-footer__link{href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", rel: "license"} Open Government Licence v3.0
+          .govuk-footer__meta-item
+            %a.govuk-footer__link.govuk-footer__copyright-logo{href: "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"} © Crown copyright
 
   :javascript
     window.GOVUKFrontend.initAll()


### PR DESCRIPTION
Because this is gov.uk service we need to include crown copyright logo in the footer.

## Changes in this PR
Because this is gov.uk service we need to include crown copyright logo in the footer.

## Screenshots of UI changes

### Before

![crown before](https://user-images.githubusercontent.com/2632224/69804183-e4a5d180-11d5-11ea-93ef-cac4725d831e.png)


### After

![crown after](https://user-images.githubusercontent.com/2632224/69804165-dd7ec380-11d5-11ea-8397-4d677ec13c2c.png)


