### PR TITLE
Chore/Update Auth0 ADR to include Classic views

### DIFF
--- a/doc/architecture/decisions/0006-use-auth0-for-authentication.md
+++ b/doc/architecture/decisions/0006-use-auth0-for-authentication.md
@@ -14,11 +14,21 @@ In order to implement this quickly, we'll use Auth0 to manage this.
 As Auth0's authentication uses OAuth2, it should be straightforward to migrate
 to another service, if BEIS have a preference for something else.
 
+Auth0 provides views for authentication that we can use in our user journeys.
+There are two versions of these views 'Classic' and 'New'.
+
+Classic uses JavaScript and is not progressively enhanced. New uses language
+that results in a poor user experience.
+
 ## Decision
 
-We will use the free tier of Auth0 for the private beta.
+We will use the free tier and 'Classic' views of Auth0 for the private beta.
 
 ## Consequences
+
+The Classic login uses JavaScript that is not progressively enhanced, however
+the speed using it brings the team is a higher priority than the work to
+replace it for the moment.
 
 We will need to consider the extent of our integration with Auth0 as an interim
 solution for which a permanent replacement is being sought.


### PR DESCRIPTION
To cover the decision to use the 'Classic' login views from Auth0 which
offer the best balance between user experience and technical debt in the
service.