### PR TITLE
Style alert messages, move styles into partials

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -20,4 +20,3 @@ $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
 
 @import "govuk-frontend/govuk/all";
 @import "partials/*";
-@import "notifications";

--- a/app/assets/stylesheets/notifications.css.scss
+++ b/app/assets/stylesheets/notifications.css.scss
@@ -1,8 +1,0 @@
-.alert {
-  background-color: govuk-colour("purple");
-  padding: 20px;
-
-  .govuk-caption-m {
-    color: govuk-colour("white");
-  }
-}

--- a/app/assets/stylesheets/partials/_alerts.css.scss
+++ b/app/assets/stylesheets/partials/_alerts.css.scss
@@ -1,0 +1,32 @@
+.alert {
+  padding: 0 govuk-spacing(4);
+  @include govuk-font($size: 24, $weight: bold);
+  border-width: govuk-spacing(1);
+  border-style: solid;
+  border-color: govuk-colour("black");
+
+  &.alert-success {
+    border-color: govuk-colour("green");
+
+    .alert-message {
+      color: govuk-colour("green");
+    }
+  }
+
+  &.alert-notice {
+    border-color: govuk-colour("blue");
+
+    .alert-message {
+      color: govuk-colour("blue");
+    }
+  }
+
+  &.alert-danger {
+    border-color: govuk-colour("red");
+
+    .alert-message {
+      color: govuk-colour("red");
+    }
+  }
+
+}

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -2,4 +2,4 @@
 - flash.each do |name, msg|
   - if msg.is_a?(String)
     %div{:class => "alert alert-#{name.to_s == 'notice' ? 'success' : 'danger'}", :role  => "alert"}
-      = content_tag :span, msg, :id => "flash_#{name}", :class => ["govuk-caption-m"]
+      = content_tag :p, msg, :id => "flash_#{name}", :class => ["alert-message"]


### PR DESCRIPTION
## Changes in this PR

Introduces different alert styling based on the type of alert: success, notice or danger.

Based on research and examples of gov.uk services using alerts, links are attached in the trello card:
https://trello.com/c/mPauGcJ0

## Screenshots of UI changes

### Before

<img width="1204" alt="Screenshot 2019-12-11 at 16 28 09" src="https://user-images.githubusercontent.com/2632224/70640040-3e28ea00-1c33-11ea-8463-e7349dabc6c0.png">


### After

<img width="1220" alt="Screenshot 2019-12-11 at 15 44 13" src="https://user-images.githubusercontent.com/2632224/70639890-0752d400-1c33-11ea-9f1d-0f66afcdd9c7.png">
<img width="1336" alt="Screenshot 2019-12-11 at 15 45 18" src="https://user-images.githubusercontent.com/2632224/70639891-0752d400-1c33-11ea-9453-4b80d335eff3.png">
<img width="1395" alt="Screenshot 2019-12-11 at 15 47 46" src="https://user-images.githubusercontent.com/2632224/70639892-0752d400-1c33-11ea-9200-f559098f118c.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
