### PR TITLE
(227) Activities collect information about participating organisations that provide the funds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@
 - Fund manager can add a programme level activity to a fund level activity
 - Fund manager can view a fund level activity's programme activities
 - Fund managers can create Budgets
+- Fund and Programme activities store funding organisation details

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -8,6 +8,9 @@ class Staff::FundsController < Staff::ActivitiesController
 
     @activity.wizard_status = "identifier"
     @activity.level = :fund
+    @activity.funding_organisation_name = "HM Treasury"
+    @activity.funding_organisation_reference = "GB-GOV-2"
+    @activity.funding_organisation_type = "10"
     @activity.save(validate: false)
 
     redirect_to activity_step_path(@activity.id, @activity.wizard_status)

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -2,16 +2,8 @@
 
 class Staff::FundsController < Staff::ActivitiesController
   def create
-    @activity = Activity.new
-    @activity.organisation = Organisation.find(organisation_id)
+    @activity = CreateFundActivity.new(organisation_id: organisation_id).call
     authorize @activity
-
-    @activity.wizard_status = "identifier"
-    @activity.level = :fund
-    @activity.funding_organisation_name = "HM Treasury"
-    @activity.funding_organisation_reference = "GB-GOV-2"
-    @activity.funding_organisation_type = "10"
-    @activity.save(validate: false)
 
     redirect_to activity_step_path(@activity.id, @activity.wizard_status)
   end

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -10,6 +10,9 @@ class Staff::ProgrammesController < Staff::ActivitiesController
 
     @activity.wizard_status = "identifier"
     @activity.level = :programme
+    @activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    @activity.funding_organisation_reference = "GB-GOV-13"
+    @activity.funding_organisation_type = "10"
     @activity.save(validate: false)
 
     redirect_to activity_step_path(@activity.id, @activity.wizard_status)

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -2,18 +2,8 @@
 
 class Staff::ProgrammesController < Staff::ActivitiesController
   def create
-    @activity = Activity.new
-    @activity.organisation = Organisation.find(organisation_id)
-    fund = Activity.find(fund_id)
-    fund.activities << @activity
+    @activity = CreateProgrammeActivity.new(organisation_id: organisation_id, fund_id: fund_id).call
     authorize @activity
-
-    @activity.wizard_status = "identifier"
-    @activity.level = :programme
-    @activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
-    @activity.funding_organisation_reference = "GB-GOV-13"
-    @activity.funding_organisation_type = "10"
-    @activity.save(validate: false)
 
     redirect_to activity_step_path(@activity.id, @activity.wizard_status)
   end

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -1,0 +1,20 @@
+class CreateFundActivity
+  attr_accessor :organisation_id
+
+  def initialize(organisation_id:)
+    self.organisation_id = organisation_id
+  end
+
+  def call
+    activity = Activity.new
+    activity.organisation = Organisation.find(organisation_id)
+
+    activity.wizard_status = "identifier"
+    activity.level = :fund
+    activity.funding_organisation_name = "HM Treasury"
+    activity.funding_organisation_reference = "GB-GOV-2"
+    activity.funding_organisation_type = "10"
+    activity.save(validate: false)
+    activity
+  end
+end

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -1,0 +1,23 @@
+class CreateProgrammeActivity
+  attr_accessor :organisation_id, :fund_id
+
+  def initialize(organisation_id:, fund_id:)
+    self.organisation_id = organisation_id
+    self.fund_id = fund_id
+  end
+
+  def call
+    activity = Activity.new
+    activity.organisation = Organisation.find(organisation_id)
+    fund = Activity.find(fund_id)
+    fund.activities << activity
+
+    activity.wizard_status = "identifier"
+    activity.level = :programme
+    activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.funding_organisation_reference = "GB-GOV-13"
+    activity.funding_organisation_type = "10"
+    activity.save(validate: false)
+    activity
+  end
+end

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -17,6 +17,8 @@
   %default-finance-type{"code" => "#{activity.finance}"}
   %default-aid-type{"code" => "#{activity.aid_type}"}
   %default-tied-status{"code" => "#{activity.tied_status}"}
+  %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
+    %narrative= activity.funding_organisation_name
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/db/migrate/20200203140136_add_funding_organisation_details_to_activities.rb
+++ b/db/migrate/20200203140136_add_funding_organisation_details_to_activities.rb
@@ -1,0 +1,9 @@
+class AddFundingOrganisationDetailsToActivities < ActiveRecord::Migration[6.0]
+  def change
+    change_table :activities do |t|
+      t.string :funding_organisation_name
+      t.string :funding_organisation_reference
+      t.string :funding_organisation_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_30_144115) do
+ActiveRecord::Schema.define(version: 2020_02_03_140136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -37,6 +37,9 @@ ActiveRecord::Schema.define(version: 2020_01_30_144115) do
     t.string "wizard_status"
     t.string "level"
     t.uuid "activity_id"
+    t.string "funding_organisation_name"
+    t.string "funding_organisation_reference"
+    t.string "funding_organisation_type"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -22,12 +22,18 @@ FactoryBot.define do
 
     association :organisation, factory: :organisation
 
-    factory :programme_activity do
-      level { :programme }
-    end
-
     factory :fund_activity do
       level { :fund }
+      funding_organisation_name { "HM Treasury" }
+      funding_organisation_reference { "GB-GOV-2" }
+      funding_organisation_type { "10" }
+    end
+
+    factory :programme_activity do
+      level { :programme }
+      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      funding_organisation_reference { "GB-GOV-13" }
+      funding_organisation_type { "10" }
     end
   end
 

--- a/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
@@ -39,6 +39,20 @@ RSpec.feature "Fund managers can create a fund level activity" do
       expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.tied_status
     end
 
+    scenario "the activity has the appropriate funding organisation defaults" do
+      identifier = "a-fund-has-a-funding-organisation"
+
+      visit organisation_path(organisation)
+      click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+      fill_in_activity_form(identifier: identifier)
+
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.funding_organisation_name).to eq("HM Treasury")
+      expect(activity.funding_organisation_reference).to eq("GB-GOV-2")
+      expect(activity.funding_organisation_type).to eq("10")
+    end
+
     context "validations" do
       scenario "validation errors work as expected" do
         visit organisation_path(organisation)

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Fund managers can create programme level activities" do
       authenticate!(user: create(:fund_manager, organisation: organisation))
     end
 
-    scenario "successfully create a activity" do
+    scenario "successfully create an activity" do
       fund = create(:activity, level: :fund, organisation: organisation)
 
       visit organisation_path(organisation)
@@ -16,6 +16,22 @@ RSpec.feature "Fund managers can create programme level activities" do
       fill_in_activity_form
 
       expect(page).to have_content I18n.t("form.programme.create.success")
+    end
+
+    scenario "the activity has the appropriate funding organisation defaults" do
+      identifier = "a-programme-has-a-funding-organisation"
+      fund = create(:activity, level: :fund, organisation: organisation)
+
+      visit organisation_path(organisation)
+      click_on fund.title
+      click_on(I18n.t("page_content.organisation.button.create_programme"))
+
+      fill_in_activity_form(identifier: identifier)
+
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(activity.funding_organisation_reference).to eq("GB-GOV-13")
+      expect(activity.funding_organisation_type).to eq("10")
     end
   end
 end

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe CreateFundActivity do
+  let(:organisation) { create(:organisation) }
+
+  describe "#call" do
+    let(:result) { described_class.new(organisation_id: organisation.id).call }
+
+    it "sets the Organisation" do
+      expect(result.organisation).to eq(organisation)
+    end
+
+    it "sets the initial wizard_status" do
+      expect(result.wizard_status).to eq("identifier")
+    end
+
+    it "sets the activity level to 'fund'" do
+      expect(result.level).to eq("fund")
+    end
+
+    it "sets the funding organisation details" do
+      expect(result.funding_organisation_name).to eq("HM Treasury")
+      expect(result.funding_organisation_reference).to eq("GB-GOV-2")
+      expect(result.funding_organisation_type).to eq("10")
+    end
+  end
+end

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe CreateProgrammeActivity do
+  let(:organisation) { create(:organisation) }
+  let(:fund) { create(:fund_activity) }
+
+  describe "#call" do
+    let(:result) { described_class.new(organisation_id: organisation.id, fund_id: fund.id).call }
+
+    it "sets the Organisation" do
+      expect(result.organisation).to eq(organisation)
+    end
+
+    it "sets the parent Activity to the fund" do
+      expect(result.activity).to eq(fund)
+    end
+
+    it "sets the initial wizard_status" do
+      expect(result.wizard_status).to eq("identifier")
+    end
+
+    it "sets the Activity level to 'programme'" do
+      expect(result.level).to eq("programme")
+    end
+
+    it "sets the funding organisation details" do
+      expect(result.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(result.funding_organisation_reference).to eq("GB-GOV-13")
+      expect(result.funding_organisation_type).to eq("10")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/LZjMGZPu/227-activities-collect-information-about-the-participating-organisations-that-provides-the-funds-funder

Add the Funding Organisation information to an Activity. For now, this is a hard-coded set of information, which differs depending on whether the Activity is a programme or fund activity. 

Eventually we will make this information something the Fund managers can choose, but for now it is static. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
