### PR TITLE
Fund managers can create a basic programme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - Restrict delivery partners so they can only view and edit their own organisation
 - Fund managers can manage users, organisations, funds, fund activites and fund transactions
 - Transaction and Activity dates are restricted to 10 years in the past or 25 years in the future at most
+- Fund managers can create basic programmes

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -14,6 +14,8 @@ class Staff::FundsController < Staff::BaseController
     transactions = policy_scope(Transaction).where(fund: @fund)
     @transaction_presenters = transactions.map { |transaction| TransactionPresenter.new(transaction) }
 
+    @programmes = @fund.programmes
+
     respond_to do |format|
       format.html
       format.xml

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Staff::ProgrammesController < Staff::BaseController
+  include Secured
+
+  def show
+    @programme = Programme.find(id)
+    authorize @programme
+  end
+
+  def new
+    @programme = Programme.new
+    @fund = Fund.find(fund_id)
+    @organisation = @fund.organisation
+
+    authorize @programme
+  end
+
+  def create
+    @programme = Programme.new(programme_params)
+    @fund = Fund.find(fund_id)
+    @programme.fund = @fund
+    @programme.organisation = @fund.organisation
+
+    authorize @programme
+
+    if @programme.valid?
+      @programme.save
+      flash[:notice] = I18n.t("form.programme.create.success")
+      redirect_to fund_programme_path(@fund, @programme)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def programme_params
+    params.require(:programme).permit(:name)
+  end
+
+  def id
+    params[:id]
+  end
+
+  def fund_id
+    params[:fund_id]
+  end
+end

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -2,4 +2,5 @@ class Fund < ApplicationRecord
   validates_presence_of :name
   belongs_to :organisation
   has_one :activity, as: :hierarchy
+  has_many :programmes
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,7 @@
 class Organisation < ApplicationRecord
   has_and_belongs_to_many :users
+  has_many :funds
+
   validates_presence_of :name, :organisation_type, :language_code, :default_currency
   scope :sorted_by_name, -> { order(name: :asc) }
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -1,0 +1,6 @@
+class Programme < ApplicationRecord
+  validates_presence_of :name
+
+  belongs_to :organisation
+  belongs_to :fund
+end

--- a/app/policies/programme_policy.rb
+++ b/app/policies/programme_policy.rb
@@ -1,0 +1,31 @@
+class ProgrammePolicy < ApplicationPolicy
+  def index?
+    user.administrator? || user.fund_manager?
+  end
+
+  def show?
+    user.administrator? || user.fund_manager?
+  end
+
+  def create?
+    user.administrator? || user.fund_manager?
+  end
+
+  def update?
+    user.administrator? || user.fund_manager?
+  end
+
+  def destroy?
+    user.administrator? || user.fund_manager?
+  end
+
+  class Scope < Scope
+    def resolve
+      if user.administrator? || user.fund_manager?
+        scope.all
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/views/staff/funds/show.html.haml
+++ b/app/views/staff/funds/show.html.haml
@@ -35,3 +35,17 @@
 
       = link_to(I18n.t("page_content.transactions.button.create"), new_fund_transaction_path(@fund), class: "govuk-button")
       = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
+
+  - if policy(Programme).index?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.organisation.programmes")
+
+        - if policy(Programme).create?
+          = link_to(t("page_content.organisation.button.create_programme"), new_fund_programme_path(@fund), class: "govuk-button")
+
+      %ul.govuk-list.govuk-list--bullet
+        - @programmes.each do |programme|
+          %li
+            = link_to programme.name, fund_programme_path(programme.fund, programme)

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -36,9 +36,9 @@
       - if policy(Fund).index?
         %h2.govuk-heading-m
           = t("page_content.organisation.funds")
-      - if policy(Fund).create?
-        = link_to(t("page_content.organisation.button.create_fund"), new_organisation_fund_path(@organisation_presenter), class: "govuk-button")
-      - if policy(Fund).index?
+        - if policy(Fund).create?
+          = link_to(t("page_content.organisation.button.create_fund"), new_organisation_fund_path(@organisation_presenter), class: "govuk-button")
+
         %ul.govuk-list.govuk-list--bullet
           - @funds.each do |fund|
             %li

--- a/app/views/staff/programmes/new.html.haml
+++ b/app/views/staff/programmes/new.html.haml
@@ -1,0 +1,15 @@
+=content_for :page_title_prefix, t("page_title.programme.new")
+
+= link_to t("generic.link.back"), organisation_fund_path(@fund.organisation, @fund), class: "govuk-back-link"
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.programme.new")
+
+      = form_with model: @programme, url: fund_programmes_path(@fund) do |f|
+        = f.govuk_error_summary
+        = f.govuk_text_field :name
+
+        = f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/programmes/show.html.haml
+++ b/app/views/staff/programmes/show.html.haml
@@ -1,0 +1,22 @@
+=content_for :page_title_prefix, t("page_title.programme.show", name: @programme.name)
+
+= link_to t("generic.link.back"), organisation_fund_path(@programme.organisation, @programme.fund), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = @programme.name
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %dl.govuk-summary-list
+        .govuk-summary-list__row.organisation_name
+          %dt.govuk-summary-list__key
+            = t("page_content.programmes.organisation_name.label")
+          %dd.govuk-summary-list__value
+            = @programme.organisation.name
+        .govuk-summary-list__row.fund_name
+          %dt.govuk-summary-list__key
+            = t("page_content.programmes.fund_name.label")
+          %dd.govuk-summary-list__value
+            = @programme.fund.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
         label: Organisation type
       update:
         success: Organisation successfully updated
+    programme:
+      create:
+        success: Programme successfully created
     transaction:
       create:
         success: Transaction successfully created
@@ -148,6 +151,7 @@ en:
     organisation:
       button:
         create_fund: Create fund
+        create_programme: Create programme
         edit: Edit organisation
       default_currency:
         label: Default currency
@@ -156,11 +160,17 @@ en:
         label: Language code
       name:
         label: Name
+      programmes: Programmes
       type:
         label: Type
     organisations:
       button:
         create: Create organisation
+    programmes:
+      fund_name:
+        label: Fund name
+      organisation_name:
+        label: Organisation name
     transactions:
       button:
         create: Create transaction
@@ -204,6 +214,9 @@ en:
       index: Organisations
       new: Create a new organisation
       show: Organisation %{name}
+    programme:
+      new: Create programme
+      show: Programme %{name}
     transaction:
       edit: Edit transaction
       new: New transaction

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -18,6 +18,8 @@ en:
         language_code: Language code
         name: Name
         organisation_type: Organisation type
+      programme:
+        fund_id: Fund
       transaction:
         currency: Currency
         date: Date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
       resources :transactions, only: [:new, :create, :show, :edit, :update]
     end
 
-    resources :funds, only: [], concerns: [:activity, :transactionable]
+    resources :funds, only: [], concerns: [:activity, :transactionable] do
+      resources :programmes, only: [:new, :create, :show]
+    end
     # TODO: Extend with more hierarchies using this format
     # resources :programmes, only: [], concerns: [:activity, :transactionable]
   end

--- a/db/migrate/20200115114151_create_programme.rb
+++ b/db/migrate/20200115114151_create_programme.rb
@@ -1,0 +1,10 @@
+class CreateProgramme < ActiveRecord::Migration[6.0]
+  def change
+    create_table :programmes, id: :uuid do |t|
+      t.string :name
+      t.references :organisation, type: :uuid
+      t.references :fund, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_17_160336) do
+ActiveRecord::Schema.define(version: 2020_01_15_114151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,16 @@ ActiveRecord::Schema.define(version: 2019_12_17_160336) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "programmes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.uuid "organisation_id"
+    t.uuid "fund_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["fund_id"], name: "index_programmes_on_fund_id"
+    t.index ["organisation_id"], name: "index_programmes_on_organisation_id"
+  end
+
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "reference"
     t.text "description"
@@ -71,11 +81,11 @@ ActiveRecord::Schema.define(version: 2019_12_17_160336) do
     t.decimal "value", precision: 13, scale: 2
     t.string "disbursement_channel"
     t.string "currency"
-    t.uuid "fund_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "provider_id"
     t.uuid "receiver_id"
+    t.uuid "fund_id"
     t.index ["fund_id"], name: "index_transactions_on_fund_id"
     t.index ["provider_id"], name: "index_transactions_on_provider_id"
     t.index ["receiver_id"], name: "index_transactions_on_receiver_id"

--- a/spec/factories/programme.rb
+++ b/spec/factories/programme.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :programme do
+    name { Faker::Company.name }
+    association :organisation
+    association :fund
+  end
+end

--- a/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
@@ -1,0 +1,48 @@
+RSpec.feature "Fund managers can create a programme" do
+  let(:organisation) { create(:organisation) }
+  let!(:fund) { create(:fund, name: "My fund", organisation: organisation) }
+
+  context "when the user is a fund manager" do
+    before { authenticate!(user: create(:fund_manager, organisations: [organisation])) }
+
+    context "when the user is not logged in" do
+      it "redirects the user to the root path" do
+        page.set_rack_session(userinfo: nil)
+        visit new_fund_programme_path(fund)
+        expect(current_path).to eq(root_path)
+      end
+    end
+
+    scenario "successfully create a programme" do
+      visit dashboard_path
+      click_link(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on("My fund")
+      click_on "Create programme"
+      fill_in "programme[name]", with: "My new programme"
+      click_on I18n.t("generic.button.submit")
+      expect(page).to have_content "My new programme"
+      expect(page).to have_content "My fund"
+      expect(page).to have_content organisation.name
+    end
+
+    scenario "can go back to the previous page" do
+      visit new_fund_programme_path(fund)
+
+      click_on I18n.t("generic.link.back")
+
+      expect(page).to have_current_path(organisation_fund_path(organisation, fund))
+    end
+  end
+
+  context "when the user is a delivery_partner" do
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+
+    scenario "shows the 'unauthorised' error message to the user" do
+      visit new_fund_programme_path(fund)
+
+      expect(page).to have_content(I18n.t("pundit.default"))
+      expect(page).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/features/staff/fund_managers_can_view_a_programme_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_a_programme_spec.rb
@@ -1,0 +1,55 @@
+RSpec.feature "Fund managers can view a programme" do
+  let(:organisation) { create(:organisation, name: "My organisation") }
+  let(:fund) { create(:fund, name: "My fund", organisation: organisation) }
+
+  context "when the user is not logged in" do
+    scenario "redirects the user to the root path" do
+      programme = create(:programme, fund: fund, organisation: organisation)
+
+      page.set_rack_session(userinfo: nil)
+      visit fund_programme_path(fund, programme)
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "when the user is a fund_manager" do
+    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+
+    scenario "allows the programme to be viewed" do
+      programme = create(:programme, fund: fund, organisation: organisation)
+
+      visit dashboard_path
+      click_link(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on(fund.name)
+      click_on(programme.name)
+
+      within "h1" do
+        expect(page).to have_content(programme.name)
+      end
+    end
+
+    scenario "can go back to the previous page" do
+      programme = create(:programme, fund: fund, organisation: organisation)
+
+      visit fund_programme_path(fund, programme)
+
+      click_on I18n.t("generic.link.back")
+
+      expect(page).to have_current_path(organisation_fund_path(organisation, fund))
+    end
+  end
+
+  context "when the user is a delivery_partner" do
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+
+    scenario "the programme cannot be viewed" do
+      programme = create(:programme, organisation: organisation, fund: fund)
+
+      visit fund_programme_path(fund, programme)
+
+      expect(page).to have_content(I18n.t("pundit.default"))
+      expect(page).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/models/fund_spec.rb
+++ b/spec/models/fund_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Fund, type: :model do
   describe "relations" do
     it { should belong_to(:organisation) }
     it { should have_one(:activity) }
+    it { should have_many(:programmes) }
   end
 end

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Programme do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe "relations" do
+    it { is_expected.to belong_to(:organisation) }
+    it { is_expected.to belong_to(:fund) }
+  end
+end

--- a/spec/policies/programme_policy_spec.rb
+++ b/spec/policies/programme_policy_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ProgrammePolicy do
+  subject { described_class.new(user, programme) }
+
+  let(:organisation) { create(:organisation) }
+  let(:fund) { create(:fund, organisation: organisation) }
+  let(:programme) { create(:programme, fund: fund) }
+
+  context "as an administrator" do
+    let(:user) { build_stubbed(:administrator) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_action(:destroy) }
+  end
+
+  context "as a fund_manager" do
+    let(:user) { build_stubbed(:fund_manager) }
+    let(:resolved_scope) do
+      described_class::Scope.new(user, Programme.all).resolve
+    end
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "includes fund in resolved scope" do
+      expect(resolved_scope).to include(programme)
+    end
+  end
+
+  context "as a delivery_partner" do
+    let(:user) { build_stubbed(:delivery_partner) }
+    let(:resolved_scope) do
+      described_class::Scope.new(user, Programme.none).resolve
+    end
+
+    it { is_expected.to forbid_action(:index) }
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/s1HLTajb/201-fund-managers-can-create-a-basic-programme

Fund managers can create a basic Programme with a name and Fund & Organisation associations.

The list of Programmes is shown on the Fund page.

## Screenshots of UI changes

<img width="1011" alt="Screenshot 2020-01-15 at 16 51 50" src="https://user-images.githubusercontent.com/1089521/72453674-65855080-37b7-11ea-8e7b-fe3938ff77a0.png">

<img width="1081" alt="Screenshot 2020-01-15 at 16 51 58" src="https://user-images.githubusercontent.com/1089521/72453681-6918d780-37b7-11ea-897e-2e3a65c84c2f.png">

<img width="1068" alt="Screenshot 2020-01-15 at 16 52 10" src="https://user-images.githubusercontent.com/1089521/72453688-6c13c800-37b7-11ea-854b-b014f9f5bd46.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
