### PR TITLE
Fund managers can add and view programme level actvities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 - Restrict delivery partners so they can only view and edit their own organisation
 - Fund managers can manage users, organisations, funds, fund activites and fund transactions
 - Transaction and Activity dates are restricted to 10 years in the past or 25 years in the future at most
-- Fund managers can create basic programmes
 - Provide a way to flag an organisation as BEIS
 - User email addresses must be valid emails
 - Users are only associated with one organisation
 - Users land on their organisation#show page when they log in, instead of a "dashboard"
+- Fund manager can add a programme level activity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,5 @@
 - User email addresses must be valid emails
 - Users are only associated with one organisation
 - Users land on their organisation#show page when they log in, instead of a "dashboard"
-- Fund manager can add a programme level activity
+- Fund manager can add a programme level activity to a fund level activity
+- Fund manager can view a fund level activity's programme activities

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -11,6 +11,8 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity = Activity.find(id)
     authorize @activity
 
+    @activities = @activity.activities.map { |activity| ActivityPresenter.new(activity) }
+
     @transactions = policy_scope(Transaction).where(activity: @activity)
 
     respond_to do |format|
@@ -31,5 +33,9 @@ class Staff::ActivitiesController < Staff::BaseController
 
   def organisation_id
     params[:organisation_id]
+  end
+
+  def fund_id
+    params[:fund_id]
   end
 end

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,7 +11,7 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    activities = policy_scope(Activity).includes(:organisation).where(organisation: organisation)
+    activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation)
     @activities = activities.map { |activity| ActivityPresenter.new(activity) }
   end
 

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -4,6 +4,8 @@ class Staff::ProgrammesController < Staff::ActivitiesController
   def create
     @activity = Activity.new
     @activity.organisation = Organisation.find(organisation_id)
+    fund = Activity.find(fund_id)
+    fund.activities << @activity
     authorize @activity
 
     @activity.wizard_status = "identifier"

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Staff::ProgrammesController < Staff::ActivitiesController
+  def create
+    @activity = Activity.new
+    @activity.organisation = Organisation.find(organisation_id)
+    authorize @activity
+
+    @activity.wizard_status = "identifier"
+    @activity.level = :programme
+    @activity.save(validate: false)
+
+    redirect_to activity_step_path(@activity.id, @activity.wizard_status)
+  end
+end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -9,4 +9,9 @@ module ActivityHelper
 
     presenter_position <= activity_position + 1
   end
+
+  def activity_back_path(activity)
+    return organisation_path(activity.organisation) if activity.is_fund_level?
+    return organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity) if activity.is_programme_level?
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -11,6 +11,8 @@ class Activity < ApplicationRecord
   validates_uniqueness_of :identifier
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
 
+  belongs_to :activity, optional: true
+  has_many :activities, foreign_key: "activity_id"
   belongs_to :organisation
 
   enum level: {

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -15,6 +15,7 @@ class Activity < ApplicationRecord
 
   enum level: {
     fund: "fund",
+    programme: "programme",
   }
 
   def identifier_step?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -20,6 +20,8 @@ class Activity < ApplicationRecord
     programme: "programme",
   }
 
+  scope :funds, -> { where(level: :fund) }
+
   def identifier_step?
     %w[identifier complete].include?(wizard_status)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -62,4 +62,12 @@ class Activity < ApplicationRecord
   def default_currency
     organisation.default_currency
   end
+
+  def is_fund_level?
+    level == "fund"
+  end
+
+  def is_programme_level?
+    level == "programme"
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -70,4 +70,9 @@ class Activity < ApplicationRecord
   def is_programme_level?
     level == "programme"
   end
+
+  def parent_activity
+    return if activity_id.nil?
+    Activity.find(activity_id)
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -21,6 +21,7 @@ class Activity < ApplicationRecord
   }
 
   scope :funds, -> { where(level: :fund) }
+  scope :programmes, -> { where(level: :programme) }
 
   def identifier_step?
     %w[identifier complete].include?(wizard_status)

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.activity.show", name: @activity.title)
 
-= link_to t("generic.link.back"), organisation_path(@activity.organisation), class: "govuk-back-link"
+= link_to t("generic.link.back"), activity_back_path(@activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -11,6 +11,18 @@
     .govuk-grid-column-two-thirds
       = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
 
+  - if @activity.is_fund_level?
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        %h2.govuk-heading-m
+          = t("page_content.organisation.programmes")
+        = form_tag(organisation_fund_programmes_path(@activity.organisation, @activity), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
+        %ul.govuk-list.govuk-list--bullet
+          - @activities.each do |activity|
+            %li
+              = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-m

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -60,6 +60,9 @@
       - if policy(Activity).index?
         %ul.govuk-list.govuk-list--bullet
           - @activities.each do |activity|
-
             %li
               = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+        %h2.govuk-heading-m
+          =t("page_content.organisation.programmes")
+        = form_tag(organisation_programmes_path(@organisation_presenter), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -62,7 +62,3 @@
           - @activities.each do |activity|
             %li
               = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
-        %h2.govuk-heading-m
-          =t("page_content.organisation.programmes")
-        = form_tag(organisation_programmes_path(@organisation_presenter), method: "post") do
-          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
         label: Organisation type
       update:
         success: Organisation successfully updated
+    programme:
+      create:
+        success: Programme successfully created
     transaction:
       create:
         success: Transaction successfully created
@@ -143,6 +146,7 @@ en:
     organisation:
       button:
         create_fund: Create fund
+        create_programme: Create programme
         edit: Edit organisation
       default_currency:
         label: Default currency
@@ -151,6 +155,7 @@ en:
         label: Language code
       name:
         label: Name
+      programmes: Programmes
       type:
         label: Type
     organisations:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
       resources :funds, only: [:create]
+      resources :programmes, only: [:create]
     end
 
     concern :transactionable do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,9 @@ Rails.application.routes.draw do
     resources :users
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
-      resources :funds, only: [:create]
-      resources :programmes, only: [:create]
+      resources :funds, only: [:create] do
+        resources :programmes, only: [:create]
+      end
     end
 
     concern :transactionable do

--- a/db/migrate/20200130144115_add_activity_reference_to_activity.rb
+++ b/db/migrate/20200130144115_add_activity_reference_to_activity.rb
@@ -1,0 +1,5 @@
+class AddActivityReferenceToActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :activities, :activity, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_155455) do
+ActiveRecord::Schema.define(version: 2020_01_30_144115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_155455) do
     t.string "tied_status"
     t.string "wizard_status"
     t.string "level"
+    t.uuid "activity_id"
+    t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
   end
@@ -81,4 +83,5 @@ ActiveRecord::Schema.define(version: 2020_01_28_155455) do
     t.index ["role"], name: "index_users_on_role"
   end
 
+  add_foreign_key "activities", "activities"
 end

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Fund managers can create programme level activities" do
       fund = create(:activity, level: :fund, organisation: organisation)
 
       visit organisation_path(organisation)
+      click_on fund.title
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
       fill_in_activity_form

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -1,0 +1,20 @@
+RSpec.feature "Fund managers can create programme level activities" do
+  let(:organisation) { create(:organisation, name: "BEIS") }
+
+  context "when signed in" do
+    before do
+      authenticate!(user: create(:fund_manager, organisation: organisation))
+    end
+
+    scenario "successfully create a activity" do
+      fund = create(:activity, level: :fund, organisation: organisation)
+
+      visit organisation_path(organisation)
+      click_on(I18n.t("page_content.organisation.button.create_programme"))
+
+      fill_in_activity_form
+
+      expect(page).to have_content I18n.t("form.programme.create.success")
+    end
+  end
+end

--- a/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
@@ -14,13 +14,13 @@ RSpec.feature "Fund managers can view fund level activities" do
       authenticate!(user: create(:fund_manager))
     end
 
-    scenario "the user will see activities on the organisation show page" do
-      activity = create(:activity, organisation: organisation)
+    scenario "the user will see fund level activities on the organisation show page" do
+      fund_activity = create(:activity, level: :fund, organisation: organisation)
       visit organisations_path
       click_link organisation.name
 
       expect(page).to have_content(I18n.t("page_content.organisation.funds"))
-      expect(page).to have_content activity.title
+      expect(page).to have_content fund_activity.title
     end
 
     context "when the activity is partially complete and doesn't have a title" do

--- a/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_fund_level_activities_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Fund managers can view fund level activities" do
   end
 
   let(:organisation) { create(:organisation) }
+  let!(:fund_activity) { create(:activity, level: :fund, organisation: organisation) }
 
   context "when the user is a fund_manager" do
     before do
@@ -15,12 +16,27 @@ RSpec.feature "Fund managers can view fund level activities" do
     end
 
     scenario "the user will see fund level activities on the organisation show page" do
-      fund_activity = create(:activity, level: :fund, organisation: organisation)
       visit organisations_path
       click_link organisation.name
 
       expect(page).to have_content(I18n.t("page_content.organisation.funds"))
       expect(page).to have_content fund_activity.title
+    end
+
+    scenario "can view a fund level activity" do
+      visit organisation_activity_path(fund_activity.organisation, fund_activity)
+
+      expect(page).to have_content fund_activity.title
+    end
+
+    scenario "can view and create programme level activities" do
+      programme_activity = create(:activity, level: :programme)
+      fund_activity.activities << programme_activity
+      activity_presenter = ActivityPresenter.new(programme_activity)
+      visit organisation_activity_path(fund_activity.organisation, fund_activity)
+
+      expect(page).to have_link activity_presenter.display_title
+      expect(page).to have_button I18n.t("page_content.organisation.button.create_programme")
     end
 
     context "when the activity is partially complete and doesn't have a title" do

--- a/spec/features/staff/fund_managers_can_view_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_programme_level_activity_spec.rb
@@ -1,14 +1,15 @@
 RSpec.feature "Fund managers can view programe level activites" do
   let(:programme) { create(:activity, level: :programme) }
+  let(:fund_activity) { create(:activity, level: :fund) }
 
   context "when signed in" do
     before do
       authenticate!(user: create(:fund_manager))
+      fund_activity.activities << programme
     end
 
     it "shows the programme level activity" do
       visit organisation_activity_path(programme.organisation, programme)
-
       expect(page).to have_content programme.title
     end
 

--- a/spec/features/staff/fund_managers_can_view_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_programme_level_activity_spec.rb
@@ -1,0 +1,34 @@
+RSpec.feature "Fund managers can view programe level activites" do
+  let(:programme) { create(:activity, level: :programme) }
+
+  context "when signed in" do
+    before do
+      authenticate!(user: create(:fund_manager))
+    end
+
+    it "shows the programme level activity" do
+      visit organisation_activity_path(programme.organisation, programme)
+
+      expect(page).to have_content programme.title
+    end
+
+    it "does not show a create programme button" do
+      visit organisation_activity_path(programme.organisation, programme)
+
+      expect(page).not_to have_button I18n.t("page_content.organisation.button.create_programme")
+    end
+
+    it "shows the create transaction button" do
+      visit organisation_activity_path(programme.organisation, programme)
+
+      expect(page).to have_link I18n.t("page_content.transactions.button.create")
+    end
+  end
+
+  context "when signed out" do
+    it "redirects to the root path" do
+      visit organisation_activity_path(programme.organisation, programme)
+      expect(current_path).to eq root_path
+    end
+  end
+end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -3,6 +3,25 @@ require "rails_helper"
 RSpec.describe ActivityHelper, type: :helper do
   let(:organisation) { create(:organisation) }
 
+  describe "#activity_back_path" do
+    context "when the activity is a fund level" do
+      it "returns the organistian path" do
+        fund = create(:activity, level: :fund)
+        expect(activity_back_path(fund)).to eq organisation_path(fund.organisation)
+      end
+    end
+
+    context "when the activity is a programme level" do
+      it "returns the fund path" do
+        fund_activity = create(:activity, level: :fund)
+        programme_activity = create(:activity, level: :programme)
+        fund_activity.activities << programme_activity
+
+        expect(activity_back_path(programme_activity)).to eq organisation_activity_path(fund_activity.organisation, fund_activity)
+      end
+    end
+  end
+
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do
       it "returns true for the purpose fields" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  describe "scopes" do
+    describe ".funds" do
+      it "only returns fund level activities" do
+        fund_activity = create(:activity, level: :fund)
+        _other_activiy = create(:activity, level: :programme)
+
+        expect(Activity.funds).to eq [fund_activity]
+      end
+    end
+  end
   describe "validations" do
     describe "constraints" do
       it { should validate_uniqueness_of(:identifier) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe Activity, type: :model do
         expect(Activity.funds).to eq [fund_activity]
       end
     end
+
+    describe ".programmes" do
+      it "only returns programme level activities" do
+        programme_activity = create(:activity, level: :programme)
+        _other_activiy = create(:activity, level: :fund)
+
+        expect(Activity.programmes).to eq [programme_activity]
+      end
+    end
   end
+
   describe "validations" do
     describe "constraints" do
       it { should validate_uniqueness_of(:identifier) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -105,5 +105,7 @@ RSpec.describe Activity, type: :model do
 
   describe "relations" do
     it { should belong_to(:organisation) }
+    it { should belong_to(:activity).optional }
+    it { should have_many(:activities).with_foreign_key("activity_id") }
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -123,9 +123,40 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "relations" do
+  describe "associations" do
     it { should belong_to(:organisation) }
     it { should belong_to(:activity).optional }
     it { should have_many(:activities).with_foreign_key("activity_id") }
+  end
+
+  describe "#is_fund_level?" do
+    it "returns true when the activity is at the fund level" do
+      activity = Activity.new(level: :fund)
+      expect(activity.is_fund_level?).to eq true
+
+      activity = Activity.new(level: :programme)
+      expect(activity.is_fund_level?).to eq false
+    end
+  end
+
+  describe "#is_programme_level?" do
+    it "returns true when the activity is at the programme level" do
+      activity = Activity.new(level: :programme)
+      expect(activity.is_programme_level?).to eq true
+
+      activity = Activity.new(level: :fund)
+      expect(activity.is_programme_level?).to eq false
+    end
+  end
+
+  describe "#parent_activity" do
+    it "returns the parent activity or nil if there is not one" do
+      fund_activity = create(:activity, level: :fund)
+      programme_activity = create(:activity, level: :programme)
+      fund_activity.activities << programme_activity
+
+      expect(programme_activity.parent_activity).to eql fund_activity
+      expect(fund_activity.parent_activity).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
Programme level activities can be added to a fund level activity. The programme level activities are only shown on the fund level activity show page to which they belong.

All Activities are still shown on their `orgnaisation/:id/activity/:id` paths.

The back link used on the activity show pages now knows on which level it is used and can provide the 'parent' activity – this feels like a bit of a quick fix – but I didn't want to go down a rabbit hole of how the system will work in the future - the back links work for this scope of work!

I've added a foriegn key constraint to the activity association to stop 'parent' activities being deleted when they still have 'children' – I wasn't 100% that this is:

- the behaviour we want in the model
- the right way to declare and test this

so please let me know what you think, it's all in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/commit/5272781b3dccf84170785cbde1a74399ac1c129c

I struggled a bit with the feature tests, as the file names and contexts and contents feel a bit off to me. I hope I got enough covered and that the exisiting tests give us the coverage for delivery partner users not seeing fund or programme level activities.

I also feel like we have some work to do around the policies and how they work with this new model, but again I felt like that is a hole we should go down together and not be a part of this work! 🐰 

The way this panned out there are two stories to move accross the board for this:

https://trello.com/c/zqHR7vCB
https://trello.com/c/66Io0Ni9
 
## Screenshots of UI changes

Viewing an organisation with a fund:
![Screenshot_2020-01-31 Organisation Department for Business, Energy Industrial Strategy — Report Official Development Assist](https://user-images.githubusercontent.com/480578/73558892-f745bc80-444b-11ea-9e66-021d4a4e0a26.png)

Viewing the fund with it's programmes:
![Screenshot_2020-01-31 Activity GCRF — Report Official Development Assistance(2)](https://user-images.githubusercontent.com/480578/73558921-0593d880-444c-11ea-8aac-5820cc570410.png)

Viewing a programme:
![Screenshot_2020-01-31 Activity Programme — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/73558956-13e1f480-444c-11ea-9431-2b3b268fd67d.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
