### PR TITLE
Fund managers can create a programme activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Provide a way to flag an organisation as BEIS
 - User email addresses must be valid emails
 - Users are only associated with one organisation
+- Fund managers can add Activity information to a Programme

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -36,8 +36,17 @@ class Staff::ActivitiesController < Staff::BaseController
     params[:fund_id]
   end
 
+  def programme_id
+    params[:programme_id]
+  end
+
   def hierarchy
-    # TODO: Add support for new hierarchies here and/or move to a service
-    @hierarchy = authorize Fund.find(fund_id)
+    # TODO: This will eventually become unsustainable,
+    # we need a better way
+    if fund_id
+      @hierarchy = authorize Fund.find(fund_id)
+    elsif programme_id
+      @hierarchy = authorize Programme.find(programme_id)
+    end
   end
 end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -1,6 +1,24 @@
 module ActivityHelper
   def hierarchy_path_for(activity:)
-    url_for([activity.hierarchy.organisation, activity.hierarchy])
+    # TODO there must be a better way
+    # organisation_fund_path when hierarchy is a fund
+    # fund_programme_path when hierarchy is a programme
+    case activity.hierarchy.class.name
+    when "Fund"
+      url_for([activity.hierarchy.organisation, activity.hierarchy])
+    when "Programme"
+      url_for([activity.hierarchy.fund, activity.hierarchy])
+    end
+  end
+
+  def edit_hierarchy_path_for(activity:)
+    # TODO there must be a better way
+    case activity.hierarchy.class.name
+    when "Fund"
+      url_for([:edit, activity.hierarchy.organisation, activity.hierarchy])
+    when "Programme"
+      url_for([:edit, activity.hierarchy.fund, activity.hierarchy])
+    end
   end
 
   def activity_path_for(activity:)

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -3,4 +3,6 @@ class Programme < ApplicationRecord
 
   belongs_to :organisation
   belongs_to :fund
+
+  has_one :activity, as: :hierarchy
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -4,27 +4,23 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def show?
-    user.administrator? ||
-      fund? && user.fund_manager?
+    user.administrator? || (user.fund_manager? && hierarchy?)
   end
 
   def create?
-    user.administrator? ||
-      fund? && user.fund_manager?
+    user.administrator? || (user.fund_manager? && hierarchy?)
   end
 
   def update?
-    user.administrator? ||
-      fund? && user.fund_manager?
+    user.administrator? || (user.fund_manager? && hierarchy?)
   end
 
   def destroy?
-    user.administrator? ||
-      fund? && user.fund_manager?
+    user.administrator? || (user.fund_manager? && hierarchy?)
   end
 
-  private def fund?
-    record.hierarchy.is_a?(Fund)
+  private def hierarchy?
+    record.hierarchy.is_a?(Programme) || record.hierarchy.is_a?(Fund)
   end
 
   class Scope < Scope
@@ -32,8 +28,11 @@ class ActivityPolicy < ApplicationPolicy
       if user.administrator?
         scope.all
       else
+        # TODO: This will eventually become unsustainable,
+        # we need a better way to do this
         funds = Fund.where(organisation_id: user.organisation)
-        scope.where(hierarchy: funds)
+        programmes = Programme.where(fund_id: funds)
+        scope.where(hierarchy: [funds + programmes])
       end
     end
   end

--- a/app/views/staff/programmes/show.html.haml
+++ b/app/views/staff/programmes/show.html.haml
@@ -9,14 +9,19 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %dl.govuk-summary-list
-        .govuk-summary-list__row.organisation_name
-          %dt.govuk-summary-list__key
-            = t("page_content.programmes.organisation_name.label")
-          %dd.govuk-summary-list__value
-            = @programme.organisation.name
-        .govuk-summary-list__row.fund_name
-          %dt.govuk-summary-list__key
-            = t("page_content.programmes.fund_name.label")
-          %dd.govuk-summary-list__value
-            = @programme.fund.name
+      - if @programme.activity
+        = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@programme.activity) }
+      - else
+        %dl.govuk-summary-list
+          .govuk-summary-list__row.organisation_name
+            %dt.govuk-summary-list__key
+              = t("page_content.programmes.organisation_name.label")
+            %dd.govuk-summary-list__value
+              = @programme.organisation.name
+          .govuk-summary-list__row.fund_name
+            %dt.govuk-summary-list__key
+              = t("page_content.programmes.fund_name.label")
+            %dd.govuk-summary-list__value
+              = @programme.fund.name
+        = form_tag(programme_activities_path(@programme), method: "post") do
+          = submit_tag t("page_content.fund.button.create_activity", activity: "programme"), class: "govuk-button"

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -5,7 +5,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.hierarchy.name
     %dd.govuk-summary-list__actions
-      = link_to t("generic.link.edit"), [:edit, activity_presenter.hierarchy.organisation, activity_presenter.hierarchy], class: "govuk-link"
+      = link_to t("generic.link.edit"), edit_hierarchy_path_for(activity: activity_presenter), class: "govuk-link"
 
   .govuk-summary-list__row
     %dt.govuk-summary-list__key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,10 +24,12 @@ Rails.application.routes.draw do
     end
 
     resources :funds, only: [], concerns: [:activity, :transactionable] do
-      resources :programmes, only: [:new, :create, :show]
+      resources :programmes, except: [:destroy]
     end
+    
     # TODO: Extend with more hierarchies using this format
     # resources :programmes, only: [], concerns: [:activity, :transactionable]
+    resources :programmes, only: [], concerns: [:activity, :transactionable]
   end
 
   # Authentication

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     resources :funds, only: [], concerns: [:activity, :transactionable] do
       resources :programmes, except: [:destroy]
     end
-    
+
     # TODO: Extend with more hierarchies using this format
     # resources :programmes, only: [], concerns: [:activity, :transactionable]
     resources :programmes, only: [], concerns: [:activity, :transactionable]

--- a/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_spec.rb
@@ -26,6 +26,17 @@ RSpec.feature "Fund managers can create a programme" do
       expect(page).to have_content organisation.name
     end
 
+    scenario "shows validation errors on the page" do
+      visit dashboard_path
+      click_link(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on("My fund")
+      click_on "Create programme"
+
+      click_on I18n.t("generic.button.submit")
+      expect(page).to have_content "can't be blank"
+    end
+
     scenario "can go back to the previous page" do
       visit new_fund_programme_path(fund)
 

--- a/spec/features/staff/users_can_create_an_activity_spec.rb
+++ b/spec/features/staff/users_can_create_an_activity_spec.rb
@@ -14,125 +14,155 @@ RSpec.feature "Users can create an activity" do
   context "when the user is a fund_manager" do
     before { authenticate!(user: build_stubbed(:fund_manager, organisation: organisation)) }
 
-    scenario "successfully creates a fund activity with all optional information" do
-      fund = create(:fund, organisation: organisation)
+    context "when the activity's hierarchy is a fund" do
+      scenario "successfully creates a fund activity with all optional information" do
+        fund = create(:fund, organisation: organisation)
 
-      visit dashboard_path
-      click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
-      click_on(organisation.name)
-      click_on(fund.name)
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
 
-      click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
+        click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
 
-      fill_in_activity_form
-    end
+        fill_in_activity_form
+      end
 
-    scenario "the activity form has some defaults for funds" do
-      fund = create(:fund, organisation: organisation)
-      visit organisation_fund_path(organisation, fund)
+      scenario "the activity form has some defaults for funds" do
+        fund = create(:fund, organisation: organisation)
+        visit organisation_fund_path(organisation, fund)
 
-      click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
-      activity = Activity.last
+        click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
+        activity = Activity.last
 
-      visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :country)
-      expect(page.find("option[@selected = 'selected']").text).to eq("Developing countries, unspecified")
+        visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :country)
+        expect(page.find("option[@selected = 'selected']").text).to eq("Developing countries, unspecified")
 
-      visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :flow)
-      expect(page.find("option[@selected = 'selected']").text).to eq("ODA")
+        visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :flow)
+        expect(page.find("option[@selected = 'selected']").text).to eq("ODA")
 
-      visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :tied_status)
-      expect(page.find("option[@selected = 'selected']").text).to eq("Untied")
-    end
+        visit fund_activity_steps_path(fund_id: fund, activity_id: activity, id: :tied_status)
+        expect(page.find("option[@selected = 'selected']").text).to eq("Untied")
+      end
 
-    context "validations" do
-      scenario "validation errors work as expected" do
+      context "validations" do
+        scenario "validation errors work as expected" do
+          fund = create(:fund, organisation: organisation)
+          visit organisation_fund_path(organisation, fund)
+          click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
+
+          # Don't provide an identifier
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "can't be blank"
+
+          fill_in "activity[identifier]", with: "foo"
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
+
+          # Don't provide a title and description
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "Title can't be blank"
+          expect(page).to have_content "Description can't be blank"
+
+          fill_in "activity[title]", with: Faker::Lorem.word
+          fill_in "activity[description]", with: Faker::Lorem.paragraph
+          click_button I18n.t("form.activity.submit")
+
+          expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
+
+          # Don't provide a sector
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "Sector can't be blank"
+
+          select "Education policy and administrative management", from: "activity[sector]"
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content I18n.t("page_title.activity_form.show.status")
+
+          # Don't provide a status
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "Status can't be blank"
+
+          select "Implementation", from: "activity[status]"
+          click_button I18n.t("form.activity.submit")
+
+          expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+
+          # Dates are not mandatory so we can move through this step
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+
+          # Region has a default and can't be set to blank so we skip
+          select "Developing countries, unspecified", from: "activity[recipient_region]"
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+
+          # Flow has a default and can't be set to blank so we skip
+          select "ODA", from: "activity[flow]"
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
+
+          # Don't select a finance
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "Finance can't be blank"
+
+          select "Standard grant", from: "activity[finance]"
+          click_button I18n.t("form.activity.submit")
+
+          expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
+
+          # Don't select an aid type
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content "Aid type can't be blank"
+
+          select "General budget support", from: "activity[aid_type]"
+          click_button I18n.t("form.activity.submit")
+
+          expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
+
+          # Tied status has a default and can't be set to blank so we skip
+          select "Untied", from: "activity[tied_status]"
+          click_button I18n.t("form.activity.submit")
+          expect(page).to have_content fund.name
+        end
+      end
+
+      scenario "can go back to the previous page" do
         fund = create(:fund, organisation: organisation)
         visit organisation_fund_path(organisation, fund)
         click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
 
-        # Don't provide an identifier
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "can't be blank"
+        click_on I18n.t("generic.link.back")
 
-        fill_in "activity[identifier]", with: "foo"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
-
-        # Don't provide a title and description
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Title can't be blank"
-        expect(page).to have_content "Description can't be blank"
-
-        fill_in "activity[title]", with: Faker::Lorem.word
-        fill_in "activity[description]", with: Faker::Lorem.paragraph
-        click_button I18n.t("form.activity.submit")
-
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
-
-        # Don't provide a sector
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Sector can't be blank"
-
-        select "Education policy and administrative management", from: "activity[sector]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.status")
-
-        # Don't provide a status
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Status can't be blank"
-
-        select "Implementation", from: "activity[status]"
-        click_button I18n.t("form.activity.submit")
-
-        expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
-
-        # Dates are not mandatory so we can move through this step
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.country")
-
-        # Region has a default and can't be set to blank so we skip
-        select "Developing countries, unspecified", from: "activity[recipient_region]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
-
-        # Flow has a default and can't be set to blank so we skip
-        select "ODA", from: "activity[flow]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
-
-        # Don't select a finance
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Finance can't be blank"
-
-        select "Standard grant", from: "activity[finance]"
-        click_button I18n.t("form.activity.submit")
-
-        expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
-
-        # Don't select an aid type
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Aid type can't be blank"
-
-        select "General budget support", from: "activity[aid_type]"
-        click_button I18n.t("form.activity.submit")
-
-        expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
-
-        # Tied status has a default and can't be set to blank so we skip
-        select "Untied", from: "activity[tied_status]"
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content fund.name
+        expect(page).to have_current_path(organisation_fund_path(fund.id, organisation_id: organisation.id))
       end
     end
 
-    scenario "can go back to the previous page" do
-      fund = create(:fund, organisation: organisation)
-      visit organisation_fund_path(organisation, fund)
-      click_on I18n.t("page_content.fund.button.create_activity", activity: "fund")
+    context "when the activity's hierarchy is a programme" do
+      scenario "successfully creates a programme activity with all optional information" do
+        fund = create(:fund, organisation: organisation)
+        programme = create(:programme, organisation: organisation, fund: fund)
 
-      click_on I18n.t("generic.link.back")
+        visit dashboard_path
+        click_on(I18n.t("page_content.dashboard.button.manage_organisations"))
+        click_on(organisation.name)
+        click_on(fund.name)
+        click_on(programme.name)
 
-      expect(page).to have_current_path(organisation_fund_path(fund.id, organisation_id: organisation.id))
+        click_on I18n.t("page_content.fund.button.create_activity", activity: "programme")
+
+        fill_in_activity_form
+      end
+
+      scenario "can go back to the previous page" do
+        fund = create(:fund, organisation: organisation)
+        programme = create(:programme, fund: fund)
+        visit fund_programme_path(fund, programme)
+        click_on I18n.t("page_content.fund.button.create_activity", activity: "programme")
+
+        click_on I18n.t("generic.link.back")
+
+        expect(page).to have_current_path(fund_programme_path(fund, programme))
+      end
     end
   end
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -13,6 +13,40 @@ RSpec.describe ActivityHelper, type: :helper do
           .to eq(organisation_fund_path(organisation.id, fund))
       end
     end
+
+    context "when the hierarchy_type is a programme" do
+      let(:fund) { create(:fund, organisation: organisation) }
+      let(:programme) { create(:programme, fund: fund) }
+      let(:programme_activity) { create(:activity, hierarchy: programme) }
+
+      it "returns the fund_programme_path" do
+        expect(helper.hierarchy_path_for(activity: programme_activity))
+          .to eq(fund_programme_path(fund, programme))
+      end
+    end
+  end
+
+  describe "#edit_hierarchy_path_for" do
+    context "when the hierarchy_type is a fund" do
+      let(:fund) { create(:fund, organisation: organisation) }
+      let(:fund_activity) { create(:activity, hierarchy: fund) }
+
+      it "returns edit_organisation_fund_path" do
+        expect(helper.edit_hierarchy_path_for(activity: fund_activity))
+          .to eq(edit_organisation_fund_path(organisation.id, fund))
+      end
+    end
+
+    context "when the hierarchy_type is a programme" do
+      let(:fund) { create(:fund, organisation: organisation) }
+      let(:programme) { create(:programme, fund: fund) }
+      let(:programme_activity) { create(:activity, hierarchy: programme) }
+
+      it "returns edit_fund_programme_path" do
+        expect(helper.edit_hierarchy_path_for(activity: programme_activity))
+          .to eq(edit_fund_programme_path(fund, programme))
+      end
+    end
   end
 
   describe "#activity_path_for" do

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Programme do
   describe "relations" do
     it { is_expected.to belong_to(:organisation) }
     it { is_expected.to belong_to(:fund) }
+    it { is_expected.to have_one(:activity) }
   end
 end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -6,8 +6,59 @@ RSpec.describe ActivityPolicy do
   subject { described_class.new(user, activity) }
 
   context "for a fund" do
-    let(:fund) { create(:fund, organisation: organisation) }
+    let!(:fund) { create(:fund, organisation: organisation) }
     let(:activity) { create(:activity, hierarchy: fund) }
+
+    context "as an administrator" do
+      let(:user) { build_stubbed(:administrator) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to permit_action(:destroy) }
+
+      it "includes activity in resolved scope" do
+        resolved_scope = described_class::Scope.new(user, Activity.all).resolve
+        expect(resolved_scope).to include(activity)
+      end
+    end
+
+    context "as a fund_manager" do
+      let(:user) { build_stubbed(:fund_manager, organisation: organisation) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to permit_action(:destroy) }
+
+      it "includes activity in resolved scope" do
+        resolved_scope = described_class::Scope.new(user, Activity.all).resolve
+        expect(resolved_scope).to include(activity)
+      end
+    end
+
+    context "as a delivery_partner" do
+      let(:user) { build_stubbed(:delivery_partner) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+
+      it "does not include activity in resolved scope" do
+        resolved_scope = described_class::Scope.new(user, Activity.all).resolve
+        expect(resolved_scope).not_to include(activity)
+      end
+    end
+  end
+
+  context "for a programme" do
+    let!(:fund) { create(:fund, organisation: organisation) }
+    let!(:programme) { create(:programme, fund: fund) }
+    let(:activity) { create(:activity, hierarchy: programme) }
 
     context "as an administrator" do
       let(:user) { build_stubbed(:administrator) }

--- a/spec/policies/programme_policy_spec.rb
+++ b/spec/policies/programme_policy_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProgrammePolicy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:destroy) }
 
-    it "includes fund in resolved scope" do
+    it "includes programme in resolved scope" do
       expect(resolved_scope).to include(programme)
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe ProgrammePolicy do
   context "as a delivery_partner" do
     let(:user) { build_stubbed(:delivery_partner) }
     let(:resolved_scope) do
-      described_class::Scope.new(user, Programme.none).resolve
+      described_class::Scope.new(user, Programme.all).resolve
     end
 
     it { is_expected.to forbid_action(:index) }
@@ -45,5 +45,9 @@ RSpec.describe ProgrammePolicy do
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
+
+    it "does not include programme in resolved scope" do
+      expect(resolved_scope).to_not include(programme)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/Y2x07ws7/202-fund-managers-can-create-a-programme-activity

Allow Fund Managers to add additional information to a Programme via an attached Activity (and activity form)

The activity form journey for a Programme is exactly the same as that for a Fund. This will need to be looked at in future, as some of the form defaults for Programmes may not be the same as for Funds.

Additionally, there are some TODOs in this PR around how we handle polymorphic links between Funds -> Organisations, and Programmes -> Funds, for example in `activity_helper.rb`

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
