### PR TITLE
GOV.UK Frontend JS is enabled

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,5 @@
 //= require jquery3
 //= require rails-ujs
 //= require turbolinks
+//= require govuk-frontend/govuk/all
 //= require_tree .


### PR DESCRIPTION
## Changes in this PR

This was being initialised in out application layout, but wasn't being loaded into the asset pipeline. This change fixes that and enables JS features that help with accessibility https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#using-javascript.

## Screenshots of UI changes

### Before

![Screenshot 2019-12-02 at 13 12 04](https://user-images.githubusercontent.com/912473/69962628-4a5fc980-1506-11ea-97b5-37fdc8e9dd61.png)
