### PR TITLE
Welcome emails are only sent after the user is persisted

### DIFF
--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -14,7 +14,6 @@ class CreateUser
       user.save
       begin
         CreateUserInAuth0.new(user: user).call
-        SendWelcomeEmail.new(user: user).call
       rescue Auth0::Exception => e
         result.success = false
         Rails.logger.error("Error adding user #{user.email} to Auth0 during CreateUser with #{e.message}.")
@@ -22,6 +21,7 @@ class CreateUser
       end
     end
 
+    SendWelcomeEmail.new(user: user).call if user.persisted?
     result
   end
 end

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe CreateUser do
       expect(result.failure?).to eq(false)
     end
 
+    it "sends a welcome email to the user" do
+      stub_auth0_create_user_request(email: user.email)
+
+      mail_server = double(SendWelcomeEmail)
+      expect(SendWelcomeEmail).to receive(:new)
+        .with(user: user)
+        .and_return(mail_server)
+
+      expect(mail_server).to receive(:call)
+
+      described_class.new(user: user).call
+    end
+
     context "when organisations are provided" do
       it "associates them to the user" do
         stub_auth0_create_user_request(email: user.email)


### PR DESCRIPTION
## Changes in this PR

Now the `user` object is sent to the mailing service (rather than an ID) there is always an initial error from Sidekiq when the user is created.

The error happens when a user is successfully created but the mailer is called before the user record is persisted to the database, due to the use of the transaction block.

When the mailer recieves the object, it tries to call `id` on it and fails with a serialisation error. This is due to the fact no ID has been created and we are dealing with a object in memory only.

Added a missing happy path test on my way through.
