### PR TITLE
The user form validates if an email looks real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 - Transaction and Activity dates are restricted to 10 years in the past or 25 years in the future at most
 - Fund managers can create basic programmes
 - Provide a way to flag an organisation as BEIS
+- User email addresses must be valid emails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_and_belongs_to_many :organisations
   validates_presence_of :name, :email
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 
   enum role: {
     administrator: "administrator",

--- a/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
+++ b/spec/features/staff/fund_managers_can_invite_new_users_spec.rb
@@ -72,21 +72,38 @@ RSpec.feature "Fund managers can invite new users to the service" do
     end
 
     context "when there was an error creating the user in auth0" do
-      it "does not create the user and displays an error message" do
-        stub_auth0_token_request
-        new_email = "email@example.com"
-        stub_auth0_create_user_request_failure(email: new_email)
+      context "when there was a generic error" do
+        it "does not create the user and displays an error message" do
+          stub_auth0_token_request
+          new_email = "email@example.com"
+          stub_auth0_create_user_request_failure(email: new_email)
 
-        visit new_user_path
+          visit new_user_path
 
-        expect(page).to have_content(I18n.t("page_title.users.new"))
-        fill_in "user[name]", with: "foo"
-        fill_in "user[email]", with: new_email
+          expect(page).to have_content(I18n.t("page_title.users.new"))
+          fill_in "user[name]", with: "foo"
+          fill_in "user[email]", with: new_email
 
-        click_button I18n.t("generic.button.submit")
+          click_button I18n.t("generic.button.submit")
 
-        expect(page).to have_content(I18n.t("form.user.create.failed"))
-        expect(User.count).to eq(0)
+          expect(page).to have_content(I18n.t("form.user.create.failed"))
+          expect(User.count).to eq(0)
+        end
+      end
+
+      context "when the email was invalid" do
+        it "does not create the user and displays an invalid email message" do
+          new_email = "tom"
+          stub_auth0_create_user_request_failure(email: new_email)
+
+          visit new_user_path
+          fill_in "user[name]", with: "tom"
+          fill_in "user[email]", with: "tom"
+          click_button I18n.t("generic.button.submit")
+
+          expect(page).to have_content("Email is invalid")
+          expect(page).not_to have_content(I18n.t("form.user.create.failed"))
+        end
       end
     end
 


### PR DESCRIPTION
Co-authored-by: Lorna <lorna@dxw.com>

## Changes in this PR

- user email addresses are validated before being sent to Auth0, this handles an unexpected error since Auth0 requires emails to be in a valid format

## Screenshots of UI changes

### Before
![Screenshot 2020-01-16 at 15 59 27](https://user-images.githubusercontent.com/912473/72617693-79ed5880-3931-11ea-9d5e-04f61117b978.png)

### After
![Screenshot 2020-01-17 at 13 57 09](https://user-images.githubusercontent.com/912473/72617698-7ce84900-3931-11ea-80cf-83800eb29e45.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
