### PR TITLE
Use 'pry' when debugging on the rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
   gem "i18n-tasks", "~> 0.9.29"
   gem "rspec-rails"
   gem "standard"
-  gem "pry"
+  gem "pry-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
@@ -448,7 +450,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1)
   parser (~> 2.6.3.0)
   pg
-  pry
+  pry-rails
   puma (~> 4.3)
   pundit
   pundit-matchers (~> 1.6.0)


### PR DESCRIPTION
Swap the plain 'pry' gem for 'pry-rails', so it's used instead of IRB for the Rails console by default, which makes debugging much nicer.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
- [ ] Do any environment variables need amending or adding?
