### PR TITLE
(105) Refactor user creation form with "govuk_design_system_formbuilder" 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.6.3"
 gem "auth0", "~> 4.9"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "coffee-rails", "~> 5.0"
+gem "govuk_design_system_formbuilder", github: "dxw/govuk_design_system_formbuilder", branch: "i18n"
 gem "haml-rails"
 gem "high_voltage"
 gem "jbuilder", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/dxw/govuk_design_system_formbuilder.git
+  revision: ecbfc40682d469f9dcbf7ab7bd59e063fadad4ba
+  branch: i18n
+  specs:
+    govuk_design_system_formbuilder (0.9.8)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -401,6 +411,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  govuk_design_system_formbuilder!
   haml-rails
   high_voltage
   html2haml

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -11,11 +11,13 @@ class Staff::UsersController < Staff::BaseController
 
   def new
     @user = policy_scope(User).new
+    @organisations = policy_scope(Organisation)
     authorize @user
   end
 
   def create
     @user = policy_scope(User).new(user_params)
+    @organisations = policy_scope(Organisation)
     authorize @user
 
     if @user.valid?
@@ -33,7 +35,7 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:name, :email, organisation_ids: [])
   end
 
   def id
@@ -41,11 +43,10 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def organisation_ids
-    params[:organisations]
+    user_params[:organisation_ids]
   end
 
   def organisations
-    return [] if organisation_ids.blank?
-    Organisation.find(organisation_ids)
+    Organisation.where(id: organisation_ids)
   end
 end

--- a/app/views/staff/users/new.html.haml
+++ b/app/views/staff/users/new.html.haml
@@ -7,25 +7,18 @@
       %h1.govuk-heading-xl
         = t("page_title.users.new")
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      = simple_form_for @user do |f|
-        .govuk-form-group
-          = f.input :name
-          = f.input :email
-        .govuk-form-group
-          %fieldset.govuk-fieldset
-            = label_tag 'organisations', "Organisations", class: 'govuk-label'
-            .govuk-checkboxes.checkbox-group
-              - if organisation_check_box_options.present?
-                - organisation_check_box_options.each_with_index do |organisation, i|
-                  .govuk-checkboxes__item
-                    = check_box_tag 'organisations[]', organisation[1], false, id: 'organisations_' + organisation[1], class: 'govuk-checkboxes__input'
-                    = label_tag 'organisations[]', organisation[0], for: 'organisations_' + organisation[1], class: 'govuk-label govuk-checkboxes__label'
-              - else
-                .govuk-inset-text
-                  = succeed "." do
-                    = t("page_content.users.new.no_organisations.cta")
-                    = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
+      = form_with model: @user do |f|
+        = f.govuk_error_summary
 
-        = f.button :submit, t("form.user.submit")
+        = f.govuk_text_field :name
+        = f.govuk_email_field :email
+
+        - if @organisations.any?
+          = f.govuk_collection_check_boxes :organisation_ids, @organisations, :id, :name
+        - else
+          .govuk-inset-text
+            = succeed "." do
+              = t("page_content.users.new.no_organisations.cta")
+              = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
+
+        = f.govuk_submit t("form.user.submit")

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,0 +1,4 @@
+Rails.application.config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+# Don't use XHR when submitting forms
+Rails.application.config.action_view.form_with_generates_remote_forms = false

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -2,3 +2,18 @@ Rails.application.config.action_view.default_form_builder = GOVUKDesignSystemFor
 
 # Don't use XHR when submitting forms
 Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Use activerecord.attributes.model.attribute_name for label scope
+module GOVUKDesignSystemFormBuilder
+  class Base
+    private def localisation_key(context)
+      return nil unless @object_name.present? && @attribute_name.present?
+
+      if context == "label"
+        ["activerecord", "attributes", @object_name, @attribute_name].join(".")
+      else
+        ["helpers", context, @object_name, @attribute_name].join(".")
+      end
+    end
+  end
+end

--- a/config/locales/generic_validation_errors.en.yml
+++ b/config/locales/generic_validation_errors.en.yml
@@ -1,0 +1,36 @@
+---
+en:
+  activerecord:
+    errors:
+      format: "%{attribute} %{message}"
+      messages:
+        accepted: "%{attribute} must be accepted"
+        blank: "%{attribute} can't be blank"
+        confirmation: doesn't match %{attribute}
+        empty: "%{attribute} can't be empty"
+        equal_to: "%{attribute} must be equal to %{count}"
+        even: "%{attribute} must be even"
+        exclusion: "%{attribute} is reserved"
+        greater_than: "%{attribute} must be greater than %{count}"
+        greater_than_or_equal_to: "%{attribute} must be greater than or equal to %{count}"
+        inclusion: "%{attribute} is not included in the list"
+        invalid: "%{attribute} is invalid"
+        less_than: "%{attribute} must be less than %{count}"
+        less_than_or_equal_to: "%{attribute} must be less than or equal to %{count}"
+        model_invalid: 'Validation failed: %{errors}'
+        not_a_number: "%{attribute} is not a number"
+        not_an_integer: "%{attribute} must be an integer"
+        odd: "%{attribute} must be odd"
+        other_than: "%{attribute} must be other than %{count}"
+        present: "%{attribute} must be blank"
+        required: "%{attribute} must exist"
+        taken: "%{attribute} has already been taken"
+        too_long:
+          one: "%{attribute} is too long (maximum is 1 character)"
+          other: "%{attribute} is too long (maximum is %{count} characters)"
+        too_short:
+          one: "%{attribute} is too short (minimum is 1 character)"
+          other: "%{attribute} is too short (minimum is %{count} characters)"
+        wrong_length:
+          one: "%{attribute} is the wrong length (should be 1 character)"
+          other: "%{attribute} is the wrong length (should be %{count} characters)"

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -4,3 +4,13 @@ en:
     attributes:
       user:
         organisation_ids: Organisations
+    errors:
+      models:
+        user:
+          attributes:
+            organisation_ids:
+              blank: Select the organisation(s) this user belongs to
+  helpers:
+    fieldset:
+      user:
+        organisation_ids: Organisations

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  activerecord:
+    attributes:
+      user:
+        organisation_ids: Organisations

--- a/doc/architecture/decisions/0011-use-govuk-design-system-form-builder.md
+++ b/doc/architecture/decisions/0011-use-govuk-design-system-form-builder.md
@@ -1,0 +1,35 @@
+# 11. Use GOV.UK Design System Form Builder
+
+Date: 2019-12-02
+
+## Status
+
+Accepted
+
+## Context
+
+Building forms in Rails that are compliant with the GOVUK Design System involve
+manually declaring the correct HTML structure, class names and ARIA attributes,
+which is time-consuming and hard to get right.
+
+Additionally, our validation errors currently use Rails' default pattern, rather
+than the one recommended for use as part of the design system, which is designed
+with accessibility in mind.
+
+## Decision
+
+We will use DfE's `govuk_design_system_formbuilder` to simplify the creation of
+GOV.UK Design System-compliant forms.
+
+As we are currently using Simple Form rather than Rails' default form builder
+for our other forms, the two form builders can co-exist for the time being,
+whilst we transition the forms over.
+
+## Consequences
+
+- Forms will be more compliant with the GOV.UK Design System and accessibility
+  standards and easier to work with
+- We will however need to spend some time moving the existing forms over to
+  new form builder
+- Uses standard Rails' i18n keys for form labels, whereas our existing forms do
+  not, so these would need to be moved over

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -1,0 +1,17 @@
+# Internationalisation (I18n)
+
+The GOVUKDesignSystemFormBuilder will by default use the following keys within
+`models_and_forms.en.yml`:
+
+- `activerecord.attributes.model_name.attribute_name` - form element labels
+- `helpers.hint.model_name.attribute_name` - form element hints
+- `helpers.legend.model_name.attribute_name` - form element legends
+
+The standard validation error messages are defined in
+`generic_validation_errors.en.yml`, with the overrides in the
+`models_and_forms.en.yml` which allows you to specify errors messages for a
+particular attribute, under this key:
+
+- `activerecord.errors.models.model_name.attributes.attribute_name.error`
+
+

--- a/spec/features/staff/users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/users_can_invite_new_users_spec.rb
@@ -82,8 +82,8 @@ RSpec.feature "users can invite new users to the service" do
 
       click_button I18n.t("form.user.submit")
 
-      expect(page).to have_content("Name\ncan't be blank")
-      expect(page).to have_content("Email\ncan't be blank")
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_content("Email can't be blank")
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

Use `govuk_design_system_formbuilder` gem to replace `simple_form` starting with the user creation form. This has been [written by DfE](https://github.com/DFE-Digital/govuk_design_system_formbuilder) to adapt the standard Rails form builder to generate markup that's 100% compliant with the [GOVUK Design System](https://design-system.service.gov.uk/)

This change should make it much easier to build forms without having to use lots of boilerplate code to make it work.

Because we are currently using the *Simple Form* form builder for the majority of our forms, the two can co-exist until we have to time to switch all forms over.

## Screenshots of UI changes

### Before

![Screenshot 2019-11-28 at 16 52 11](https://user-images.githubusercontent.com/3166/69822983-9279a600-11ff-11ea-9b2d-00262949c231.png)

### After

![Screenshot 2019-11-28 at 16 53 42](https://user-images.githubusercontent.com/3166/69823025-aa512a00-11ff-11ea-8f76-34b2e679d469.png)

## Next steps

- [X] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
