### PR TITLE
(261) Activities collect information about accountable participating organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 - Fund manager can view a fund level activity's programme activities
 - Fund managers can create Budgets
 - Fund and Programme activities store funding organisation details
+- Fund and Programme activities store accountable organisation details

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -11,9 +11,15 @@ class CreateFundActivity
 
     activity.wizard_status = "identifier"
     activity.level = :fund
+
     activity.funding_organisation_name = "HM Treasury"
     activity.funding_organisation_reference = "GB-GOV-2"
     activity.funding_organisation_type = "10"
+
+    activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.accountable_organisation_reference = "GB-GOV-13"
+    activity.accountable_organisation_type = "10"
+
     activity.save(validate: false)
     activity
   end

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -14,9 +14,15 @@ class CreateProgrammeActivity
 
     activity.wizard_status = "identifier"
     activity.level = :programme
+
     activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
     activity.funding_organisation_reference = "GB-GOV-13"
     activity.funding_organisation_type = "10"
+
+    activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.accountable_organisation_reference = "GB-GOV-13"
+    activity.accountable_organisation_type = "10"
+
     activity.save(validate: false)
     activity
   end

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -19,6 +19,8 @@
   %default-tied-status{"code" => "#{activity.tied_status}"}
   %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
     %narrative= activity.funding_organisation_name
+  %participating-org{"ref" => activity.accountable_organisation_reference, "type" => activity.accountable_organisation_type, "role" => 2}
+    %narrative= activity.accountable_organisation_name
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/db/migrate/20200204115513_add_accountable_organisation_details_to_activities.rb
+++ b/db/migrate/20200204115513_add_accountable_organisation_details_to_activities.rb
@@ -1,0 +1,9 @@
+class AddAccountableOrganisationDetailsToActivities < ActiveRecord::Migration[6.0]
+  def change
+    change_table :activities do |t|
+      t.string :accountable_organisation_name
+      t.string :accountable_organisation_reference
+      t.string :accountable_organisation_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_03_140136) do
+ActiveRecord::Schema.define(version: 2020_02_04_115513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -40,6 +40,9 @@ ActiveRecord::Schema.define(version: 2020_02_03_140136) do
     t.string "funding_organisation_name"
     t.string "funding_organisation_reference"
     t.string "funding_organisation_type"
+    t.string "accountable_organisation_name"
+    t.string "accountable_organisation_reference"
+    t.string "accountable_organisation_type"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -27,6 +27,9 @@ FactoryBot.define do
       funding_organisation_name { "HM Treasury" }
       funding_organisation_reference { "GB-GOV-2" }
       funding_organisation_type { "10" }
+      accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      accountable_organisation_reference { "GB-GOV-13" }
+      accountable_organisation_type { "10" }
     end
 
     factory :programme_activity do
@@ -34,6 +37,9 @@ FactoryBot.define do
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
+      accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      accountable_organisation_reference { "GB-GOV-13" }
+      accountable_organisation_type { "10" }
     end
   end
 

--- a/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
@@ -53,6 +53,20 @@ RSpec.feature "Fund managers can create a fund level activity" do
       expect(activity.funding_organisation_type).to eq("10")
     end
 
+    scenario "the activity has the appropriate accountable organisation defaults" do
+      identifier = "a-fund-has-an-accountable-organisation"
+
+      visit organisation_path(organisation)
+      click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+      fill_in_activity_form(identifier: identifier)
+
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(activity.accountable_organisation_type).to eq("10")
+    end
+
     context "validations" do
       scenario "validation errors work as expected" do
         visit organisation_path(organisation)

--- a/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_programme_level_activity_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Fund managers can create programme level activities" do
     end
 
     scenario "the activity has the appropriate funding organisation defaults" do
-      identifier = "a-programme-has-a-funding-organisation"
       fund = create(:activity, level: :fund, organisation: organisation)
+      identifier = "a-programme-has-a-funding-organisation"
 
       visit organisation_path(organisation)
       click_on fund.title
@@ -32,6 +32,22 @@ RSpec.feature "Fund managers can create programme level activities" do
       expect(activity.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
       expect(activity.funding_organisation_reference).to eq("GB-GOV-13")
       expect(activity.funding_organisation_type).to eq("10")
+    end
+
+    scenario "the activity has the appropriate accountable organisation defaults" do
+      fund = create(:activity, level: :fund, organisation: organisation)
+      identifier = "a-fund-has-an-accountable-organisation"
+
+      visit organisation_path(organisation)
+      click_on fund.title
+      click_on(I18n.t("page_content.organisation.button.create_programme"))
+
+      fill_in_activity_form(identifier: identifier)
+
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(activity.accountable_organisation_type).to eq("10")
     end
   end
 end

--- a/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
@@ -19,10 +19,14 @@ RSpec.feature "Fund managers can view an activity as XML" do
         expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
 
         # The funding organisation XML is present
-        expect(xml.at("iati-activity/participating-org/@ref").text).to eq(activity.funding_organisation_reference)
-        expect(xml.at("iati-activity/participating-org/@type").text).to eq(activity.funding_organisation_type)
-        expect(xml.at("iati-activity/participating-org/narrative").text).to eq(activity.funding_organisation_name)
-        expect(xml.at("iati-activity/participating-org/@role").text).to eq("1")
+        expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
+        expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
+        expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+
+        # The accountable organisation XML is present
+        expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
+        expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
+        expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
 
         # The transaction XML is present
         expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
@@ -42,10 +46,14 @@ RSpec.feature "Fund managers can view an activity as XML" do
         expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
 
         # The funding organisation XML is present
-        expect(xml.at("iati-activity/participating-org/@ref").text).to eq(activity.funding_organisation_reference)
-        expect(xml.at("iati-activity/participating-org/@type").text).to eq(activity.funding_organisation_type)
-        expect(xml.at("iati-activity/participating-org/narrative").text).to eq(activity.funding_organisation_name)
-        expect(xml.at("iati-activity/participating-org/@role").text).to eq("1")
+        expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
+        expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
+        expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+
+        # The accountable organisation XML is present
+        expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
+        expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
+        expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
       end
     end
   end

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -23,5 +23,11 @@ RSpec.describe CreateFundActivity do
       expect(result.funding_organisation_reference).to eq("GB-GOV-2")
       expect(result.funding_organisation_type).to eq("10")
     end
+
+    it "sets the accountable organisation details" do
+      expect(result.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(result.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(result.accountable_organisation_type).to eq("10")
+    end
   end
 end

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -28,5 +28,11 @@ RSpec.describe CreateProgrammeActivity do
       expect(result.funding_organisation_reference).to eq("GB-GOV-13")
       expect(result.funding_organisation_type).to eq("10")
     end
+
+    it "sets the accountable organisation details" do
+      expect(result.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(result.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(result.accountable_organisation_type).to eq("10")
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/9gobZxRi/261-activities-collect-information-about-the-participating-organisations-that-are-accountable

Add Accountable Organisation details to Activity records. These are `participating-org` organisations with a `@role` of 2, according to IATI.

Currently these values are hardcoded for MVP, but eventually they will be selectable. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
