### PR TITLE
104 Users can edit a fund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Create Transactions associated with a Fund
 - Remove the distinction between Fund and Activity from the user
 - Users can edit an organisation
+- Users can edit the basic fund record

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -78,6 +78,6 @@ class Staff::ActivityFormsController < Staff::BaseController
   def finish_wizard_path
     flash[:notice] = I18n.t("form.activity.create.success")
 
-    fund_path(@fund)
+    organisation_fund_path(@fund.organisation, @fund)
   end
 end

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -37,6 +37,26 @@ class Staff::FundsController < Staff::BaseController
     end
   end
 
+  def edit
+    @fund = policy_scope(Fund).find(id)
+    authorize @fund
+  end
+
+  def update
+    @fund = policy_scope(Fund).find(id)
+    authorize @fund
+
+    @fund.assign_attributes(fund_params)
+
+    if @fund.valid?
+      @fund.save
+      flash[:notice] = I18n.t("form.fund.update.success")
+      redirect_to organisation_fund_path(@fund.organisation, @fund)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def fund_params

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -18,18 +18,20 @@ class Staff::FundsController < Staff::BaseController
 
   def new
     @fund = policy_scope(Fund).new
+    @organisation = Organisation.find(organisation_id)
     authorize @fund
   end
 
   def create
     @fund = policy_scope(Fund).new(fund_params)
+    @organisation = Organisation.find(organisation_id)
+    @fund.organisation = @organisation
     authorize @fund
-    @fund.organisation = Organisation.find params[:organisation_id]
 
     if @fund.valid?
       @fund.save
       flash[:notice] = I18n.t("form.fund.create.success")
-      redirect_to fund_path(@fund)
+      redirect_to organisation_fund_path(@organisation, @fund)
     else
       render :new
     end
@@ -43,5 +45,9 @@ class Staff::FundsController < Staff::BaseController
 
   def id
     params[:id]
+  end
+
+  def organisation_id
+    params[:organisation_id]
   end
 end

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -21,7 +21,7 @@ class Staff::TransactionsController < Staff::BaseController
 
     if @transaction.save
       flash[:notice] = I18n.t("form.transaction.create.success")
-      redirect_to fund_path(@fund)
+      redirect_to organisation_fund_path(@fund.organisation, @fund)
     else
       render :new
     end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -1,20 +1,9 @@
 module ActivityHelper
   def hierarchy_path_for(activity)
-    case activity.hierarchy_type
-    when "Fund"
-      fund = Fund.find activity.hierarchy_id
-      organisation_fund_path(activity.hierarchy_id, organisation_id: fund.organisation)
-    else
-      raise "Other hierarchy types not implemented yet"
-    end
+    url_for([activity.hierarchy.organisation, activity.hierarchy])
   end
 
   def activity_path_for(activity)
-    case activity.hierarchy_type
-    when "Fund"
-      fund_activity_path(id: activity.id, fund_id: activity.hierarchy_id)
-    else
-      raise "Other hierarchy types not implemented yet"
-    end
+    url_for([activity.hierarchy, activity])
   end
 end

--- a/app/views/staff/funds/_form.html.haml
+++ b/app/views/staff/funds/_form.html.haml
@@ -1,0 +1,3 @@
+= f.govuk_error_summary
+= f.govuk_text_field :name
+= f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/funds/edit.html.haml
+++ b/app/views/staff/funds/edit.html.haml
@@ -1,0 +1,11 @@
+=content_for :page_title_prefix, t("page_title.fund.edit")
+
+= link_to t("generic.link.back"), organisation_path(@fund.organisation), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.fund.edit")
+
+      = form_with model: @fund, url: organisation_fund_path(@fund.organisation), method: :put do |f|
+        = render partial: 'form', locals: { f: f }

--- a/app/views/staff/funds/index.html.haml
+++ b/app/views/staff/funds/index.html.haml
@@ -13,4 +13,4 @@
         %ul.govuk-list.govuk-list--bullet
           - @funds.each do |fund|
             %li
-              = link_to fund.name, fund_path(fund.id)
+              = link_to fund.name, organisation_fund_path(fund.organisation, fund.id)

--- a/app/views/staff/funds/new.html.haml
+++ b/app/views/staff/funds/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.fund.new")
 
-= link_to t("generic.link.back"), organisation_path(params["organisation_id"]), class: "govuk-back-link"
+= link_to t("generic.link.back"), organisation_path(@organisation), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/funds/new.html.haml
+++ b/app/views/staff/funds/new.html.haml
@@ -7,10 +7,5 @@
       %h1.govuk-heading-xl
         = t("page_title.fund.new")
 
-      = simple_form_for(@fund, method: :post, url: organisation_funds_path) do |f|
-        .govuk-form-group
-          = f.input :organisation_id,
-                    as: :hidden
-          = f.input :name
-
-        = f.button :submit, t("generic.button.submit")
+      = form_with model: @fund, url: organisation_funds_path(@organisation) do |f|
+        = render partial: 'form', locals: { f: f }

--- a/app/views/staff/funds/show.html.haml
+++ b/app/views/staff/funds/show.html.haml
@@ -13,11 +13,13 @@
         = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@fund.activity) }
       - else
         %dl.govuk-summary-list
-          .govuk-summary-list__row
+          .govuk-summary-list__row.fund_name
             %dt.govuk-summary-list__key
               = t("page_content.fund.name.label")
             %dd.govuk-summary-list__value
               = @fund.name
+            %dd.govuk-summary-list__actions
+              = link_to t("generic.link.edit"), [:edit, @fund.organisation, @fund], class: "govuk-link"
           .govuk-summary-list__row
             %dt.govuk-summary-list__key
               = t("page_content.fund.organisation.label")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -1,9 +1,11 @@
 %dl.govuk-summary-list
-  .govuk-summary-list__row
+  .govuk-summary-list__row.fund_name
     %dt.govuk-summary-list__key
       = t("page_content.fund.name.label")
     %dd.govuk-summary-list__value
       = activity_presenter.hierarchy.name
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), [:edit, activity_presenter.hierarchy.organisation, activity_presenter.hierarchy], class: "govuk-link"
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("page_content.fund.organisation.label")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,8 @@ en:
         success: Fund successfully created
       organisation:
         hint: The organisation this fund is associated with
+      update:
+        success: Fund successfully updated
     organisation:
       create:
         success: Organisation successfully created
@@ -153,6 +155,7 @@ en:
       button:
         create_activity: Add %{activity} information
         create_transaction: Create transaction
+        edit: Edit fund
       name:
         label: Name
       organisation:
@@ -211,6 +214,7 @@ en:
     errors:
       not_authorised: You are not authorised
     fund:
+      edit: Edit fund
       index: Funds
       new: Create fund
       show: Fund %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       resources :funds, only: [:index, :show, :new, :create]
     end
 
-    resources :funds do
+    resources :funds, only: [] do
       resources :activities, only: [:new, :create, :show] do
         resources :steps, controller: "activity_forms"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show
     resources :users
     resources :organisations, except: [:destroy] do
-      resources :funds, only: [:index, :show, :new, :create]
+      resources :funds, except: [:destroy]
     end
 
     resources :funds, only: [] do

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can create a transaction" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
       page.set_rack_session(userinfo: nil)
-      visit fund_path(fund)
+      visit organisation_fund_path(organisation, fund)
       expect(current_path).to eq(root_path)
     end
   end

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -10,14 +10,14 @@ RSpec.feature "Users can create an activity" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
       page.set_rack_session(userinfo: nil)
-      visit fund_path(fund)
+      visit organisation_fund_path(organisation, fund)
       expect(current_path).to eq(root_path)
     end
   end
 
   context "when the hierarchy is a Fund" do
     scenario "successfully creating an activity with all optional information" do
-      visit fund_path(fund)
+      visit organisation_fund_path(organisation, fund)
       click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
 
       expect(page).to have_content I18n.t("page_title.activity_form.show.identifier")
@@ -82,7 +82,7 @@ RSpec.feature "Users can create an activity" do
 
     context "validations" do
       scenario "validation errors work as expected" do
-        visit fund_path(fund)
+        visit organisation_fund_path(organisation, fund)
         click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
         click_button I18n.t("form.activity.submit")
         expect(page).not_to have_content I18n.t("form.activity.create.success")
@@ -91,7 +91,7 @@ RSpec.feature "Users can create an activity" do
     end
 
     scenario "can go back to the previous page" do
-      visit fund_path(fund)
+      visit organisation_fund_path(organisation, fund)
       click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
 
       click_on I18n.t("generic.link.back")

--- a/spec/features/staff/users_can_edit_a_fund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_fund_spec.rb
@@ -1,0 +1,58 @@
+RSpec.feature "Users can edit a fund" do
+  before do
+    authenticate!(user: user)
+  end
+
+  let(:fund) { create(:fund, name: "old name", organisation: organisation) }
+  let(:organisation) { create(:organisation, name: "UKSA") }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  context "when the user is not logged in" do
+    it "redirects the user to the root path" do
+      page.set_rack_session(userinfo: nil)
+      visit edit_organisation_fund_path(organisation, fund)
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "when no activity record exists" do
+    scenario "successfully editing a fund" do
+      fund = create(:fund, organisation: organisation)
+
+      visit dashboard_path
+      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+
+      click_on(organisation.name)
+      click_on(fund.name)
+
+      within(".fund_name") do
+        click_on(I18n.t("generic.link.edit"))
+      end
+
+      fill_in "fund[name]", with: "My New Fund name"
+      click_button I18n.t("generic.button.submit")
+      expect(page).to have_content("My New Fund name")
+    end
+  end
+
+  context "when an activity record exists" do
+    scenario "successfully editing a fund" do
+      fund = create(:fund, organisation: organisation)
+      create(:activity, hierarchy: fund)
+
+      visit dashboard_path
+      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+
+      click_on(organisation.name)
+      click_on(fund.name)
+
+      within(".fund_name") do
+        click_on(I18n.t("generic.link.edit"))
+      end
+
+      fill_in "fund[name]", with: "My New Fund name"
+      click_button I18n.t("generic.button.submit")
+      expect(page).to have_content("My New Fund name")
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_a_fund_spec.rb
+++ b/spec/features/staff/users_can_view_a_fund_spec.rb
@@ -12,14 +12,14 @@ RSpec.feature "Users can view a fund" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
       page.set_rack_session(userinfo: nil)
-      visit fund_path(viewable_fund)
+      visit organisation_fund_path(organisation, viewable_fund)
       expect(current_path).to eq(root_path)
     end
   end
 
   context "when the fund belongs to the user's organisation" do
     scenario "the user can view the fund" do
-      visit fund_path(viewable_fund)
+      visit organisation_fund_path(organisation, viewable_fund)
 
       expect(page).to have_content viewable_fund.name
     end
@@ -27,12 +27,13 @@ RSpec.feature "Users can view a fund" do
 
   context "when the fund belongs to another organisation" do
     scenario "the user cannot view the fund" do
-      expect { visit fund_path(forbidden_fund) }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { visit organisation_fund_path(organisation, forbidden_fund) }
+        .to raise_exception(ActiveRecord::RecordNotFound)
     end
   end
 
   scenario "can go back to the previous page" do
-    visit fund_path(viewable_fund)
+    visit organisation_fund_path(organisation, viewable_fund)
 
     click_on I18n.t("generic.link.back")
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -43,7 +43,8 @@ RSpec.feature "Users can view an activity" do
 
   context "when the activity belongs to another organisation" do
     scenario "the user cannot view the activity" do
-      expect { visit fund_path(forbidden_activity) }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { visit organisation_fund_path(organisation, forbidden_activity) }
+        .to raise_exception(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -52,6 +53,8 @@ RSpec.feature "Users can view an activity" do
 
     click_on I18n.t("generic.link.back")
 
-    expect(page).to have_current_path(organisation_fund_path(viewable_fund, organisation_id: organisation))
+    expect(page).to have_current_path(
+      organisation_fund_path(viewable_fund, organisation_id: organisation)
+    )
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:fund_activity) { create(:activity, hierarchy: fund) }
 
       it "returns the organisation_fund_path" do
-        expect(helper.hierarchy_path_for(fund_activity)).to eq(organisation_fund_path(fund, organisation_id: organisation.id))
+        expect(helper.hierarchy_path_for(fund_activity)).to eq(organisation_fund_path(organisation.id, fund))
       end
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:fund_activity) { create(:activity, hierarchy: fund) }
 
       it "returns the fund_activity_path" do
-        expect(helper.activity_path_for(fund_activity)).to eq(fund_activity_path(fund_activity, fund_id: fund.id))
+        expect(helper.activity_path_for(fund_activity)).to eq(fund_activity_path(fund, fund_activity))
       end
     end
   end


### PR DESCRIPTION
**Important - this change is based on https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/75 so requires that to be agreed and merged first** 

## Changes in this PR

- remove fund level routing that didn't require an organisation
- refactor `simple_form` out of the form new form
- allow the `fund` record to be edited. Note this change does not include editing the associated `activity` record to keep this proposal small, however I imagine the edit journey will be very similar. The links for activity edit will go to `ActivityFormController` rather than `FundController`

## Screenshots of UI changes

![Screenshot 2019-12-06 at 17 48 21](https://user-images.githubusercontent.com/912473/70344041-a8671680-1850-11ea-80ed-c18b5fea1136.png)
![Screenshot 2019-12-06 at 17 48 30](https://user-images.githubusercontent.com/912473/70344042-a8671680-1850-11ea-83aa-4152432c9ddc.png)
![Screenshot 2019-12-06 at 17 48 37](https://user-images.githubusercontent.com/912473/70344043-a8ffad00-1850-11ea-8a66-1875bef89081.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
