### PR TITLE
Remove skipped test

### DIFF
--- a/spec/features/staff/users_can_view_all_organisations_spec.rb
+++ b/spec/features/staff/users_can_view_all_organisations_spec.rb
@@ -23,16 +23,6 @@ RSpec.feature "Users can view all organisations" do
     expect(page).to have_content organisation.name
   end
 
-  scenario "user does not see organisations they do not belong to" do
-    skip "Not implemented yet"
-    organisation_2 = create(:organisation)
-
-    visit organisations_path
-
-    expect(page).to have_content(I18n.t("page_title.organisation.index"))
-    expect(page).to_not have_content organisation_2.name
-  end
-
   scenario "can go back to the previous page" do
     visit organisations_path
 


### PR DESCRIPTION
Removing this skipped test as, from looking at `OrganisationPolicy`, we are not
restricting any Organisations from being viewed by users.
