### PR TITLE
(275) Validate the activity records with the IATI validator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 - [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
 - [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
 - [ ] Do any environment variables need amending or adding?
+- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -79,4 +79,22 @@ class Activity < ApplicationRecord
     return if activity_id.nil?
     Activity.find(activity_id)
   end
+
+  def has_funding_organisation?
+    funding_organisation_reference.present? &&
+      funding_organisation_name.present? &&
+      funding_organisation_type.present?
+  end
+
+  def has_accountable_organisation?
+    accountable_organisation_reference.present? &&
+      accountable_organisation_name.present? &&
+      accountable_organisation_type.present?
+  end
+
+  def has_extending_organisation?
+    extending_organisation_reference.present? &&
+      extending_organisation_name.present? &&
+      extending_organisation_type.present?
+  end
 end

--- a/app/views/staff/activities/show.xml.haml
+++ b/app/views/staff/activities/show.xml.haml
@@ -1,3 +1,4 @@
 !!! XML
-%iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}"}
+%iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
+"generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   = render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions }

--- a/app/views/staff/activities/show.xml.haml
+++ b/app/views/staff/activities/show.xml.haml
@@ -1,2 +1,3 @@
 !!! XML
-= render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions }
+%iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}"}
+  = render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -17,12 +17,15 @@
   %default-finance-type{"code" => "#{activity.finance}"}
   %default-aid-type{"code" => "#{activity.aid_type}"}
   %default-tied-status{"code" => "#{activity.tied_status}"}
-  %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
-    %narrative= activity.funding_organisation_name
-  %participating-org{"ref" => activity.accountable_organisation_reference, "type" => activity.accountable_organisation_type, "role" => 2}
-    %narrative= activity.accountable_organisation_name
-  %participating-org{"ref" => activity.extending_organisation_reference, "type" => activity.extending_organisation_type, "role" => 3}
-    %narrative= activity.extending_organisation_name
+  - if activity.has_funding_organisation?
+    %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
+      %narrative= activity.funding_organisation_name
+  - if activity.has_accountable_organisation?
+    %participating-org{"ref" => activity.accountable_organisation_reference, "type" => activity.accountable_organisation_type, "role" => 2}
+      %narrative= activity.accountable_organisation_name
+  - if activity.has_extending_organisation?
+    %participating-org{"ref" => activity.extending_organisation_reference, "type" => activity.extending_organisation_type, "role" => 3}
+      %narrative= activity.extending_organisation_name
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,22 +1,11 @@
-%iati-activity{"default-currency" => "#{activity.default_currency}"}
+%iati-activity{"default-currency" => "#{activity.default_currency}", "xml:lang" => activity.organisation.language_code }
   %iati-identifier= activity.identifier
-  %reporting-org
+  %reporting-org{"type" => activity.organisation.organisation_type, "ref" => "" }
     %narrative= activity.organisation.name
   %title
     %narrative= activity.title
   %description{type: "1"}
     %narrative= activity.description
-  %activity-status{code: "#{activity.status}"}
-  %activity-date{"iso-date" => "#{activity.planned_start_date}", type: "1"}
-  %activity-date{"iso-date" => "#{activity.planned_end_date}", type: "2"}
-  %activity-date{"iso-date" => "#{activity.actual_start_date}", type: "3"}
-  %activity-date{"iso-date" => "#{activity.actual_end_date}", type: "4"}
-  %recipient-region{"code" => "#{activity.recipient_region}"}
-  %sector{"vocabulary" => "1", "code" => "#{activity.sector}"}
-  %default-flow-type{"code" => "#{activity.flow}"}
-  %default-finance-type{"code" => "#{activity.finance}"}
-  %default-aid-type{"code" => "#{activity.aid_type}"}
-  %default-tied-status{"code" => "#{activity.tied_status}"}
   - if activity.has_funding_organisation?
     %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
       %narrative= activity.funding_organisation_name
@@ -26,6 +15,17 @@
   - if activity.has_extending_organisation?
     %participating-org{"ref" => activity.extending_organisation_reference, "type" => activity.extending_organisation_type, "role" => 3}
       %narrative= activity.extending_organisation_name
+  %activity-status{code: "#{activity.status}"}/
+  %activity-date{"iso-date" => "#{activity.planned_start_date}", type: "1"}/
+  %activity-date{"iso-date" => "#{activity.planned_end_date}", type: "2"}/
+  %activity-date{"iso-date" => "#{activity.actual_start_date}", type: "3"}/
+  %activity-date{"iso-date" => "#{activity.actual_end_date}", type: "4"}/
+  %recipient-region{"code" => "#{activity.recipient_region}"}/
+  %sector{"vocabulary" => "1", "code" => "#{activity.sector}"}/
+  %default-flow-type{"code" => "#{activity.flow}"}/
+  %default-finance-type{"code" => "#{activity.finance}"}/
+  %default-aid-type{"code" => "#{activity.aid_type}"}/
+  %default-tied-status{"code" => "#{activity.tied_status}"}/
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/doc/xml-validation.md
+++ b/doc/xml-validation.md
@@ -1,0 +1,9 @@
+# IATI XML Validation
+
+We aim for all XML outputs from this app to be valid against the [IATI Standard](https://iatistandard.org/en/). 
+
+If you have made any changes to the XML outputs, validate them against the "new" [IATI XML validator](https://test-validator.iatistandard.org/)* before committing.
+
+Critical failures in the validation should be addressed in your PR; or if that's not possible then a ticket should be opened to address the issues in Trello.
+
+*There is also the "old" [IATI validator](http://validator.iatistandard.org/) which the "new" validator will supersede. 

--- a/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/fund_managers_can_view_an_activity_as_xml_spec.rb
@@ -10,6 +10,11 @@ RSpec.feature "Fund managers can view an activity as XML" do
       let!(:transaction) { create(:transaction, activity: activity) }
       let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
+      it "contains a top-level activities element with the IATI version" do
+        visit organisation_activity_path(organisation, activity, format: :xml)
+        expect(xml.at("iati-activities/@version").text).to eq(IATI_VERSION.tr("_", "."))
+      end
+
       it "contains the activity XML" do
         visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
@@ -23,7 +28,7 @@ RSpec.feature "Fund managers can view an activity as XML" do
         expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
       end
 
-      it "contains the accountable organisatino XML" do
+      it "contains the accountable organisation XML" do
         visit organisation_activity_path(organisation, activity, format: :xml)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
         expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -179,4 +179,46 @@ RSpec.describe Activity, type: :model do
       expect(activity.wizard_complete?).to be_falsey
     end
   end
+
+  describe "#has_funding_organisation?" do
+    it "returns true if all funding_organisation fields are present" do
+      activity = build(:fund_activity)
+
+      expect(activity.has_funding_organisation?).to be true
+    end
+
+    it "returns false if all funding_organisation fields are not present" do
+      activity = build(:activity)
+
+      expect(activity.has_funding_organisation?).to be false
+    end
+  end
+
+  describe "#has_accountable_organisation?" do
+    it "returns true if all accountable_organisation fields are present" do
+      activity = build(:fund_activity)
+
+      expect(activity.has_accountable_organisation?).to be true
+    end
+  end
+
+  it "returns false if all accountable_organisation fields are not present" do
+    activity = build(:activity)
+
+    expect(activity.has_accountable_organisation?).to be false
+  end
+
+  describe "#has_extending_organisation?" do
+    it "returns true if all extending_organisation fields are present" do
+      activity = build(:fund_activity)
+
+      expect(activity.has_extending_organisation?).to be true
+    end
+  end
+
+  it "returns false if all extending_organisation fields are not present" do
+    activity = build(:activity)
+
+    expect(activity.has_extending_organisation?).to be false
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/f0sswz5n/275-validate-the-activity-records-with-the-iati-validator-and-put-necessary-changes-into-sprint-backlog

We have run the existing Activity XML through the new validator (https://test-validator.iatistandard.org/) and as a result:

* Empty elements are now self-closing
* `provider-org` elements do not show if they are empty
* Required attributes have been added (with one exception - see below)
* Elements have been re-ordered as per the IATI standard

The `reporting-org` element requires a `@ref` attribute but we don't currently collect that on the Organisation model. We have opened https://trello.com/c/pJaaUq1B/295-organisations-must-have-their-iati-reference-number to address this.

Also we have added a new check to the pull request template, to prompt developers to check the generated XML in the validator if it has changed.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
