### PR TITLE
(136) Users see a styled and informative sign in error message

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -10,6 +10,6 @@ class Auth0Controller < ApplicationController
 
   def failure
     # show a failure page or redirect to an error page
-    @error_msg = request.params["message"]
+    @error_message = request.params["message"]
   end
 end

--- a/app/views/auth0/failure.html.haml
+++ b/app/views/auth0/failure.html.haml
@@ -1,1 +1,13 @@
-%h1 Failure
+= content_for :page_title_prefix, t("page_title.errors.auth0.failed")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h2.govuk-heading-xl
+        = t("page_content.errors.auth0.failed.explanation")
+
+      - if @error_message
+        %div.govuk-inset-text= @error_message
+
+      %p.govuk-body
+        = t("page_content.errors.auth0.failed.prompt")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,10 @@ en:
         manage_organisations: Organisations
         manage_users: Users
     errors:
+      auth0:
+        failed:
+          explanation: Your request to sign in failed
+          prompt: Try signing in again and if you continue to have this issue please contact support.
       not_authorised:
         explanation: Whilst you have successfully signed in you have not been authorised to see this page.
       support_prompt: If you believe this to be in error, please contact the person who invited you to the service.
@@ -186,6 +190,8 @@ en:
         tied_status: Tied status
     dashboard: Dashboard
     errors:
+      auth0:
+        failed: Sign in failed
       not_authorised: You are not authorised
     fund:
       edit: Edit fund

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -63,4 +63,23 @@ RSpec.feature "Users can sign in with Auth0" do
       expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))
     end
   end
+
+  context "when there was a problem and Auth0 redirects to /failure" do
+    before(:each) do
+      OmniAuth.config.mock_auth[:auth0] = :invalid_credentials
+    end
+
+    it "the user is shown what the error message so they can try to correct the problem themselves" do
+      visit dashboard_path
+
+      within ".app-header__user-links" do
+        expect(page).to have_content(I18n.t("generic.link.sign_in"))
+        click_on I18n.t("generic.link.sign_in")
+      end
+
+      expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.explanation"))
+      expect(page).to have_content("invalid_credentials")
+      expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.prompt"))
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

* When Oauth redirects the user to the standard /failure endpoint we now give the user a styled page that has an error message and a prompt as to what to do next.
* We don't have a support contact yet so omit it. We will need this before going live.

## Screenshots of UI changes

### Before


![Screenshot 2019-12-19 at 17 50 58](https://user-images.githubusercontent.com/912473/71198488-ca6a8b00-228b-11ea-8fbb-eee5b0f68cd5.png)

### After

![Screenshot 2019-12-19 at 18 12 16](https://user-images.githubusercontent.com/912473/71198483-c8083100-228b-11ea-9129-14193b4a699d.png)
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
