### PR TITLE
Remove the word "Organisation" from the organisation show page title

### DIFF
--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -6,7 +6,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       %h1.govuk-heading-xl
-        = t("page_title.organisation.show", name: @organisation_presenter.name)
+        = @organisation_presenter.name
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can view an organisation" do
       scenario "can see their own organisation page" do
         visit organisation_path(organisation)
 
-        expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
+        expect(page).to have_content(organisation.name)
       end
 
       scenario "does not see a back link on their organisation page" do
@@ -37,7 +37,7 @@ RSpec.feature "Users can view an organisation" do
         click_link I18n.t("page_content.dashboard.button.manage_organisations")
         click_link other_organisation.name
 
-        expect(page).to have_content(I18n.t("page_title.organisation.show", name: other_organisation.name))
+        expect(page).to have_content(other_organisation.name)
       end
 
       scenario "can go back to the previous page" do
@@ -62,7 +62,7 @@ RSpec.feature "Users can view an organisation" do
     scenario "can see their organisation page" do
       visit organisation_path(organisation)
 
-      expect(page).to have_content(I18n.t("page_title.organisation.show", name: organisation.name))
+      expect(page).to have_content(organisation.name)
     end
 
     scenario "does not see a back link on their organisation home page" do


### PR DESCRIPTION
# Changes in this PR

https://trello.com/c/S1w9OyXP/214-all-user-roles-are-taken-to-the-organisation-show-page-rather-than-a-dashboard#comment-5e3453bb0232ed133ea28d48

Adding the word "Organisation" from the organisation page title was confusing -
two people on product have pointed out that it's unnecessary. Just show the name
of the organisation as the page title.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
