### PR TITLE
Chore to run default rake tasks in expected order

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,1 +1,1 @@
-task default: %i[standard spec] if Rails.env.test? || Rails.env.development?
+task(:default).clear_prerequisites.enhance(%i[standard spec]) if Rails.env.test? || Rails.env.development?


### PR DESCRIPTION
## Changes in this PR
This is a tiny quality of life improvement that makes the default rake task run in the order specified.

By default the rspec configuration always loads the specs first so the`spec` task here is ignored.

By clearing the default task prerequisites and then adding (enhancing) in order we get the expected behaviour.

As someone who often slips up with formatting, this means I don't have to wait for all the specs to run before finding out I have a formatting issue, which saves time.
