### PR TITLE
(171) Add receiver and provider organisation to the transaction table

### DIFF
--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -3,19 +3,19 @@
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header
-          Reference
+          =t("activerecord.attributes.transaction.reference")
         %th.govuk-table__header
-          Description
+          =t("activerecord.attributes.transaction.description")
         %th.govuk-table__header
-          Type
+          =t("activerecord.attributes.transaction.transaction_type")
         %th.govuk-table__header
-          Date
+          =t("activerecord.attributes.transaction.date")
         %th.govuk-table__header
-          Currency
+          =t("activerecord.attributes.transaction.currency")
         %th.govuk-table__header
-          Value
+          =t("activerecord.attributes.transaction.value")
         %th.govuk-table__header
-          Disbursement Channel
+          =t("activerecord.attributes.transaction.disbursement_channel")
         %th.govuk-table__header
 
     %tbody.govuk-table__body

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -17,6 +17,10 @@
         %th.govuk-table__header
           =t("activerecord.attributes.transaction.disbursement_channel")
         %th.govuk-table__header
+          =t("activerecord.attributes.transaction.provider_id")
+        %th.govuk-table__header
+          =t("activerecord.attributes.transaction.receiver_id")
+        %th.govuk-table__header
 
     %tbody.govuk-table__body
       - transactions.each do |transaction|
@@ -28,5 +32,7 @@
           %td.govuk-table__cell= transaction.currency
           %td.govuk-table__cell= transaction.value
           %td.govuk-table__cell= transaction.disbursement_channel
+          %td.govuk-table__cell= transaction.provider.name
+          %td.govuk-table__cell= transaction.receiver.name
           %td.govuk-table__cell
             = link_to(I18n.t('generic.link.edit'), edit_fund_transaction_path(transaction.fund, transaction), class: 'govuk-link')

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -20,6 +20,7 @@ en:
         organisation_type: Organisation type
       transaction:
         currency: Currency
+        date: Date
         description: Description
         disbursement_channel: Disbursement channel
         provider_id: Providing organisation

--- a/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
@@ -19,4 +19,23 @@ RSpec.feature "Users can view funds on an organisation page" do
     expect(page).to have_content(transaction.reference)
     expect(page).to_not have_content(other_transaction.reference)
   end
+
+  scenario "transaction information is shown on the page" do
+    transaction = create(:transaction, fund: fund)
+    transaction_presenter = TransactionPresenter.new(transaction)
+
+    visit organisations_path
+    click_link organisation.name
+    click_link fund.name
+
+    expect(page).to have_content(transaction_presenter.reference)
+    expect(page).to have_content(transaction_presenter.description)
+    expect(page).to have_content(transaction_presenter.transaction_type)
+    expect(page).to have_content(transaction_presenter.date)
+    expect(page).to have_content(transaction_presenter.currency)
+    expect(page).to have_content(transaction_presenter.value)
+    expect(page).to have_content(transaction_presenter.disbursement_channel)
+    expect(page).to have_content(transaction_presenter.receiver.name)
+    expect(page).to have_content(transaction_presenter.provider.name)
+  end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -126,15 +126,8 @@ module FormHelpers
         expect(page).to have_content(value)
         expect(page).to have_content(disbursement_channel)
         expect(page).to have_content(currency)
-
-        # TODO: The table cannot support more horiztonal columns right now.
-        # Remove temporary substitute assertion that checks the DB instead.
-        # expect(page).to have_content(provider_organisation.name)
-        # expect(page).to have_content(receiver_organisation.name)
-        expect(Transaction.find_by(reference: reference).provider.name)
-          .to eq(provider_organisation.name)
-        expect(Transaction.find_by(reference: reference).receiver.name)
-          .to eq(receiver_organisation.name)
+        expect(page).to have_content(provider_organisation.name)
+        expect(page).to have_content(receiver_organisation.name)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/VqODQmSn/171-add-receiver-and-provider-org-to-the-transaction-table

* Add the Provider org and Receiver org names to the Transaction table on fund#show
