### PR TITLE
(204) Editing a complete activity form returns to the activity

### DIFF
--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -52,6 +52,8 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def update_wizard_status
+    return if @activity.invalid?
+
     if @activity.wizard_complete?
       flash[:notice] ||= I18n.t("form.#{@activity.level}.update.success")
       jump_to Wicked::FINISH_STEP

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -32,8 +32,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     authorize @activity
 
     @activity.assign_attributes(activity_params)
-    @activity.wizard_status = step
-    @activity.save
+    update_wizard_status
+
     render_wizard @activity
   end
 
@@ -46,7 +46,17 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def finish_wizard_path
-    flash[:notice] = I18n.t("form.#{@activity.level}.create.success")
+    flash[:notice] ||= I18n.t("form.#{@activity.level}.create.success")
+    @activity.update(wizard_status: "complete")
     organisation_activity_path(@activity.organisation, @activity)
+  end
+
+  def update_wizard_status
+    if @activity.wizard_complete?
+      flash[:notice] ||= I18n.t("form.#{@activity.level}.update.success")
+      jump_to Wicked::FINISH_STEP
+    else
+      @activity.wizard_status = step
+    end
   end
 end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -2,7 +2,8 @@ module ActivityHelper
   def step_is_complete_or_next?(activity:, step:)
     steps = Staff::ActivityFormsController::FORM_STEPS
 
-    return true if activity.wizard_status.nil?
+    return false if activity.wizard_status.nil?
+    return true if activity.wizard_complete?
 
     presenter_position = steps.index(step.to_sym)
     activity_position = steps.index(activity.wizard_status.to_sym)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -24,39 +24,43 @@ class Activity < ApplicationRecord
   scope :programmes, -> { where(level: :programme) }
 
   def identifier_step?
-    %w[identifier complete].include?(wizard_status)
+    wizard_status == "identifier" || wizard_complete?
   end
 
   def purpose_step?
-    %w[purpose complete].include?(wizard_status)
+    wizard_status == "purpose" || wizard_complete?
   end
 
   def sector_step?
-    %w[sector complete].include?(wizard_status)
+    wizard_status == "sector" || wizard_complete?
   end
 
   def status_step?
-    %w[status complete].include?(wizard_status)
+    wizard_status == "status" || wizard_complete?
   end
 
   def country_step?
-    %w[country complete].include?(wizard_status)
+    wizard_status == "country" || wizard_complete?
   end
 
   def flow_step?
-    %w[flow complete].include?(wizard_status)
+    wizard_status == "flow" || wizard_complete?
   end
 
   def finance_step?
-    %w[finance complete].include?(wizard_status)
+    wizard_status == "finance" || wizard_complete?
   end
 
   def aid_type_step?
-    %w[aid_type complete].include?(wizard_status)
+    wizard_status == "aid_type" || wizard_complete?
   end
 
   def tied_status_step?
-    %w[tied_status complete].include?(wizard_status)
+    wizard_status == "tied_status" || wizard_complete?
+  end
+
+  def wizard_complete?
+    wizard_status == "complete"
   end
 
   def default_currency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
     fund:
       create:
         success: Fund successfully created
+      update:
+        success: Fund successfully updated
     organisation:
       create:
         success: Organisation successfully created

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     tied_status { "3" }
     level { :fund }
 
-    wizard_status { "tied_status" } # this is the final step, aka "complete"
+    wizard_status { "complete" } # wizard is complete
 
     association :organisation, factory: :organisation
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -29,26 +29,27 @@ FactoryBot.define do
     factory :fund_activity do
       level { :fund }
     end
-
-    trait :at_purpose_step do
-      wizard_status { "identifier" }
-      title { nil }
-      description { nil }
-      sector { nil }
-      status { nil }
-      planned_start_date { nil }
-      planned_end_date { nil }
-      actual_start_date { nil }
-      actual_end_date { nil }
-      recipient_region { nil }
-      flow { nil }
-      finance { nil }
-      aid_type { nil }
-      tied_status { nil }
-    end
   end
 
   trait :at_identifier_step do
+    identifier { nil }
+    wizard_status { "identifier" }
+    title { nil }
+    description { nil }
+    sector { nil }
+    status { nil }
+    planned_start_date { nil }
+    planned_end_date { nil }
+    actual_start_date { nil }
+    actual_end_date { nil }
+    recipient_region { nil }
+    flow { nil }
+    finance { nil }
+    aid_type { nil }
+    tied_status { nil }
+  end
+
+  trait :at_purpose_step do
     wizard_status { "identifier" }
     title { nil }
     description { nil }

--- a/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Fund managers can view fund level activities" do
 
     context "when the activity is partially complete and doesn't have a title" do
       scenario "it to show a meaningful link to the activity" do
-        activity = create(:activity, :at_identifier_step, organisation: organisation, title: nil)
+        activity = create(:activity, :at_purpose_step, organisation: organisation, title: nil)
 
         visit organisation_path(organisation)
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -61,9 +61,20 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
 
-    context "when the activity has a null .wizard_status field" do
-      it "shows all steps" do
+    context "when the activity wizard hasn't been started" do
+      it "shows no steps" do
         activity = build(:activity, :nil_wizard_status)
+        all_steps = Staff::ActivityFormsController::FORM_STEPS
+
+        all_steps.each do |step|
+          expect(helper.step_is_complete_or_next?(activity: activity, step: step)).to be(false)
+        end
+      end
+    end
+
+    context "when the activity wizard has been completed" do
+      it "shows all steps" do
+        activity = build(:activity, wizard_status: "complete")
         all_steps = Staff::ActivityFormsController::FORM_STEPS
 
         all_steps.each do |step|

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -159,4 +159,24 @@ RSpec.describe Activity, type: :model do
       expect(fund_activity.parent_activity).to be_nil
     end
   end
+
+  describe "#wizard_complete?" do
+    it "is true if the wizard has been completed" do
+      activity = build(:activity, wizard_status: :complete)
+
+      expect(activity.wizard_complete?).to be_truthy
+    end
+
+    it "is false if the wizard is in progress" do
+      activity = build(:activity, wizard_status: :purpose)
+
+      expect(activity.wizard_complete?).to be_falsey
+    end
+
+    it "is false if the wizard is not started" do
+      activity = build(:activity, wizard_status: nil)
+
+      expect(activity.wizard_complete?).to be_falsey
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe ActivityPresenter do
   describe "#display_title" do
     context "when the title is nil" do
       it "returns a default display_title" do
-        activity = create(:activity, :at_identifier_step, title: nil)
+        activity = create(:activity, :at_purpose_step, title: nil)
         expect(described_class.new(activity).display_title).to eql("Untitled (#{activity.id})")
       end
     end


### PR DESCRIPTION
@mec says:

I've picked this up whilst @leeky was on a support sprint.

The work changed once we refactored the model and was only about returning the user to the appropriate place when editing an activity.

- when the activity is complete, the user edits an attribute and returns to the activity summary view
- when the activity is incomplete, the user edits or adds an attribute they continue the stepped form flow.

I also found some of the Actvity factory traits weren't reflecting the behaviour of the model so took the opportunity to update them:

Becuase an Activity can now have a nil identifier attribute when the `wizard_step` is 'identifier' some specs were updated to use the 'purpose' step as this better reflects the state of the activity under test i.e. has a 'identifier' value set.

I've left @leeky comment as it is mostly his work:

----
Allow editing a programme activity.

This introduces a `wizard_complete?` method on an activity (completed wizards set the `wizard_status` to 'complete'). This allows edits to individual form steps to return to the summary page afterwards, instead of continuing on as per the initial run through of the wizard.