### PR TITLE
Activity record creation is decoupled from working only with Funds

### DIFF
--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -19,17 +19,24 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity = policy_scope(Activity).new
     authorize @activity
 
-    @fund = policy_scope(Fund).find(params[:fund_id])
-    @activity.hierarchy = @fund
-
+    @activity.hierarchy = hierarchy
     @activity.save(validate: false)
 
-    redirect_to fund_activity_steps_path(@fund, @activity)
+    redirect_to url_for([@activity.hierarchy, @activity, :steps])
   end
 
   private
 
   def id
     params[:id]
+  end
+
+  def fund_id
+    params[:fund_id]
+  end
+
+  def hierarchy
+    # TODO: Add support for new hierarchies here and/or move to a service
+    @hierarchy = policy_scope(Fund).find(fund_id)
   end
 end

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -1,6 +1,7 @@
 class Staff::ActivityFormsController < Staff::BaseController
   include Wicked::Wizard
   include DateHelper
+  include ActivityHelper
 
   steps(
     :identifier,
@@ -26,7 +27,6 @@ class Staff::ActivityFormsController < Staff::BaseController
     @page_title = t("page_title.activity_form.show.#{step}")
 
     @activity = policy_scope(Activity).find(params[:activity_id])
-    @fund = policy_scope(Fund).find(params[:fund_id])
     authorize @activity
 
     render_wizard
@@ -36,7 +36,6 @@ class Staff::ActivityFormsController < Staff::BaseController
     @page_title = t("page_title.activity_form.show.#{step}")
 
     @activity = policy_scope(Activity).find(params[:activity_id])
-    @fund = policy_scope(Fund).find(params[:fund_id])
     authorize @activity
 
     case step
@@ -77,7 +76,6 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def finish_wizard_path
     flash[:notice] = I18n.t("form.activity.create.success")
-
-    organisation_fund_path(@fund.organisation, @fund)
+    hierarchy_path_for(activity: @activity)
   end
 end

--- a/app/views/staff/activity_forms/_wrapper.html.haml
+++ b/app/views/staff/activity_forms/_wrapper.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, @page_title
 
-%p= link_to t("generic.link.back"), organisation_fund_path(@fund.id, organisation_id: @fund.organisation.id), class: "govuk-back-link"
+%p= link_to t("generic.link.back"), hierarchy_path_for(activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,12 +13,19 @@ Rails.application.routes.draw do
       resources :funds, except: [:destroy]
     end
 
-    resources :funds, only: [] do
+    concern :activity do
       resources :activities, only: [:new, :create, :show] do
         resources :steps, controller: "activity_forms"
       end
+    end
+
+    concern :transactionable do
       resources :transactions, only: [:new, :create, :show, :edit, :update]
     end
+
+    resources :funds, only: [], concerns: [:activity, :transactionable]
+    # TODO: Extend with more hierarchies using this format
+    # resources :programmes, only: [], concerns: [:activity, :transactionable]
   end
 
   # Authentication


### PR DESCRIPTION
# Changes in this PR

* Although we aren't adding programmes and other levels of the `hierarchy` yet, I was trying to consider how to implement editing an activity in a future proof way. This led me to do this refactoring which I think is useful in isolation to make it easier to extend.
* Provide comments for guidance to increase confidence when we do these extensions.
* Use routing `concerns` to avoid repeating the nested resource blocks for each hierarchy and to ensure that the right configuration is managed centrally eg. `only: [:destroy]`

Prefer:

```
    concern :activity do
      resources :activities, only: [:new, :create, :show] do
        resources :steps, controller: "activity_forms"
      end
    end

    concern :transactionable do
      resources :transactions, only: [:new, :create, :show]
    end

    resources :funds, only: [], concerns: [:activity, :transactionable]
    resources :programmes, only: [], concerns: [:activity, :transactionable]
    resources :projects, only: [], concerns: [:activity, :transactionable]
    resources :sub_projects only: [], concerns: [:activity, :transactionable]
```

Over:

```
resource :fund
  resource :activity, only: [:show]
  resource :transaction, except: [:destroy]
  …
end

resource :programme
  resource :activity, only: [:show]
  resource :transaction, except: [:destroy]
  …
end

resource :project
  resource :activity, only: [:show]
  resource :transaction, except: [:destroy]
  …
end

resource :sub_project
  resource :activity, only: [:show]
  resource :transaction, except: [:destroy]
  …
end

```

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
