### PR TITLE
(90) Edit a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add Google Tag Manager in place of templated Google Analytics code
 - Ensure missing I18n strings cause tests to fail
-- Users can be created both locally and in Auth0
+- Users can be created/updated both locally and in Auth0
 - Users can be associated with multiple organisations
 - Allow roles to be assigned to users
 - Users are welcomed and able to create their new password to access the service

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -34,6 +34,25 @@ class Staff::UsersController < Staff::BaseController
     end
   end
 
+  def edit
+    @user = policy_scope(User).find(id)
+    @organisations = policy_scope(Organisation)
+    authorize @user
+  end
+
+  def update
+    @user = policy_scope(User).find(id)
+    @organisations = policy_scope(Organisation)
+    authorize @user
+
+    if @user.update(user_params)
+      flash.now[:notice] = I18n.t("form.user.update.success")
+      redirect_to user_path(@user)
+    else
+      render :edit
+    end
+  end
+
   def user_params
     params.require(:user).permit(:name, :email, organisation_ids: [])
   end

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -45,9 +45,18 @@ class Staff::UsersController < Staff::BaseController
     @organisations = policy_scope(Organisation)
     authorize @user
 
-    if @user.update(user_params)
-      flash.now[:notice] = I18n.t("form.user.update.success")
-      redirect_to user_path(@user)
+    @user.assign_attributes(user_params)
+
+    if @user.valid?
+      result = UpdateUser.new(user: @user, organisations: organisations).call
+
+      if result.success?
+        flash.now[:notice] = I18n.t("form.user.update.success")
+        redirect_to user_path(@user)
+      else
+        flash.now[:error] = I18n.t("form.user.update.failed")
+        render :edit
+      end
     else
       render :edit
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   enum role: {
     administrator: "administrator",
     delivery_partner: "delivery_partner",
+    fund_manager: "fund_manager",
   }
 
   attribute :role, :string, default: "delivery_partner"

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,4 +6,12 @@ class UserPolicy < ApplicationPolicy
   def show?
     true
   end
+
+  def create?
+    user.administrator? || user.fund_manager?
+  end
+
+  def update?
+    user.administrator? || user.fund_manager?
+  end
 end

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,0 +1,26 @@
+class UpdateUser
+  attr_accessor :user, :organisations
+
+  def initialize(user:, organisations: [])
+    self.user = user
+    self.organisations = organisations
+  end
+
+  def call
+    result = Result.new(true)
+
+    User.transaction do
+      user.organisations = organisations
+      user.save
+      begin
+        UpdateUserInAuth0.new(user: user).call
+      rescue Auth0::Exception => e
+        result.success = false
+        Rails.logger.error("Error updating user #{user.email} to Auth0 during UpdateUser with #{e.message}.")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    result
+  end
+end

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -11,7 +11,7 @@ class UpdateUser
 
     User.transaction do
       user.organisations = organisations
-      user.save
+
       begin
         UpdateUserInAuth0.new(user: user).call
       rescue Auth0::Exception => e
@@ -19,6 +19,8 @@ class UpdateUser
         Rails.logger.error("Error updating user #{user.email} to Auth0 during UpdateUser with #{e.message}.")
         raise ActiveRecord::Rollback
       end
+
+      user.save
     end
 
     result

--- a/app/services/update_user_in_auth0.rb
+++ b/app/services/update_user_in_auth0.rb
@@ -8,6 +8,8 @@ class UpdateUserInAuth0
   end
 
   def call
+    return unless synchronise?
+
     auth0_client.update_user(
       user.identifier,
       email: user.email,
@@ -19,5 +21,9 @@ class UpdateUserInAuth0
 
   def auth0_client
     @auth0_client ||= Auth0Api.new.client
+  end
+
+  def synchronise?
+    user.email_changed? || user.name_changed?
   end
 end

--- a/app/services/update_user_in_auth0.rb
+++ b/app/services/update_user_in_auth0.rb
@@ -1,0 +1,23 @@
+require "./lib/auth0_api"
+
+class UpdateUserInAuth0
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    auth0_client.update_user(
+      user.identifier,
+      email: user.email,
+      name: user.name,
+    )
+  end
+
+  private
+
+  def auth0_client
+    @auth0_client ||= Auth0Api.new.client
+  end
+end

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -12,4 +12,6 @@
       %tr.govuk-table__row
         %td.govuk-table__cell= user.name
         %td.govuk-table__cell= user.email
-        %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), user_path(user), class: 'govuk-link', id: "#{user.email}-show")
+        %td.govuk-table__cell
+          = link_to(I18n.t('generic.link.show'), user_path(user), class: 'govuk-link')
+          = link_to(I18n.t('generic.link.edit'), edit_user_path(user), class: 'govuk-link')

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -1,0 +1,15 @@
+= form_with model: @user do |f|
+  = f.govuk_error_summary
+
+  = f.govuk_text_field :name
+  = f.govuk_email_field :email
+
+  - if @organisations.any?
+    = f.govuk_collection_check_boxes :organisation_ids, @organisations, :id, :name
+  - else
+    .govuk-inset-text
+      = succeed "." do
+        = t("page_content.users.new.no_organisations.cta")
+        = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
+
+  = f.govuk_submit t("form.user.submit")

--- a/app/views/staff/users/edit.html.haml
+++ b/app/views/staff/users/edit.html.haml
@@ -1,24 +1,10 @@
 =content_for :page_title_prefix, t("page_title.users.edit")
 
-%p= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
         = t("page_title.users.edit")
 
-      = form_with model: @user do |f|
-        = f.govuk_error_summary
-
-        = f.govuk_text_field :name
-        = f.govuk_email_field :email
-
-        - if @organisations.any?
-          = f.govuk_collection_check_boxes :organisation_ids, @organisations, :id, :name
-        - else
-          .govuk-inset-text
-            = succeed "." do
-              = t("page_content.users.new.no_organisations.cta")
-              = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
-
-        = f.govuk_submit t("form.user.submit")
+      = render "form"

--- a/app/views/staff/users/edit.html.haml
+++ b/app/views/staff/users/edit.html.haml
@@ -1,0 +1,24 @@
+=content_for :page_title_prefix, t("page_title.users.edit")
+
+%p= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.users.edit")
+
+      = form_with model: @user do |f|
+        = f.govuk_error_summary
+
+        = f.govuk_text_field :name
+        = f.govuk_email_field :email
+
+        - if @organisations.any?
+          = f.govuk_collection_check_boxes :organisation_ids, @organisations, :id, :name
+        - else
+          .govuk-inset-text
+            = succeed "." do
+              = t("page_content.users.new.no_organisations.cta")
+              = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
+
+        = f.govuk_submit t("form.user.submit")

--- a/app/views/staff/users/new.html.haml
+++ b/app/views/staff/users/new.html.haml
@@ -7,18 +7,4 @@
       %h1.govuk-heading-xl
         = t("page_title.users.new")
 
-      = form_with model: @user do |f|
-        = f.govuk_error_summary
-
-        = f.govuk_text_field :name
-        = f.govuk_email_field :email
-
-        - if @organisations.any?
-          = f.govuk_collection_check_boxes :organisation_ids, @organisations, :id, :name
-        - else
-          .govuk-inset-text
-            = succeed "." do
-              = t("page_content.users.new.no_organisations.cta")
-              = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
-
-        = f.govuk_submit t("generic.button.submit")
+      = render "form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,11 +86,15 @@ en:
       create:
         failed: The service is experiencing issues creating new users and the team has been alerted to the problem.
         success: User successfully created
+      submit: Submit
+      update:
+        success: User successfully updated
   generic:
     button:
       submit: Submit
     link:
       back: Back
+      edit: Edit
       show: Show
       sign_out: Sign out
       start_now: Start now
@@ -214,6 +218,7 @@ en:
     transaction:
       new: New transaction
     users:
+      edit: Edit user
       index: Users
       new: Create user
       show: User

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
         success: User successfully created
       submit: Submit
       update:
+        failed: The service is experiencing issues updating users and the team has been alerted to the problem.
         success: User successfully updated
   generic:
     button:

--- a/spec/features/staff/users_can_edit_existing_users_spec.rb
+++ b/spec/features/staff/users_can_edit_existing_users_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Editing a user" do
+  before do
+    authenticate!(user: build_stubbed(:user, role: :fund_manager))
+  end
+
+  scenario "the details of the user can be updated" do
+    create(:user, name: "Old Name", email: "old@example.com")
+
+    updated_name = "New Name"
+    updated_email = "new@example.com"
+
+    # Navigate from the landing page
+    visit dashboard_path
+    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+
+    # Navigate to the users page
+    expect(page).to have_content(I18n.t("page_title.users.index"))
+
+    # Click on edit button
+    click_on(I18n.t("generic.link.edit"))
+
+    # Fill out the form
+    fill_in "user[name]", with: updated_name
+    fill_in "user[email]", with: updated_email
+
+    # Submit the form
+    click_button I18n.t("form.user.submit")
+
+    # Verify the user was updated
+    expect(page).to have_content(updated_name)
+    expect(page).to have_content(updated_email)
+  end
+end

--- a/spec/features/staff/users_can_edit_existing_users_spec.rb
+++ b/spec/features/staff/users_can_edit_existing_users_spec.rb
@@ -3,13 +3,20 @@ require "rails_helper"
 RSpec.feature "Editing a user" do
   before do
     authenticate!(user: build_stubbed(:user, role: :fund_manager))
+    stub_auth0_token_request
   end
 
   scenario "the details of the user can be updated" do
-    create(:user, name: "Old Name", email: "old@example.com")
+    target_user = create(:user, name: "Old Name", email: "old@example.com")
 
     updated_name = "New Name"
     updated_email = "new@example.com"
+
+    stub_auth0_update_user_request(
+      auth0_identifier: target_user.identifier,
+      email: updated_email,
+      name: updated_name
+    )
 
     # Navigate from the landing page
     visit dashboard_path

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe UserPolicy do
     it { is_expected.to permit_action(:destroy) }
   end
 
+  context "as a fund manager" do
+    let(:user) { build_stubbed(:user, role: :fund_manager) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
   context "as a delivery partner" do
     let(:user) { build_stubbed(:user) }
 

--- a/spec/services/update_user_in_auth0_spec.rb
+++ b/spec/services/update_user_in_auth0_spec.rb
@@ -5,13 +5,44 @@ RSpec.describe UpdateUserInAuth0 do
   describe "#call" do
     let(:user) { create(:user, identifier: "auth0|555ffff") }
 
+    let(:updated_name) { "New Name" }
+    let(:updated_email) { "new@example.com" }
+
     subject { described_class.new(user: user) }
 
     before(:each) do
       stub_auth0_token_request
     end
 
-    it "updates the user in Auth0" do
+    it "updates the user in Auth0 if their name has changed" do
+      user.name = updated_name
+
+      auth0_update_call = stub_auth0_update_user_request(
+        auth0_identifier: "auth0|555ffff",
+        email: user.email,
+        name: updated_name,
+      )
+
+      subject.call
+
+      expect(auth0_update_call).to have_been_requested
+    end
+
+    it "updates the user in Auth0 if their email address has changed" do
+      user.email = updated_email
+
+      auth0_update_call = stub_auth0_update_user_request(
+        auth0_identifier: "auth0|555ffff",
+        email: updated_email,
+        name: user.name,
+      )
+
+      subject.call
+
+      expect(auth0_update_call).to have_been_requested
+    end
+
+    it "doesn't call Auth0 if name or email unchanged" do
       auth0_update_call = stub_auth0_update_user_request(
         auth0_identifier: "auth0|555ffff",
         email: "new@example.com",
@@ -20,12 +51,14 @@ RSpec.describe UpdateUserInAuth0 do
 
       subject.call
 
-      expect(auth0_update_call).to have_been_requested
+      expect(auth0_update_call).not_to have_been_requested
     end
 
     context "when an error is thrown" do
       context "for an unexpected reason" do
         it "raises the error as an unhandled exception" do
+          user.email = updated_email
+
           params = JSON[{
             "statusCode" => 500,
             "error" => "Foo",

--- a/spec/services/update_user_in_auth0_spec.rb
+++ b/spec/services/update_user_in_auth0_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "auth0"
+
+RSpec.describe UpdateUserInAuth0 do
+  describe "#call" do
+    let(:user) { create(:user, identifier: "auth0|555ffff") }
+
+    subject { described_class.new(user: user) }
+
+    before(:each) do
+      stub_auth0_token_request
+    end
+
+    it "updates the user in Auth0" do
+      auth0_update_call = stub_auth0_update_user_request(
+        auth0_identifier: "auth0|555ffff",
+        email: "new@example.com",
+        name: "New Name",
+      )
+
+      subject.call
+
+      expect(auth0_update_call).to have_been_requested
+    end
+
+    context "when an error is thrown" do
+      context "for an unexpected reason" do
+        it "raises the error as an unhandled exception" do
+          params = JSON[{
+            "statusCode" => 500,
+            "error" => "Foo",
+            "message" => "Bar",
+            "errorCode" => "x_error",
+          }]
+
+          unexpected_error = Auth0::Unsupported.new(params)
+
+          allow_any_instance_of(Auth0Api).to receive_message_chain(:client, :update_user)
+            .and_raise(unexpected_error)
+
+          expect { subject.call }.to raise_error(unexpected_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe UpdateUser do
+  let(:user) { create(:user, identifier: "auth0|1234") }
+
+  before(:each) do
+    stub_auth0_token_request
+  end
+
+  describe "#call" do
+    it "returns a successful result" do
+      stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
+
+      result = described_class.new(user: user).call
+
+      expect(result.success?).to eq(true)
+      expect(result.failure?).to eq(false)
+    end
+
+    context "when organisations are provided" do
+      it "associates them to the user" do
+        stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
+
+        first_organisation = create(:organisation)
+        second_organisation = create(:organisation)
+
+        described_class.new(
+          user: user,
+          organisations: [first_organisation, second_organisation]
+        ).call
+
+        expect(user.reload.organisations).to include(first_organisation)
+        expect(user.reload.organisations).to include(second_organisation)
+      end
+    end
+
+    context "when Auth0 errors" do
+      before(:each) do
+        stub_auth0_update_user_request_failure(auth0_identifier: "auth0|1234")
+      end
+
+      it "returns a failed result" do
+        result = described_class.new(user: user).call
+        expect(result.failure?).to eq(true)
+      end
+
+      it "does not save the user" do
+        expect { described_class.new(user: user).call }.to_not change { user.reload }
+      end
+
+      it "logs a failure message" do
+        expect(Rails.logger).to receive(:error)
+          .with("Error updating user #{user.email} to Auth0 during UpdateUser with .")
+
+        described_class.new(user: user).call
+      end
+    end
+  end
+end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe UpdateUser do
   let(:user) { create(:user, identifier: "auth0|1234") }
 
+  let(:updated_email) { "new@example.com" }
+  let(:updated_name) { "New Name" }
+
   before(:each) do
     stub_auth0_token_request
   end
@@ -37,6 +40,7 @@ RSpec.describe UpdateUser do
     context "when Auth0 errors" do
       before(:each) do
         stub_auth0_update_user_request_failure(auth0_identifier: "auth0|1234")
+        user.email = updated_email
       end
 
       it "returns a failed result" do

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -24,4 +24,15 @@ module Auth0Helpers
         body: "{\"ticket\":\"https://testdomain/lo/reset?ticket=123#\"}"
       )
   end
+
+  def stub_auth0_update_user_request(auth0_identifier:, email:, name:)
+    stub_request(:patch, "https://testdomain/api/v2/users/#{auth0_identifier}")
+      .with(body: hash_including(email: email, name: name))
+      .to_return(status: 200, body: "{\"user_id\":\"#{auth0_identifier}\"}")
+  end
+
+  def stub_auth0_update_user_request_failure(auth0_identifier:)
+    stub_request(:patch, "https://testdomain/api/v2/users/#{auth0_identifier}")
+      .to_return(status: 500, body: "")
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- Create a new 'fund manager' role, who can manage users
- Allow users to be edited (by administrators or fund managers only). Any changes to `name` or `email` are synchronised to Auth0.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
