### PR TITLE
154 Edit all activity fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - Users can edit an organisation
 - Users can edit the basic fund record
 - Users can edit a transaction
+- Users can edit an activity record

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -1,9 +1,9 @@
 module ActivityHelper
-  def hierarchy_path_for(activity)
+  def hierarchy_path_for(activity:)
     url_for([activity.hierarchy.organisation, activity.hierarchy])
   end
 
-  def activity_path_for(activity)
+  def activity_path_for(activity:)
     url_for([activity.hierarchy, activity])
   end
 end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -6,4 +6,8 @@ module ActivityHelper
   def activity_path_for(activity:)
     url_for([activity.hierarchy, activity])
   end
+
+  def edit_activity_path_for(activity:, step: :identifier)
+    url_for([activity.hierarchy, activity]) + "/steps/#{step}"
+  end
 end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,8 +1,5 @@
 =content_for :page_title_prefix, t("page_title.activity.show", name: @activity_presenter.title)
 
--# TODO: This back links is going to break when we have programme activities. We
--# could put this in a helper called something like `link_to_parent_hierarchy`?
-
 = link_to t("generic.link.back"), hierarchy_path_for(@activity_presenter), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.activity.show", name: @activity_presenter.title)
 
-= link_to t("generic.link.back"), hierarchy_path_for(@activity_presenter), class: "govuk-back-link"
+= link_to t("generic.link.back"), hierarchy_path_for(activity: @activity_presenter), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -20,7 +20,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.identifier
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :identifier), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :identifier), class: "govuk-link"
 
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
@@ -28,7 +28,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :sector), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :sector), class: "govuk-link"
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
@@ -36,7 +36,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.title
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :purpose), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
 
   .govuk-summary-list__row.description
     %dt.govuk-summary-list__key
@@ -44,7 +44,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.description
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :purpose), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key
@@ -52,7 +52,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.status
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :status), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :status), class: "govuk-link"
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key
@@ -60,7 +60,7 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_start_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.planned_end_date
@@ -69,7 +69,7 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_end_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.actual_start_date
@@ -78,7 +78,7 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_start_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.actual_end_date
@@ -87,7 +87,7 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_end_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.recipient_region
@@ -96,7 +96,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.recipient_region
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :country), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :country), class: "govuk-link"
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
@@ -104,7 +104,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.flow
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :flow), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :flow), class: "govuk-link"
 
   .govuk-summary-list__row.finance
     %dt.govuk-summary-list__key
@@ -112,7 +112,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.finance
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :finance), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :finance), class: "govuk-link"
 
   .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
@@ -120,7 +120,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.aid_type
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :aid_type), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :aid_type), class: "govuk-link"
 
   .govuk-summary-list__row.tied_status
     %dt.govuk-summary-list__key
@@ -128,4 +128,4 @@
     %dd.govuk-summary-list__value
       = activity_presenter.tied_status
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :tied_status), class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :tied_status), class: "govuk-link"

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -6,78 +6,126 @@
       = activity_presenter.hierarchy.name
     %dd.govuk-summary-list__actions
       = link_to t("generic.link.edit"), [:edit, activity_presenter.hierarchy.organisation, activity_presenter.hierarchy], class: "govuk-link"
+
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("page_content.fund.organisation.label")
     %dd.govuk-summary-list__value
       = link_to activity_presenter.hierarchy.organisation.name, organisation_path(activity_presenter.hierarchy.organisation)
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+
+  .govuk-summary-list__row.identifier
     %dt.govuk-summary-list__key
       = t("page_content.activity.identitfier.label")
     %dd.govuk-summary-list__value
       = activity_presenter.identifier
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :identifier), class: "govuk-link"
+
+  .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
       = t("page_content.activity.sector.label")
     %dd.govuk-summary-list__value
       = activity_presenter.sector
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :sector), class: "govuk-link"
+
+  .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
       = t("page_content.activity.title.label")
     %dd.govuk-summary-list__value
       = activity_presenter.title
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :purpose), class: "govuk-link"
+
+  .govuk-summary-list__row.description
     %dt.govuk-summary-list__key
       = t("page_content.activity.description.label")
     %dd.govuk-summary-list__value
       = activity_presenter.description
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :purpose), class: "govuk-link"
+
+  .govuk-summary-list__row.status
     %dt.govuk-summary-list__key
       = t("page_content.activity.status.label")
     %dd.govuk-summary-list__value
       = activity_presenter.status
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :status), class: "govuk-link"
+
+  .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key
       = t("page_content.activity.planned_start_date.label")
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_start_date)
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+
+
+  .govuk-summary-list__row.planned_end_date
     %dt.govuk-summary-list__key
       = t("page_content.activity.planned_end_date.label")
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_end_date)
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+
+
+  .govuk-summary-list__row.actual_start_date
     %dt.govuk-summary-list__key
       = t("page_content.activity.actual_start_date.label")
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_start_date)
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+
+
+  .govuk-summary-list__row.actual_end_date
     %dt.govuk-summary-list__key
       = t("page_content.activity.actual_end_date.label")
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_end_date)
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :dates), class: "govuk-link"
+
+
+  .govuk-summary-list__row.recipient_region
     %dt.govuk-summary-list__key
       = t("page_content.activity.recipient_region.label")
     %dd.govuk-summary-list__value
       = activity_presenter.recipient_region
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :country), class: "govuk-link"
+
+  .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
       = t("page_content.activity.flow.label")
     %dd.govuk-summary-list__value
       = activity_presenter.flow
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :flow), class: "govuk-link"
+
+  .govuk-summary-list__row.finance
     %dt.govuk-summary-list__key
       = t("page_content.activity.finance.label")
     %dd.govuk-summary-list__value
       = activity_presenter.finance
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :finance), class: "govuk-link"
+
+  .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
       = t("page_content.activity.aid_type.label")
     %dd.govuk-summary-list__value
       = activity_presenter.aid_type
-  .govuk-summary-list__row
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :aid_type), class: "govuk-link"
+
+  .govuk-summary-list__row.tied_status
     %dt.govuk-summary-list__key
       = t("page_content.activity.tied_status.label")
     %dd.govuk-summary-list__value
       = activity_presenter.tied_status
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), fund_activity_step_path(fund_id: activity_presenter.hierarchy, activity_id: activity_presenter, id: :tied_status), class: "govuk-link"

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -20,64 +20,7 @@ RSpec.feature "Users can create an activity" do
       visit organisation_fund_path(organisation, fund)
       click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
 
-      expect(page).to have_content I18n.t("page_title.activity_form.show.identifier")
-      fill_in "activity[identifier]", with: "A-Unique-Identifier"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
-      fill_in "activity[title]", with: "My Aid Activity"
-      fill_in "activity[description]", with: Faker::Lorem.paragraph
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
-      select "Education policy and administrative management", from: "activity[sector]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.status")
-      select "Implementation", from: "activity[status]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
-      fill_in "planned_start_date[day]", with: "1"
-      fill_in "planned_start_date[month]", with: "1"
-      fill_in "planned_start_date[year]", with: "2020"
-      fill_in "planned_end_date[day]", with: "1"
-      fill_in "planned_end_date[month]", with: "1"
-      fill_in "planned_end_date[year]", with: "2021"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.country")
-      select "Developing countries, unspecified", from: "activity[recipient_region]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
-      select "ODA", from: "activity[flow]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
-      select "Standard grant", from: "activity[finance]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
-      select "General budget support", from: "activity[aid_type]"
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
-      select "Untied", from: "activity[tied_status]"
-
-      click_button I18n.t("form.activity.submit")
-
-      expect(page).to have_content I18n.t("form.activity.create.success")
-      expect(page).to have_content "A-Unique-Identifier"
-      expect(page).to have_content "Education policy and administrative management"
-      expect(page).to have_content "My Aid Activity"
-      expect(page).to have_content "Developing countries, unspecified"
-      expect(page).to have_content "ODA"
-      expect(page).to have_content "Standard grant"
-      expect(page).to have_content "General budget support"
-      expect(page).to have_content "Untied"
-      expect(page).to have_content "2020-01-01"
-      expect(page).to have_content "2021-01-01"
+      fill_in_activity_form
     end
 
     context "validations" do

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,4 +1,6 @@
 RSpec.feature "Users can edit an activity" do
+  include ActivityHelper
+
   before do
     authenticate!(user: user)
   end
@@ -42,7 +44,7 @@ RSpec.feature "Users can edit an activity" do
     within(".identifier") do
       click_on I18n.t("generic.link.edit")
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/identifier"
+        edit_activity_path_for(activity: activity, step: :identifier)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -50,7 +52,7 @@ RSpec.feature "Users can edit an activity" do
     within(".sector") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/sector"
+        edit_activity_path_for(activity: activity, step: :sector)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -58,7 +60,7 @@ RSpec.feature "Users can edit an activity" do
     within(".title") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/purpose"
+        edit_activity_path_for(activity: activity, step: :purpose)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -66,7 +68,7 @@ RSpec.feature "Users can edit an activity" do
     within(".description") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/purpose"
+        edit_activity_path_for(activity: activity, step: :purpose)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -74,7 +76,7 @@ RSpec.feature "Users can edit an activity" do
     within(".status") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/status"
+        edit_activity_path_for(activity: activity, step: :status)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -82,7 +84,7 @@ RSpec.feature "Users can edit an activity" do
     within(".planned_start_date") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/dates"
+        edit_activity_path_for(activity: activity, step: :dates)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -90,7 +92,7 @@ RSpec.feature "Users can edit an activity" do
     within(".planned_end_date") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/dates"
+        edit_activity_path_for(activity: activity, step: :dates)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -98,7 +100,7 @@ RSpec.feature "Users can edit an activity" do
     within(".actual_start_date") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/dates"
+        edit_activity_path_for(activity: activity, step: :dates)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -106,7 +108,7 @@ RSpec.feature "Users can edit an activity" do
     within(".actual_end_date") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/dates"
+        edit_activity_path_for(activity: activity, step: :dates)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -114,7 +116,7 @@ RSpec.feature "Users can edit an activity" do
     within(".recipient_region") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/country"
+        edit_activity_path_for(activity: activity, step: :country)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -122,7 +124,7 @@ RSpec.feature "Users can edit an activity" do
     within(".flow") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/flow"
+        edit_activity_path_for(activity: activity, step: :flow)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -130,7 +132,7 @@ RSpec.feature "Users can edit an activity" do
     within(".finance") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/finance"
+        edit_activity_path_for(activity: activity, step: :finance)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -138,7 +140,7 @@ RSpec.feature "Users can edit an activity" do
     within(".aid_type") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/aid_type"
+        edit_activity_path_for(activity: activity, step: :aid_type)
       )
     end
     click_on(I18n.t("generic.link.back"))
@@ -146,7 +148,7 @@ RSpec.feature "Users can edit an activity" do
     within(".tied_status") do
       click_on(I18n.t("generic.link.edit"))
       expect(page).to have_current_path(
-        url_for([activity.hierarchy, activity]) + "/steps/tied_status"
+        edit_activity_path_for(activity: activity, step: :tied_status)
       )
     end
     click_on(I18n.t("generic.link.back"))

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,0 +1,154 @@
+RSpec.feature "Users can edit an activity" do
+  before do
+    authenticate!(user: user)
+  end
+
+  let(:organisation) { create(:organisation, name: "UKSA") }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  context "when the activity belongs to a fund" do
+    it "clicking edit starts the ActivityForm journey from that step" do
+      fund = create(:fund, organisation: organisation)
+      create(:activity, hierarchy: fund)
+
+      visit dashboard_path
+      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on(fund.name)
+
+      # Click the first edit link that opens the form on step 1
+      within(".identifier") do
+        click_on(I18n.t("generic.link.edit"))
+      end
+
+      # This helper fills in the form from step 1
+      fill_in_activity_form
+    end
+
+    it "all edit links are available to take the user to the right step" do
+      fund = create(:fund, organisation: organisation)
+      activity = create(:activity, hierarchy: fund)
+
+      visit dashboard_path
+      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on(fund.name)
+
+      assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+    end
+  end
+
+  def assert_all_edit_links_go_to_the_correct_form_step(activity:)
+    within(".identifier") do
+      click_on I18n.t("generic.link.edit")
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/identifier"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".sector") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/sector"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".title") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/purpose"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".description") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/purpose"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".status") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/status"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".planned_start_date") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/dates"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".planned_end_date") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/dates"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".actual_start_date") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/dates"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".actual_end_date") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/dates"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".recipient_region") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/country"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".flow") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/flow"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".finance") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/finance"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".aid_type") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/aid_type"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+
+    within(".tied_status") do
+      click_on(I18n.t("generic.link.edit"))
+      expect(page).to have_current_path(
+        url_for([activity.hierarchy, activity]) + "/steps/tied_status"
+      )
+    end
+    click_on(I18n.t("generic.link.back"))
+  end
+end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -26,4 +26,35 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
   end
+
+  describe "#edit_activity_path_for" do
+    context "when the hierarchy_type is a fund" do
+      let(:fund) { create(:fund, organisation: organisation) }
+      let(:fund_activity) { create(:activity, hierarchy: fund) }
+
+      it "returns the edit path for the first step by default" do
+        expect(
+          helper.edit_activity_path_for(activity: fund_activity)
+        ).to eq(
+          fund_activity_step_path(
+            fund_id: fund,
+            activity_id: fund_activity,
+            id: :identifier
+          )
+        )
+      end
+
+      it "returns the edit path for the given step" do
+        expect(
+          helper.edit_activity_path_for(activity: fund_activity, step: :sector)
+        ).to eq(
+          fund_activity_step_path(
+            fund_id: fund,
+            activity_id: fund_activity,
+            id: :sector
+          )
+        )
+      end
+    end
+  end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:fund_activity) { create(:activity, hierarchy: fund) }
 
       it "returns the organisation_fund_path" do
-        expect(helper.hierarchy_path_for(fund_activity)).to eq(organisation_fund_path(organisation.id, fund))
+        expect(helper.hierarchy_path_for(activity: fund_activity))
+          .to eq(organisation_fund_path(organisation.id, fund))
       end
     end
   end
@@ -20,7 +21,8 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:fund_activity) { create(:activity, hierarchy: fund) }
 
       it "returns the fund_activity_path" do
-        expect(helper.activity_path_for(fund_activity)).to eq(fund_activity_path(fund, fund_activity))
+        expect(helper.activity_path_for(activity: fund_activity))
+          .to eq(fund_activity_path(fund, fund_activity))
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ RSpec.configure do |config|
   config.include AuthenticationHelpers
   config.include Auth0Helpers
   config.include EmailHelpers
+  config.include FormHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,0 +1,97 @@
+module FormHelpers
+  def fill_in_activity_form(
+    identifier: "A-Unique-Identifier",
+    title: "My Aid Activity",
+    description: Faker::Lorem.paragraph,
+    sector: "Education policy and administrative management",
+    status: "Implementation",
+    planned_start_date_day: "1",
+    planned_start_date_month: "1",
+    planned_start_date_year: "2020",
+    planned_end_date_day: "1",
+    planned_end_date_month: "1",
+    planned_end_date_year: "2021",
+    recipient_region: "Developing countries, unspecified",
+    flow: "ODA",
+    finance: "Standard grant",
+    aid_type: "General budget support",
+    tied_status: "Untied"
+  )
+    expect(page).to have_content I18n.t("page_title.activity_form.show.identifier")
+    fill_in "activity[identifier]", with: identifier
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
+    fill_in "activity[title]", with: title
+    fill_in "activity[description]", with: description
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
+    select sector, from: "activity[sector]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.status")
+    select status, from: "activity[status]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+    fill_in "planned_start_date[day]", with: planned_start_date_day
+    fill_in "planned_start_date[month]", with: planned_start_date_month
+    fill_in "planned_start_date[year]", with: planned_start_date_year
+    fill_in "planned_end_date[day]", with: planned_end_date_day
+    fill_in "planned_end_date[month]", with: planned_end_date_month
+    fill_in "planned_end_date[year]", with: planned_end_date_year
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+    select recipient_region, from: "activity[recipient_region]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+    select flow, from: "activity[flow]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
+    select finance, from: "activity[finance]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
+    select aid_type, from: "activity[aid_type]"
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
+    select tied_status, from: "activity[tied_status]"
+
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("form.activity.create.success")
+    expect(page).to have_content identifier
+    expect(page).to have_content title
+    expect(page).to have_content description
+    expect(page).to have_content sector
+    expect(page).to have_content status
+    expect(page).to have_content recipient_region
+    expect(page).to have_content flow
+    expect(page).to have_content finance
+    expect(page).to have_content aid_type
+    expect(page).to have_content tied_status
+    expect(page).to have_content I18n.l(
+      date(
+        year: planned_start_date_year,
+        month: planned_start_date_month,
+        day: planned_start_date_day
+      )
+    )
+    expect(page).to have_content I18n.l(
+      date(
+        year: planned_end_date_year,
+        month: planned_end_date_month,
+        day: planned_end_date_day
+      )
+    )
+  end
+
+  def date(year:, month:, day:)
+    Date.parse("#{year}-#{month}-#{day}")
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- each activity field has an edit link that can be used to take the user to that step in the existing activity form journey
- once on the right step of the journey, the user can update the field's value and will have to continue through the journey or press 'back' to go backwards. Using the same flow for create and edit has trade-offs that I hope to documented on the commits.
- refactor the edit URLs to be open to extension for more hierarchies to keep this as open to extension as possible. Issues were had in trying to use `url_for` for the polymorphic routes and in a way that is compatible with the routing requirements of the Wicked gem. I'd love to make this better and remove the concatonation if there are suggestions!

## Screenshots of UI changes

### Before

![Screenshot 2019-12-12 at 11 45 19](https://user-images.githubusercontent.com/912473/70709491-e5119280-1cd4-11ea-91e7-e2e741a13522.png)

### After

![Screenshot 2019-12-12 at 11 41 40](https://user-images.githubusercontent.com/912473/70709604-24d87a00-1cd5-11ea-8c75-405772e292b0.png)
![Screenshot 2019-12-12 at 11 41 45](https://user-images.githubusercontent.com/912473/70709624-2f930f00-1cd5-11ea-9d6c-5a67a3f6f186.png)
![Screenshot 2019-12-12 at 11 41 40](https://user-images.githubusercontent.com/912473/70709615-2ace5b00-1cd5-11ea-87b4-d578923931aa.png)
![Screenshot 2019-12-12 at 11 41 50](https://user-images.githubusercontent.com/912473/70709630-33269600-1cd5-11ea-9067-749a2753835f.png)
![Screenshot 2019-12-12 at 11 41 50](https://user-images.githubusercontent.com/912473/70709650-420d4880-1cd5-11ea-8edf-2d153f9b55f9.png)
![Screenshot 2019-12-12 at 11 41 57](https://user-images.githubusercontent.com/912473/70709652-43d70c00-1cd5-11ea-81af-ff72d9ab4607.png)
![Screenshot 2019-12-12 at 11 41 57](https://user-images.githubusercontent.com/912473/70709672-50f3fb00-1cd5-11ea-92dd-623c09194e8b.png)
![Screenshot 2019-12-12 at 11 42 00](https://user-images.githubusercontent.com/912473/70709678-55201880-1cd5-11ea-87d0-404fa7285bb5.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
