### PR TITLE
Feature/271 edit links are accessible

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,13 @@ module ApplicationHelper
     classes << "govuk-header__navigation-item--active" if current_page?(path)
     classes.join(" ")
   end
+
+  def a11y_action_link(text, href, context = "")
+    if context.blank?
+      link_to(text, href, class: "govuk-link")
+    else
+      span = content_tag :span, context, class: "govuk-visually-hidden"
+      link_to("#{text} #{raw(span)}".html_safe, href, class: "govuk-link")
+    end
+  end
 end

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -13,7 +13,7 @@
       = activity_presenter.identifier
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :identifier)
-        = link_to t("generic.link.edit"), activity_step_path(activity_presenter, :identifier), class: "govuk-link"
+        = a11y_action_link(t("generic.link.edit"), activity_step_path(activity_presenter, :identifier), t("page_content.activity.identitfier.label").downcase)
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
@@ -22,7 +22,8 @@
       = activity_presenter.title
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:title)}"), activity_step_path(activity_presenter, :purpose), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:title)}"),
+        activity_step_path(activity_presenter, :purpose), t("page_content.activity.title.label"))
 
   .govuk-summary-list__row.description
     %dt.govuk-summary-list__key
@@ -31,7 +32,7 @@
       = activity_presenter.description
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), class: "govuk-link"
+        =a11y_action_link(I18n.t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
 
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
@@ -40,7 +41,7 @@
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :sector)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector), t("page_content.activity.sector.label"))
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key
@@ -49,7 +50,7 @@
       = activity_presenter.status
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :status)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), t("page_content.activity.status.label"))
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key
@@ -58,7 +59,7 @@
       = activity_presenter.planned_start_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_start_date.label"))
 
 
   .govuk-summary-list__row.planned_end_date
@@ -68,8 +69,7 @@
       = activity_presenter.planned_end_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
-
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_end_date.label"))
 
   .govuk-summary-list__row.actual_start_date
     %dt.govuk-summary-list__key
@@ -78,8 +78,7 @@
       = activity_presenter.actual_start_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
-
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_start_date.label"))
 
   .govuk-summary-list__row.actual_end_date
     %dt.govuk-summary-list__key
@@ -88,8 +87,7 @@
       = activity_presenter.actual_end_date
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), class: "govuk-link"
-
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_end_date.label"))
 
   .govuk-summary-list__row.recipient_region
     %dt.govuk-summary-list__key
@@ -98,7 +96,7 @@
       = activity_presenter.recipient_region
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :country)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :country), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :country), t("page_content.activity.recipient_region.label"))
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
@@ -107,7 +105,7 @@
       = activity_presenter.flow
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :flow)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("page_content.activity.flow.label"))
 
   .govuk-summary-list__row.finance
     %dt.govuk-summary-list__key
@@ -116,7 +114,7 @@
       = activity_presenter.finance
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :finance)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:finance)}"), activity_step_path(activity_presenter, :finance), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:finance)}"), activity_step_path(activity_presenter, :finance), t("page_content.activity.finance.label"))
 
   .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
@@ -125,7 +123,7 @@
       = activity_presenter.aid_type
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("page_content.activity.aid_type.label"))
 
   .govuk-summary-list__row.tied_status
     %dt.govuk-summary-list__key
@@ -134,4 +132,4 @@
       = activity_presenter.tied_status
     %dd.govuk-summary-list__actions
       - if step_is_complete_or_next?(activity: activity_presenter, step: :tied_status)
-        = link_to t("generic.link.#{activity_presenter.call_to_action(:tied_status)}"), activity_step_path(activity_presenter, :tied_status), class: "govuk-link"
+        =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:tied_status)}"), activity_step_path(activity_presenter, :tied_status), t("page_content.activity.tied_status.label"))

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -35,4 +35,4 @@
           %td.govuk-table__cell= transaction.provider.name
           %td.govuk-table__cell= transaction.receiver.name
           %td.govuk-table__cell
-            = link_to(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.activity, transaction), class: 'govuk-link')
+            = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.activity, transaction))

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -16,5 +16,5 @@
         %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
         %td.govuk-table__cell
-          = link_to(I18n.t('generic.link.show'), user_path(user), class: 'govuk-link')
-          = link_to(I18n.t('generic.link.edit'), edit_user_path(user), class: 'govuk-link')
+          = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")
+          = a11y_action_link(I18n.t("generic.link.edit"), edit_user_path(user), user.name)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(subject).to eql "govuk-header__navigation-item govuk-header__navigation-item--active"
     end
   end
+
+  describe "#a11y_action_link" do
+    it "gives action links more context available to a screen reader" do
+      span = content_tag :span, "Pear", class: "govuk-visually-hidden"
+      accessible_action_link = link_to("Edit #{raw(span)}".html_safe, "pear.com", class: "govuk-link")
+      expect(helper.a11y_action_link("Edit", "pear.com", "Pear")).to eql accessible_action_link
+    end
+
+    context "when there is no context as a third argument" do
+      it "creates the link and doesn't include the span" do
+        expect(helper.a11y_action_link("Edit", "pear.com", "")).to eql(link_to("Edit", "pear.com", class: "govuk-link"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Add the `a11y_action_link` helper to make our action links more accessible.

For action links such as Edit and Add, we want them to provide more context to the element that will be edited when a link is clicked.

To do that we include a span within a link, that is visually hidden but available to the screen readers. It’s a pattern used in gov.uk design system.

So that when a screen reader stops at a link, it will read more meaningful description such as ‘Edit transaction’ instead of general edit.

Our helper uses ruby link_to method but takes an optional third parameter that adds the span with more context description.

Currently our ‘Edit’ and ‘Add’ action links are in activity, thransactions and users views, so we used a11y_ction_link helper method to provide more context to them.

Co-authored-by: Meyric <meyric@dxw.com>

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
