### PR TITLE
Feature/108 improve basic styling

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,9 +42,8 @@
           %span.govuk-phase-banner__text
             This is a new service
 
-      %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
-        = render 'layouts/messages'
-        = yield
+      = render 'layouts/messages'
+      = yield
 
 
     %footer.govuk-footer{role: "contentinfo"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -45,7 +45,6 @@
       = render 'layouts/messages'
       = yield
 
-
     %footer.govuk-footer{role: "contentinfo"}
       .govuk-width-container
         .govuk-footer__meta

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -1,6 +1,6 @@
 %nav
-  %ul.govuk-header__navigation
+  %ul{class: 'govuk-header__navigation', aria: { label: "Top Level Navigation"}}
     -if defined?(current_user) && current_user
-      %li
+      %li.govuk-header__navigation-item
         %a{ href: sign_out_path, class: 'govuk-header__link' }
           = t("generic.link.sign_out")

--- a/app/views/staff/dashboards/show.html.haml
+++ b/app/views/staff/dashboards/show.html.haml
@@ -11,16 +11,16 @@
           = t("dashboards.show.welcome", name: current_user.name)
 
       %p.govuk-body
-        %a{ href: sign_out_path }
+        %a{ href: sign_out_path, class: 'govuk-link govuk-link--no-visited-state' }
           = t("generic.link.sign_out")
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %hr
+      %hr.govuk-section-break.govuk-section-break--visible.govuk-section-break--m
       %h3.govuk-heading-m
         = t("page_content.dashboard.header.manage_users")
       = link_to t("page_content.dashboard.button.manage_users"), users_path, class: "govuk-button"
-      %hr
+      %hr.govuk-section-break.govuk-section-break--visible.govuk-section-break--m
       %h3.govuk-heading-m
         = t("page_content.dashboard.header.manage_organisations")
       = link_to t("page_content.dashboard.button.manage_organisations"), organisations_path, class: "govuk-button"


### PR DESCRIPTION
## Changes in this PR

*  Removed `main` from the application.html layout, because 
    We are generating nested `<main>` elements by having it in the application.htm’ and in rendered partials via =yeld. This breaks the styling and also will be confusing for screen readers.

* added missing classes and ARIA labes to the navigation (based on the page template from gov.uk)

* %hr also have a gov.uk styling

## Screenshots of UI changes

### Before

Before are dependent on the previous PR's or removing bootstrap to be merged

### After





