### PR TITLE
(218) Developers see test coverage warnings locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 ])
 
 SimpleCov.minimum_coverage 98
-SimpleCov.start
 
 require "webmock/rspec"
 require "rack_session_access/capybara"
@@ -116,4 +115,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  # Don't generate coverage for partial test runs
+  SimpleCov.start if config.files_to_run.map { |file| file.split("spec/").last.split("/").first }.uniq.size > 3
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
+require "simplecov"
 require "coveralls"
-Coveralls.wear!
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter,
+])
+
+SimpleCov.minimum_coverage 98
+SimpleCov.start
 
 require "webmock/rspec"
 require "rack_session_access/capybara"


### PR DESCRIPTION
Run the simplecov test coverage locally, in addition to it being run on CI. This will allow us to observe coverage drops before raising a PR.

I've configured it so in most everyday scenarios, you shouldn't get a test coverage report when only running a small number of specs/files.

Additionally, it writes an HTML version of the coverage report into `coverage/index.html` for reference. NB: this directory has already been added to `.gitignore`.

**NB: We've historically been calling simplecov with its default profile rather than the Rails one. I've done the same here as it changes the coverage result considerably, but might be something we want to consider using**