### PR TITLE
151 Transactions capture provider and reciever organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - Users can edit the basic fund record
 - Users can edit a transaction
 - Users can edit an activity record
+- Transactions record the provider and receiver organisations

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,6 +1,6 @@
 module FormHelper
   def list_of_organisations
     @list_of_organisations ||=
-      [OpenStruct.new(name: "", id: ""), Organisation.all].flatten
+      [OpenStruct.new(name: "", id: ""), Organisation.sorted_by_name].flatten
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,6 @@
+module FormHelper
+  def list_of_organisations
+    @list_of_organisations ||=
+      [OpenStruct.new(name: "", id: ""), Organisation.all].flatten
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,5 @@
 class Organisation < ApplicationRecord
   has_and_belongs_to_many :users
   validates_presence_of :name, :organisation_type, :language_code, :default_currency
+  scope :sorted_by_name, -> { order(name: :asc) }
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,7 @@
 class Transaction < ApplicationRecord
   belongs_to :fund
   validates_presence_of :reference, :description, :transaction_type, :date, :currency, :value, :disbursement_channel
+  belongs_to :provider, foreign_key: :provider_id, class_name: "Organisation"
+  belongs_to :receiver, foreign_key: :receiver_id, class_name: "Organisation"
   validates :value, inclusion: 1..99_999_999_999.00
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,7 +1,13 @@
 class Transaction < ApplicationRecord
   belongs_to :fund
-  validates_presence_of :reference, :description, :transaction_type, :date, :currency, :value, :disbursement_channel
   belongs_to :provider, foreign_key: :provider_id, class_name: "Organisation"
   belongs_to :receiver, foreign_key: :receiver_id, class_name: "Organisation"
+  validates_presence_of :reference,
+    :description,
+    :transaction_type,
+    :date,
+    :currency,
+    :value,
+    :disbursement_channel
   validates :value, inclusion: 1..99_999_999_999.00
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,4 +10,9 @@ class Transaction < ApplicationRecord
     :value,
     :disbursement_channel
   validates :value, inclusion: 1..99_999_999_999.00
+
+  FORM_FIELD_TRANSLATIONS = {
+    provider_id: :provider,
+    receiver_id: :receiver,
+  }.freeze
 end

--- a/app/views/staff/funds/edit.html.haml
+++ b/app/views/staff/funds/edit.html.haml
@@ -7,5 +7,5 @@
       %h1.govuk-heading-xl
         = t("page_title.fund.edit")
 
-      = form_with model: @fund, url: organisation_fund_path(@fund.organisation), method: :put do |f|
+      = form_with model: @fund, url: organisation_fund_path(@fund.organisation) do |f|
         = render partial: 'form', locals: { f: f }

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -18,4 +18,15 @@
                                :code,
                                :name,
                                hint_text: t("form.transaction.disbursement_channel.hint")
+= f.govuk_collection_select :provider_id,
+                               list_of_organisations,
+                               :id,
+                               :name,
+                               hint_text: t("form.transaction.provider.hint")
+= f.govuk_collection_select :receiver_id,
+                               list_of_organisations,
+                               :id,
+                               :name,
+                               hint_text: t("form.transaction.receiver.hint")
+
 = f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/transactions/edit.html.haml
+++ b/app/views/staff/transactions/edit.html.haml
@@ -8,4 +8,4 @@
         = t("page_title.transaction.edit")
 
       = form_with model: @transaction, url: fund_transaction_path(@fund) do |f|
-        = render partial: "form", locals: { f: f }
+        = render partial: "form", locals: { f: f, organisations: @organisations }

--- a/app/views/staff/transactions/new.html.haml
+++ b/app/views/staff/transactions/new.html.haml
@@ -8,4 +8,4 @@
         = t("page_title.transaction.new")
 
       = form_with model: @transaction, url: fund_transactions_path(@fund) do |f|
-        = render partial: "form", locals: { f: f }
+        = render partial: "form", locals: { f: f, organisations: @organisations }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true # raise an error if n+1 query occurs
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
   end
 
   config.middleware.use RackSessionAccess::Middleware

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -15,5 +15,61 @@ module GOVUKDesignSystemFormBuilder
         ["helpers", context, @object_name, @attribute_name].join(".")
       end
     end
+
+    def has_errors?
+      @builder.object.errors.any? &&
+        @builder.object.errors.messages.dig(
+          translated_attribute_name(attribute_name: @attribute_name)
+        ).present?
+    end
+
+    # In order to support associations where the model association is
+    # eg. `provider` but the form attribute needs to be `provider_id`.
+    # The form field must be wrapped in errors and be linkable from the summary.
+    #
+    # 1. We cannot change the form field to `provider` since the value will
+    # not read from an object with a value already set.
+    #
+    # 2. We cannot change the model association to be `provider_id` as calling
+    # `transaction.provider_id` rather than the resource  `transaction.provider`
+    # would be unconventional and also require a hack.
+    #
+    # 3. We cannot overwride the @attribute_name on create since that will have
+    # the same affect as point 1.
+    private def translated_attribute_name(attribute_name:)
+      translations = @builder.object.class.try("::FORM_FIELD_TRANSLATIONS") || {}
+
+      if translations[attribute_name].present?
+        translations[attribute_name]
+      else
+        attribute_name
+      end
+    end
+  end
+end
+
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Select < GOVUKDesignSystemFormBuilder::Base
+      def error_element
+        @error_element ||= Elements::ErrorMessage.new(
+          @builder,
+          @object_name,
+          translated_attribute_name(attribute_name: @attribute_name)
+        )
+      end
+
+      def field_id(link_errors: false)
+        if link_errors && has_errors?
+          build_id(
+            "field-error",
+            include_value: false,
+            attribute_name: translated_attribute_name(attribute_name: @attribute_name)
+          )
+        else
+          build_id("field")
+        end
+      end
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,10 @@ en:
       disbursement_channel:
         hint: The channel through which the funds will flow for this transaction.
         label: Disbursement channel
+      provider:
+        hint: The organisation where this transaction is coming from
+      receiver:
+        hint: The organisation receiving the money from this transaction
       reference:
         hint: This reference should link this activity back to the finance system.
       transaction_type:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -11,6 +11,8 @@ en:
         currency: Currency
         description: Description
         disbursement_channel: Disbursement channel
+        provider_id: Providing organisation
+        receiver_id: Receiving organisation
         reference: Reference
         transaction_type: Transaction type
         value: Value

--- a/db/migrate/20191213123607_add_provider_and_receiver_org_to_transactons.rb
+++ b/db/migrate/20191213123607_add_provider_and_receiver_org_to_transactons.rb
@@ -1,0 +1,6 @@
+class AddProviderAndReceiverOrgToTransactons < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :transactions, :provider, type: :uuid
+    add_reference :transactions, :receiver, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_11_114801) do
+ActiveRecord::Schema.define(version: 2019_12_13_123607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -73,7 +73,11 @@ ActiveRecord::Schema.define(version: 2019_12_11_114801) do
     t.uuid "fund_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "provider_id"
+    t.uuid "receiver_id"
     t.index ["fund_id"], name: "index_transactions_on_fund_id"
+    t.index ["provider_id"], name: "index_transactions_on_provider_id"
+    t.index ["receiver_id"], name: "index_transactions_on_receiver_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,9 +10,20 @@
 
 # Generic development user
 if Rails.env.development?
-  User.find_or_create_by(
+  organisation_params = FactoryBot.build(
+    :organisation, name: "Department for Business, Energy & Industrial Strategy"
+  ).attributes
+  organisation = Organisation.find_or_create_by(organisation_params)
+
+  user = User.find_or_initialize_by(
     name: "Generic development user",
     email: "roda@dxw.com",
-    identifier: "auth0|5dc53e4b85758e0e95b062f0"
+    identifier: "auth0|5dc53e4b85758e0e95b062f0",
+    role: :administrator
   )
+  user.organisations << organisation
+  user.save
+
+  fund_params = FactoryBot.build(:fund, name: "GCRF", organisation: organisation).attributes
+  Fund.find_or_create_by(fund_params)
 end

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -9,5 +9,7 @@ FactoryBot.define do
     value { 110.01 }
     disbursement_channel { "1" }
     currency { "gbp" }
+    association :provider, factory: :organisation
+    association :receiver, factory: :organisation
   end
 end

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -53,7 +53,9 @@ RSpec.feature "Users can edit a transaction" do
       date_year: "2021",
       value: "2000.51",
       disbursement_channel: "Aid in kind: Donors manage funds themselves",
-      currency: "US Dollar"
+      currency: "US Dollar",
+      provider_organisation: organisation,
+      receiver_organisation: organisation
     )
 
     expect(page).to have_content(I18n.t("form.transaction.update.success"))

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe FormHelper, type: :helper do
+  describe "#list_of_organisations" do
+    it "asks for a sorted list of organisations" do
+      expect(Organisation).to receive(:sorted_by_name)
+      helper.list_of_organisations
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe Organisation, type: :model do
   describe "associations" do
     it { should have_and_belong_to_many(:users) }
   end
+
+  describe ".sorted_by_name" do
+    it "should sort name name a->z" do
+      a_organisation = create(:organisation, name: "A", created_at: 3.days.ago)
+      b_organisation = create(:organisation, name: "B", created_at: 1.days.ago)
+      c_organisation = create(:organisation, name: "C", created_at: 2.days.ago)
+
+      result = Organisation.sorted_by_name
+
+      expect(result.first).to eq(a_organisation)
+      expect(result.second).to eq(b_organisation)
+      expect(result.third).to eq(c_organisation)
+    end
+  end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -100,7 +100,9 @@ module FormHelpers
     date_day: "2",
     value: "1000.01",
     disbursement_channel: "Money is disbursed through central Ministry of Finance or Treasury",
-    currency: "Pound Sterling")
+    currency: "Pound Sterling",
+    provider_organisation: Organisation.first,
+    receiver_organisation: Organisation.first)
     fill_in "transaction[reference]", with: reference
     fill_in "transaction[description]", with: description
     select transaction_type, from: "transaction[transaction_type]"
@@ -110,6 +112,8 @@ module FormHelpers
     fill_in "transaction[value]", with: value
     select disbursement_channel, from: "transaction[disbursement_channel]"
     select currency, from: "transaction[currency]"
+    select provider_organisation.name, from: "transaction[provider_id]"
+    select receiver_organisation.name, from: "transaction[receiver_id]"
 
     click_on(I18n.t("generic.button.submit"))
 
@@ -122,6 +126,15 @@ module FormHelpers
         expect(page).to have_content(value)
         expect(page).to have_content(disbursement_channel)
         expect(page).to have_content(currency)
+
+        # TODO: The table cannot support more horiztonal columns right now.
+        # Remove temporary substitute assertion that checks the DB instead.
+        # expect(page).to have_content(provider_organisation.name)
+        # expect(page).to have_content(receiver_organisation.name)
+        expect(Transaction.find_by(reference: reference).provider.name)
+          .to eq(provider_organisation.name)
+        expect(Transaction.find_by(reference: reference).receiver.name)
+          .to eq(receiver_organisation.name)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

- transactions require 2 new fields: provider and receiver
- these fields are currently required and we can make it optional if the users are unable to succeed. This ensures we have a chance of having pristine data from the start given that this data will help us score well on transparency
- this proposal includes a tricky patch for the govuk form builder to ensure error messages are shown ontop of association fields. I wonder if there is an easier way to do this? If not, I hope it is extendable for when we have to add more associations for participating organisations in future. More info on the commit
- there is no room to put this new information in the transactions table as a new horizontal column. Until we have redesigned this page or implemented an individual transaction#show page we are only storing this data internally

http://reference.iatistandard.org/202/activity-standard/iati-activities/iati-activity/transaction/
http://reference.iatistandard.org/202/activity-standard/iati-activities/iati-activity/transaction/provider-org/
http://reference.iatistandard.org/202/activity-standard/iati-activities/iati-activity/transaction/receiver-org/

## Screenshots of UI changes

![Screenshot 2019-12-16 at 15 57 49](https://user-images.githubusercontent.com/912473/70921834-f6340980-201c-11ea-8560-bceb72d8414e.png)
![Screenshot 2019-12-16 at 15 57 58](https://user-images.githubusercontent.com/912473/70921835-f6340980-201c-11ea-82c1-48d4f929040c.png)
![Screenshot 2019-12-16 at 15 58 06](https://user-images.githubusercontent.com/912473/70921836-f6340980-201c-11ea-9083-f0fbaa9f9a2b.png)
![Screenshot 2019-12-16 at 15 58 15](https://user-images.githubusercontent.com/912473/70921837-f6cca000-201c-11ea-82a6-91486f9b556c.png)
![Screenshot 2019-12-16 at 15 58 22](https://user-images.githubusercontent.com/912473/70921838-f6cca000-201c-11ea-828d-7a6651295c22.png)
![Screenshot 2019-12-16 at 15 58 31](https://user-images.githubusercontent.com/912473/70921841-f7653680-201c-11ea-854a-96d39f92d4da.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
