### PR TITLE
Fix/215 users belong to one organisation only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Fund managers can create basic programmes
 - Provide a way to flag an organisation as BEIS
 - User email addresses must be valid emails
+- Users are only associated with one organisation

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -21,7 +21,7 @@ class Staff::UsersController < Staff::BaseController
     @organisations = policy_scope(Organisation)
 
     if @user.valid?
-      result = CreateUser.new(user: @user, organisations: organisations).call
+      result = CreateUser.new(user: @user, organisation: organisation).call
       if result.success?
         flash.now[:notice] = I18n.t("form.user.create.success")
         redirect_to user_path(@user.reload.id)
@@ -48,7 +48,7 @@ class Staff::UsersController < Staff::BaseController
     @user.assign_attributes(user_params)
 
     if @user.valid?
-      result = UpdateUser.new(user: @user, organisations: organisations).call
+      result = UpdateUser.new(user: @user, organisation: organisation).call
 
       if result.success?
         flash.now[:notice] = I18n.t("form.user.update.success")
@@ -63,18 +63,18 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :role, organisation_ids: [])
+    params.require(:user).permit(:name, :email, :role, :organisation_id)
   end
 
   def id
     params[:id]
   end
 
-  def organisation_ids
-    user_params[:organisation_ids]
+  def organisation_id
+    user_params[:organisation_id]
   end
 
-  def organisations
-    Organisation.where(id: organisation_ids)
+  def organisation
+    Organisation.find(organisation_id)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,5 @@
 class Organisation < ApplicationRecord
-  has_and_belongs_to_many :users
+  has_many :users
   has_many :funds
 
   validates_presence_of :name, :organisation_type, :language_code, :default_currency

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_and_belongs_to_many :organisations
+  belongs_to :organisation, optional: true
   validates_presence_of :name, :email
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  belongs_to :organisation, optional: true
+  belongs_to :organisation
   validates_presence_of :name, :email
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 
@@ -10,6 +10,10 @@ class User < ApplicationRecord
   }
 
   attribute :role, :string, default: "delivery_partner"
+
+  FORM_FIELD_TRANSLATIONS = {
+    organisation_id: :organisation,
+  }.freeze
 
   def role_name
     I18n.t("activerecord.attributes.user.roles.#{role}")

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -32,8 +32,7 @@ class ActivityPolicy < ApplicationPolicy
       if user.administrator?
         scope.all
       else
-        organisations = user.organisation_ids
-        funds = Fund.where(organisation_id: organisations)
+        funds = Fund.where(organisation_id: user.organisation)
         scope.where(hierarchy: funds)
       end
     end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -20,7 +20,7 @@ class OrganisationPolicy < ApplicationPolicy
   end
 
   private def associated_user?
-    user.organisations.include?(record)
+    user.organisation.eql?(record)
   end
 
   class Scope < Scope
@@ -28,7 +28,7 @@ class OrganisationPolicy < ApplicationPolicy
       if user.administrator? || user.fund_manager?
         scope.all
       else
-        scope.where(id: user.organisation_ids)
+        scope.where(id: user.organisation_id)
       end
     end
   end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -32,8 +32,7 @@ class TransactionPolicy < ApplicationPolicy
       if user.administrator?
         scope.all
       else
-        organisations = user.organisation_ids
-        funds = Fund.where(organisation_id: organisations)
+        funds = Fund.where(organisation_id: user.organisation)
         scope.where(fund_id: funds)
       end
     end

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -1,16 +1,16 @@
 class CreateUser
-  attr_accessor :user, :organisations
+  attr_accessor :user, :organisation
 
-  def initialize(user:, organisations: [])
+  def initialize(user:, organisation:)
     self.user = user
-    self.organisations = organisations
+    self.organisation = organisation
   end
 
   def call
     result = Result.new(true)
 
     User.transaction do
-      user.organisations = organisations
+      user.organisation = organisation
       user.save
       begin
         CreateUserInAuth0.new(user: user).call

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,16 +1,16 @@
 class UpdateUser
-  attr_accessor :user, :organisations
+  attr_accessor :user, :organisation
 
-  def initialize(user:, organisations: [])
+  def initialize(user:, organisation: [])
     self.user = user
-    self.organisations = organisations
+    self.organisation = organisation
   end
 
   def call
     result = Result.new(true)
 
     User.transaction do
-      user.organisations = organisations
+      user.organisation = organisation
 
       begin
         UpdateUserInAuth0.new(user: user).call

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -10,11 +10,12 @@
       legend: { tag: :h2 }
 
   - if @organisations.any?
-    = f.govuk_collection_check_boxes :organisation_ids,
+    = f.govuk_collection_radio_buttons :organisation_id,
         @organisations,
         :id,
         :name,
-        legend: { tag: :h2 }
+        legend: { tag: :h2 , text: t('form.user.organisation.label')},
+        hint_text: t("form.user.organisation.hint")
   - else
     .govuk-inset-text
       = succeed "." do

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -28,11 +28,11 @@
             = @user.role_name
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
+            = t("user.organisation")
+          %dd.govuk-summary-list__value
+            = @user.organisation.name
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
             = t("user.identifier")
           %dd.govuk-summary-list__value
             = @user.identifier
-    .govuk-grid-column-one-third.organisations
-      %h2.govuk-heading-m Organisations
-      %ul.govuk-list.govuk-list--bullet
-        - @user.organisations.each do |organisation|
-          %li= organisation.name

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -81,5 +81,21 @@ module GOVUKDesignSystemFormBuilder
         end
       end
     end
+
+    module Radios
+      class CollectionRadioButton < GOVUKDesignSystemFormBuilder::Base
+        def field_id(link_errors: false)
+          if link_errors && has_errors?
+            build_id(
+              "field-error",
+              include_value: false,
+              attribute_name: translated_attribute_name(attribute_name: @attribute_name)
+            )
+          else
+            build_id("field")
+          end
+        end
+      end
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,9 @@ en:
       create:
         failed: The service is experiencing issues creating new users and the team has been alerted to the problem.
         success: User successfully created
+      organisation:
+        hint: What organisation does this user belong to?
+        label: Choose an organisation
       submit: Submit
       update:
         failed: The service is experiencing issues updating users and the team has been alerted to the problem.
@@ -233,4 +236,5 @@ en:
     email: Email address
     identifier: Auth0 identifier
     name: Full name
+    organisation: Organisation
     role: Role

--- a/db/migrate/20200115142955_add_organisation_to_user_directly_rather_than_join.rb
+++ b/db/migrate/20200115142955_add_organisation_to_user_directly_rather_than_join.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToUserDirectlyRatherThanJoin < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :organisation, index: true, type: :uuid
+  end
+end

--- a/db/migrate/20200116162341_remove_unused_organisation_user_join_table.rb
+++ b/db/migrate/20200116162341_remove_unused_organisation_user_join_table.rb
@@ -1,0 +1,5 @@
+class RemoveUnusedOrganisationUserJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :organisations_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,7 +99,9 @@ ActiveRecord::Schema.define(version: 2020_01_16_172705) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "role"
+    t.uuid "organisation_id"
     t.index ["identifier"], name: "index_users_on_identifier"
+    t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["role"], name: "index_users_on_role"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,13 +57,6 @@ ActiveRecord::Schema.define(version: 2020_01_16_172705) do
     t.boolean "service_owner", default: false
   end
 
-  create_table "organisations_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.uuid "organisation_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "programmes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "organisation_id"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     email { Faker::Internet.email }
     role { :delivery_partner }
 
+    organisation
+
     factory :administrator do
       role { :administrator }
     end

--- a/spec/features/staff/fund_managers_can_create_a_fund_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_fund_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Fund managers can create a fund" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: create(:fund_manager, organisation: nil)) }
+    before { authenticate!(user: create(:fund_manager)) }
 
     scenario "successfully create a fund" do
       visit dashboard_path

--- a/spec/features/staff/fund_managers_can_create_a_fund_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_fund_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Fund managers can create a fund" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: create(:fund_manager, organisations: [])) }
+    before { authenticate!(user: create(:fund_manager, organisation: nil)) }
 
     scenario "successfully create a fund" do
       visit dashboard_path
@@ -45,7 +45,7 @@ RSpec.feature "Fund managers can create a fund" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     scenario "hides the 'Create fund' button" do
       visit dashboard_path

--- a/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature "Fund managers can create a programme" do
   let!(:fund) { create(:fund, name: "My fund", organisation: organisation) }
 
   context "when the user is a fund manager" do
-    before { authenticate!(user: create(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
 
     context "when the user is not logged in" do
       it "redirects the user to the root path" do
@@ -36,7 +36,7 @@ RSpec.feature "Fund managers can create a programme" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     scenario "shows the 'unauthorised' error message to the user" do
       visit new_fund_programme_path(fund)

--- a/spec/features/staff/fund_managers_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_an_organisation_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature "Fund managers can create organisations" do
     end
   end
 
-  context "when the user does not belong to an organisation" do
-    let(:user) { create(:delivery_partner, organisation: nil) }
+  context "when the user is a delivery_partner" do
+    let(:user) { create(:delivery_partner) }
 
     before do
       authenticate!(user: user)

--- a/spec/features/staff/fund_managers_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_an_organisation_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Fund managers can create organisations" do
   end
 
   context "when the user does not belong to an organisation" do
-    let(:user) { create(:delivery_partner, organisations: []) }
+    let(:user) { create(:delivery_partner, organisation: nil) }
 
     before do
       authenticate!(user: user)

--- a/spec/features/staff/fund_managers_can_edit_a_fund_spec.rb
+++ b/spec/features/staff/fund_managers_can_edit_a_fund_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Fund managers can edit a fund" do
 
   context "when the user is a fund_manager" do
     before do
-      authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation]))
+      authenticate!(user: build_stubbed(:fund_manager, organisation: organisation))
     end
 
     context "when no associated fund activity exists" do
@@ -59,7 +59,7 @@ RSpec.feature "Fund managers can edit a fund" do
 
   context "when the user is a delivery_partner" do
     before do
-      authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation))
     end
 
     scenario "the user cannot edit the fund" do

--- a/spec/features/staff/fund_managers_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/fund_managers_can_edit_an_organisation_spec.rb
@@ -35,14 +35,14 @@ RSpec.feature "Fund managers can edit organisations" do
 
   context "when the user is a delivery partner" do
     scenario "successfully editing an organisation" do
-      authenticate!(user: create(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: create(:delivery_partner, organisation: organisation))
 
       successfully_edit_an_organisation
     end
 
     context "and does not belong to the organisation" do
       scenario "cannot visit that organisations page" do
-        authenticate!(user: create(:delivery_partner, organisations: []))
+        authenticate!(user: create(:delivery_partner, organisation: nil))
 
         visit dashboard_path
 
@@ -51,7 +51,7 @@ RSpec.feature "Fund managers can edit organisations" do
       end
 
       scenario "shows the 'unauthorised' error message to the user" do
-        authenticate!(user: create(:delivery_partner, organisations: []))
+        authenticate!(user: create(:delivery_partner, organisation: nil))
 
         visit edit_organisation_path(organisation)
 

--- a/spec/features/staff/fund_managers_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/fund_managers_can_edit_an_organisation_spec.rb
@@ -42,18 +42,24 @@ RSpec.feature "Fund managers can edit organisations" do
 
     context "and does not belong to the organisation" do
       scenario "cannot visit that organisations page" do
-        authenticate!(user: create(:delivery_partner, organisation: nil))
+        first_organisation = create(:organisation)
+        second_organisation = create(:organisation)
+        authenticate!(user: create(:delivery_partner, organisation: first_organisation))
 
         visit dashboard_path
 
         click_link I18n.t("page_content.dashboard.button.manage_organisations")
-        expect(page).to have_no_content(organisation.name)
+        expect(page).to have_content(first_organisation.name)
+        expect(page).to have_no_content(second_organisation.name)
       end
 
       scenario "shows the 'unauthorised' error message to the user" do
-        authenticate!(user: create(:delivery_partner, organisation: nil))
+        first_organisation = create(:organisation)
+        second_organisation = create(:organisation)
 
-        visit edit_organisation_path(organisation)
+        authenticate!(user: create(:delivery_partner, organisation: first_organisation))
+
+        visit edit_organisation_path(second_organisation)
 
         expect(page).to have_content(I18n.t("pundit.default"))
         expect(page).to have_http_status(:unauthorized)

--- a/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
+++ b/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
@@ -44,16 +44,13 @@ RSpec.feature "Fund managers can invite new users to the service" do
       expect(page).to have_content(I18n.t("page_title.users.new"))
       fill_in "user[name]", with: new_user_name
       fill_in "user[email]", with: new_user_email
-      check first_organisation.name
-      check second_organisation.name
+      choose first_organisation.name
 
       # Submit the form
       click_button I18n.t("generic.button.submit")
 
-      within(".organisations") do
-        expect(page).to have_content(first_organisation.name)
-        expect(page).to have_content(second_organisation.name)
-      end
+      expect(page).to have_content(first_organisation.name)
+      expect(page).not_to have_content(second_organisation.name)
     end
 
     context "when the name and email are not provided" do
@@ -77,12 +74,14 @@ RSpec.feature "Fund managers can invite new users to the service" do
           stub_auth0_token_request
           new_email = "email@example.com"
           stub_auth0_create_user_request_failure(email: new_email)
+          organisation = create(:organisation)
 
           visit new_user_path
 
           expect(page).to have_content(I18n.t("page_title.users.new"))
           fill_in "user[name]", with: "foo"
           fill_in "user[email]", with: new_email
+          choose organisation.name
 
           click_button I18n.t("generic.button.submit")
 
@@ -95,10 +94,13 @@ RSpec.feature "Fund managers can invite new users to the service" do
         it "does not create the user and displays an invalid email message" do
           new_email = "tom"
           stub_auth0_create_user_request_failure(email: new_email)
+          organisation = create(:organisation)
 
           visit new_user_path
           fill_in "user[name]", with: "tom"
           fill_in "user[email]", with: "tom"
+          choose organisation.name
+          
           click_button I18n.t("generic.button.submit")
 
           expect(page).to have_content("Email is invalid")

--- a/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
+++ b/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Fund managers can invite new users to the service" do
           fill_in "user[name]", with: "tom"
           fill_in "user[email]", with: "tom"
           choose organisation.name
-          
+
           click_button I18n.t("generic.button.submit")
 
           expect(page).to have_content("Email is invalid")

--- a/spec/features/staff/fund_managers_can_view_a_fund_as_xml_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_a_fund_as_xml_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Fund managers can view a fund as XML" do
       fund = create(:fund, organisation: organisation)
       activity = create(:activity, hierarchy: fund)
       transaction = create(:transaction, fund: fund)
-      authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation]))
+      authenticate!(user: build_stubbed(:fund_manager, organisation: organisation))
 
       visit organisation_fund_path(organisation, fund, format: :xml)
 

--- a/spec/features/staff/fund_managers_can_view_a_fund_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_a_fund_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Fund managers can view a fund" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "allows the fund to be viewed" do
       existing_fund = create(:fund, organisation: organisation)
@@ -32,7 +32,7 @@ RSpec.feature "Fund managers can view a fund" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     scenario "the fund cannot be viewed" do
       existing_fund = create(:fund, organisation: organisation)

--- a/spec/features/staff/fund_managers_can_view_a_programme_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_a_programme_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Fund managers can view a programme" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "allows the programme to be viewed" do
       programme = create(:programme, fund: fund, organisation: organisation)
@@ -41,7 +41,7 @@ RSpec.feature "Fund managers can view a programme" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     scenario "the programme cannot be viewed" do
       programme = create(:programme, organisation: organisation, fund: fund)

--- a/spec/features/staff/fund_managers_can_view_funds_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_funds_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Fund managers can view funds on an organisation page" do
 
   context "when the user is a fund_manager" do
     before do
-      authenticate!(user: create(:fund_manager, organisation: nil))
+      authenticate!(user: create(:fund_manager))
     end
 
     scenario "the user will see them on the organisation show page" do

--- a/spec/features/staff/fund_managers_can_view_funds_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_funds_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Fund managers can view funds on an organisation page" do
 
   context "when the user is a fund_manager" do
     before do
-      authenticate!(user: create(:fund_manager, organisations: []))
+      authenticate!(user: create(:fund_manager, organisation: nil))
     end
 
     scenario "the user will see them on the organisation show page" do
@@ -35,7 +35,7 @@ RSpec.feature "Fund managers can view funds on an organisation page" do
 
   context "when the user is a delivery_partner" do
     before do
-      authenticate!(user: create(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: create(:delivery_partner, organisation: organisation))
     end
 
     scenario "the user will not see them on the show page for their organisation" do

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can create a transaction" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "successfully creates a transaction on a fund" do
       fund = create(:fund, organisation: organisation)
@@ -195,7 +195,7 @@ RSpec.feature "Users can create a transaction" do
     # for projects and programmes etc, we will want to test that users who are
     # deliver partners can create transactions for project activities too.
     context "when the user is a delivery_partner" do
-      before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+      before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
       scenario "cannot create an transaction that belongs to a fund activity" do
         fund = create(:fund, organisation: organisation)

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can create an activity" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "successfully creates a fund activity with all optional information" do
       fund = create(:fund, organisation: organisation)
@@ -140,7 +140,7 @@ RSpec.feature "Users can create an activity" do
   # These journeys will start off the same but may eventually diverge with different
   # default form values etc. Bear this in mind when thinking about reuse.
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     # Create and Edit flows use the same URL, protecting it tests both
     # 'create?' and 'update?' actions in the ActivityPolicy

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can edit a transaction" do
   let(:organisation) { create(:organisation) }
   let!(:fund) { create(:fund, organisation: organisation) }
   let!(:transaction) { create(:transaction, fund: fund) }
-  let(:user) { create(:administrator, organisations: [organisation]) }
+  let(:user) { create(:administrator, organisation: organisation) }
 
   context "when the user is not logged in" do
     it "redirects the user to the root path" do

--- a/spec/features/staff/users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/users_can_edit_a_user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Editing a user" do
-  let!(:user) { create(:delivery_partner) }
+  let!(:user) { create(:delivery_partner, organisation: create(:organisation)) }
 
   before do
     stub_auth0_token_request

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Users can edit an activity" do
   let(:organisation) { create(:organisation, name: "UKSA") }
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "clicking edit starts the ActivityForm journey from that step" do
       fund = create(:fund, organisation: organisation)

--- a/spec/features/staff/users_can_view_a_transaction_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_a_transaction_as_xml_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can view a transaction as XML" do
   let(:fund) { create(:fund, organisation: organisation) }
   let!(:activity) { create(:activity, hierarchy: fund) }
   let(:transaction) { create(:transaction, fund: fund) }
-  let(:user) { create(:administrator, organisations: [organisation]) }
+  let(:user) { create(:administrator, organisation: organisation) }
 
   context "when the user is not logged in" do
     it "redirects the user to the root path" do

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can view activities (on a fund page)" do
 
   let(:organisation) { create(:organisation) }
   let(:fund) { create(:fund, organisation: organisation) }
-  let(:user) { create(:administrator, organisations: [organisation]) }
+  let(:user) { create(:administrator, organisation: organisation) }
 
   context "when the user is not logged in" do
     it "redirects the user to the root path" do

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can download an activity as XML" do
       planned_start_date: Date.today,
       planned_end_date: Date.tomorrow)
   end
-  let(:user) { create(:administrator, organisations: [organisation]) }
+  let(:user) { create(:administrator, organisation: organisation) }
 
   context "when the user is not logged in" do
     it "redirects the user to the root path" do

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can view an activity" do
   end
 
   context "when the user is a fund_manager" do
-    before { authenticate!(user: build_stubbed(:fund_manager, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
     scenario "a fund activity can be viewed" do
       activity = create(:activity, hierarchy: fund)
@@ -50,7 +50,7 @@ RSpec.feature "Users can view an activity" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisations: [organisation])) }
+    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
 
     scenario "the user cannot view the fund activity" do
       visit organisation_fund_path(organisation, fund)

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Users can view an organisation" do
   context "when the user is a delivery_partner that belongs to that organisation" do
     scenario "can see the organisation page" do
       organisation = create(:organisation)
-      authenticate!(user: create(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: create(:delivery_partner, organisation: organisation))
 
       visit dashboard_path
       click_link I18n.t("page_content.dashboard.button.manage_organisations")

--- a/spec/features/staff/users_can_view_organisations_spec.rb
+++ b/spec/features/staff/users_can_view_organisations_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can view organisations" do
   context "when the user is a fund manager" do
     scenario "organisation index page" do
       organisation = create(:organisation)
-      authenticate!(user: create(:fund_manager, organisations: []))
+      authenticate!(user: create(:fund_manager, organisation: nil))
 
       visit organisations_path
 
@@ -19,7 +19,7 @@ RSpec.feature "Users can view organisations" do
     end
 
     scenario "can go back to the previous page" do
-      authenticate!(user: create(:fund_manager, organisations: []))
+      authenticate!(user: create(:fund_manager, organisation: nil))
 
       visit organisations_path
 
@@ -32,7 +32,7 @@ RSpec.feature "Users can view organisations" do
   context "when the user is a delivery partner" do
     scenario "organisation index page" do
       organisation = create(:organisation)
-      authenticate!(user: create(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: create(:delivery_partner, organisation: organisation))
 
       visit organisations_path
 
@@ -42,7 +42,7 @@ RSpec.feature "Users can view organisations" do
 
     scenario "can go back to the previous page" do
       organisation = create(:organisation)
-      authenticate!(user: create(:delivery_partner, organisations: [organisation]))
+      authenticate!(user: create(:delivery_partner, organisation: organisation))
 
       visit organisations_path
 
@@ -54,7 +54,7 @@ RSpec.feature "Users can view organisations" do
     context "when the delivery partner is not associated with the organisation" do
       scenario "cannot see the organisation" do
         organisation = create(:organisation)
-        authenticate!(user: create(:delivery_partner, organisations: []))
+        authenticate!(user: create(:delivery_partner, organisation: nil))
 
         visit organisations_path
 

--- a/spec/features/staff/users_can_view_organisations_spec.rb
+++ b/spec/features/staff/users_can_view_organisations_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can view organisations" do
   context "when the user is a fund manager" do
     scenario "organisation index page" do
       organisation = create(:organisation)
-      authenticate!(user: create(:fund_manager, organisation: nil))
+      authenticate!(user: create(:fund_manager))
 
       visit organisations_path
 
@@ -19,7 +19,7 @@ RSpec.feature "Users can view organisations" do
     end
 
     scenario "can go back to the previous page" do
-      authenticate!(user: create(:fund_manager, organisation: nil))
+      authenticate!(user: create(:fund_manager))
 
       visit organisations_path
 
@@ -51,15 +51,17 @@ RSpec.feature "Users can view organisations" do
       expect(page).to have_current_path(dashboard_path)
     end
 
-    context "when the delivery partner is not associated with the organisation" do
+    context "when the user is a delivery partner" do
       scenario "cannot see the organisation" do
-        organisation = create(:organisation)
-        authenticate!(user: create(:delivery_partner, organisation: nil))
+        organisation_they_belong_to = create(:organisation)
+        another_organisation = create(:organisation)
+        authenticate!(user: create(:delivery_partner, organisation: organisation_they_belong_to))
 
         visit organisations_path
 
         expect(page).to have_content(I18n.t("page_title.organisation.index"))
-        expect(page).not_to have_content organisation.name
+        expect(page).to have_content organisation_they_belong_to.name
+        expect(page).not_to have_content another_organisation.name
       end
     end
   end

--- a/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_fund_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Users can view funds on an organisation page" do
   end
 
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:administrator, organisations: [organisation]) }
+  let(:user) { create(:administrator, organisation: organisation) }
   let(:fund) { create(:fund, organisation: organisation) }
   let(:other_fund) { create(:fund, organisation: organisation) }
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Organisation, type: :model do
   end
 
   describe "associations" do
-    it { should have_and_belong_to_many(:users) }
+    it { should have_many(:users) }
   end
 
   describe "service_owner?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
-  # This also validates that the relationship is present
-  it { is_expected.to belong_to(:organisation).optional(true) }
+    # This also validates that the relationship is present
+    it { is_expected.to belong_to(:organisation) }
   end
 
   describe "#role_name" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
-    it { should have_and_belong_to_many(:organisations) }
+  # This also validates that the relationship is present
+  it { is_expected.to belong_to(:organisation).optional(true) }
   end
 
   describe "#role_name" do

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActivityPolicy do
     end
 
     context "as a fund_manager" do
-      let(:user) { build_stubbed(:fund_manager, organisations: [organisation]) }
+      let(:user) { build_stubbed(:fund_manager, organisation: organisation) }
 
       it { is_expected.to permit_action(:index) }
       it { is_expected.to permit_action(:show) }

--- a/spec/policies/fund_policy_spec.rb
+++ b/spec/policies/fund_policy_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FundPolicy do
     it { is_expected.to forbid_action(:destroy) }
 
     context "with funds from my own organisation" do
-      let(:user) { create(:delivery_partner, organisations: [organisation]) }
+      let(:user) { create(:delivery_partner, organisation: organisation) }
 
       it "does not include fund in resolved scope" do
         expect(resolved_scope).not_to include(fund)

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OrganisationPolicy do
 
     context "that belongs to that organisation" do
       let(:user) do
-        build_stubbed(:delivery_partner, organisations: [organisation])
+        build_stubbed(:delivery_partner, organisation: organisation)
       end
 
       it { is_expected.to permit_action(:index) }

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TransactionPolicy do
     end
 
     context "as a fund_manager" do
-      let(:user) { build_stubbed(:fund_manager, organisations: [organisation]) }
+      let(:user) { build_stubbed(:fund_manager, organisation: organisation) }
 
       it { is_expected.to permit_action(:index) }
       it { is_expected.to permit_action(:show) }

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe UpdateUser do
       end
 
       it "does not save the user" do
-        expect do
+        expect {
           described_class.new(user: user, organisation: build_stubbed(:organisation)).call
-        end.to_not change { user.reload }
+        }.to_not change { user.reload }
       end
 
       it "logs a failure message" do


### PR DESCRIPTION
## Changes in this PR

- when creating a user you can now only associate it with one organisation
- previously a user could be creating without any organisation, now it is required
- error messages for radio buttons with our form builder proved to be tricky, as it was with select boxes. It's not perfect but hopefully it's good enough for now. See commit for more details.
- remove the now unused join table

## Screenshots of UI changes

### Before

![Screenshot 2020-01-16 at 16 27 32](https://user-images.githubusercontent.com/912473/72543079-1d306600-387d-11ea-840e-24f677bc13d7.png)

### After

![Screenshot 2020-01-16 at 16 13 54](https://user-images.githubusercontent.com/912473/72542977-e9edd700-387c-11ea-9a47-421db472aaef.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
