### PR TITLE
Add gov.uk styles to definition lists

### DIFF
--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -12,60 +12,74 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %dl
-        %dt
-          = t("page_content.activity.identitfier.label")
-        %dd
-          = @activity_presenter.identifier
-        %dt
-          = t("page_content.activity.sector.label")
-        %dd
-          = @activity_presenter.sector
-        %dt
-          = t("page_content.activity.title.label")
-        %dd
-          = @activity_presenter.title
-        %dt
-          = t("page_content.activity.description.label")
-        %dd
-          = @activity_presenter.description
-        %dt
-          = t("page_content.activity.status.label")
-        %dd
-          = @activity_presenter.status
-        %dt
-          = t("page_content.activity.planned_start_date.label")
-        %dd
-          = l(@activity_presenter.planned_start_date)
-        %dt
-          = t("page_content.activity.planned_end_date.label")
-        %dd
-          = l(@activity_presenter.planned_end_date)
-        %dt
-          = t("page_content.activity.actual_start_date.label")
-        %dd
-          = l(@activity_presenter.actual_start_date)
-        %dt
-          = t("page_content.activity.actual_end_date.label")
-        %dd
-          = l(@activity_presenter.actual_end_date)
-        %dt
-          = t("page_content.activity.recipient_region.label")
-        %dd
-          = @activity_presenter.recipient_region
-        %dt
-          = t("page_content.activity.flow.label")
-        %dd
-          = @activity_presenter.flow
-        %dt
-          = t("page_content.activity.finance.label")
-        %dd
-          = @activity_presenter.finance
-        %dt
-          = t("page_content.activity.aid_type.label")
-        %dd
-          = @activity_presenter.aid_type
-        %dt
-          = t("page_content.activity.tied_status.label")
-        %dd
-          = t("activity.tied_status.#{@activity_presenter.tied_status}")
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.identitfier.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.identifier
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.sector.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.sector
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.title.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.title
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.description.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.description
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.status.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.status
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.planned_start_date.label")
+          %dd.govuk-summary-list__value
+            = l(@activity_presenter.planned_start_date)
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.planned_end_date.label")
+          %dd.govuk-summary-list__value
+            = l(@activity_presenter.planned_end_date)
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.actual_start_date.label")
+          %dd.govuk-summary-list__value
+            = l(@activity_presenter.actual_start_date)
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.actual_end_date.label")
+          %dd.govuk-summary-list__value
+            = l(@activity_presenter.actual_end_date)
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.recipient_region.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.recipient_region
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.flow.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.flow
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.finance.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.finance
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.aid_type.label")
+          %dd.govuk-summary-list__value
+            = @activity_presenter.aid_type
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.activity.tied_status.label")
+          %dd.govuk-summary-list__value
+            = t("activity.tied_status.#{@activity_presenter.tied_status}")

--- a/app/views/staff/funds/show.html.haml
+++ b/app/views/staff/funds/show.html.haml
@@ -9,15 +9,17 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %dl
-        %dt
-          = t("page_content.fund.name.label")
-        %dd
-          = @fund.name
-        %dt
-          = t("page_content.fund.organisation.label")
-        %dd
-          = link_to @fund.organisation.name, organisation_path(@fund.organisation)
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.fund.name.label")
+          %dd.govuk-summary-list__value
+            = @fund.name
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.fund.organisation.label")
+          %dd.govuk-summary-list__value
+            = link_to @fund.organisation.name, organisation_path(@fund.organisation)
 
     .govuk-grid-column-one-third
       %h2.govuk-heading-m

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -9,23 +9,28 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %dl
-        %dt
-          = t("page_content.organisation.name.label")
-        %dd
-          = @organisation_presenter.name
-        %dt
-          = t("page_content.organisation.type.label")
-        %dd
-          = t("organisation.organisation_type.#{@organisation_presenter.organisation_type}")
-        %dt
-          = t("page_content.organisation.language_code.label")
-        %dd
-          = t("organisation.language_code.#{@organisation_presenter.language_code}")
-        %dt
-          = t("page_content.organisation.default_currency.label")
-        %dd
-          = t("organisation.default_currency.#{@organisation_presenter.default_currency}")
+      %h2.govuk-heading-m Details
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.organisation.name.label")
+          %dd.govuk-summary-list__value
+            = @organisation_presenter.name
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.organisation.type.label")
+          %dd.govuk-summary-list__value
+            = t("organisation.organisation_type.#{@organisation_presenter.organisation_type}")
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.organisation.language_code.label")
+          %dd.govuk-summary-list__value
+            = t("organisation.language_code.#{@organisation_presenter.language_code}")
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("page_content.organisation.default_currency.label")
+          %dd.govuk-summary-list__value
+            = t("organisation.default_currency.#{@organisation_presenter.default_currency}")
 
     .govuk-grid-column-one-third
       %h2.govuk-heading-m

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -10,19 +10,22 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m Details
-      %dl
-        %dt
-          = t("user.name")
-        %dd
-          = @user.name
-        %dt
-          = t("user.email")
-        %dd
-          = @user.email
-        %dt
-          = t("user.identifier")
-        %dd
-          = @user.identifier
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("user.name")
+          %dd.govuk-summary-list__value
+            = @user.name
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("user.email")
+          %dd.govuk-summary-list__value
+            = @user.email
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("user.identifier")
+          %dd.govuk-summary-list__value
+            = @user.identifier
     .govuk-grid-column-one-third.organisations
       %h2.govuk-heading-m Organisations
       %ul


### PR DESCRIPTION
After removing bootstrap the definition lists reverted to browser’s default styling, which didn’t look good.
Added gov.uk classes to the definition list and now they are more clear and use ‘summary-list’ component.

## Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2019-12-02 at 14 06 18](https://user-images.githubusercontent.com/2632224/69966207-d4f7f700-150d-11ea-98d0-c7eb00d68aa6.png)


### After

![Screenshot 2019-12-02 at 14 06 45](https://user-images.githubusercontent.com/2632224/69966216-db866e80-150d-11ea-886c-602ecff11c84.png)

![Screenshot 2019-12-04 at 13 37 38](https://user-images.githubusercontent.com/2632224/70147102-82e4dc00-169b-11ea-97c0-ac365adb5db3.png)
![Screenshot 2019-12-04 at 13 38 08](https://user-images.githubusercontent.com/2632224/70147105-82e4dc00-169b-11ea-9f99-d6047b8de73d.png)
![Screenshot 2019-12-04 at 13 38 16](https://user-images.githubusercontent.com/2632224/70147108-837d7280-169b-11ea-8b47-77cc715b0be6.png)

