### PR TITLE
Remove paragraph wrap from back links

### DIFF
--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -2,8 +2,8 @@
 
 -# TODO: This back links is going to break when we have programme activities. We
 -# could put this in a helper called something like `link_to_parent_hierarchy`?
-%p
-  = link_to t("generic.link.back"), hierarchy_path_for(@activity_presenter), class: "govuk-back-link"
+
+= link_to t("generic.link.back"), hierarchy_path_for(@activity_presenter), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/activity_forms/everything.html.haml
+++ b/app/views/staff/activity_forms/everything.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.activity.new")
 
-%p= link_to t("generic.link.back"), organisation_fund_path(@fund.id, organisation_id: @fund.organisation.id), class: "govuk-back-link"
+= link_to t("generic.link.back"), organisation_fund_path(@fund.id, organisation_id: @fund.organisation.id), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/funds/index.html.haml
+++ b/app/views/staff/funds/index.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.fund.index")
 
-%p
-  = link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/funds/new.html.haml
+++ b/app/views/staff/funds/new.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.fund.new")
 
-%p
-  = link_to t("generic.link.back"), organisation_path(params["organisation_id"]), class: "govuk-back-link"
+= link_to t("generic.link.back"), organisation_path(params["organisation_id"]), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/funds/show.html.haml
+++ b/app/views/staff/funds/show.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.fund.show", name: @fund.name)
 
-%p
-  = link_to t("generic.link.back"), organisation_path(@fund.organisation), class: "govuk-back-link"
+= link_to t("generic.link.back"), organisation_path(@fund.organisation), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/index.html.haml
+++ b/app/views/staff/organisations/index.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.organisation.index")
 
-%p
-  = link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/new.html.haml
+++ b/app/views/staff/organisations/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.organisation.new")
 
-%p= link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.organisation.show", name: @organisation_presenter.name)
 
-%p
-  = link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/index.html.haml
+++ b/app/views/staff/users/index.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.dashboard")
 
-%p= link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), dashboard_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/new.html.haml
+++ b/app/views/staff/users/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.users.new")
 
-%p= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -1,7 +1,6 @@
 =content_for :page_title_prefix, t("page_title.users.show", name: @user.name)
 
-%p
-  = link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds


### PR DESCRIPTION
Following the design system page template back links are stand alone links and don’t need to be wrapped in paragraphs. This is removing the paragraphs. more read https://design-system.service.gov.uk/styles/page-template/

## Changes in this PR

- removed paragraphs from back links

## Screenshots of UI changes
No UI changes, but here's an example from [gov.uk design system page template](https://design-system.service.gov.uk/styles/page-template/)

<img width="967" alt="Screenshot 2019-12-02 at 11 07 27" src="https://user-images.githubusercontent.com/2632224/69955643-0b297c80-14f6-11ea-9973-53c2d27c1a9d.png">
