### PR TITLE
Dates updated to have human readable format as default

### DIFF
--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -16,6 +16,26 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.status.#{super}")
   end
 
+  def planned_start_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def planned_end_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def actual_start_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def actual_end_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
   def recipient_region
     return if super.blank?
     I18n.t("activity.recipient_region.#{super}")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -55,7 +55,7 @@
     %dt.govuk-summary-list__key
       = t("page_content.activity.planned_start_date.label")
     %dd.govuk-summary-list__value
-      = l(activity_presenter.planned_start_date)
+      = activity_presenter.planned_start_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
@@ -65,7 +65,7 @@
     %dt.govuk-summary-list__key
       = t("page_content.activity.planned_end_date.label")
     %dd.govuk-summary-list__value
-      = l(activity_presenter.planned_end_date)
+      = activity_presenter.planned_end_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
@@ -75,7 +75,7 @@
     %dt.govuk-summary-list__key
       = t("page_content.activity.actual_start_date.label")
     %dd.govuk-summary-list__value
-      = l(activity_presenter.actual_start_date)
+      = activity_presenter.actual_start_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
@@ -85,7 +85,7 @@
     %dt.govuk-summary-list__key
       = t("page_content.activity.actual_end_date.label")
     %dd.govuk-summary-list__value
-      = l(activity_presenter.actual_end_date)
+      = activity_presenter.actual_end_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,9 @@
 en:
   app:
     title: Report Official Development Assistance
+  date:
+    formats:
+      default: "%-d %b %Y"
   form:
     activity:
       create:

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -34,6 +34,33 @@ RSpec.feature "Users can view an activity" do
       expect(page).to have_content activity_presenter.flow
     end
 
+    scenario "a fund activity has human readable date format" do
+      travel_to Time.zone.local(2020, 1, 29) do
+        activity = create(:activity, planned_start_date: Date.new(2020, 2, 3),
+                                     planned_end_date: Date.new(2024, 6, 22),
+                                     actual_start_date: Date.new(2020, 4, 3),
+                                     actual_end_date: Date.new(2024, 8, 22))
+
+        visit organisation_activity_path(organisation, activity)
+
+        within(".planned_start_date") do
+          expect(page).to have_content("3 Feb 2020")
+        end
+
+        within(".planned_end_date") do
+          expect(page).to have_content("22 Jun 2024")
+        end
+
+        within(".actual_start_date") do
+          expect(page).to have_content("3 Apr 2020")
+        end
+
+        within(".actual_end_date") do
+          expect(page).to have_content("22 Aug 2024")
+        end
+      end
+    end
+
     scenario "can go back to the previous page" do
       activity = create(:activity, organisation: organisation)
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "localises dates as expected" do
-      expect(helper.l(Date.today)).to eq(Date.today.strftime("%Y-%m-%d"))
+      expect(helper.l(Date.today)).to eq(Date.today.strftime("%-d %b %Y"))
     end
   end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -63,6 +63,78 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#planned_start_date" do
+    context "when the planned start date exists" do
+      it "returns a human readable date" do
+        activity = build(:activity, planned_start_date: "2020-02-25")
+        result = described_class.new(activity).planned_start_date
+        expect(result).to eql("25 Feb 2020")
+      end
+    end
+
+    context "when the planned start date does not exist" do
+      it "returns nil" do
+        activity = build(:activity, planned_start_date: nil)
+        result = described_class.new(activity)
+        expect(result.planned_start_date).to be_nil
+      end
+    end
+  end
+
+  describe "#planned_end_date" do
+    context "when the planned end date exists" do
+      it "returns a human readable date" do
+        activity = build(:activity, planned_end_date: "2021-04-03")
+        result = described_class.new(activity).planned_end_date
+        expect(result).to eql("3 Apr 2021")
+      end
+    end
+
+    context "when the planned end date does not exist" do
+      it "returns nil" do
+        activity = build(:activity, planned_end_date: nil)
+        result = described_class.new(activity)
+        expect(result.planned_end_date).to be_nil
+      end
+    end
+  end
+
+  describe "#actual_start_date" do
+    context "when the actual start date exists" do
+      it "returns a human readable date" do
+        activity = build(:activity, actual_start_date: "2020-11-06")
+        result = described_class.new(activity).actual_start_date
+        expect(result).to eql("6 Nov 2020")
+      end
+    end
+
+    context "when the actual start date does not exist" do
+      it "returns nil" do
+        activity = build(:activity, actual_start_date: nil)
+        result = described_class.new(activity)
+        expect(result.actual_start_date).to be_nil
+      end
+    end
+  end
+
+  describe "#actual_end_date" do
+    context "when the actual end date exists" do
+      it "returns a human readable date" do
+        activity = build(:activity, actual_end_date: "2029-05-27")
+        result = described_class.new(activity).actual_end_date
+        expect(result).to eql("27 May 2029")
+      end
+    end
+
+    context "when the actual end date does not exist" do
+      it "returns nil" do
+        activity = build(:activity, actual_end_date: nil)
+        result = described_class.new(activity)
+        expect(result.actual_end_date).to be_nil
+      end
+    end
+  end
+
   describe "#recipient_region" do
     context "when the aid_type recipient_region" do
       it "returns the locale value for the code" do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
## Changes in this PR

We have set  a default date format in translation locale. Added presenters for all the fund activity dates and included tests checking if those specific dates are in a human readable format.

We used ruby travel_to helper method in our tests to ensure that they will continue to pass without being dependent on a current date.  Especially becaue we know that activity dates are validated to be within a certain time frame.

We thought about using strftime in our helper, but then we realised it would’ve been duplicated in a lot of places. Therefore setting the date format in locale file means we don’t need to worry about using locale in the views for an activity and it will be easier to change our time formats in the future.

Co-authored-by: Tom <tomhipkin@gmail.com>

## Screenshots of UI changes

### Before

<img width="717" alt="Screenshot 2020-01-28 at 12 13 00" src="https://user-images.githubusercontent.com/2632224/73371065-0fcba080-42ad-11ea-8838-1d000eaa163a.png">

### After

<img width="808" alt="Screenshot 2020-01-29 at 15 40 36" src="https://user-images.githubusercontent.com/2632224/73371539-bca61d80-42ad-11ea-80ea-386f1f953514.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
