### PR TITLE
(Feature/257) Re-introduce programmes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 - Restrict delivery partners so they can only view and edit their own organisation
 - Fund managers can manage users, organisations, funds, fund activites and fund transactions
 - Transaction and Activity dates are restricted to 10 years in the past or 25 years in the future at most
-- Fund managers can create basic programmes
 - Provide a way to flag an organisation as BEIS
 - User email addresses must be valid emails
 - Users are only associated with one organisation
 - Users land on their organisation#show page when they log in, instead of a "dashboard"
+- Fund manager can add a programme level activity

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -11,6 +11,8 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity = Activity.find(id)
     authorize @activity
 
+    @activities = @activity.activities
+
     @transactions = policy_scope(Transaction).where(activity: @activity)
 
     respond_to do |format|
@@ -31,5 +33,9 @@ class Staff::ActivitiesController < Staff::BaseController
 
   def organisation_id
     params[:organisation_id]
+  end
+
+  def fund_id
+    params[:fund_id]
   end
 end

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,7 +11,7 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    activities = policy_scope(Activity).includes(:organisation).where(organisation: organisation)
+    activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation)
     @activities = activities.map { |activity| ActivityPresenter.new(activity) }
   end
 

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -4,6 +4,8 @@ class Staff::ProgrammesController < Staff::ActivitiesController
   def create
     @activity = Activity.new
     @activity.organisation = Organisation.find(organisation_id)
+    fund = Activity.find(fund_id)
+    fund.activities << @activity
     authorize @activity
 
     @activity.wizard_status = "identifier"

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Staff::ProgrammesController < Staff::ActivitiesController
+  def create
+    @activity = Activity.new
+    @activity.organisation = Organisation.find(organisation_id)
+    authorize @activity
+
+    @activity.wizard_status = "identifier"
+    @activity.level = :programme
+    @activity.save(validate: false)
+
+    redirect_to activity_step_path(@activity.id, @activity.wizard_status)
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -19,6 +19,7 @@ class Activity < ApplicationRecord
   }
 
   scope :funds, -> { where(level: :fund) }
+  scope :programmes, -> { where(level: :programme) }
 
   def identifier_step?
     %w[identifier complete].include?(wizard_status)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -11,6 +11,8 @@ class Activity < ApplicationRecord
   validates_uniqueness_of :identifier
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
 
+  belongs_to :activity, optional: true
+  has_many :activities, foreign_key: "activity_id"
   belongs_to :organisation
 
   enum level: {

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -15,6 +15,7 @@ class Activity < ApplicationRecord
 
   enum level: {
     fund: "fund",
+    programme: "programme",
   }
 
   def identifier_step?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -18,6 +18,8 @@ class Activity < ApplicationRecord
     programme: "programme",
   }
 
+  scope :funds, -> { where(level: :fund) }
+
   def identifier_step?
     %w[identifier complete].include?(wizard_status)
   end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -12,6 +12,20 @@
       = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
 
   .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      - if policy(Activity).index?
+        %h2.govuk-heading-m
+          = t("page_content.organisation.programmes")
+      - if policy(Activity).create?
+        = form_tag(organisation_fund_programmes_path(@activity.organisation, @activity), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
+      - if @activities.present?
+        %ul.govuk-list.govuk-list--bullet
+          - @activities.each do |activity|
+            %li
+              = link_to activity.title, organisation_activity_path(activity.organisation, activity)
+
+  .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-m
         = t("page_content.activity.transactions")

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -60,6 +60,9 @@
       - if policy(Activity).index?
         %ul.govuk-list.govuk-list--bullet
           - @activities.each do |activity|
-
             %li
               = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+        %h2.govuk-heading-m
+          =t("page_content.organisation.programmes")
+        = form_tag(organisation_programmes_path(@organisation_presenter), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -62,7 +62,3 @@
           - @activities.each do |activity|
             %li
               = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
-        %h2.govuk-heading-m
-          =t("page_content.organisation.programmes")
-        = form_tag(organisation_programmes_path(@organisation_presenter), method: "post") do
-          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@ en:
     fund:
       create:
         success: Fund successfully created
+    programme:
+      create:
+        success: Programme successfully created
     organisation:
       create:
         success: Organisation successfully created
@@ -143,6 +146,7 @@ en:
     organisation:
       button:
         create_fund: Create fund
+        create_programme: Create programme
         edit: Edit organisation
       default_currency:
         label: Default currency
@@ -151,6 +155,7 @@ en:
         label: Language code
       name:
         label: Name
+      programmes: Programmes
       type:
         label: Type
     organisations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,9 +21,6 @@ en:
     fund:
       create:
         success: Fund successfully created
-    programme:
-      create:
-        success: Programme successfully created
     organisation:
       create:
         success: Organisation successfully created
@@ -39,6 +36,9 @@ en:
         label: Organisation type
       update:
         success: Organisation successfully updated
+    programme:
+      create:
+        success: Programme successfully created
     transaction:
       create:
         success: Transaction successfully created

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
       resources :funds, only: [:create]
+      resources :programmes, only: [:create]
     end
 
     concern :transactionable do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,9 @@ Rails.application.routes.draw do
     resources :users
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
-      resources :funds, only: [:create]
-      resources :programmes, only: [:create]
+      resources :funds, only: [:create] do
+        resources :programmes, only: [:create]
+      end
     end
 
     concern :transactionable do

--- a/db/migrate/20200130144115_add_activity_reference_to_activity.rb
+++ b/db/migrate/20200130144115_add_activity_reference_to_activity.rb
@@ -1,0 +1,5 @@
+class AddActivityReferenceToActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :activities, :activity, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_155455) do
+ActiveRecord::Schema.define(version: 2020_01_30_144115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_155455) do
     t.string "tied_status"
     t.string "wizard_status"
     t.string "level"
+    t.uuid "activity_id"
+    t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
   end
@@ -80,4 +82,5 @@ ActiveRecord::Schema.define(version: 2020_01_28_155455) do
     t.index ["role"], name: "index_users_on_role"
   end
 
+  add_foreign_key "activities", "activities"
 end

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -1,0 +1,18 @@
+RSpec.feature "Create a programme level activity" do
+  let!(:organisation) { create(:organisation, name: "UKSA") }
+
+  context "when the user is a fund_manager" do
+    before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
+
+    scenario "successfully create a activity" do
+      visit organisation_path(organisation)
+      click_link(I18n.t("page_content.dashboard.button.manage_organisations"))
+      click_on(organisation.name)
+      click_on(I18n.t("page_content.organisation.button.create_programme"))
+
+      fill_in_activity_form
+
+      expect(page).to have_content I18n.t("form.programme.create.success")
+    end
+  end
+end

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -1,13 +1,16 @@
 RSpec.feature "Create a programme level activity" do
-  let!(:organisation) { create(:organisation, name: "UKSA") }
+  let!(:organisation) { create(:organisation, name: "BEIS") }
 
   context "when the user is a fund_manager" do
     before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
 
     scenario "successfully create a activity" do
+      fund = create(:activity, level: :fund, organisation: organisation)
+
       visit organisation_path(organisation)
       click_link(I18n.t("page_content.dashboard.button.manage_organisations"))
       click_on(organisation.name)
+      click_on(fund.title)
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
       fill_in_activity_form

--- a/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
@@ -14,13 +14,13 @@ RSpec.feature "Fund managers can view fund level activities" do
       authenticate!(user: create(:fund_manager))
     end
 
-    scenario "the user will see activities on the organisation show page" do
-      activity = create(:activity, organisation: organisation)
+    scenario "the user will see fund level activities on the organisation show page" do
+      fund_activity = create(:activity, level: :fund, organisation: organisation)
       visit organisations_path
       click_link organisation.name
 
       expect(page).to have_content(I18n.t("page_content.organisation.funds"))
-      expect(page).to have_content activity.title
+      expect(page).to have_content fund_activity.title
     end
 
     context "when the activity is partially complete and doesn't have a title" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  describe "scopes" do
+    describe ".funds" do
+      it "only returns fund level activities" do
+        fund_activity = create(:activity, level: :fund)
+        _other_activiy = create(:activity, level: :programme)
+
+        expect(Activity.funds).to eq [fund_activity]
+      end
+    end
+  end
   describe "validations" do
     describe "constraints" do
       it { should validate_uniqueness_of(:identifier) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe Activity, type: :model do
         expect(Activity.funds).to eq [fund_activity]
       end
     end
+
+    describe ".programmes" do
+      it "only returns programme level activities" do
+        programme_activity = create(:activity, level: :programme)
+        _other_activiy = create(:activity, level: :fund)
+
+        expect(Activity.programmes).to eq [programme_activity]
+      end
+    end
   end
+
   describe "validations" do
     describe "constraints" do
       it { should validate_uniqueness_of(:identifier) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -125,5 +125,7 @@ RSpec.describe Activity, type: :model do
 
   describe "relations" do
     it { should belong_to(:organisation) }
+    it { should belong_to(:activity).optional }
+    it { should have_many(:activities).with_foreign_key("activity_id") }
   end
 end


### PR DESCRIPTION
## Changes in this PR
Now the work to simplify the activity model is complete we can re-introduce the programme level.

At this point the aim is to just be able to add programme level activities, not associate them to funds which will be the next step. By adding programme level activities now we can un-block work that relies on an assoication to programme level activities.

We thought about showing programme level activities on the organisation show page but decided not to for two reasons:

1. It felt more natural for them to appear on the associated fund level activity show page and we do not have that associations as yet
2. It would make the scope feature tests more complicated

We wondered about calling the instance variable in `ProgrammeController` `@programme` but settled on `@activity` we may want to think about this as more activity levels are added to the service?

## Screenshots of UI changes

The 'Create programme' button:
![Screenshot_2020-01-30 Organisation Department for Business, Energy Industrial Strategy — Report Official Development Assist](https://user-images.githubusercontent.com/480578/73436358-4b647a00-4342-11ea-8fc5-67b545c268cb.png)

A successfully created programme level activity:
![Screenshot_2020-01-30 Activity Another Programme — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/73436343-41427b80-4342-11ea-81e7-f9124509a0ae.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
