### PR TITLE
Lock Rake to v13.0.1 to fix Heroku deployment issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 - postgresql
 before_install:
 - gem update --system 3.0.3
+- gem update rake 13.0.1
 - gem install bundler
 before_script:
 - psql -c 'create database roda_test;' -U postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ ENV RACK_ENV=${RAILS_ENV:-production}
 COPY Gemfile $INSTALL_PATH/Gemfile
 COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
 
-RUN gem update --system
+RUN gem update --system 3.0.3
+RUN gem update rake 13.0.1
 RUN gem install bundler
 
 # bundle ruby gems based on the current environment, default to production


### PR DESCRIPTION
See https://dashboard.heroku.com/apps/beis-roda-production release v69 and below

