### PR TITLE
(142) Add Budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 - Users land on their organisation#show page when they log in, instead of a "dashboard"
 - Fund manager can add a programme level activity to a fund level activity
 - Fund manager can view a fund level activity's programme activities
+- Fund managers can create Budgets

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -14,10 +14,12 @@ class Staff::ActivitiesController < Staff::BaseController
     @activities = @activity.activities.map { |activity| ActivityPresenter.new(activity) }
 
     @transactions = policy_scope(Transaction).where(activity: @activity)
+    @budgets = policy_scope(Budget).where(activity: @activity)
 
     respond_to do |format|
       format.html do
         @transaction_presenters = @transactions.map { |transaction| TransactionPresenter.new(transaction) }
+        @budget_presenters = @budgets.map { |budget| BudgetPresenter.new(budget) }
       end
       format.xml
     end

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -8,6 +8,11 @@ class Staff::BudgetsController < Staff::BaseController
     @budget.activity = @activity
 
     authorize @budget
+
+    unless @activity.is_programme_level?
+      flash[:warning] = I18n.t("page_title.errors.budget.not_possible")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    end
   end
 
   def create

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -1,0 +1,57 @@
+class Staff::BudgetsController < Staff::BaseController
+  include Secured
+  include DateHelper
+
+  def new
+    @activity = Activity.find(activity_id)
+    @budget = Budget.new
+    @budget.activity = @activity
+
+    authorize @budget
+  end
+
+  def create
+    @activity = Activity.find(activity_id)
+    @budget = Budget.new(budget_params)
+    @budget.activity = @activity
+    authorize @budget
+
+    @budget.value = monetary_value
+    @budget.period_start_date = format_date(period_start_date)
+    @budget.period_end_date = format_date(period_end_date)
+
+    if @budget.save
+      flash[:notice] = I18n.t("form.budget.create.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def activity_id
+    params[:activity_id]
+  end
+
+  def budget_params
+    params.require(:budget).permit(:budget_type, :status, :value)
+  end
+
+  def monetary_value
+    @monetary_value ||= begin
+                          string_value = params.require(:budget).permit(:value)
+                          Monetize.parse(string_value).to_f
+                        end
+  end
+
+  def period_start_date
+    date_fields = params.require(:budget).permit("period_start_date(3i)", "period_start_date(2i)", "period_start_date(1i)")
+    {day: date_fields["period_start_date(3i)"], month: date_fields["period_start_date(2i)"], year: date_fields["period_start_date(1i)"]}
+  end
+
+  def period_end_date
+    date_fields = params.require(:budget).permit("period_end_date(3i)", "period_end_date(2i)", "period_end_date(1i)")
+    {day: date_fields["period_end_date(3i)"], month: date_fields["period_end_date(2i)"], year: date_fields["period_end_date(1i)"]}
+  end
+end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -9,4 +9,16 @@ module FormHelper
       User.roles.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.user.roles.#{name}")) }
     end
   end
+
+  def list_of_budget_types
+    @list_of_budget_types ||= begin
+      Budget::BUDGET_TYPES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.budget.budget_type.#{name}")) }
+    end
+  end
+
+  def list_of_budget_statuses
+    @list_of_budget_statuses ||= begin
+      Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.budget.status.#{name}")) }
+    end
+  end
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -1,0 +1,7 @@
+class Budget < ApplicationRecord
+  belongs_to :activity
+
+  validates_presence_of :budget_type, :status, :period_start_date, :period_end_date, :value
+  validates :value, inclusion: 1..99_999_999_999.00
+  validates :period_start_date, :period_end_date, date_within_boundaries: true
+end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -4,4 +4,7 @@ class Budget < ApplicationRecord
   validates_presence_of :budget_type, :status, :period_start_date, :period_end_date, :value
   validates :value, inclusion: 1..99_999_999_999.00
   validates :period_start_date, :period_end_date, date_within_boundaries: true
+
+  BUDGET_TYPES = {original: "original", updated: "updated"}
+  STATUSES = {indicative: "indicative", committed: "committed"}
 end

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -1,0 +1,31 @@
+class BudgetPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    user.administrator? || user.fund_manager?
+  end
+
+  def create?
+    user.administrator? || user.fund_manager?
+  end
+
+  def update?
+    user.administrator? || user.fund_manager?
+  end
+
+  def destroy?
+    user.administrator? || user.fund_manager?
+  end
+
+  class Scope < Scope
+    def resolve
+      if user.administrator? || user.fund_manager?
+        scope.all
+      else
+        []
+      end
+    end
+  end
+end

--- a/app/presenters/budget_presenter.rb
+++ b/app/presenters/budget_presenter.rb
@@ -1,0 +1,21 @@
+class BudgetPresenter < SimpleDelegator
+  def budget_type
+    return if super.blank?
+    I18n.t("page_content.budget.budget_type.#{super}")
+  end
+
+  def status
+    return if super.blank?
+    I18n.t("page_content.budget.status.#{super}")
+  end
+
+  def period_start_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def period_end_date
+    return if super.blank?
+    I18n.l(super)
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -37,3 +37,4 @@
         = t("page_content.activity.budgets")
 
       = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
+      = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -31,10 +31,11 @@
       = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
       = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
 
-  .govuk-grid-row
-    .govuk-grid-column-full
-      %h2.govuk-heading-m
-        = t("page_content.activity.budgets")
+  - if @activity.is_programme_level?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.activity.budgets")
 
-      = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
-      = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }
+        = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
+        = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -30,3 +30,10 @@
 
       = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
       = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.activity.budgets")
+
+      = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -1,0 +1,18 @@
+= f.govuk_error_summary
+= f.govuk_collection_radio_buttons :budget_type,
+  list_of_budget_types,
+  :id,
+  :name,
+  legend: { tag: :h2, text: t('form.budget.budget_type.label') }
+= f.govuk_collection_radio_buttons :status,
+  list_of_budget_statuses,
+  :id,
+  :name,
+  legend: { tag: :h2, text: t('form.budget.status.label') }
+= f.govuk_date_field :period_start_date,
+          legend: { text: t("form.budget.period_start_date.label"), size: "s" }
+= f.govuk_date_field :period_end_date,
+          legend: { text: t("form.budget.period_end_date.label"), size: "s" }
+= f.govuk_text_field :value
+
+= f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/budgets/new.html.haml
+++ b/app/views/staff/budgets/new.html.haml
@@ -1,0 +1,12 @@
+=content_for :page_title_prefix, t("page_title.budget.new")
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.new")
+
+      = form_with model: @budget, url: activity_budgets_path(@activity) do |f|
+        = render partial: "form", locals: { f: f }

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -1,0 +1,25 @@
+- unless budgets.empty?
+  %table.govuk-table.transactions
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("form.budget.budget_type.label")
+        %th.govuk-table__header
+          =t("form.budget.status.label")
+        %th.govuk-table__header
+          =t("form.budget.period_start_date.label")
+        %th.govuk-table__header
+          =t("form.budget.period_end_date.label")
+        %th.govuk-table__header
+          =t("form.budget.value.label")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - budgets.each do |budget|
+        %tr.govuk-table__row{id: budget.id}
+          %td.govuk-table__cell= budget.budget_type
+          %td.govuk-table__cell= budget.status
+          %td.govuk-table__cell= budget.period_start_date
+          %td.govuk-table__cell= budget.period_end_date
+          %td.govuk-table__cell= budget.value
+          %td.govuk-table__cell

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,8 @@ en:
     errors:
       auth0:
         failed: Sign in failed
+      budget:
+        not_possible: It is not possible to create a budget on this activity type
       not_authorised: You are not authorised
     home: Home
     organisation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,18 @@ en:
       submit: Continue
       update:
         success: Activity successfully updated
+      year: Year
+    budget:
+      budget_type:
+        label: Budget type
+      create:
+        success: Budget successfully created
+      period_end_date:
+        label: Period end date
+      period_start_date:
+        label: Period start date
+      status:
+        label: Status
     fund:
       create:
         success: Fund successfully created
@@ -101,6 +113,7 @@ en:
         label: Actual start date
       aid_type:
         label: Aid type
+      budgets: Budgets
       button:
         create: Create activity
       description:
@@ -128,6 +141,13 @@ en:
       title:
         label: Title
       transactions: Transactions
+    budget:
+      budget_type:
+        original: Original
+        updated: Updated
+      status:
+        committed: Committed
+        indicative: Indicative
     dashboard:
       button:
         manage_organisations: Manage organisations
@@ -186,6 +206,8 @@ en:
         sector: Sector
         status: Status
         tied_status: Tied status
+    budget:
+      new: Create budget
     errors:
       auth0:
         failed: Sign in failed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@ en:
         label: Period start date
       status:
         label: Status
+      value:
+        label: Value
     fund:
       create:
         success: Fund successfully created
@@ -148,6 +150,9 @@ en:
       status:
         committed: Committed
         indicative: Indicative
+    budgets:
+      button:
+        create: Create budget
     dashboard:
       button:
         manage_organisations: Manage organisations

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -13,6 +13,15 @@ en:
         status: Status
         tied_status: Tied status
         title: Title
+      budget:
+        budget_type:
+          one: Budget type
+          original: The original budget allocated to the activity
+          updated: The updated budget for an activity
+        status:
+          committed: Committed - A binding agreement for the described budget
+          indicative: Indicative - A non-binding estimate for the described budget
+          one: Status
       organisation:
         default_currency: Default currency
         language_code: Language code

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -46,6 +46,12 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
             planned_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+        budget:
+          attributes:
+            period_end_date:
+              between: Date must be between %{min} years ago and %{max} years in the future
+            period_start_date:
+              between: Date must be between %{min} years ago and %{max} years in the future
         transaction:
           attributes:
             date:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -18,10 +18,13 @@ en:
           one: Budget type
           original: The original budget allocated to the activity
           updated: The updated budget for an activity
+        period_end_date: Period end date
+        period_start_date: Period start date
         status:
           committed: Committed - A binding agreement for the described budget
           indicative: Indicative - A non-binding estimate for the described budget
           one: Status
+        value: Value
       organisation:
         default_currency: Default currency
         language_code: Language code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,13 +20,12 @@ Rails.application.routes.draw do
       resources :transactions, only: [:new, :create, :show, :edit, :update]
     end
 
-    resources :activities, only: [], concerns: [:transactionable] do
-      resources :steps, controller: "activity_forms"
+    concern :budgetable do
+      resources :budgets, only: [:new, :create, :show, :edit, :update]
     end
-    # TODO: Extend with more hierarchies using this format
-    # resources :programmes, only: [], concerns: [:activity, :transactionable]
-    resources :programmes, only: [], concerns: [:transactionable] do
-      resources :budgets, except: [:destroy]
+
+    resources :activities, only: [], concerns: [:transactionable, :budgetable] do
+      resources :steps, controller: "activity_forms"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     end
     # TODO: Extend with more hierarchies using this format
     # resources :programmes, only: [], concerns: [:activity, :transactionable]
+    resources :programmes, only: [], concerns: [:transactionable] do
+      resources :budgets, except: [:destroy]
+    end
   end
 
   # Authentication

--- a/db/migrate/20200122150646_create_budgets.rb
+++ b/db/migrate/20200122150646_create_budgets.rb
@@ -1,0 +1,12 @@
+class CreateBudgets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :budgets, id: :uuid do |t|
+      t.references :activity, type: :uuid
+      t.string :budget_type
+      t.string :status
+      t.date :period_start_date
+      t.date :period_end_date
+      t.decimal :value, precision: 13, scale: 2
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,16 @@ ActiveRecord::Schema.define(version: 2020_01_30_144115) do
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
   end
 
+  create_table "budgets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "activity_id"
+    t.string "budget_type"
+    t.string "status"
+    t.date "period_start_date"
+    t.date "period_end_date"
+    t.decimal "value", precision: 13, scale: 2
+    t.index ["activity_id"], name: "index_budgets_on_activity_id"
+  end
+
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "organisation_type"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -22,6 +22,14 @@ FactoryBot.define do
 
     association :organisation, factory: :organisation
 
+    factory :programme_activity do
+      level { :programme }
+    end
+
+    factory :fund_activity do
+      level { :fund }
+    end
+
     trait :at_purpose_step do
       wizard_status { "identifier" }
       title { nil }

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :budget do
+    budget_type { "original" }
+    status { "indicative" }
+    period_start_date { Date.today }
+    period_end_date { Date.tomorrow }
+    value { 110.01 }
+    association :activity
+  end
+end

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Users can create a budget" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.programme.button.create_budget"))
+        click_on(I18n.t("page_content.budgets.button.create"))
 
         click_button I18n.t("generic.button.submit")
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe "Users can create a budget" do
+  let(:organisation) { create(:organisation, name: "UKSA") }
+
+  context "when the user is not logged in" do
+    it "redirects the user to the root path" do
+      activity = create(:activity)
+      page.set_rack_session(userinfo: nil)
+      visit new_activity_budget_path(activity)
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "on a programme" do
+    let!(:activity) { create(:activity, organisation: organisation) }
+
+    context "as a fund manager" do
+      let(:fund_manager) { create(:fund_manager, organisation: organisation) }
+
+      before { authenticate!(user: fund_manager) }
+
+      scenario "successfully creates a budget" do
+        visit organisation_path(organisation)
+
+        click_on(activity.title)
+
+        click_on(I18n.t("page_content.budgets.button.create"))
+
+        choose("budget[budget_type]", option: "original")
+        choose("budget[status]", option: "indicative")
+        fill_in "budget[period_start_date(3i)]", with: "01"
+        fill_in "budget[period_start_date(2i)]", with: "01"
+        fill_in "budget[period_start_date(1i)]", with: "2020"
+        fill_in "budget[period_end_date(3i)]", with: "01"
+        fill_in "budget[period_end_date(2i)]", with: "01"
+        fill_in "budget[period_end_date(1i)]", with: "2021"
+        fill_in "budget[value]", with: "1000.00"
+        click_button I18n.t("generic.button.submit")
+
+        expect(page).to have_content(I18n.t("form.budget.create.success"))
+      end
+
+      scenario "sees validation errors for missing attributes" do
+        visit organisation_path(organisation)
+
+        click_on(activity.title)
+
+        click_on(I18n.t("page_content.programme.button.create_budget"))
+
+        click_button I18n.t("generic.button.submit")
+
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("Budget type can't be blank")
+        expect(page).to have_content("Status can't be blank")
+        expect(page).to have_content("Period start date can't be blank")
+        expect(page).to have_content("Period end date can't be blank")
+        expect(page).to have_content("Value is not included in the list")
+      end
+    end
+
+    context "as a delivery partner" do
+      let(:delivery_partner) { create(:delivery_partner, organisation: organisation) }
+
+      before { authenticate!(user: delivery_partner) }
+
+      scenario "cannot create a budget on a programme" do
+        visit new_activity_budget_path(activity)
+
+        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -4,24 +4,46 @@ RSpec.feature "Users can view budgets on an activity page" do
   end
 
   let(:organisation) { create(:organisation) }
-  let(:activity) { create(:activity, organisation: organisation) }
 
-  context "when the user is a fund manager" do
-    let(:user) { create(:fund_manager, organisation: organisation) }
+  context "when the activity is fund_level" do
+    context "when the user is a fund manager" do
+      let(:user) { create(:fund_manager, organisation: organisation) }
 
-    scenario "budget information is shown on the page" do
-      budget = create(:budget, activity: activity)
-      budget_presenter = BudgetPresenter.new(budget)
+      scenario "budget information is not shown on the page" do
+        fund_activity = create(:fund_activity, organisation: organisation)
+        _budget = create(:budget)
 
-      visit organisations_path
-      click_link organisation.name
-      click_link activity.title
+        visit organisations_path
+        click_link organisation.name
+        click_link fund_activity.title
 
-      expect(page).to have_content(budget_presenter.budget_type)
-      expect(page).to have_content(budget_presenter.status)
-      expect(page).to have_content(budget_presenter.period_start_date)
-      expect(page).to have_content(budget_presenter.period_end_date)
-      expect(page).to have_content(budget_presenter.value)
+        expect(page).to_not have_content(I18n.t("page_content.activity.budgets"))
+      end
+    end
+  end
+
+  context "when the activity is programme level" do
+    let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+    let(:programme_activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+
+    context "when the user is a fund manager" do
+      let(:user) { create(:fund_manager, organisation: organisation) }
+
+      scenario "budget information is shown on the page" do
+        budget = create(:budget, activity: programme_activity)
+        budget_presenter = BudgetPresenter.new(budget)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link fund_activity.title
+        click_link programme_activity.title
+
+        expect(page).to have_content(budget_presenter.budget_type)
+        expect(page).to have_content(budget_presenter.status)
+        expect(page).to have_content(budget_presenter.period_start_date)
+        expect(page).to have_content(budget_presenter.period_end_date)
+        expect(page).to have_content(budget_presenter.value)
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -1,0 +1,27 @@
+RSpec.feature "Users can view budgets on an activity page" do
+  before do
+    authenticate!(user: user)
+  end
+
+  let(:organisation) { create(:organisation) }
+  let(:activity) { create(:activity, organisation: organisation) }
+
+  context "when the user is a fund manager" do
+    let(:user) { create(:fund_manager, organisation: organisation) }
+
+    scenario "budget information is shown on the page" do
+      budget = create(:budget, activity: activity)
+      budget_presenter = BudgetPresenter.new(budget)
+
+      visit organisations_path
+      click_link organisation.name
+      click_link activity.title
+
+      expect(page).to have_content(budget_presenter.budget_type)
+      expect(page).to have_content(budget_presenter.status)
+      expect(page).to have_content(budget_presenter.period_start_date)
+      expect(page).to have_content(budget_presenter.period_end_date)
+      expect(page).to have_content(budget_presenter.value)
+    end
+  end
+end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Budget do
+  describe "relations" do
+    it { should belong_to(:activity) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:status) }
+    it { should validate_presence_of(:budget_type) }
+    it { should validate_presence_of(:period_start_date) }
+    it { should validate_presence_of(:period_end_date) }
+    it { should validate_presence_of(:value) }
+  end
+
+  context "value must be between 1 and 99,999,999,999.00 (100 billion minus one)" do
+    it "allows the maximum possible value" do
+      budget = build(:budget, value: 99_999_999_999.00)
+      expect(budget).to be_valid
+    end
+
+    it "does not allow a value of less than 1" do
+      budget = build(:budget, value: -1)
+      expect(budget).to_not be_valid
+    end
+
+    it "does not allow a value of more than 99,999,999,999.00" do
+      budget = build(:budget, value: 100_000_000_000.00)
+      expect(budget).to_not be_valid
+    end
+
+    it "allows a value between 1 and 99,999,999,999.00" do
+      budget = build(:budget, value: 500_000.00)
+      expect(budget).to be_valid
+    end
+  end
+
+  context "date must be between 10 years ago and 25 years from now" do
+    it "does not allow a date more than 10 years ago" do
+      budget = build(:budget, period_start_date: 11.years.ago)
+      expect(budget).to_not be_valid
+      expect(budget.errors[:period_start_date]).to include "Date must be between 10 years ago and 25 years in the future"
+    end
+
+    it "does not allow a date more than 25 years in the future" do
+      budget = build(:budget, period_start_date: 26.years.from_now)
+      expect(budget).to_not be_valid
+      expect(budget.errors[:period_start_date]).to include "Date must be between 10 years ago and 25 years in the future"
+    end
+
+    it "allows a date between 10 years ago and 25 years in the future" do
+      budget = build(:budget, period_start_date: Date.today)
+      expect(budget).to be_valid
+    end
+
+    it "does not allow nil date" do
+      budget = build(:budget, period_start_date: nil)
+      expect(budget).to_not be_valid
+    end
+  end
+end

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe BudgetPolicy do
+  let(:activity) { create(:activity) }
+  let(:budget) { create(:budget, activity: activity) }
+  subject { described_class.new(user, budget) }
+
+  context "as an administrator" do
+    let(:user) { build_stubbed(:administrator) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "includes budget in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Budget.all).resolve
+      expect(resolved_scope).to include(budget)
+    end
+  end
+
+  context "as a fund manager" do
+    let(:user) { build_stubbed(:fund_manager) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "includes budget in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Budget.all).resolve
+      expect(resolved_scope).to include(budget)
+    end
+  end
+
+  context "as a delivery partner" do
+    let(:user) { build_stubbed(:delivery_partner) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "does not include include budget in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Budget.all).resolve
+      expect(resolved_scope).not_to include(budget)
+    end
+  end
+end

--- a/spec/presenters/budget_presenter_spec.rb
+++ b/spec/presenters/budget_presenter_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe BudgetPresenter do
+  let(:budget) { build_stubbed(:budget, period_start_date: "2020-02-02", period_end_date: "2021-01-01") }
+
+  describe "#budget_type" do
+    it "returns the I18n string for the budget_type" do
+      expect(described_class.new(budget).budget_type).to eq("Original")
+    end
+  end
+
+  describe "#status" do
+    it "returns the I18n string for the status" do
+      expect(described_class.new(budget).status).to eq("Indicative")
+    end
+  end
+
+  describe "#period_start_date" do
+    it "returns the localised date for the period_start_date" do
+      expect(described_class.new(budget).period_start_date).to eq("2 Feb 2020")
+    end
+  end
+
+  describe "#period_start_date" do
+    it "returns the localised date for the period_end_date" do
+      expect(described_class.new(budget).period_end_date).to eq("1 Jan 2021")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/GcJI6seX/142-add-budgets-to-a-programme

Fund managers can create Budgets on an Activity.

Budgets can only be created against Programme Activities. Budgets are not listed on Fund Activity show pages, and if the user tries to create a Budget against a fund, they will see an error message. 

## Screenshots of UI changes

<img width="826" alt="Screenshot 2020-01-30 at 17 20 40" src="https://user-images.githubusercontent.com/1089521/73473558-e2eabc80-4384-11ea-9bc7-8185e11c42f9.png">

<img width="1138" alt="Screenshot 2020-01-30 at 17 19 19" src="https://user-images.githubusercontent.com/1089521/73473576-e8480700-4384-11ea-9620-1c30adeb5c56.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
