### PR TITLE
Fix a typo in the PR template which was annoying me

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@
 ## Next steps
 
 - [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
-- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has to impact outside the development team.
+- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
 - [ ] Do any environment variables need amending or adding?


### PR DESCRIPTION
## Changes in this PR

`- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has` __NO__ ` impact outside the development team.`