### PR TITLE
Feature/restrict who can edit organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@
 - All forms now use `govuk_design_system_formbuilder` instead of `simple_form`
 - Activity multi-step form now has validations
 - Users can view an XML representation of Transactions and Funds
+- Delivery partners cannot interact with organisations they are not already associated with
+- Users can only create funds if they are associated with a given organisation

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -4,7 +4,7 @@ class Staff::ActivitiesController < Staff::BaseController
   include ActivityHelper
 
   def show
-    @activity = policy_scope(Activity).find(id)
+    @activity = Activity.find(id)
     authorize @activity
 
     @activity_presenter = ActivityPresenter.new(@activity)
@@ -16,7 +16,7 @@ class Staff::ActivitiesController < Staff::BaseController
   end
 
   def create
-    @activity = policy_scope(Activity).new
+    @activity = Activity.new
     authorize @activity
 
     @activity.hierarchy = hierarchy
@@ -38,6 +38,6 @@ class Staff::ActivitiesController < Staff::BaseController
 
   def hierarchy
     # TODO: Add support for new hierarchies here and/or move to a service
-    @hierarchy = policy_scope(Fund).find(fund_id)
+    @hierarchy = Fund.find(fund_id)
   end
 end

--- a/app/controllers/staff/base_controller.rb
+++ b/app/controllers/staff/base_controller.rb
@@ -4,5 +4,6 @@ class Staff::BaseController < ApplicationController
   include Pundit
 
   # Ensure that Pundit 'authorize' and scopes are used
-  after_action :verify_authorized, :verify_policy_scoped
+  after_action :verify_authorized, except: :index
+  after_action :verify_policy_scoped, only: :index
 end

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -9,7 +9,7 @@ class Staff::FundsController < Staff::BaseController
   end
 
   def show
-    @fund = policy_scope(Fund).find(id)
+    @fund = Fund.find(id)
     authorize @fund
 
     transactions = policy_scope(Transaction).where(fund: @fund)
@@ -22,13 +22,13 @@ class Staff::FundsController < Staff::BaseController
   end
 
   def new
-    @fund = policy_scope(Fund).new
+    @fund = Fund.new
     @organisation = Organisation.find(organisation_id)
     authorize @fund
   end
 
   def create
-    @fund = policy_scope(Fund).new(fund_params)
+    @fund = Fund.new(fund_params)
     @organisation = Organisation.find(organisation_id)
     @fund.organisation = @organisation
     authorize @fund
@@ -43,12 +43,12 @@ class Staff::FundsController < Staff::BaseController
   end
 
   def edit
-    @fund = policy_scope(Fund).find(id)
+    @fund = Fund.find(id)
     authorize @fund
   end
 
   def update
-    @fund = policy_scope(Fund).find(id)
+    @fund = Fund.find(id)
     authorize @fund
 
     @fund.assign_attributes(fund_params)

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -7,7 +7,7 @@ class Staff::OrganisationsController < Staff::BaseController
   end
 
   def show
-    organisation = policy_scope(Organisation).find(params[:id])
+    organisation = Organisation.find(id)
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
@@ -33,12 +33,12 @@ class Staff::OrganisationsController < Staff::BaseController
   end
 
   def edit
-    @organisation = policy_scope(Organisation).find(id)
+    @organisation = Organisation.find(id)
     authorize @organisation
   end
 
   def update
-    @organisation = policy_scope(Organisation).find(id)
+    @organisation = Organisation.find(id)
     authorize @organisation
 
     @organisation.assign_attributes(organisation_params)

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -5,14 +5,14 @@ class Staff::TransactionsController < Staff::BaseController
   include DateHelper
 
   def new
-    @transaction = policy_scope(Transaction).new
+    @transaction = Transaction.new
     authorize @transaction
 
     @fund = Fund.find(fund_id)
   end
 
   def create
-    @transaction = policy_scope(Transaction).new(transaction_params)
+    @transaction = Transaction.new(transaction_params)
     authorize @transaction
 
     @fund = Fund.find(fund_id)
@@ -33,14 +33,14 @@ class Staff::TransactionsController < Staff::BaseController
   end
 
   def edit
-    @transaction = policy_scope(Transaction).find(id)
+    @transaction = Transaction.find(id)
     authorize @transaction
 
     @fund = Fund.find(fund_id)
   end
 
   def update
-    @transaction = policy_scope(Transaction).find(id)
+    @transaction = Transaction.find(id)
     authorize @transaction
 
     @fund = Fund.find(fund_id)
@@ -60,7 +60,7 @@ class Staff::TransactionsController < Staff::BaseController
   end
 
   def show
-    @transaction = policy_scope(Transaction).find(id)
+    @transaction = Transaction.find(id)
     authorize @transaction
 
     @activity = Activity.find_by(hierarchy_id: @transaction.fund)

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -5,18 +5,18 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def show
-    @user = policy_scope(User).find(id)
+    @user = User.find(id)
     authorize @user
   end
 
   def new
-    @user = policy_scope(User).new
+    @user = User.new
     @organisations = policy_scope(Organisation)
     authorize @user
   end
 
   def create
-    @user = policy_scope(User).new(user_params)
+    @user = User.new(user_params)
     @organisations = policy_scope(Organisation)
     authorize @user
 
@@ -35,13 +35,13 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def edit
-    @user = policy_scope(User).find(id)
+    @user = User.find(id)
     @organisations = policy_scope(Organisation)
     authorize @user
   end
 
   def update
-    @user = policy_scope(User).find(id)
+    @user = User.find(id)
     @organisations = policy_scope(Organisation)
     authorize @user
 

--- a/app/policies/fund_policy.rb
+++ b/app/policies/fund_policy.rb
@@ -1,22 +1,22 @@
 class FundPolicy < ApplicationPolicy
   def index?
-    true
+    user.administrator? || user.organisations.include?(@record.organisation)
   end
 
   def show?
-    true
+    user.administrator? || user.organisations.include?(@record.organisation)
   end
 
   def create?
-    true
+    user.administrator?
   end
 
   def update?
-    true
+    user.administrator?
   end
 
   def destroy?
-    true
+    user.administrator?
   end
 
   class Scope < Scope

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -4,6 +4,20 @@ class OrganisationPolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    user.administrator? || user.organisations.include?(@record)
+  end
+
+  def update?
+    user.administrator? || user.organisations.include?(@record)
+  end
+
+  class Scope < Scope
+    def resolve
+      if user.administrator?
+        scope.all
+      else
+        scope.where(id: user.organisation_ids)
+      end
+    end
   end
 end

--- a/app/views/staff/funds/show.html.haml
+++ b/app/views/staff/funds/show.html.haml
@@ -19,7 +19,8 @@
             %dd.govuk-summary-list__value
               = @fund.name
             %dd.govuk-summary-list__actions
-              = link_to t("generic.link.edit"), [:edit, @fund.organisation, @fund], class: "govuk-link"
+              - if policy(Fund).update?
+                = link_to t("generic.link.edit"), [:edit, @fund.organisation, @fund], class: "govuk-link"
           .govuk-summary-list__row
             %dt.govuk-summary-list__key
               = t("page_content.fund.organisation.label")

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -35,7 +35,10 @@
 
       %h2.govuk-heading-m
         = t("page_content.organisation.funds")
-      = link_to(t("page_content.organisation.button.create_fund"), new_organisation_fund_path(@organisation_presenter), class: "govuk-button")
+
+      - if policy(Fund).new?
+        = link_to(t("page_content.organisation.button.create_fund"), new_organisation_fund_path(@organisation_presenter), class: "govuk-button")
+
       %ul.govuk-list.govuk-list--bullet
         - @funds.each do |fund|
           %li

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -5,7 +5,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.hierarchy.name
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), [:edit, activity_presenter.hierarchy.organisation, activity_presenter.hierarchy], class: "govuk-link"
+      - if policy(Fund).new?
+        = link_to t("generic.link.edit"), [:edit, activity_presenter.hierarchy.organisation, activity_presenter.hierarchy], class: "govuk-link"
 
   .govuk-summary-list__row
     %dt.govuk-summary-list__key

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     factory :administrator do
       role { :administrator }
     end
+
+    factory :delivery_partner do
+      role { :delivery_partner }
+    end
   end
 end

--- a/spec/features/staff/users_can_create_a_fund_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_spec.rb
@@ -1,43 +1,72 @@
 RSpec.feature "Users can create a fund" do
-  before do
-    authenticate!(user: user)
-  end
-
-  let(:organisation) { create(:organisation, name: "UKSA") }
-  let(:user) { create(:user, organisations: [organisation]) }
-
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
+      organisation = create(:organisation)
+      authenticate!(user: build_stubbed(:user))
       page.set_rack_session(userinfo: nil)
       visit new_organisation_fund_path(organisation)
       expect(current_path).to eq(root_path)
     end
   end
 
-  scenario "successfully creating a fund" do
-    visit new_organisation_fund_path(organisation_id: organisation.id)
+  context "when the user is an administrator" do
+    scenario "they can create a fund" do
+      organisation = create(:organisation)
+      user = create(:administrator)
+      authenticate!(user: user)
 
-    expect(page).to have_content(I18n.t("page_title.fund.new"))
-    fill_in "fund[name]", with: "My Space Fund"
-    click_button I18n.t("generic.button.submit")
-    expect(page).to have_content I18n.t("form.fund.create.success")
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
+      click_on I18n.t("page_title.fund.new")
+
+      fill_in "fund[name]", with: "My Space Fund"
+      click_button I18n.t("generic.button.submit")
+      expect(page).to have_content I18n.t("form.fund.create.success")
+    end
+
+    scenario "presence validation works as expected" do
+      organisation = create(:organisation)
+      user = create(:administrator)
+      authenticate!(user: user)
+
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
+      click_on I18n.t("page_title.fund.new")
+
+      click_button I18n.t("generic.button.submit")
+      expect(page).to_not have_content I18n.t("form.fund.create.success")
+      expect(page).to have_content "can't be blank"
+    end
+
+    scenario "can go back to the previous page" do
+      organisation = create(:organisation)
+      user = create(:administrator)
+      authenticate!(user: user)
+
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
+      click_on I18n.t("page_title.fund.new")
+
+      click_on I18n.t("generic.link.back")
+
+      expect(page).to have_current_path(organisation_path(organisation.id))
+    end
   end
 
-  scenario "presence validation works as expected" do
-    visit visit new_organisation_fund_path(organisation_id: organisation.id)
+  context "when the user is a delivery partner" do
+    scenario "they cannot create a fund" do
+      organisation = create(:organisation)
+      user = create(:delivery_partner, organisations: [organisation])
+      authenticate!(user: user)
 
-    expect(page).to have_content(I18n.t("page_title.fund.new"))
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
 
-    click_button I18n.t("generic.button.submit")
-    expect(page).to_not have_content I18n.t("form.fund.create.success")
-    expect(page).to have_content "can't be blank"
-  end
-
-  scenario "can go back to the previous page" do
-    visit new_organisation_fund_path(organisation_id: organisation.id)
-
-    click_on I18n.t("generic.link.back")
-
-    expect(page).to have_current_path(organisation_path(organisation.id))
+      expect(page).not_to have_content(I18n.t("page_title.fund.new"))
+    end
   end
 end

--- a/spec/features/staff/users_can_view_a_fund_spec.rb
+++ b/spec/features/staff/users_can_view_a_fund_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "Users can view a fund" do
 
   context "when the fund belongs to another organisation" do
     scenario "the user cannot view the fund" do
-      expect { visit organisation_fund_path(organisation, forbidden_fund) }
-        .to raise_exception(ActiveRecord::RecordNotFound)
+      visit organisation_fund_path(organisation, forbidden_fund)
+      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
     end
   end
 

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -1,27 +1,69 @@
 RSpec.feature "Users can view an individual organisation" do
-  let!(:organisation) { create(:organisation) }
-  before do
-    authenticate!
-  end
-
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
+      organisation = create(:organisation)
+      authenticate!(user: build_stubbed(:user))
       page.set_rack_session(userinfo: nil)
       visit organisation_path(organisation)
       expect(current_path).to eq(root_path)
     end
   end
 
-  scenario "organisation show page" do
-    organisation = FactoryBot.create(:organisation)
-    visit dashboard_path
-    click_link I18n.t("page_content.dashboard.button.manage_organisations")
-    click_link organisation.name
+  context "when the user is an administrator" do
+    it "allows them to view the organisations page" do
+      organisation = create(:organisation)
+      user = create(:administrator)
+      authenticate!(user: user)
 
-    expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
+
+      expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
+    end
+  end
+
+  context "when the user belongs to that organisation" do
+    it "allows them to view the organisations page" do
+      organisation = create(:organisation)
+      user = create(:delivery_partner, organisations: [organisation])
+      authenticate!(user: user)
+
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      click_link organisation.name
+
+      expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
+    end
+  end
+
+  context "when the user does NOT belong to that organisation" do
+    it "does NOT provide a link to that organisation's page" do
+      organisation = create(:organisation)
+      user = create(:delivery_partner, organisations: [])
+      authenticate!(user: user)
+
+      visit dashboard_path
+      click_link I18n.t("page_content.dashboard.button.manage_organisations")
+      expect(page).not_to have_content(organisation.name)
+    end
+
+    it "shows the 'unauthorised' error message to the user" do
+      organisation = create(:organisation)
+      user = create(:delivery_partner, organisations: [])
+      authenticate!(user: user)
+
+      visit edit_organisation_path(organisation)
+
+      expect(page).to have_content(I18n.t("pundit.default"))
+      expect(page).to have_http_status(:unauthorized)
+    end
   end
 
   scenario "can go back to the previous page" do
+    organisation = create(:organisation)
+    authenticate!(user: create(:administrator))
+
     visit organisation_path(organisation)
 
     click_on I18n.t("generic.link.back")

--- a/spec/policies/fund_policy_spec.rb
+++ b/spec/policies/fund_policy_spec.rb
@@ -17,23 +17,20 @@ RSpec.describe FundPolicy do
   end
 
   context "as a delivery partner" do
-    let(:user) { build_stubbed(:user) }
+    let(:user) { build_stubbed(:delivery_partner) }
     let(:resolved_scope) do
       described_class::Scope.new(user, Fund.all).resolve
     end
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to permit_action(:destroy) }
-
     context "with funds from my own organisation" do
-      let(:user) { create(:user, organisations: [organisation]) }
+      let(:user) { create(:delivery_partner, organisations: [organisation]) }
 
       it "includes fund in resolved scope" do
         expect(resolved_scope).to include(fund)
       end
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
     end
 
     context "with funds from another organisation" do
@@ -43,6 +40,12 @@ RSpec.describe FundPolicy do
       it "does not include fund in resolved scope" do
         expect(resolved_scope).to_not include(forbidden_fund)
       end
+
+      it { is_expected.to forbid_action(:index) }
+      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
     end
   end
 end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -16,13 +16,21 @@ RSpec.describe OrganisationPolicy do
   end
 
   context "as a delivery partner" do
-    let(:user) { build_stubbed(:user) }
+    let(:user) { build_stubbed(:delivery_partner) }
 
     it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_action(:show) }
 
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
+
+    context "when the delivery_partner belongs to that organisation" do
+      let(:user) { build_stubbed(:delivery_partner, organisations: [organisation]) }
+      let(:organisation) { create(:organisation) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

By default the delivery partner role cannot see or edit an organisation they are not associated with. This then fixes a problem where any role could see and create new funds, I've prevented fund creation however we probably need something more robust to prevent fund transactions from being created too with a specially crafted URLs. Any ideas appreciated, should we be checking the users organisation all the way down through organisation > fund > transaction?

- only use Pundit scopes on the querying of lists ie. index pages, after finding a problem with 404 errors not being raised if records don't exist, I re-read the documentation for the edits I've made which is on the commit
- only administrators or users who belong to an organisation can see and navigate to it
- only administrators or users who belong to an organisation can edit 
- only administrators or users who belong to an organisation can see associated funds

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
