### PR TITLE
Transactions have human readable dates

### DIFF
--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -4,6 +4,11 @@ class TransactionPresenter < SimpleDelegator
     I18n.t("transaction.transaction_type.#{super}")
   end
 
+  def date
+    return if super.blank?
+    I18n.l(super)
+  end
+
   def currency
     return if super.blank?
     I18n.t("generic.default_currency.#{super.downcase}")

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe TransactionPresenter do
     end
   end
 
+  describe "#date" do
+    it "returns a human readable date" do
+      transaction.date = "2020-06-25"
+      expect(described_class.new(transaction).date).to eq("25 Jun 2020")
+    end
+  end
+
   describe "#currency" do
     it "returns the I18n string for the currency" do
       expect(described_class.new(transaction).currency).to eq("Pound Sterling")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -116,19 +116,15 @@ module FormHelpers
     expect(page).to have_content finance
     expect(page).to have_content aid_type
     expect(page).to have_content tied_status
-    expect(page).to have_content I18n.l(
-      date(
-        year: planned_start_date_year,
-        month: planned_start_date_month,
-        day: planned_start_date_day
-      )
+    expect(page).to have_content localise_date_from_input_fields(
+      year: planned_start_date_year,
+      month: planned_start_date_month,
+      day: planned_start_date_day
     )
-    expect(page).to have_content I18n.l(
-      date(
-        year: planned_end_date_year,
-        month: planned_end_date_month,
-        day: planned_end_date_day
-      )
+    expect(page).to have_content localise_date_from_input_fields(
+      year: planned_end_date_year,
+      month: planned_end_date_month,
+      day: planned_end_date_day
     )
   end
 
@@ -163,7 +159,11 @@ module FormHelpers
         expect(page).to have_content(reference)
         expect(page).to have_content(description)
         expect(page).to have_content(transaction_type)
-        expect(page).to have_content(date(year: date_year, month: date_month, day: date_day))
+        expect(page).to have_content localise_date_from_input_fields(
+          year: date_year,
+          month: date_month,
+          day: date_day
+        )
         expect(page).to have_content(value)
         expect(page).to have_content(disbursement_channel)
         expect(page).to have_content(currency)
@@ -173,7 +173,7 @@ module FormHelpers
     end
   end
 
-  def date(year:, month:, day:)
-    Date.parse("#{year}-#{month}-#{day}")
+  def localise_date_from_input_fields(year:, month:, day:)
+    I18n.l(Date.parse("#{year}-#{month}-#{day}"))
   end
 end


### PR DESCRIPTION
## Changes in this PR
Added a presenter for a transaction that turns the date into a readable format.

Renamed the spec form helper date method to be more specific and used the local translation inside the method to remove the repetition.

## Screenshots of UI changes

### Before

### After

![transac afterzz Screenshot_2020-02-03 Activity Iusto exercitationem — Report Official Development Assistance](https://user-images.githubusercontent.com/2632224/73677649-95d15800-46ae-11ea-9780-5647a56ced9a.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
