### PR TITLE
(113) Force SSL in production environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - All forms now use `govuk_design_system_formbuilder` instead of `simple_form`
 - Activity multi-step form now has validations
 - Users can view an XML representation of Transactions and Funds
+- Force SSL in production environments

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
NB: This redirects non-SSL requests to their SSL equivalents, forces secure cookies and enables HSTS (which means browsers will *never* visit the non-SSL version of the site after the first visit).

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
