### PR TITLE
(262) Fund activities share their extending organisation in IATI XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 - Fund managers can create Budgets
 - Fund and Programme activities store funding organisation details
 - Fund and Programme activities store accountable organisation details
+- Fund activities store extending organisation details

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -20,6 +20,10 @@ class CreateFundActivity
     activity.accountable_organisation_reference = "GB-GOV-13"
     activity.accountable_organisation_type = "10"
 
+    activity.extending_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.extending_organisation_reference = "GB-GOV-13"
+    activity.extending_organisation_type = "10"
+
     activity.save(validate: false)
     activity
   end

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -21,6 +21,8 @@
     %narrative= activity.funding_organisation_name
   %participating-org{"ref" => activity.accountable_organisation_reference, "type" => activity.accountable_organisation_type, "role" => 2}
     %narrative= activity.accountable_organisation_name
+  %participating-org{"ref" => activity.extending_organisation_reference, "type" => activity.extending_organisation_type, "role" => 3}
+    %narrative= activity.extending_organisation_name
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/db/migrate/20200205105914_add_extending_organisation_details_to_activities.rb
+++ b/db/migrate/20200205105914_add_extending_organisation_details_to_activities.rb
@@ -1,0 +1,9 @@
+class AddExtendingOrganisationDetailsToActivities < ActiveRecord::Migration[6.0]
+  def change
+    change_table :activities do |t|
+      t.string :extending_organisation_name
+      t.string :extending_organisation_reference
+      t.string :extending_organisation_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_115513) do
+ActiveRecord::Schema.define(version: 2020_02_05_105914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -43,6 +43,9 @@ ActiveRecord::Schema.define(version: 2020_02_04_115513) do
     t.string "accountable_organisation_name"
     t.string "accountable_organisation_reference"
     t.string "accountable_organisation_type"
+    t.string "extending_organisation_name"
+    t.string "extending_organisation_reference"
+    t.string "extending_organisation_type"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -30,6 +30,9 @@ FactoryBot.define do
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
+      extending_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      extending_organisation_reference { "GB-GOV-13" }
+      extending_organisation_type { "10" }
     end
 
     factory :programme_activity do

--- a/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/fund_managers_can_create_a_fund_level_activity_spec.rb
@@ -67,6 +67,20 @@ RSpec.feature "Fund managers can create a fund level activity" do
       expect(activity.accountable_organisation_type).to eq("10")
     end
 
+    scenario "the activity has the appropriate extending organisation defaults" do
+      identifier = "a-fund-has-an-extending-organisation"
+
+      visit organisation_path(organisation)
+      click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+      fill_in_activity_form(identifier: identifier)
+
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.extending_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(activity.extending_organisation_reference).to eq("GB-GOV-13")
+      expect(activity.extending_organisation_type).to eq("10")
+    end
+
     context "validations" do
       scenario "validation errors work as expected" do
         visit organisation_path(organisation)

--- a/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
@@ -28,6 +28,11 @@ RSpec.feature "Fund managers can view an activity as XML" do
         expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
 
+        # The extending organisation XML is present
+        expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation_reference)
+        expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation_type)
+        expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation_name)
+
         # The transaction XML is present
         expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
       end

--- a/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
@@ -6,56 +6,62 @@ RSpec.feature "Fund managers can view an activity as XML" do
     before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
 
     context "when the activity is a fund activity" do
-      it "returns an XML response" do
-        activity = create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER")
-        transaction = create(:transaction, activity: activity)
+      let(:activity) { create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+      let!(:transaction) { create(:transaction, activity: activity) }
+      let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
+      it "contains the activity XML" do
         visit organisation_activity_path(organisation, activity, format: :xml)
-
-        xml = Nokogiri::XML::Document.parse(page.body)
-
-        # The activity XML is present
         expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
         expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+      end
 
-        # The funding organisation XML is present
+      it "contains the funding organisation XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+      end
 
-        # The accountable organisation XML is present
+      it "contains the accountable organisatino XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
+      end
 
-        # The extending organisation XML is present
+      it "contains the extending organisation XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation_name)
+      end
 
-        # The transaction XML is present
+      it "contains the transaction XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
       end
     end
 
     context "when the activity is a programme activity" do
-      it "returns an XML response" do
-        activity = create(:programme_activity, organisation: organisation, identifier: "IND-ENT-IFIER")
+      let(:activity) { create(:programme_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+      let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
+      it "contains the activity XML" do
         visit organisation_activity_path(organisation, activity, format: :xml)
-
-        xml = Nokogiri::XML::Document.parse(page.body)
-
-        # The activity XML is present
         expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
         expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+      end
 
-        # The funding organisation XML is present
+      it "contains the funding organisation XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+      end
 
-        # The accountable organisation XML is present
+      it "contains the accountable organisation XML" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
         expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/Isi8Hlay/262-fund-activities-share-their-extending-organisation-in-iati-xml

Add extending organisation details to fund activities in much the same way as #175 and #173. However in this PR we are only adding default extending organisation details to _funds_, not _programmes_, as the extending organisation for a programme is a little more involved. This will follow in a future PR.

I have also refactored the XML feature test as it was getting unwieldy. I think in this new format it will be easier to add "unhappy" paths if we need them.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
