### PR TITLE
Chore/299 signing in with auth0 does not require js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 - Fund and Programme activities store funding organisation details
 - Fund and Programme activities store accountable organisation details
 - Fund activities store extending organisation details
+- Sign in button works when JS is disabled

--- a/app/views/public/visitors/index.html.haml
+++ b/app/views/public/visitors/index.html.haml
@@ -6,8 +6,7 @@
       %h1.govuk-heading-xl
         = t("page_title.welcome")
 
-      %a.govuk-button.govuk-button--start{ data: { method: "post" }, href: "/auth/auth0", role: 'button', draggable: 'false' }
+      = button_to '/auth/auth0', class: 'govuk-button', role: 'button', draggable: 'false' do
         = t("generic.link.sign_in")
-
         %svg.govuk-button__start-icon{ xmlns: "http://www.w3.org/2000/svg", width: "17.5", height: "19", viewBox: "0 0 33 40", role: "presentation", focusable: "false" }
           %path{ fill: "currentColor", d: "M0 0h13l20 20-20 20H0l20-20z" }

--- a/doc/architecture/decisions/0006-use-auth0-for-authentication.md
+++ b/doc/architecture/decisions/0006-use-auth0-for-authentication.md
@@ -4,7 +4,7 @@ Date: 2019-10-28
 
 ## Status
 
-Accepted
+Superceded by [16. Disable Auth0's requirement for Javascript during the authentication journey](0016-disable-auth0-s-requirement-for-javascript-during-the-authentication-journey.md)
 
 ## Context
 

--- a/doc/architecture/decisions/0015-disable-auth0s-requirement-for-javascript-during-the-authentication-journey.md
+++ b/doc/architecture/decisions/0015-disable-auth0s-requirement-for-javascript-during-the-authentication-journey.md
@@ -1,0 +1,28 @@
+# 16. Disable Auth0's requirement for Javascript during the authentication journey
+
+Date: 2020-02-05
+
+## Status
+
+Accepted
+
+Partial supersede of [6. Use Auth0 for authentication](0006-use-auth0-for-authentication.md)
+
+## Context
+
+The welcome and the sign in journey currently bounce our user to pages controlled by Auth0. Auth0 give us 2 options called 'experiences' in the admin area under 'Universal Login':
+
+1. Classic - requires Javascript to be enabled in the browser
+2. New - no Javascript required
+
+https://auth0.com/docs/universal-login/new
+
+The [service standard does not mention failing or passing an assessment if the service doesn't work without JS](https://www.gov.uk/service-manual/service-assessments/pre-july-2019-digital-service-standard) the guidance I can find is from the [service manual which advises that we should use progressive enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement) to ensure that when a user doesn't have JS enabled, the service remains functional.
+
+## Decision
+
+Use Auth0 in all environments without requiring Javascript.
+
+## Consequences
+
+- When users follow the welcome journey they will be met with an extra step that states "Go back to all applications" which is not obviously clear. We plan to test how this affects the user journey before deciding what action to take. The hypothesis is that whilst it isn't clear, users should be able to succeed if they click the button. Auth0 does not give us the ability to configure the text on this page, or to remove this page when using our custom welcome emails. A big change we could make would be to stop using GOV.UK Notify for our welcome emails and instead pay for and customise the Auth0 email templates, using their email providers.


### PR DESCRIPTION
## Changes in this PR

- Users can sign into the service both when JS is enabled **and** disabled in the browser
- Fix the sign in button to work without JS after an unexpected error occurred with where Rails was unable to render the `data` attribute and convert the link into a POST request
- Auth0 has been updated to switch to the "new experience" - this shouldn't affect the development team unless they happen to have JS disabled

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
