### PR TITLE
(Fix) Correct display of a Fund's Tied Status on Fund#show

### DIFF
--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -78,4 +78,4 @@
     %dt.govuk-summary-list__key
       = t("page_content.activity.tied_status.label")
     %dd.govuk-summary-list__value
-      = t("activity.tied_status.#{activity_presenter.tied_status}")
+      = activity_presenter.tied_status


### PR DESCRIPTION
## Changes in this PR

ActivityPresenter returns the i18n string for the Fund's Tied Status so there
is no need to get the internationalized string in the view

## Screenshots of UI changes

### Before

<img width="810" alt="Screenshot 2019-12-09 at 16 50 43" src="https://user-images.githubusercontent.com/1089521/70455528-60403200-1aa4-11ea-93e7-e7551cf99f09.png">

