### PR TITLE
Sidekiq logging configuration updated for version 6.x

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,6 +5,7 @@ options = {
 }
 
 Sidekiq.configure_server do |config|
+  config.logger.level = Logger::WARN if Rails.env.production?
   config.options.merge!(options)
   config.redis = {
     url: redis_url,
@@ -19,5 +20,3 @@ Sidekiq.configure_client do |config|
     size: config.options[:concurrency] + 5,
   }
 end
-
-Sidekiq::Logging.logger.level = Logger::WARN if Rails.env.production?


### PR DESCRIPTION
Looks like in the major verison bump from 5. to 6. the API for configuring logging changed https://github.com/mperham/sidekiq/wiki/Logging#api-changes - this means that our deployments are failing due to our logging config only being applied in the production environment

This new instruction documents how we would do configure sidekiq logging to avoid lots of verbose logging https://github.com/mperham/sidekiq/wiki/Logging#default-logger-and-verboseness this is a concern as our papertrail limit may quickly disappear due to retrying jobs.
