### PR TITLE
Remove old styling to keep gov.uk defults

### DIFF
--- a/app/assets/stylesheets/partials/_forms.css.scss
+++ b/app/assets/stylesheets/partials/_forms.css.scss
@@ -1,10 +1,3 @@
-.govuk-checkboxes__label::after {
-  top: 11px;
-  left: 7px;
-  width: 27px;
-  height: 12px;
-}
-
 .govuk-textarea {
   height: 100%;
 }


### PR DESCRIPTION
The checkbox ovewriting styles where probably added when the app was using bootstrap to compensate for inconsistent look. Removing them fixes this and allows the app to use default gov.uk styling for checkboxes.

## Screenshots of UI changes

### Before

<img width="698" alt="Screenshot 2020-01-07 at 13 49 05" src="https://user-images.githubusercontent.com/2632224/71900143-1c992080-3155-11ea-902d-4c2d937a5613.png">


### After

<img width="772" alt="Screenshot 2020-01-07 at 13 44 49" src="https://user-images.githubusercontent.com/2632224/71900164-26bb1f00-3155-11ea-9bb3-96b17840f85f.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
