### PR TITLE
(122) Add validations to Activity multi-step form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
 - Users can edit an activity record
 - Transactions record the provider and receiver organisations
 - All forms now use `govuk_design_system_formbuilder` instead of `simple_form`
+- Activity multi-step form now has validations

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -21,7 +21,6 @@ class Staff::ActivitiesController < Staff::BaseController
 
     @activity.hierarchy = hierarchy
     @activity.wizard_status = "identifier"
-    @activity.set_hierarchy_defaults
     @activity.save(validate: false)
 
     redirect_to url_for([@activity.hierarchy, @activity, :steps])

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -20,6 +20,7 @@ class Staff::ActivitiesController < Staff::BaseController
     authorize @activity
 
     @activity.hierarchy = hierarchy
+    @activity.wizard_status = "identifier"
     @activity.set_hierarchy_defaults
     @activity.save(validate: false)
 

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -3,7 +3,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   include DateHelper
   include ActivityHelper
 
-  steps(
+  FORM_STEPS = [
     :identifier,
     :purpose,
     :sector,
@@ -14,7 +14,9 @@ class Staff::ActivityFormsController < Staff::BaseController
     :finance,
     :aid_type,
     :tied_status,
-  )
+  ]
+
+  steps(*FORM_STEPS)
 
   def index
     skip_policy_scope

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -38,8 +38,9 @@ class Staff::ActivityFormsController < Staff::BaseController
     @activity = policy_scope(Activity).find(params[:activity_id])
     authorize @activity
 
-    @activity.update(activity_params)
-
+    @activity.assign_attributes(activity_params)
+    @activity.wizard_status = step
+    @activity.save
     render_wizard @activity
   end
 

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -10,4 +10,12 @@ module ActivityHelper
   def edit_activity_path_for(activity:, step: :identifier)
     url_for([activity.hierarchy, activity]) + "/steps/#{step}"
   end
+
+  def show_activity_field?(activity:, step:)
+    steps = Staff::ActivityFormsController::FORM_STEPS
+    form_position = steps.index(step.to_sym)
+    activity_position = steps.index(activity.wizard_status.to_sym)
+
+    form_position <= activity_position + 1
+  end
 end

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -28,6 +28,11 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
   end
 
+  def tied_status_select_options
+    objects = yaml_to_objects(entity: "activity", type: "tied_status", with_empty_item: false)
+    objects.unshift(OpenStruct.new(name: "Untied", code: "5")).uniq
+  end
+
   def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module CodelistHelper
-  def yaml_to_objects(entity, type, with_empty_item = true)
-    data = load_yaml(entity, type)
+  def yaml_to_objects(entity:, type:, with_empty_item: true)
+    data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
 
     objects = data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"]) }.sort_by(&:name)
@@ -14,11 +14,11 @@ module CodelistHelper
   end
 
   def currency_select_options
-    objects = yaml_to_objects("generic", "default_currency", false)
+    objects = yaml_to_objects(entity: "generic", type: "default_currency", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "Pound Sterling", code: "GBP")).uniq
   end
 
-  def load_yaml(entity, type)
+  def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]
   rescue

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -18,6 +18,11 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "Pound Sterling", code: "GBP")).uniq
   end
 
+  def region_select_options
+    objects = yaml_to_objects(entity: "activity", type: "recipient_region", with_empty_item: false)
+    objects.unshift(OpenStruct.new(name: "Developing countries, unspecified", code: "998")).uniq
+  end
+
   def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -23,6 +23,11 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "Developing countries, unspecified", code: "998")).uniq
   end
 
+  def flow_select_options
+    objects = yaml_to_objects(entity: "activity", type: "flow", with_empty_item: false)
+    objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
+  end
+
   def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,39 +12,39 @@ class Activity < ApplicationRecord
   validates_uniqueness_of :identifier
 
   def identifier_step?
-    wizard_status == "identifier"
+    %w[identifier complete].include?(wizard_status)
   end
 
   def purpose_step?
-    wizard_status == "purpose"
+    %w[purpose complete].include?(wizard_status)
   end
 
   def sector_step?
-    wizard_status == "sector"
+    %w[sector complete].include?(wizard_status)
   end
 
   def status_step?
-    wizard_status == "status"
+    %w[status complete].include?(wizard_status)
   end
 
   def country_step?
-    wizard_status == "country"
+    %w[country complete].include?(wizard_status)
   end
 
   def flow_step?
-    wizard_status == "flow"
+    %w[flow complete].include?(wizard_status)
   end
 
   def finance_step?
-    wizard_status == "finance"
+    %w[finance complete].include?(wizard_status)
   end
 
   def aid_type_step?
-    wizard_status == "aid_type"
+    %w[aid_type complete].include?(wizard_status)
   end
 
   def tied_status_step?
-    wizard_status == "tied_status"
+    %w[tied_status complete].include?(wizard_status)
   end
 
   def default_currency

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -64,7 +64,6 @@ class Activity < ApplicationRecord
   private
 
   def set_fund_defaults
-    self.recipient_region = "998"
     self.flow = "10"
     self.tied_status = "5"
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,10 +1,50 @@
 class Activity < ApplicationRecord
   belongs_to :hierarchy, polymorphic: true
   validates :identifier, presence: true, if: :identifier_step?
+  validates :title, :description, presence: true, if: :purpose_step?
+  validates :sector, presence: true, if: :sector_step?
+  validates :status, presence: true, if: :status_step?
+  validates :recipient_region, presence: true, if: :country_step?
+  validates :flow, presence: true, if: :flow_step?
+  validates :finance, presence: true, if: :finance_step?
+  validates :aid_type, presence: true, if: :aid_type_step?
+  validates :tied_status, presence: true, if: :tied_status_step?
   validates_uniqueness_of :identifier
 
   def identifier_step?
     wizard_status == "identifier"
+  end
+
+  def purpose_step?
+    wizard_status == "purpose"
+  end
+
+  def sector_step?
+    wizard_status == "sector"
+  end
+
+  def status_step?
+    wizard_status == "status"
+  end
+
+  def country_step?
+    wizard_status == "country"
+  end
+
+  def flow_step?
+    wizard_status == "flow"
+  end
+
+  def finance_step?
+    wizard_status == "finance"
+  end
+
+  def aid_type_step?
+    wizard_status == "aid_type"
+  end
+
+  def tied_status_step?
+    wizard_status == "tied_status"
   end
 
   def set_hierarchy_defaults

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,7 +1,11 @@
 class Activity < ApplicationRecord
   belongs_to :hierarchy, polymorphic: true
-  validates_presence_of :identifier
+  validates :identifier, presence: true, if: :identifier_step?
   validates_uniqueness_of :identifier
+
+  def identifier_step?
+    wizard_status == "identifier"
+  end
 
   def set_hierarchy_defaults
     case hierarchy.class.name

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -47,23 +47,11 @@ class Activity < ApplicationRecord
     wizard_status == "tied_status"
   end
 
-  def set_hierarchy_defaults
-    case hierarchy.class.name
-    when "Fund" then set_fund_defaults
-    end
-  end
-
   def default_currency
     organisation.default_currency
   end
 
   def organisation
     hierarchy.organisation
-  end
-
-  private
-
-  def set_fund_defaults
-    self.tied_status = "5"
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -64,7 +64,6 @@ class Activity < ApplicationRecord
   private
 
   def set_fund_defaults
-    self.flow = "10"
     self.tied_status = "5"
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -35,4 +35,8 @@ class ActivityPresenter < SimpleDelegator
     return if super.blank?
     I18n.t("activity.tied_status.#{super}")
   end
+
+  def call_to_action(attribute)
+    send(attribute).present? ? "edit" : "add"
+  end
 end

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :aid_type, yaml_to_objects("activity", "aid_type"), :code, :name
+  = f.govuk_collection_select :aid_type, yaml_to_objects(entity: "activity", type: "aid_type"), :code, :name

--- a/app/views/staff/activity_forms/country.html.haml
+++ b/app/views/staff/activity_forms/country.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :recipient_region, yaml_to_objects("activity", "recipient_region"), :code, :name
+  = f.govuk_collection_select :recipient_region, yaml_to_objects(entity: "activity", type: "recipient_region"), :code, :name

--- a/app/views/staff/activity_forms/country.html.haml
+++ b/app/views/staff/activity_forms/country.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :recipient_region, yaml_to_objects(entity: "activity", type: "recipient_region"), :code, :name
+  = f.govuk_collection_select :recipient_region, region_select_options, :code, :name, options: { selected: f.object.recipient_region || region_select_options.first.code }

--- a/app/views/staff/activity_forms/finance.html.haml
+++ b/app/views/staff/activity_forms/finance.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :finance, yaml_to_objects("activity", "finance"), :code, :name
+  = f.govuk_collection_select :finance, yaml_to_objects(entity: "activity", type: "finance"), :code, :name

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, yaml_to_objects("activity", "flow"), :code, :name
+  = f.govuk_collection_select :flow, yaml_to_objects(entity: "activity", type: "flow"), :code, :name

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, yaml_to_objects(entity: "activity", type: "flow"), :code, :name
+  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,3 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector, yaml_to_objects("activity", "sector"), :code, :name
-
+  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :status, yaml_to_objects("activity", "status"), :code, :name
+  = f.govuk_collection_select :status, yaml_to_objects(entity: "activity", type: "status"), :code, :name

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :tied_status, yaml_to_objects(entity: "activity", type: "tied_status"), :code, :name
+  = f.govuk_collection_select :tied_status, tied_status_select_options, :code, :name, options: { selected: f.object.tied_status || tied_status_select_options.first.code }

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :tied_status, yaml_to_objects("activity", "tied_status"), :code, :name
+  = f.govuk_collection_select :tied_status, yaml_to_objects(entity: "activity", type: "tied_status"), :code, :name

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -1,16 +1,16 @@
 = f.govuk_error_summary
 = f.govuk_text_field :name
 = f.govuk_collection_select :organisation_type,
-                     yaml_to_objects("organisation", "organisation_type"),
+                     yaml_to_objects(entity: "organisation", type: "organisation_type"),
                      :code,
                      :name
 = f.govuk_collection_select :language_code,
-                     yaml_to_objects("organisation", "language_code"),
+                     yaml_to_objects(entity: "organisation", type: "language_code"),
                      :code,
                      :name,
                      hint_text: t("form.organisation.language_code.hint")
 = f.govuk_collection_select :default_currency,
-                     yaml_to_objects("generic", "default_currency"),
+                     yaml_to_objects(entity: "generic", type: "default_currency"),
                      :code,
                      :name,
                      hint_text: t("form.organisation.default_currency.hint")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -20,7 +20,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.identifier
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :identifier), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :identifier)
+        = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :identifier), class: "govuk-link"
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
@@ -28,7 +29,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.title
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :purpose)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:title)}"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
 
   .govuk-summary-list__row.description
     %dt.govuk-summary-list__key
@@ -36,7 +38,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.description
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :purpose)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:description)}"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
 
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
@@ -44,7 +47,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :sector), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :sector)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:sector)}"), edit_activity_path_for(activity: activity_presenter, step: :sector), class: "govuk-link"
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key
@@ -52,7 +56,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.status
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :status), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :status)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:status)}"), edit_activity_path_for(activity: activity_presenter, step: :status), class: "govuk-link"
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key
@@ -60,7 +65,8 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_start_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :dates)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.planned_end_date
@@ -69,7 +75,8 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.planned_end_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :dates)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.actual_start_date
@@ -78,7 +85,8 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_start_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :dates)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.actual_end_date
@@ -87,7 +95,8 @@
     %dd.govuk-summary-list__value
       = l(activity_presenter.actual_end_date)
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :dates)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), edit_activity_path_for(activity: activity_presenter, step: :dates), class: "govuk-link"
 
 
   .govuk-summary-list__row.recipient_region
@@ -96,7 +105,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.recipient_region
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :country), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :country)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), edit_activity_path_for(activity: activity_presenter, step: :country), class: "govuk-link"
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
@@ -104,7 +114,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.flow
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :flow), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :flow)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:flow)}"), edit_activity_path_for(activity: activity_presenter, step: :flow), class: "govuk-link"
 
   .govuk-summary-list__row.finance
     %dt.govuk-summary-list__key
@@ -112,7 +123,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.finance
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :finance), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :finance)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:finance)}"), edit_activity_path_for(activity: activity_presenter, step: :finance), class: "govuk-link"
 
   .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
@@ -120,7 +132,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.aid_type
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :aid_type), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :aid_type)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), edit_activity_path_for(activity: activity_presenter, step: :aid_type), class: "govuk-link"
 
   .govuk-summary-list__row.tied_status
     %dt.govuk-summary-list__key
@@ -128,4 +141,5 @@
     %dd.govuk-summary-list__value
       = activity_presenter.tied_status
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :tied_status), class: "govuk-link"
+      - if show_activity_field?(activity: activity_presenter, step: :tied_status)
+        = link_to t("generic.link.#{activity_presenter.call_to_action(:tied_status)}"), edit_activity_path_for(activity: activity_presenter, step: :tied_status), class: "govuk-link"

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -22,14 +22,6 @@
     %dd.govuk-summary-list__actions
       = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :identifier), class: "govuk-link"
 
-  .govuk-summary-list__row.sector
-    %dt.govuk-summary-list__key
-      = t("page_content.activity.sector.label")
-    %dd.govuk-summary-list__value
-      = activity_presenter.sector
-    %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :sector), class: "govuk-link"
-
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
       = t("page_content.activity.title.label")
@@ -45,6 +37,14 @@
       = activity_presenter.description
     %dd.govuk-summary-list__actions
       = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :purpose), class: "govuk-link"
+
+  .govuk-summary-list__row.sector
+    %dt.govuk-summary-list__key
+      = t("page_content.activity.sector.label")
+    %dd.govuk-summary-list__value
+      = activity_presenter.sector
+    %dd.govuk-summary-list__actions
+      = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :sector), class: "govuk-link"
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -2,7 +2,7 @@
 = f.govuk_text_field :reference
 = f.govuk_text_area :description
 = f.govuk_collection_select :transaction_type,
-                               yaml_to_objects("transaction", "transaction_type"),
+                               yaml_to_objects(entity: "transaction", type: "transaction_type"),
                                :code,
                                :name,
                                hint_text: t("form.transaction.transaction_type.hint")
@@ -14,7 +14,7 @@
                                :name
 = f.govuk_text_field :value
 = f.govuk_collection_select :disbursement_channel,
-                               yaml_to_objects("transaction", "disbursement_channel"),
+                               yaml_to_objects(entity: "transaction", type: "disbursement_channel"),
                                :code,
                                :name,
                                hint_text: t("form.transaction.disbursement_channel.hint")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
       menu: Menu
       submit: Submit
     link:
+      add: Add
       back: Back
       edit: Edit
       show: Show

--- a/db/migrate/20191217160336_add_wizard_status_to_activity.rb
+++ b/db/migrate/20191217160336_add_wizard_status_to_activity.rb
@@ -1,0 +1,5 @@
+class AddWizardStatusToActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:activities, :wizard_status, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_13_123607) do
+ActiveRecord::Schema.define(version: 2019_12_17_160336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2019_12_13_123607) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "hierarchy_type"
     t.uuid "hierarchy_id"
+    t.string "wizard_status"
     t.index ["hierarchy_type", "hierarchy_id"], name: "index_activities_on_hierarchy_type_and_hierarchy_id"
   end
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -7,14 +7,45 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     sector { "99" }
     status { "2" }
+    planned_start_date { Date.today }
+    planned_end_date { Date.tomorrow }
+    actual_start_date { Date.today }
+    actual_end_date { Date.tomorrow }
     recipient_region { "489" }
     flow { "10" }
     finance { "110" }
     aid_type { "A01" }
     tied_status { "3" }
-  end
 
-  factory :fund_activity do
-    association :hierarchy, factory: :fund
+    wizard_status { "tied_status" } # this is the final step, aka "complete"
+
+    factory :fund_activity do
+      association :hierarchy, factory: :fund
+
+      factory :activity_at_identifier_step do
+        wizard_status { "identifier" }
+        title { nil }
+        description { nil }
+        sector { nil }
+        status { nil }
+        planned_start_date { nil }
+        planned_end_date { nil }
+        actual_start_date { nil }
+        actual_end_date { nil }
+        recipient_region { nil }
+        flow { nil }
+        finance { nil }
+        aid_type { nil }
+        tied_status { nil }
+      end
+
+      factory :activity_at_country_step do
+        wizard_status { "country" }
+        flow { nil }
+        finance { nil }
+        aid_type { nil }
+        tied_status { nil }
+      end
+    end
   end
 end

--- a/spec/factories/fund.rb
+++ b/spec/factories/fund.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :fund do
     name { Faker::Company.name }
+    association :organisation, factory: :organisation
   end
 end

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -83,11 +83,7 @@ RSpec.feature "Users can create an activity" do
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.country")
 
-        # Recipient region has a default, so we need to deliberately select blank!
-        select "", from: "activity[recipient_region]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Recipient region can't be blank"
-
+        # Region has a default and can't be set to blank so we skip
         select "Developing countries, unspecified", from: "activity[recipient_region]"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.flow")

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -88,11 +88,7 @@ RSpec.feature "Users can create an activity" do
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
 
-        # Flow has a default, so we need to select blank!
-        select "", from: "activity[flow]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Flow can't be blank"
-
+        # Flow has a default and can't be set to blank so we skip
         select "ODA", from: "activity[flow]"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.finance")

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -43,7 +43,6 @@ RSpec.feature "Users can create an activity" do
         visit organisation_fund_path(organisation, fund)
         click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
         click_button I18n.t("form.activity.submit")
-        expect(page).not_to have_content I18n.t("form.activity.create.success")
         expect(page).to have_content "can't be blank"
       end
     end

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -111,11 +111,7 @@ RSpec.feature "Users can create an activity" do
 
         expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
 
-        # Tied status has a default so we need to select blank!
-        select "", from: "activity[tied_status]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Tied status can't be blank"
-
+        # Tied status has a default and can't be set to blank so we skip
         select "Untied", from: "activity[tied_status]"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content fund.name

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -42,8 +42,14 @@ RSpec.feature "Users can create an activity" do
       scenario "validation errors work as expected" do
         visit organisation_fund_path(organisation, fund)
         click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
+
+        # Don't provide an identifier
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content "can't be blank"
+
+        fill_in "activity[identifier]", with: "foo"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
       end
     end
 

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -50,6 +50,83 @@ RSpec.feature "Users can create an activity" do
         fill_in "activity[identifier]", with: "foo"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
+
+        # Don't provide a title and description
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Title can't be blank"
+        expect(page).to have_content "Description can't be blank"
+
+        fill_in "activity[title]", with: Faker::Lorem.word
+        fill_in "activity[description]", with: Faker::Lorem.paragraph
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
+
+        # Don't provide a sector
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Sector can't be blank"
+
+        select "Education policy and administrative management", from: "activity[sector]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.status")
+
+        # Don't provide a status
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Status can't be blank"
+
+        select "Implementation", from: "activity[status]"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+
+        # Dates are not mandatory so we can move through this step
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+
+        # Recipient region has a default, so we need to deliberately select blank!
+        select "", from: "activity[recipient_region]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Recipient region can't be blank"
+
+        select "Developing countries, unspecified", from: "activity[recipient_region]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+
+        # Flow has a default, so we need to select blank!
+        select "", from: "activity[flow]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Flow can't be blank"
+
+        select "ODA", from: "activity[flow]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
+
+        # Don't select a finance
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Finance can't be blank"
+
+        select "Standard grant", from: "activity[finance]"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
+
+        # Don't select an aid type
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Aid type can't be blank"
+
+        select "General budget support", from: "activity[aid_type]"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
+
+        # Tied status has a default so we need to select blank!
+        select "", from: "activity[tied_status]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Tied status can't be blank"
+
+        select "Untied", from: "activity[tied_status]"
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content fund.name
       end
     end
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -27,16 +27,74 @@ RSpec.feature "Users can edit an activity" do
       fill_in_activity_form
     end
 
-    it "all edit links are available to take the user to the right step" do
-      fund = create(:fund, organisation: organisation)
-      activity = create(:activity, hierarchy: fund)
+    context "when the activity only has an identifier (and is incomplete)" do
+      it "shows edit link on the identifier, and add link on only the next step" do
+        fund = create(:fund, organisation: organisation)
+        _activity = create(:activity_at_identifier_step, hierarchy: fund)
 
-      visit dashboard_path
-      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
-      click_on(organisation.name)
-      click_on(fund.name)
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
 
-      assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+        within(".identifier") do
+          expect(page).to have_content(I18n.t("generic.link.edit"))
+        end
+
+        within(".title") do
+          expect(page).to have_content(I18n.t("generic.link.add"))
+        end
+
+        within(".sector") do
+          expect(page).to_not have_content(I18n.t("generic.link.add"))
+        end
+      end
+    end
+
+    context "when the activity is complete" do
+      it "all edit links are available to take the user to the right step" do
+        fund = create(:fund, organisation: organisation)
+        activity = create(:activity, hierarchy: fund)
+
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
+
+        assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+      end
+    end
+
+    context "when an activity attribute is present" do
+      it "the call to action is 'Edit'" do
+        fund = create(:fund, organisation: organisation)
+        _activity = create(:activity, hierarchy: fund, title: "My title", wizard_status: :purpose)
+
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
+
+        within(".title") do
+          expect(page).to have_content(I18n.t("generic.link.edit"))
+        end
+      end
+    end
+
+    context "when an activity attribute is not present" do
+      it "the call to action is 'Add'" do
+        fund = create(:fund, organisation: organisation)
+        _activity = create(:activity, hierarchy: fund, title: nil, wizard_status: :identifier)
+
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
+
+        within(".title") do
+          expect(page).to have_content(I18n.t("generic.link.add"))
+        end
+      end
     end
   end
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -57,4 +57,44 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
   end
+
+  describe "#show_activity_field?" do
+    context "when the activity has passed the identification step" do
+      it "returns true for the purpose fields" do
+        activity = build(:activity_at_identifier_step)
+        expect(helper.show_activity_field?(activity: activity, step: "purpose")).to be(true)
+      end
+
+      it "returns false for the next fields following the purpose field" do
+        activity = build(:activity_at_identifier_step)
+        expect(helper.show_activity_field?(activity: activity, step: "sector")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "status")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "dates")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "country")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "flow")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "finance")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "aid_type")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "tied_status")).to be(false)
+      end
+    end
+
+    context "when the activity has passed the country step" do
+      it "returns true for the previous field and only for the next field" do
+        activity = build(:activity_at_country_step)
+        expect(helper.show_activity_field?(activity: activity, step: "purpose")).to be(true)
+        expect(helper.show_activity_field?(activity: activity, step: "sector")).to be(true)
+        expect(helper.show_activity_field?(activity: activity, step: "status")).to be(true)
+        expect(helper.show_activity_field?(activity: activity, step: "dates")).to be(true)
+        expect(helper.show_activity_field?(activity: activity, step: "country")).to be(true)
+        expect(helper.show_activity_field?(activity: activity, step: "flow")).to be(true)
+      end
+
+      it "returns false for the next fields" do
+        activity = build(:activity_at_country_step)
+        expect(helper.show_activity_field?(activity: activity, step: "finance")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "aid_type")).to be(false)
+        expect(helper.show_activity_field?(activity: activity, step: "tied_status")).to be(false)
+      end
+    end
+  end
 end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -7,30 +7,46 @@ RSpec.describe CodelistHelper, type: :helper do
     let(:version) { "2_03" }
     describe "#yaml_to_objects" do
       it "gracefully handles a missing or incorrect yaml file" do
-        expect(helper.yaml_to_objects("generic", "favourite_colours")).to eq([])
+        expect(helper.yaml_to_objects(entity: "generic", type: "favourite_colours")).to eq([])
       end
 
       it "formats the data in a yaml file to an array of objects for use in govuk form builder" do
-        expect(helper.yaml_to_objects("generic", "default_currency")).to include(
-          OpenStruct.new(name: "Afghani", code: "AFN"),
-          OpenStruct.new(name: "Lek", code: "ALL"),
-          OpenStruct.new(name: "Armenian Dram", code: "AMD"),
-          OpenStruct.new(name: "Netherlands Antillian Guilder", code: "ANG"),
-          OpenStruct.new(name: "Kwanza", code: "AOA")
-        )
+        expect(helper.yaml_to_objects(entity: "generic", type: "default_currency"))
+          .to include(
+            OpenStruct.new(name: "Afghani", code: "AFN"),
+            OpenStruct.new(name: "Lek", code: "ALL"),
+            OpenStruct.new(name: "Armenian Dram", code: "AMD"),
+            OpenStruct.new(name: "Netherlands Antillian Guilder", code: "ANG"),
+            OpenStruct.new(name: "Kwanza", code: "AOA")
+          )
       end
 
       it "adds a blank first item by default" do
-        expect(helper.yaml_to_objects("generic", "default_currency").first).to eq(OpenStruct.new(name: "", code: ""))
+        expect(helper.yaml_to_objects(
+          entity: "generic",
+          type: "default_currency"
+        ).first).to eq(OpenStruct.new(name: "", code: ""))
       end
 
       it "removes the blank first item if you need it to" do
-        expect(helper.yaml_to_objects("generic", "default_currency", false).first).to_not eq(OpenStruct.new(name: "", code: ""))
+        expect(helper.yaml_to_objects(
+          entity: "generic",
+          type: "default_currency",
+          with_empty_item: false
+        ).first).to_not eq(OpenStruct.new(name: "", code: ""))
       end
 
       it "sorts the resulting objects by name order" do
-        expect(helper.yaml_to_objects("generic", "default_currency", false).first).to eq(OpenStruct.new(name: "Afghani", code: "AFN"))
-        expect(helper.yaml_to_objects("generic", "default_currency", false).last).to eq(OpenStruct.new(name: "Zloty", code: "PLN"))
+        expect(helper.yaml_to_objects(
+          entity: "generic",
+          type: "default_currency",
+          with_empty_item: false
+        ).first).to eq(OpenStruct.new(name: "Afghani", code: "AFN"))
+        expect(helper.yaml_to_objects(
+          entity: "generic",
+          type: "default_currency",
+          with_empty_item: false
+        ).last).to eq(OpenStruct.new(name: "Zloty", code: "PLN"))
       end
     end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -52,7 +52,15 @@ RSpec.describe CodelistHelper, type: :helper do
 
     describe "#currency_select_options" do
       it "returns an array of objects with GBP as the first (default) option" do
-        expect(helper.currency_select_options.first).to eq(OpenStruct.new(name: "Pound Sterling", code: "GBP"))
+        expect(helper.currency_select_options.first)
+          .to eq(OpenStruct.new(name: "Pound Sterling", code: "GBP"))
+      end
+    end
+
+    describe "#region_select_options" do
+      it "returns an array of region objects with 998 as the first (default) option" do
+        expect(helper.region_select_options.first)
+          .to eq(OpenStruct.new(name: "Developing countries, unspecified", code: "998"))
       end
     end
   end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -63,5 +63,12 @@ RSpec.describe CodelistHelper, type: :helper do
           .to eq(OpenStruct.new(name: "Developing countries, unspecified", code: "998"))
       end
     end
+
+    describe "#flow_select_options" do
+      it "returns an array of flow objects with 10 as the first (default) option" do
+        expect(helper.flow_select_options.first)
+          .to eq(OpenStruct.new(name: "ODA", code: "10"))
+      end
+    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -31,22 +31,22 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when planned_start_date is blank" do
-      subject { build(:activity, planned_start_date: nil, wizard_status: :dates)}
+      subject { build(:activity, planned_start_date: nil, wizard_status: :dates) }
       it { should_not validate_presence_of(:planned_start_date) }
     end
 
     context "when planned_end_date is blank" do
-      subject { build(:activity, planned_end_date: nil, wizard_status: :dates)}
+      subject { build(:activity, planned_end_date: nil, wizard_status: :dates) }
       it { should_not validate_presence_of(:planned_end_date) }
     end
 
     context "when actual_start_date is blank" do
-      subject { build(:activity, actual_start_date: nil, wizard_status: :dates)}
+      subject { build(:activity, actual_start_date: nil, wizard_status: :dates) }
       it { should_not validate_presence_of(:actual_start_date) }
     end
 
     context "when actual_end_date is blank" do
-      subject { build(:activity, actual_end_date: nil, wizard_status: :dates)}
+      subject { build(:activity, actual_end_date: nil, wizard_status: :dates) }
       it { should_not validate_presence_of(:actual_end_date) }
     end
 
@@ -67,6 +67,22 @@ RSpec.describe Activity, type: :model do
 
     context "when tied_status is blank" do
       subject { build(:activity, tied_status: nil, wizard_status: :tied_status) }
+      it { should validate_presence_of(:tied_status) }
+    end
+
+    context "when the wizard_status is complete" do
+      subject { build(:activity, wizard_status: "complete") }
+      it { should validate_presence_of(:title) }
+      it { should validate_presence_of(:description) }
+      it { should validate_presence_of(:sector) }
+      it { should validate_presence_of(:status) }
+      it { should_not validate_presence_of(:planned_start_date) }
+      it { should_not validate_presence_of(:planned_end_date) }
+      it { should_not validate_presence_of(:actual_start_date) }
+      it { should_not validate_presence_of(:actual_end_date) }
+      it { should validate_presence_of(:recipient_region) }
+      it { should validate_presence_of(:flow) }
+      it { should validate_presence_of(:finance) }
       it { should validate_presence_of(:tied_status) }
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe Activity, type: :model do
     it { should validate_uniqueness_of(:identifier) }
   end
 
+  describe "validations" do
+    context "when recipient_region is blank" do
+      it "raises an error" do
+        activity = build(:activity, recipient_region: nil, wizard_status: :country)
+        activity.valid?
+        expect(activity.errors.messages)
+          .to include(recipient_region: ["Recipient region can't be blank"])
+      end
+    end
+  end
+
   describe "#set_hierarchy_defaults" do
     let(:fund) { build_stubbed(:fund) }
 
@@ -21,12 +32,6 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when it's a fund" do
-      it "should set the recipient_region to 998" do
-        activity = build_stubbed(:activity, hierarchy: fund)
-        activity.set_hierarchy_defaults
-        expect(activity.recipient_region).to eq("998")
-      end
-
       it "should set the flow to 10" do
         activity = build_stubbed(:activity, hierarchy: fund)
         activity.set_hierarchy_defaults

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Activity, type: :model do
           .to include(recipient_region: ["Recipient region can't be blank"])
       end
     end
+
+    context "when flow is blank" do
+      it "raises an error" do
+        activity = build(:activity, flow: nil, wizard_status: :flow)
+        activity.valid?
+        expect(activity.errors.messages)
+          .to include(flow: ["Flow can't be blank"])
+      end
+    end
   end
 
   describe "#set_hierarchy_defaults" do
@@ -32,12 +41,6 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when it's a fund" do
-      it "should set the flow to 10" do
-        activity = build_stubbed(:activity, hierarchy: fund)
-        activity.set_hierarchy_defaults
-        expect(activity.flow).to eq("10")
-      end
-
       it "should set the tied_status to 5" do
         activity = build_stubbed(:activity, hierarchy: fund)
         activity.set_hierarchy_defaults

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -11,30 +11,18 @@ RSpec.describe Activity, type: :model do
 
   describe "validations" do
     context "when recipient_region is blank" do
-      it "raises an error" do
-        activity = build(:activity, recipient_region: nil, wizard_status: :country)
-        activity.valid?
-        expect(activity.errors.messages)
-          .to include(recipient_region: ["Recipient region can't be blank"])
-      end
+      subject { build(:activity, recipient_region: nil, wizard_status: :country) }
+      it { should validate_presence_of(:recipient_region) }
     end
 
     context "when flow is blank" do
-      it "raises an error" do
-        activity = build(:activity, flow: nil, wizard_status: :flow)
-        activity.valid?
-        expect(activity.errors.messages)
-          .to include(flow: ["Flow can't be blank"])
-      end
+      subject { build(:activity, flow: nil, wizard_status: :flow) }
+      it { should validate_presence_of(:flow) }
     end
 
     context "when tied_status is blank" do
-      it "raises an error" do
-        activity = build(:activity, tied_status: nil, wizard_status: :tied_status)
-        activity.valid?
-        expect(activity.errors.messages)
-          .to include(tied_status: ["Tied status can't be blank"])
-      end
+      subject { build(:activity, tied_status: nil, wizard_status: :tied_status) } 
+      it { should validate_presence_of(:tied_status) }
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -27,24 +27,13 @@ RSpec.describe Activity, type: :model do
           .to include(flow: ["Flow can't be blank"])
       end
     end
-  end
 
-  describe "#set_hierarchy_defaults" do
-    let(:fund) { build_stubbed(:fund) }
-
-    context "when the hierarchy is unknown" do
-      it "should not set any defaults" do
-        activity = Activity.new(hierarchy: nil)
-        activity.set_hierarchy_defaults
-        expect(activity.changed?).to eq(false)
-      end
-    end
-
-    context "when it's a fund" do
-      it "should set the tied_status to 5" do
-        activity = build_stubbed(:activity, hierarchy: fund)
-        activity.set_hierarchy_defaults
-        expect(activity.tied_status).to eq("5")
+    context "when tied_status is blank" do
+      it "raises an error" do
+        activity = build(:activity, tied_status: nil, wizard_status: :tied_status)
+        activity.valid?
+        expect(activity.errors.messages)
+          .to include(tied_status: ["Tied status can't be blank"])
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -10,6 +10,46 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "validations" do
+    context "when title is blank" do
+      subject { build(:activity, title: nil, wizard_status: :purpose) }
+      it { should validate_presence_of(:title) }
+    end
+
+    context "when description is blank" do
+      subject { build(:activity, description: nil, wizard_status: :purpose) }
+      it { should validate_presence_of(:description) }
+    end
+
+    context "when sector is blank" do
+      subject { build(:activity, sector: nil, wizard_status: :sector) }
+      it { should validate_presence_of(:sector) }
+    end
+
+    context "when status is blank" do
+      subject { build(:activity, status: nil, wizard_status: :status) }
+      it { should validate_presence_of(:status) }
+    end
+
+    context "when planned_start_date is blank" do
+      subject { build(:activity, planned_start_date: nil, wizard_status: :dates)}
+      it { should_not validate_presence_of(:planned_start_date) }
+    end
+
+    context "when planned_end_date is blank" do
+      subject { build(:activity, planned_end_date: nil, wizard_status: :dates)}
+      it { should_not validate_presence_of(:planned_end_date) }
+    end
+
+    context "when actual_start_date is blank" do
+      subject { build(:activity, actual_start_date: nil, wizard_status: :dates)}
+      it { should_not validate_presence_of(:actual_start_date) }
+    end
+
+    context "when actual_end_date is blank" do
+      subject { build(:activity, actual_end_date: nil, wizard_status: :dates)}
+      it { should_not validate_presence_of(:actual_end_date) }
+    end
+
     context "when recipient_region is blank" do
       subject { build(:activity, recipient_region: nil, wizard_status: :country) }
       it { should validate_presence_of(:recipient_region) }
@@ -20,8 +60,13 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:flow) }
     end
 
+    context "when finance is blank" do
+      subject { build(:activity, finance: nil, wizard_status: :finance) }
+      it { should validate_presence_of(:finance) }
+    end
+
     context "when tied_status is blank" do
-      subject { build(:activity, tied_status: nil, wizard_status: :tied_status) } 
+      subject { build(:activity, tied_status: nil, wizard_status: :tied_status) }
       it { should validate_presence_of(:tied_status) }
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -136,4 +136,16 @@ RSpec.describe ActivityPresenter do
       end
     end
   end
+
+  describe "#call_to_action" do
+    it "returns 'edit' if the desired attribute is present" do
+      activity = build(:activity, title: "My title")
+      expect(described_class.new(activity).call_to_action(:title)).to eql("edit")
+    end
+
+    it "returns 'add' if the desired attribute is not present" do
+      activity = build(:activity, title: nil)
+      expect(described_class.new(activity).call_to_action(:title)).to eql("add")
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActivityPresenter do
+  let(:activity) { build(:activity) }
+
+  describe "#aid_type" do
+    context "when the aid_type exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, aid_type: "a01")
+        result = described_class.new(activity).aid_type
+        expect(result).to eql("General budget support")
+      end
+
+      it "returns the locale value when the code is upper case" do
+        activity = build(:activity, aid_type: "A01")
+        result = described_class.new(activity).aid_type
+        expect(result).to eql("General budget support")
+      end
+    end
+
+    context "when the activity does not have an aid_type set" do
+      it "returns nil" do
+        activity = build(:activity_at_identifier_step)
+        result = described_class.new(activity)
+        expect(result.aid_type).to be_nil
+      end
+    end
+  end
+
+  describe "#sector" do
+    context "when the sector exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, sector: "11110")
+        result = described_class.new(activity).sector
+        expect(result).to eql("Education policy and administrative management")
+      end
+    end
+
+    context "when the activity does not have a sector set" do
+      it "returns nil" do
+        activity = build(:activity, sector: nil)
+        result = described_class.new(activity)
+        expect(result.sector).to be_nil
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when the status exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, status: "2")
+        result = described_class.new(activity).status
+        expect(result).to eql("Implementation")
+      end
+    end
+
+    context "when the activity does not have a status set" do
+      it "returns nil" do
+        activity = build(:activity, status: nil)
+        result = described_class.new(activity)
+        expect(result.status).to be_nil
+      end
+    end
+  end
+
+  describe "#recipient_region" do
+    context "when the aid_type recipient_region" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, recipient_region: "489")
+        result = described_class.new(activity).recipient_region
+        expect(result).to eql("South America, regional")
+      end
+    end
+
+    context "when the activity does not have a recipient_region set" do
+      it "returns nil" do
+        activity = build(:activity, recipient_region: nil)
+        result = described_class.new(activity)
+        expect(result.recipient_region).to be_nil
+      end
+    end
+  end
+
+  describe "#flow" do
+    context "when flow aid_type exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, flow: "20")
+        result = described_class.new(activity).flow
+        expect(result).to eql("OOF")
+      end
+    end
+
+    context "when the activity does not have a flow set" do
+      it "returns nil" do
+        activity = build(:activity, flow: nil)
+        result = described_class.new(activity)
+        expect(result.flow).to be_nil
+      end
+    end
+  end
+
+  describe "#finance" do
+    context "when the finance exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, finance: "111")
+        result = described_class.new(activity).finance
+        expect(result).to eql("Subsidies to national private investors")
+      end
+    end
+
+    context "when the activity does not have a finance set" do
+      it "returns nil" do
+        activity = build(:activity, finance: nil)
+        result = described_class.new(activity)
+        expect(result.finance).to be_nil
+      end
+    end
+  end
+
+  describe "#tied_status" do
+    context "when the tied_status exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, tied_status: "3")
+        result = described_class.new(activity).tied_status
+        expect(result).to eql("Partially tied")
+      end
+    end
+
+    context "when the activity does not have a tied_status set" do
+      it "returns nil" do
+        activity = build(:activity, tied_status: nil)
+        result = described_class.new(activity)
+        expect(result.tied_status).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/GiHeA5QU/122-add-validations-to-activity-multi-step-form

* Implement validations on the Activity form. All fields are required (except dates) but the user can add them in their own time, but only in one order.
* Add a helper which hides the "Edit" links for fields on the fund#show page which have not been filled in yet, *unless* those fields form part of the next Wizard step. This encourages the user to fill the form out from start to finish. 
* If a field has not been filled out yet, the CTA is "Add". If it's been filled in before, the CTA is "Edit", so the user knows the attributes can be edited.
* Default attributes are presented in the select boxes but are no longer automatically saved onto the record. We found that a consequence of this prior design that it appeared to the user that they had already provided a `flow`, `tied_status` and `recipient_region` when in fact they hadn't even got that far in the journey.

<img width="754" alt="Screenshot 2019-12-18 at 15 51 37" src="https://user-images.githubusercontent.com/1089521/71101493-b7ce5400-21ae-11ea-8e23-50127505c141.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?

Co-authored-by: @tahb 
