### PR TITLE
Link Transactions to Funds via polymorphic association "Hierarchy"

### DIFF
--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -12,7 +12,7 @@ class Staff::FundsController < Staff::BaseController
     @fund = policy_scope(Fund).find(id)
     authorize @fund
 
-    transactions = policy_scope(Transaction).where(fund: @fund)
+    transactions = policy_scope(Transaction).where(hierarchy: @fund)
     @transaction_presenters = transactions.map { |transaction| TransactionPresenter.new(transaction) }
 
     respond_to do |format|

--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -1,0 +1,15 @@
+module TransactionHelper
+  def hierarchy_for(transaction:)
+    case transaction.hierarchy_type
+    when "Fund" then Fund.find(transaction.hierarchy_id)
+    end
+  end
+
+  def transaction_hierarchy_path_for(transaction:)
+    url_for([transaction.hierarchy.organisation, transaction.hierarchy])
+  end
+
+  def hierarchy_object_path(hierarchy:)
+    url_for([hierarchy.organisation, hierarchy])
+  end
+end

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -2,4 +2,5 @@ class Fund < ApplicationRecord
   validates_presence_of :name
   belongs_to :organisation
   has_one :activity, as: :hierarchy
+  has_many :transactions, as: :hierarchy
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,6 +1,5 @@
 class Transaction < ApplicationRecord
-  # TODO Make fund association polymorphic
-  belongs_to :fund
+  belongs_to :hierarchy, polymorphic: true
   belongs_to :provider, foreign_key: :provider_id, class_name: "Organisation"
   belongs_to :receiver, foreign_key: :receiver_id, class_name: "Organisation"
   validates_presence_of :reference,

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -24,9 +24,10 @@ class TransactionPolicy < ApplicationPolicy
       if user.administrator?
         scope.all
       else
+        # TODO: when we add other hierarchy types, include them here somehow!
         organisations = user.organisation_ids
         funds = Fund.where(organisation_id: organisations)
-        scope.where(fund_id: funds)
+        scope.where(hierarchy_id: funds)
       end
     end
   end

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -35,4 +35,4 @@
           %td.govuk-table__cell= transaction.provider.name
           %td.govuk-table__cell= transaction.receiver.name
           %td.govuk-table__cell
-            = link_to(I18n.t('generic.link.edit'), edit_fund_transaction_path(transaction.fund, transaction), class: 'govuk-link')
+            = link_to(I18n.t('generic.link.edit'), edit_fund_transaction_path(transaction.hierarchy, transaction), class: 'govuk-link')

--- a/app/views/staff/transactions/edit.html.haml
+++ b/app/views/staff/transactions/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.transaction.edit")
 
-= link_to t("generic.link.back"), organisation_fund_path(@fund.organisation, @fund), class: "govuk-back-link"
+= link_to t("generic.link.back"), transaction_hierarchy_path_for(transaction: @transaction), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/transactions/new.html.haml
+++ b/app/views/staff/transactions/new.html.haml
@@ -1,11 +1,12 @@
 =content_for :page_title_prefix, t("page_title.transaction.new")
 
-%p= link_to t("generic.link.back"), organisation_fund_path(@fund.id, organisation_id: @fund.organisation.id), class: "govuk-back-link"
+%p= link_to t("generic.link.back"), hierarchy_object_path(hierarchy: @hierarchy), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
         = t("page_title.transaction.new")
 
-      = form_with model: @transaction, url: fund_transactions_path(@fund) do |f|
+      =# TODO: replace fund_transactions_path with something hierarchy-agnostic
+      = form_with model: @transaction, url: fund_transactions_path(@hierarchy) do |f|
         = render partial: "form", locals: { f: f, organisations: @organisations }

--- a/db/migrate/20191223094933_add_polymorphic_hierarchy_to_transactions.rb
+++ b/db/migrate/20191223094933_add_polymorphic_hierarchy_to_transactions.rb
@@ -1,0 +1,8 @@
+class AddPolymorphicHierarchyToTransactions < ActiveRecord::Migration[6.0]
+  def change
+    change_table :transactions do |t|
+      t.references :hierarchy, polymorphic: true, type: :uuid
+      t.remove :fund_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_17_160336) do
+ActiveRecord::Schema.define(version: 2019_12_23_094933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -71,12 +71,13 @@ ActiveRecord::Schema.define(version: 2019_12_17_160336) do
     t.decimal "value", precision: 13, scale: 2
     t.string "disbursement_channel"
     t.string "currency"
-    t.uuid "fund_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "provider_id"
     t.uuid "receiver_id"
-    t.index ["fund_id"], name: "index_transactions_on_fund_id"
+    t.string "hierarchy_type"
+    t.uuid "hierarchy_id"
+    t.index ["hierarchy_type", "hierarchy_id"], name: "index_transactions_on_hierarchy_type_and_hierarchy_id"
     t.index ["provider_id"], name: "index_transactions_on_provider_id"
     t.index ["receiver_id"], name: "index_transactions_on_receiver_id"
   end

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can edit a transaction" do
 
   let(:organisation) { create(:organisation) }
   let!(:fund) { create(:fund, organisation: organisation) }
-  let!(:transaction) { create(:transaction, fund: fund) }
+  let!(:transaction) { create(:transaction, hierarchy: fund) }
   let(:user) { create(:user, organisations: [organisation]) }
 
   context "when the user is not logged in" do

--- a/spec/features/staff/users_can_view_a_fund_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_a_fund_as_xml_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can view a fund as XML" do
   let(:organisation) { create(:organisation) }
   let(:fund) { create(:fund, organisation: organisation) }
   let!(:activity) { create(:activity, hierarchy: fund) }
-  let!(:transaction) { create(:transaction, fund: fund) }
+  let!(:transaction) { create(:transaction, hierarchy: fund) }
   let(:user) { create(:user, organisations: [organisation]) }
 
   context "when the user is not logged in" do

--- a/spec/features/staff/users_can_view_a_transaction_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_a_transaction_as_xml_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can view a transaction as XML" do
   let(:organisation) { create(:organisation) }
   let(:fund) { create(:fund, organisation: organisation) }
   let!(:activity) { create(:activity, hierarchy: fund) }
-  let(:transaction) { create(:transaction, fund: fund) }
+  let(:transaction) { create(:transaction, hierarchy: fund) }
   let(:user) { create(:user, organisations: [organisation]) }
 
   context "when the user is not logged in" do

--- a/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
@@ -9,8 +9,8 @@ RSpec.feature "Users can view funds on an organisation page" do
   let(:other_fund) { create(:fund, organisation: organisation) }
 
   scenario "only transactions belonging to this fund are shown on the Fund#show page" do
-    transaction = create(:transaction, fund: fund)
-    other_transaction = create(:transaction, fund: other_fund)
+    transaction = create(:transaction, hierarchy: fund)
+    other_transaction = create(:transaction, hierarchy: other_fund)
 
     visit organisations_path
     click_link organisation.name
@@ -21,7 +21,7 @@ RSpec.feature "Users can view funds on an organisation page" do
   end
 
   scenario "transaction information is shown on the page" do
-    transaction = create(:transaction, fund: fund)
+    transaction = create(:transaction, hierarchy: fund)
     transaction_presenter = TransactionPresenter.new(transaction)
 
     visit organisations_path

--- a/spec/helpers/transaction_helper_spec.rb
+++ b/spec/helpers/transaction_helper_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe TransactionHelper, type: :helper do
+  describe "#hierarchy_for" do
+    context "when the hierarchy_type is Fund" do
+      it "returns the Fund" do
+        fund = create(:fund)
+        transaction = build(:transaction, hierarchy: fund)
+        expect(helper.hierarchy_for(transaction: transaction)).to eq(fund)
+      end
+    end
+  end
+
+  describe "#transaction_hierarchy_path_for" do
+    context "when the hierarchy_type is Fund" do
+      it "returns the Fund show page" do
+        fund = create(:fund)
+        transaction = build(:transaction, hierarchy: fund)
+        expect(helper.transaction_hierarchy_path_for(transaction: transaction))
+          .to eq(organisation_fund_path(fund.organisation, fund))
+      end
+    end
+  end
+
+  describe "#hierarchy_object_path" do
+    context "when the hierarchy_type is Fund" do
+      it "returns the Fund show page" do
+        fund = create(:fund)
+        expect(helper.hierarchy_object_path(hierarchy: fund))
+          .to eq(organisation_fund_path(fund.organisation, fund))
+      end
+    end
+  end
+end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Transaction, type: :model do
   describe "relations" do
-    it { should belong_to(:fund) }
+    it { should belong_to(:hierarchy) }
   end
 
   describe "validations" do
@@ -19,22 +19,22 @@ RSpec.describe Transaction, type: :model do
     let(:fund) { build(:fund) }
 
     it "does allows the maximum possible value" do
-      transaction = build(:transaction, fund: fund, value: 99_999_999_999.00)
+      transaction = build(:transaction, hierarchy: fund, value: 99_999_999_999.00)
       expect(transaction.valid?).to be_truthy
     end
 
     it "does not allow a value of less than 1" do
-      transaction = build(:transaction, fund: fund, value: -1)
+      transaction = build(:transaction, hierarchy: fund, value: -1)
       expect(transaction.valid?).to be_falsey
     end
 
     it "does not allow a value of more than 99,999,999,999.00" do
-      transaction = build(:transaction, fund: fund, value: 100_000_000_000.00)
+      transaction = build(:transaction, hierarchy: fund, value: 100_000_000_000.00)
       expect(transaction.valid?).to be_falsey
     end
 
     it "allows a value between 1 and 99,999,999,999.00" do
-      transaction = build(:transaction, fund: fund, value: 500_000.00)
+      transaction = build(:transaction, hierarchy: fund, value: 500_000.00)
       expect(transaction.valid?).to be_truthy
     end
   end

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TransactionPolicy do
 
   let(:organisation) { create(:organisation) }
   let!(:fund) { create(:fund, organisation: organisation) }
-  let!(:transaction) { create(:transaction, fund: fund) }
+  let!(:transaction) { create(:transaction, hierarchy: fund) }
 
   context "as an administrator" do
     let(:user) { build_stubbed(:administrator) }
@@ -40,7 +40,7 @@ RSpec.describe TransactionPolicy do
     context "with transactions from funds in another organisation" do
       let(:other_organisation) { create(:organisation) }
       let(:forbidden_fund) { create(:fund, organisation: other_organisation) }
-      let(:transaction) { create(:transaction, fund: forbidden_fund) }
+      let(:transaction) { create(:transaction, hierarchy: forbidden_fund) }
 
       it "does not include transaction in resolved scope" do
         expect(resolved_scope).to_not include(transaction)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/XpMDq8O8/175-refactor-make-fund-transaction-association-polymorphic

Previously Transactions belonged to a Fund. Now they can belong to a Fund via the polymorphic association `hierarchy`, which means when we add Projects/Programmes etc they will also be able to have Transactions.

There are still some TODOs here which will need to be addressed when we add more `hierarchy` types
