### PR TITLE
Provide a way to flag an organisation as BEIS

### DIFF
--- a/db/migrate/20200116172705_add_service_owner_to_organisations.rb
+++ b/db/migrate/20200116172705_add_service_owner_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddServiceOwnerToOrganisations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organisations, :service_owner, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_155455) do
     t.string "default_currency"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "service_owner", default: false
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -12,6 +12,38 @@ RSpec.describe Organisation, type: :model do
     it { should have_many(:users) }
   end
 
+  describe "service_owner?" do
+    context "when an organisation is has been flagged as BEIS" do
+      it "should return true" do
+        beis_organisation = create(:organisation, service_owner: true)
+
+        result = beis_organisation.service_owner?
+
+        expect(result).to eq(true)
+      end
+    end
+
+    context "when an organisation is not flagged as BEIS" do
+      it " should return false" do
+        other_organisation = create(:organisation, service_owner: false)
+
+        result = other_organisation.service_owner?
+
+        expect(result).to eq(false)
+      end
+    end
+
+    context "when an organisation is not deliberately flagged as BEIS" do
+      it "should default to false" do
+        new_organisation = create(:organisation)
+
+        result = new_organisation.service_owner?
+
+        expect(result).to eq(false)
+      end
+    end
+  end
+
   describe ".sorted_by_name" do
     it "should sort name name a->z" do
       a_organisation = create(:organisation, name: "A", created_at: 3.days.ago)


### PR DESCRIPTION
This change re-adds a feature that has already been merged into develop once before https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/141. During the [refactor of the activity hierarchy](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/154) the original work was deliberately force pushed away.

This original work has been rebased on top of the new develop so it is now compatible with the new architecture.

cture.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
