### PR TITLE
Bugfix - Show all steps if Activity has a nil `wizard_status`

### DIFF
--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -13,6 +13,9 @@ module ActivityHelper
 
   def show_activity_field?(activity:, step:)
     steps = Staff::ActivityFormsController::FORM_STEPS
+
+    return true if activity.wizard_status.nil?
+
     form_position = steps.index(step.to_sym)
     activity_position = steps.index(activity.wizard_status.to_sym)
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     factory :fund_activity do
       association :hierarchy, factory: :fund
 
-      factory :activity_at_identifier_step do
+      trait :at_identifier_step do
         wizard_status { "identifier" }
         title { nil }
         description { nil }
@@ -39,7 +39,7 @@ FactoryBot.define do
         tied_status { nil }
       end
 
-      factory :activity_at_country_step do
+      trait :at_country_step do
         wizard_status { "country" }
         flow { nil }
         finance { nil }
@@ -47,7 +47,7 @@ FactoryBot.define do
         tied_status { nil }
       end
 
-      factory :activity_with_nil_wizard_status do
+      trait :nil_wizard_status do
         wizard_status { nil }
       end
     end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -46,6 +46,10 @@ FactoryBot.define do
         aid_type { nil }
         tied_status { nil }
       end
+
+      factory :activity_with_nil_wizard_status do
+        wizard_status { nil }
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Users can edit an activity" do
     context "when the activity only has an identifier (and is incomplete)" do
       it "shows edit link on the identifier, and add link on only the next step" do
         fund = create(:fund, organisation: organisation)
-        _activity = create(:activity_at_identifier_step, hierarchy: fund)
+        _activity = create(:fund_activity, :at_identifier_step, hierarchy: fund)
 
         visit dashboard_path
         click_on(I18n.t("page_content.dashboard.button.manage_organisations"))

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -96,5 +96,16 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(helper.show_activity_field?(activity: activity, step: "tied_status")).to be(false)
       end
     end
+
+    context "when the activity has a null .wizard_status field" do
+      it "shows all steps" do
+        activity = build(:activity_with_nil_wizard_status)
+        all_steps = Staff::ActivityFormsController::FORM_STEPS
+
+        all_steps.each do |step|
+          expect(helper.show_activity_field?(activity: activity, step: step)).to be(true)
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe ActivityHelper, type: :helper do
   describe "#show_activity_field?" do
     context "when the activity has passed the identification step" do
       it "returns true for the purpose fields" do
-        activity = build(:activity_at_identifier_step)
+        activity = build(:fund_activity, :at_identifier_step)
         expect(helper.show_activity_field?(activity: activity, step: "purpose")).to be(true)
       end
 
       it "returns false for the next fields following the purpose field" do
-        activity = build(:activity_at_identifier_step)
+        activity = build(:fund_activity, :at_identifier_step)
         expect(helper.show_activity_field?(activity: activity, step: "sector")).to be(false)
         expect(helper.show_activity_field?(activity: activity, step: "status")).to be(false)
         expect(helper.show_activity_field?(activity: activity, step: "dates")).to be(false)
@@ -80,7 +80,7 @@ RSpec.describe ActivityHelper, type: :helper do
 
     context "when the activity has passed the country step" do
       it "returns true for the previous field and only for the next field" do
-        activity = build(:activity_at_country_step)
+        activity = build(:fund_activity, :at_country_step)
         expect(helper.show_activity_field?(activity: activity, step: "purpose")).to be(true)
         expect(helper.show_activity_field?(activity: activity, step: "sector")).to be(true)
         expect(helper.show_activity_field?(activity: activity, step: "status")).to be(true)
@@ -90,7 +90,7 @@ RSpec.describe ActivityHelper, type: :helper do
       end
 
       it "returns false for the next fields" do
-        activity = build(:activity_at_country_step)
+        activity = build(:fund_activity, :at_country_step)
         expect(helper.show_activity_field?(activity: activity, step: "finance")).to be(false)
         expect(helper.show_activity_field?(activity: activity, step: "aid_type")).to be(false)
         expect(helper.show_activity_field?(activity: activity, step: "tied_status")).to be(false)
@@ -99,7 +99,7 @@ RSpec.describe ActivityHelper, type: :helper do
 
     context "when the activity has a null .wizard_status field" do
       it "shows all steps" do
-        activity = build(:activity_with_nil_wizard_status)
+        activity = build(:fund_activity, :nil_wizard_status)
         all_steps = Staff::ActivityFormsController::FORM_STEPS
 
         all_steps.each do |step|

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have an aid_type set" do
       it "returns nil" do
-        activity = build(:activity_at_identifier_step)
+        activity = build(:fund_activity, :at_identifier_step)
         result = described_class.new(activity)
         expect(result.aid_type).to be_nil
       end


### PR DESCRIPTION
## Changes in this PR

Trello comment which alerted us to this: https://trello.com/c/J9fiyVbh/143-add-transaction-information-an-activity-xml#comment-5dfcf58bdad0708e3adc8425

Some Activities in the staging db have a nil Wizard Status as they were added
before we added the `wizard_status` field. Handle this in the code - show all
fields in the Fund#show page if the `wizard_status` is nil

Raised by this error on staging:

```
Dec 23 09:26:39 beis-roda-staging app/web.1: F, [2019-12-23T09:26:39.234730 #8] FATAL -- : [e04e1584-e2fc-41b6-9799-c5532736f449]   
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449] ActionView::Template::Error (undefined method `to_sym' for nil:NilClass):
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     20:     %dd.govuk-summary-list__value
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     21:       = activity_presenter.identifier
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     22:     %dd.govuk-summary-list__actions
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     23:       - if show_activity_field?(activity: activity_presenter, step: :identifier)
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     24:         = link_to t("generic.link.edit"), edit_activity_path_for(activity: activity_presenter, step: :identifier), class: "govuk-link"
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     25: 
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]     26:   .govuk-summary-list__row.title
Dec 23 09:26:39 beis-roda-staging app/web.1: [e04e1584-e2fc-41b6-9799-c5532736f449]   
```



