### PR TITLE
(150) Only show transactions for the given Fund on Fund page

### DIFF
--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -12,7 +12,7 @@ class Staff::FundsController < Staff::BaseController
     @fund = policy_scope(Fund).find(id)
     authorize @fund
 
-    transactions = policy_scope(Transaction)
+    transactions = policy_scope(Transaction).where(fund: @fund)
     @transaction_presenters = transactions.map { |transaction| TransactionPresenter.new(transaction) }
   end
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,7 +11,7 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    @funds = Fund.where(organisation: organisation)
+    @funds = Fund.includes(:organisation).where(organisation: organisation)
   end
 
   def new

--- a/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
@@ -1,0 +1,22 @@
+RSpec.feature "Users can view funds on an organisation page" do
+  before do
+    authenticate!(user: user)
+  end
+
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:fund) { create(:fund, organisation: organisation) }
+  let(:other_fund) { create(:fund, organisation: organisation) }
+
+  scenario "only transactions belonging to this fund are shown on the Fund#show page" do
+    transaction = create(:transaction, fund: fund)
+    other_transaction = create(:transaction, fund: other_fund)
+
+    visit organisations_path
+    click_link organisation.name
+    click_link fund.name
+
+    expect(page).to have_content(transaction.reference)
+    expect(page).to_not have_content(other_transaction.reference)
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/LsOoYdS6/150-only-show-transactions-for-the-given-fund-rather-than-all

On the Fund#show page we were showing all Transactions for the given _Organisation_, not just the ones for that Fund. This corrects that error.