### PR TITLE
(270) Users can create a project (level C) activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,5 @@
 - Fund managers can set and change the extending organisation
 - Date inputs in forms for creating activity, transaction and a budget have a hint text
 - Transaction provider and receiver IATI references are exposed in the XML if present
+- Project activities can be created, and have budgets & transactions
+

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,7 +11,7 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation)
+    activities = policy_scope(Activity.fund).includes(:organisation).where(organisation: organisation)
     @activities = activities.map { |activity| ActivityPresenter.new(activity) }
   end
 

--- a/app/controllers/staff/projects_controller.rb
+++ b/app/controllers/staff/projects_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Staff::ProjectsController < Staff::ActivitiesController
+  def create
+    @activity = CreateProjectActivity.new(organisation_id: organisation_id, programme_id: programme_id).call
+    authorize @activity
+
+    redirect_to activity_step_path(@activity.id, @activity.wizard_status)
+  end
+
+  def programme_id
+    params[:programme_id]
+  end
+end

--- a/app/controllers/staff/projects_controller.rb
+++ b/app/controllers/staff/projects_controller.rb
@@ -2,7 +2,7 @@
 
 class Staff::ProjectsController < Staff::ActivitiesController
   def create
-    @activity = CreateProjectActivity.new(organisation_id: organisation_id, programme_id: programme_id).call
+    @activity = CreateProjectActivity.new(organisation_id: organisation_id, programme_id: programme_id, user: current_user).call
     authorize @activity
 
     redirect_to activity_step_path(@activity.id, @activity.wizard_status)

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -13,6 +13,6 @@ module ActivityHelper
 
   def activity_back_path(activity)
     return organisation_path(activity.organisation) if activity.is_fund_level?
-    return organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity) if activity.is_programme_level?
+    organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity)
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -20,10 +20,12 @@ class Activity < ApplicationRecord
   enum level: {
     fund: "fund",
     programme: "programme",
+    project: "project",
   }
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
+  scope :projects, -> { where(level: :project) }
 
   def identifier_step?
     wizard_status == "identifier" || wizard_complete?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -23,10 +23,6 @@ class Activity < ApplicationRecord
     project: "project",
   }
 
-  scope :funds, -> { where(level: :fund) }
-  scope :programmes, -> { where(level: :programme) }
-  scope :projects, -> { where(level: :project) }
-
   def identifier_step?
     wizard_status == "identifier" || wizard_complete?
   end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -19,18 +19,20 @@ class ActivityPolicy < ApplicationPolicy
     user.administrator? || user.fund_manager?
   end
 
-  private def associated_user?
-    user.organisation.id.eql?(record.organisation_id)
+  private def associated_delivery_partner?
+    user.delivery_partner? && user.organisation.id.eql?(record.organisation_id)
   end
 
   private def user_can_access?
     return true if user.administrator? || user.fund_manager?
-    associated_user?
+    associated_delivery_partner?
   end
 
   private def user_can_create_and_update?
-    return true if user.administrator? || user.fund_manager?
-    associated_user? && record.level.eql?("project")
+
+    return true if user.administrator?
+    return true if user.fund_manager? && !record.level.eql?("project")
+    associated_delivery_partner? && record.level.eql?("project")
   end
 
   class Scope < Scope

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,22 +1,36 @@
 class ActivityPolicy < ApplicationPolicy
   def index?
-    user.administrator? || user.fund_manager?
+    true
   end
 
   def show?
-    user.administrator? || user.fund_manager?
+    user_can_access?
   end
 
   def create?
-    user.administrator? || user.fund_manager?
+    user_can_create_and_update?
   end
 
   def update?
-    create?
+    user_can_create_and_update?
   end
 
   def destroy?
     user.administrator? || user.fund_manager?
+  end
+
+  private def associated_user?
+    user.organisation.id.eql?(record.organisation_id)
+  end
+
+  private def user_can_access?
+    return true if user.administrator? || user.fund_manager?
+    associated_user?
+  end
+
+  private def user_can_create_and_update?
+    return true if user.administrator? || user.fund_manager?
+    associated_user? && record.level.eql?("project")
   end
 
   class Scope < Scope
@@ -24,7 +38,7 @@ class ActivityPolicy < ApplicationPolicy
       if user.administrator? || user.fund_manager?
         scope.all
       else
-        scope.none
+        scope.where(organisation: user.organisation)
       end
     end
   end

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -24,7 +24,7 @@ class BudgetPolicy < ApplicationPolicy
       if user.administrator? || user.fund_manager?
         scope.all
       else
-        []
+        scope.none
       end
     end
   end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -5,17 +5,20 @@ class TransactionPolicy < ApplicationPolicy
 
   def show?
     user.administrator? ||
-      activity? && user.fund_manager?
+      activity? && user.fund_manager? ||
+      activity_is_project_level? && user.delivery_partner?
   end
 
   def create?
     user.administrator? ||
-      activity? && user.fund_manager?
+      activity? && user.fund_manager? ||
+      activity_is_project_level? && user.delivery_partner?
   end
 
   def update?
     user.administrator? ||
-      activity? && user.fund_manager?
+      activity? && user.fund_manager? ||
+      activity_is_project_level? && user.delivery_partner?
   end
 
   def destroy?
@@ -25,6 +28,12 @@ class TransactionPolicy < ApplicationPolicy
 
   private def activity?
     record.activity_id.present?
+  end
+
+  private def activity_is_project_level?
+    return unless activity?
+    activity = Activity.find(record.activity_id)
+    activity.project?
   end
 
   class Scope < Scope

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -1,9 +1,10 @@
 class CreateProjectActivity
-  attr_accessor :organisation_id, :programme_id
+  attr_accessor :organisation_id, :programme_id, :user
 
-  def initialize(organisation_id:, programme_id:)
+  def initialize(organisation_id:, programme_id:, user:)
     self.organisation_id = organisation_id
     self.programme_id = programme_id
+    self.user = user
   end
 
   def call
@@ -22,6 +23,8 @@ class CreateProjectActivity
     activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
     activity.accountable_organisation_reference = "GB-GOV-13"
     activity.accountable_organisation_type = "10"
+
+    activity.extending_organisation = user.delivery_partner? ? user.organisation : nil
 
     activity.save(validate: false)
     activity

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -1,0 +1,29 @@
+class CreateProjectActivity
+  attr_accessor :organisation_id, :programme_id
+
+  def initialize(organisation_id:, programme_id:)
+    self.organisation_id = organisation_id
+    self.programme_id = programme_id
+  end
+
+  def call
+    activity = Activity.new
+    activity.organisation = Organisation.find(organisation_id)
+    programme = Activity.find(programme_id)
+    programme.activities << activity
+
+    activity.wizard_status = "identifier"
+    activity.level = :project
+
+    activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.funding_organisation_reference = "GB-GOV-13"
+    activity.funding_organisation_type = "10"
+
+    activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
+    activity.accountable_organisation_reference = "GB-GOV-13"
+    activity.accountable_organisation_type = "10"
+
+    activity.save(validate: false)
+    activity
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -16,8 +16,9 @@
       .govuk-grid-column-two-thirds
         %h2.govuk-heading-m
           = t("page_content.organisation.programmes")
-        = form_tag(organisation_fund_programmes_path(@activity.organisation, @activity), method: "post") do
-          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
+        - if current_user.administrator? || current_user.fund_manager?
+          = form_tag(organisation_fund_programmes_path(@activity.organisation, @activity), method: "post") do
+            = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
         %ul.govuk-list.govuk-list--bullet
           - @activities.each do |activity|
             %li
@@ -40,14 +41,29 @@
       %h2.govuk-heading-m
         = t("page_content.activity.transactions")
 
-      = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
-      = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
+        = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
+        = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
 
   - if @activity.is_programme_level?
+    - if current_user.administrator? || current_user.fund_manager?
+      .govuk-grid-row
+        .govuk-grid-column-full
+          %h2.govuk-heading-m
+            = t("page_content.activity.budgets")
+
+          = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
+          = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }
+
     .govuk-grid-row
       .govuk-grid-column-full
         %h2.govuk-heading-m
-          = t("page_content.activity.budgets")
+          = t("page_content.activity.projects")
 
-        = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
-        = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }
+        = form_tag(organisation_fund_programme_projects_path(@activity.organisation, @activity.activity, @activity), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_project"), class: "govuk-button"
+
+        %ul.govuk-list.govuk-list--bullet
+          - @activities.each do |activity|
+            %li
+              = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+              

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -11,59 +11,7 @@
     .govuk-grid-column-two-thirds
       = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
 
-  - if @activity.is_fund_level?
-    .govuk-grid-row
-      .govuk-grid-column-two-thirds
-        %h2.govuk-heading-m
-          = t("page_content.organisation.programmes")
-        - if current_user.administrator? || current_user.fund_manager?
-          = form_tag(organisation_fund_programmes_path(@activity.organisation, @activity), method: "post") do
-            = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
-        %ul.govuk-list.govuk-list--bullet
-          - @activities.each do |activity|
-            %li
-              = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+    = render partial: '/staff/shared/activities/activity_activities', locals: { activity: @activity, activities: @activities }
+    = render partial: '/staff/shared/activities/activity_transactions', locals: { activity: @activity, transactions: @transaction_presenters }
+    = render partial: '/staff/shared/activities/activity_budgets', locals: { activity: @activity, budgets: @budget_presenters }
 
-  - if @activity.is_programme_level?
-    .govuk-grid-row
-      .govuk-grid-column-full
-        %h2.govuk-heading-m
-          = t("page_content.activity.extending_organisation.heading")
-
-        -if @activity.extending_organisation.present?
-          %p.govuk-body
-            = @activity.extending_organisation.name
-
-        = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisation_path(@activity), class: "govuk-button")
-
-  .govuk-grid-row
-    .govuk-grid-column-full
-      %h2.govuk-heading-m
-        = t("page_content.activity.transactions")
-
-        = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
-        = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
-
-  - if @activity.is_programme_level?
-    - if current_user.administrator? || current_user.fund_manager?
-      .govuk-grid-row
-        .govuk-grid-column-full
-          %h2.govuk-heading-m
-            = t("page_content.activity.budgets")
-
-          = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(@activity), class: "govuk-button")
-          = render partial: '/staff/shared/budgets/table', locals: { budgets: @budget_presenters }
-
-    .govuk-grid-row
-      .govuk-grid-column-full
-        %h2.govuk-heading-m
-          = t("page_content.activity.projects")
-
-        = form_tag(organisation_fund_programme_projects_path(@activity.organisation, @activity.activity, @activity), method: "post") do
-          = submit_tag t("page_content.organisation.button.create_project"), class: "govuk-button"
-
-        %ul.govuk-list.govuk-list--bullet
-          - @activities.each do |activity|
-            %li
-              = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
-              

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -59,7 +59,7 @@
       - if policy(Activity).index?
         %h2.govuk-heading-m
           = t("page_content.organisation.funds")
-      - if policy(Activity).create?
+      - if current_user.administrator? || current_user.fund_manager?
         = form_tag(organisation_funds_path(@organisation_presenter), method: "post") do
           = submit_tag t("page_content.organisation.button.create_fund"), class: "govuk-button"
       - if policy(Activity).index?

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -12,7 +12,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.identifier
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :identifier)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :identifier) && policy(@activity).update?
         = a11y_action_link(t("generic.link.edit"), activity_step_path(activity_presenter, :identifier), t("page_content.activity.identitfier.label").downcase)
 
   .govuk-summary-list__row.title
@@ -21,7 +21,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.title
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:title)}"),
         activity_step_path(activity_presenter, :purpose), t("page_content.activity.title.label"))
 
@@ -31,7 +31,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.description
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :purpose) && policy(@activity).update?
         =a11y_action_link(I18n.t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
 
   .govuk-summary-list__row.sector
@@ -40,7 +40,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :sector)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :sector) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector), t("page_content.activity.sector.label"))
 
   .govuk-summary-list__row.status
@@ -49,7 +49,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.status
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :status)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :status) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), t("page_content.activity.status.label"))
 
   .govuk-summary-list__row.planned_start_date
@@ -58,7 +58,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.planned_start_date
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_start_date.label"))
 
 
@@ -68,7 +68,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.planned_end_date
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_end_date.label"))
 
   .govuk-summary-list__row.actual_start_date
@@ -77,7 +77,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.actual_start_date
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_start_date.label"))
 
   .govuk-summary-list__row.actual_end_date
@@ -86,7 +86,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.actual_end_date
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :dates) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_end_date.label"))
 
   .govuk-summary-list__row.recipient_region
@@ -95,7 +95,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.recipient_region
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :country)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :country) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :country), t("page_content.activity.recipient_region.label"))
 
   .govuk-summary-list__row.flow
@@ -104,7 +104,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.flow
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :flow)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :flow) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("page_content.activity.flow.label"))
 
   .govuk-summary-list__row.finance
@@ -113,7 +113,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.finance
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :finance)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :finance) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:finance)}"), activity_step_path(activity_presenter, :finance), t("page_content.activity.finance.label"))
 
   .govuk-summary-list__row.aid_type
@@ -122,7 +122,7 @@
     %dd.govuk-summary-list__value
       = activity_presenter.aid_type
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :aid_type) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("page_content.activity.aid_type.label"))
 
   .govuk-summary-list__row.tied_status
@@ -131,5 +131,5 @@
     %dd.govuk-summary-list__value
       = activity_presenter.tied_status
     %dd.govuk-summary-list__actions
-      - if step_is_complete_or_next?(activity: activity_presenter, step: :tied_status)
+      - if step_is_complete_or_next?(activity: activity_presenter, step: :tied_status) && policy(@activity).update?
         =a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:tied_status)}"), activity_step_path(activity_presenter, :tied_status), t("page_content.activity.tied_status.label"))

--- a/app/views/staff/shared/activities/_activity_activities.html.haml
+++ b/app/views/staff/shared/activities/_activity_activities.html.haml
@@ -1,0 +1,37 @@
+- if activity.is_fund_level?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.organisation.programmes")
+      - if current_user.administrator? || current_user.fund_manager?
+        = form_tag(organisation_fund_programmes_path(activity.organisation, activity), method: "post") do
+          = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
+      %ul.govuk-list.govuk-list--bullet
+        - activities.each do |sub_activity|
+          %li
+            = link_to sub_activity.display_title, organisation_activity_path(sub_activity.organisation, sub_activity)
+
+- if activity.is_programme_level?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.activity.extending_organisation.heading")
+
+      - if @activity.extending_organisation.present?
+        %p.govuk-body
+          = @activity.extending_organisation.name
+
+      = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisation_path(@activity), class: "govuk-button")
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.activity.projects")
+
+      = form_tag(organisation_fund_programme_projects_path(activity.organisation, activity.activity, activity), method: "post") do
+        = submit_tag t("page_content.organisation.button.create_project"), class: "govuk-button"
+
+      %ul.govuk-list.govuk-list--bullet
+        - activities.each do |sub_activity|
+          %li
+            = link_to sub_activity.display_title, organisation_activity_path(sub_activity.organisation, sub_activity)

--- a/app/views/staff/shared/activities/_activity_budgets.html.haml
+++ b/app/views/staff/shared/activities/_activity_budgets.html.haml
@@ -2,7 +2,7 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.budgets")
-
+        
     - if policy(@activity).update?
       = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
 

--- a/app/views/staff/shared/activities/_activity_budgets.html.haml
+++ b/app/views/staff/shared/activities/_activity_budgets.html.haml
@@ -1,0 +1,9 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.budgets")
+
+    - if policy(@activity).update?
+      = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
+
+    = render partial: '/staff/shared/budgets/table', locals: { budgets: budgets }

--- a/app/views/staff/shared/activities/_activity_transactions.html.haml
+++ b/app/views/staff/shared/activities/_activity_transactions.html.haml
@@ -1,4 +1,4 @@
-- if current_user.administrator? || current_user.fund_manager?
+- if policy(@activity).update?
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-m

--- a/app/views/staff/shared/activities/_activity_transactions.html.haml
+++ b/app/views/staff/shared/activities/_activity_transactions.html.haml
@@ -1,0 +1,8 @@
+- if current_user.administrator? || current_user.fund_manager?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.activity.transactions")
+
+      = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
+      = render partial: '/staff/shared/transactions/table', locals: { transactions: transactions }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,9 @@ en:
         success: Programme successfully created
       update:
         success: Programme successfully updated
+    project:
+      create:
+        success: Project successfully created
     transaction:
       create:
         success: Transaction successfully created
@@ -151,6 +154,7 @@ en:
         label: Planned end date
       planned_start_date:
         label: Planned start date
+      projects: Projects
       recipient_region:
         label: Recipient region
       sector:
@@ -192,6 +196,7 @@ en:
         choose_extending_organisation: Choose extending organisation
         create_fund: Create fund
         create_programme: Create programme
+        create_project: Create project
         edit: Edit organisation
       default_currency:
         label: Default currency

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,11 @@ Rails.application.routes.draw do
     resources :users
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
+      # TODO this hierarchy is too deep, make it shallower
       resources :funds, only: [:create] do
-        resources :programmes, only: [:create]
+        resources :programmes, only: [:create] do
+          resources :projects, only: [:create]
+        end
       end
     end
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -43,6 +43,16 @@ FactoryBot.define do
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
     end
+
+    factory :project_activity do
+      level { :project }
+      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      funding_organisation_reference { "GB-GOV-13" }
+      funding_organisation_type { "10" }
+      accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      accountable_organisation_reference { "GB-GOV-13" }
+      accountable_organisation_type { "10" }
+    end
   end
 
   trait :at_identifier_step do

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     identifier
     description { Faker::Lorem.paragraph }
-    sector { "99" }
+    sector { "11110" }
     status { "2" }
     planned_start_date { Date.today }
     planned_end_date { Date.tomorrow }

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
+      association :activity
     end
 
     factory :project_activity do
@@ -52,6 +53,7 @@ FactoryBot.define do
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
+      association :activity
     end
   end
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -69,9 +69,12 @@ RSpec.describe "Users can create a budget" do
       before { authenticate!(user: delivery_partner) }
 
       scenario "cannot create a budget on a programme" do
-        visit new_activity_budget_path(programme_activity)
+        visit organisation_path(organisation)
 
-        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+        click_on(fund_activity.title)
+        click_on(programme_activity.title)
+
+        expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
       end
     end
   end
@@ -97,9 +100,11 @@ RSpec.describe "Users can create a budget" do
 
       scenario "cannot create a budget on a fund" do
         fund_activity = create(:fund_activity, organisation: organisation)
-        visit new_activity_budget_path(fund_activity)
+        visit organisation_path(organisation)
 
-        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+        click_on(fund_activity.title)
+
+        expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Users can create a project level activity" do
+  let(:organisation) { create(:organisation, name: "UKSA") }
+  let!(:fund) { create(:fund_activity, organisation: organisation) }
+  let!(:programme) { create(:programme_activity, activity: fund, organisation: organisation) }
+
+  before do
+    authenticate!(user: user)
+  end
+
+  context "as a fund manager" do
+    let(:user) { create(:fund_manager, organisation: organisation) }
+
+    context "on a programme" do
+      scenario "successfully create a project" do
+        visit organisation_path(organisation)
+        click_on fund.title
+        click_on programme.title
+
+        click_on(I18n.t("page_content.organisation.button.create_project"))
+
+        fill_in_activity_form
+
+        expect(page).to have_content I18n.t("form.project.create.success")
+      end
+    end
+
+    context "on a fund" do
+      scenario "a project cannot be created on a fund" do
+        visit organisation_path(organisation)
+        click_on fund.title
+
+        expect(page).to_not have_content(I18n.t("page_content.organisation.button.create_project"))
+      end
+    end
+  end
+
+  context "as a delivery partner" do
+    let(:user) { create(:delivery_partner, organisation: organisation) }
+
+    context "on a programme" do
+      scenario "successfully create a project" do
+        visit organisation_path(organisation)
+        click_on fund.title
+        click_on programme.title
+
+        click_on(I18n.t("page_content.organisation.button.create_project"))
+
+        fill_in_activity_form
+
+        expect(page).to have_content I18n.t("form.project.create.success")
+      end
+    end
+
+    context "on a fund" do
+      scenario "a project cannot be created on a fund" do
+        visit organisation_path(organisation)
+        click_on fund.title
+
+        expect(page).to_not have_content I18n.t("page_content.organisation.button.create_project")
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Fund managers can edit a fund level activity" do
+RSpec.feature "Users can edit an activity" do
   include ActivityHelper
 
   let(:organisation) { create(:organisation, name: "UKSA") }
@@ -93,6 +93,42 @@ RSpec.feature "Fund managers can edit a fund level activity" do
         within(".title") do
           expect(page).to have_content(I18n.t("generic.link.add"))
         end
+      end
+    end
+  end
+
+  context "when the user is a delivery partner" do
+    before { authenticate!(user: create(:delivery_partner, organisation: organisation)) }
+
+    context "when the activity is a fund activity" do
+      scenario "the user cannot edit the fund" do
+        activity = create(:fund_activity, organisation: organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("generic.link.edit"))
+      end
+    end
+
+    context "when the activity is a programme activity" do
+      scenario "the user cannot edit the programme" do
+        activity = create(:programme_activity, organisation: organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("generic.link.edit"))
+      end
+    end
+
+    context "when the activity is a project activity" do
+      scenario "the user can edit the project" do
+        activity = create(:project_activity, organisation: organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to have_content(I18n.t("generic.link.edit"))
+
+        assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -75,14 +75,60 @@ RSpec.feature "Users can view an activity" do
   end
 
   context "when the user is a delivery_partner" do
-    before { authenticate!(user: build_stubbed(:delivery_partner, organisation: organisation)) }
+    before { authenticate!(user: create(:delivery_partner, organisation: organisation)) }
 
-    scenario "the user cannot view the activity" do
-      activity = create(:activity, organisation: organisation)
+    context "when the activity is a fund" do
+      scenario "the user can view the activity" do
+        activity = create(:fund_activity, organisation: organisation)
 
-      visit organisation_activity_path(organisation, activity)
+        visit organisation_activity_path(organisation, activity)
 
-      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+        expect(page).to have_content(activity.title)
+      end
+
+      scenario "the user cannot edit the activity" do
+        activity = create(:fund_activity, organisation: organisation)
+
+        visit organisation_activity_path(organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("generic.link.edit"))
+      end
+    end
+
+    context "when the activity is a programme" do
+      scenario "the user can view the activity" do
+        activity = create(:programme_activity, organisation: organisation)
+
+        visit organisation_activity_path(organisation, activity)
+
+        expect(page).to have_content(activity.title)
+      end
+
+      scenario "the user cannot edit the activity" do
+        activity = create(:programme_activity, organisation: organisation)
+
+        visit organisation_activity_path(organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("generic.link.edit"))
+      end
+    end
+
+    context "when the activity is a project" do
+      scenario "the user can view the activity" do
+        activity = create(:project_activity, organisation: organisation)
+
+        visit organisation_activity_path(organisation, activity)
+
+        expect(page).to have_content(activity.title)
+      end
+
+      scenario "the user can edit the activity" do
+        activity = create(:project_activity, organisation: organisation)
+
+        visit organisation_activity_path(organisation, activity)
+
+        expect(page).to have_content(I18n.t("generic.link.edit"))
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -9,15 +9,15 @@ RSpec.feature "Users can view budgets on an activity page" do
     context "when the user is a fund manager" do
       let(:user) { create(:fund_manager, organisation: organisation) }
 
-      scenario "budget information is not shown on the page" do
+      scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: organisation)
-        _budget = create(:budget)
+        budget = create(:budget, activity: fund_activity)
 
         visit organisations_path
         click_link organisation.name
         click_link fund_activity.title
 
-        expect(page).to_not have_content(I18n.t("page_content.activity.budgets"))
+        budget_details_are_present(budget)
       end
     end
   end
@@ -31,19 +31,75 @@ RSpec.feature "Users can view budgets on an activity page" do
 
       scenario "budget information is shown on the page" do
         budget = create(:budget, activity: programme_activity)
-        budget_presenter = BudgetPresenter.new(budget)
 
         visit organisations_path
         click_link organisation.name
         click_link fund_activity.title
         click_link programme_activity.title
 
-        expect(page).to have_content(budget_presenter.budget_type)
-        expect(page).to have_content(budget_presenter.status)
-        expect(page).to have_content(budget_presenter.period_start_date)
-        expect(page).to have_content(budget_presenter.period_end_date)
-        expect(page).to have_content(budget_presenter.value)
+        budget_details_are_present(budget)
       end
     end
+
+    context "when the user is a delivery partner" do
+      let(:user) { create(:delivery_partner, organisation: organisation) }
+
+      scenario "budget information is shown on the page" do
+        budget = create(:budget, activity: programme_activity)
+
+        visit organisation_path(organisation)
+        click_link fund_activity.title
+        click_link programme_activity.title
+
+        budget_details_are_present(budget)
+      end
+    end
+  end
+
+  context "when the activity is project level" do
+    let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+    let(:programme_activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+    let(:project_activity) { create(:project_activity, activity: programme_activity, organisation: organisation) }
+
+    context "when the user is a fund manager" do
+      let(:user) { create(:fund_manager, organisation: organisation) }
+
+      scenario "budget information is shown on the page" do
+        budget = create(:budget, activity: project_activity)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link fund_activity.title
+        click_link programme_activity.title
+
+        click_link project_activity.title
+
+        budget_details_are_present(budget)
+      end
+    end
+
+    context "when the user is a delivery partner" do
+      let(:user) { create(:delivery_partner, organisation: organisation) }
+
+      scenario "budget information is shown on the page" do
+        budget = create(:budget, activity: project_activity)
+
+        visit organisation_path(organisation)
+        click_link fund_activity.title
+        click_link programme_activity.title
+        click_link project_activity.title
+
+        budget_details_are_present(budget)
+      end
+    end
+  end
+
+  def budget_details_are_present(budget)
+    budget_presenter = BudgetPresenter.new(budget)
+    expect(page).to have_content(budget_presenter.budget_type)
+    expect(page).to have_content(budget_presenter.status)
+    expect(page).to have_content(budget_presenter.period_start_date)
+    expect(page).to have_content(budget_presenter.period_end_date)
+    expect(page).to have_content(budget_presenter.value)
   end
 end

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -4,29 +4,110 @@ RSpec.feature "Users can view transactions on an activity page" do
   end
 
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:administrator, organisation: organisation) }
-  let(:activity) { create(:activity, organisation: organisation) }
-  let(:other_activity) { create(:activity, organisation: organisation) }
 
-  scenario "only transactions belonging to this activity are shown on the Activity#show page" do
-    transaction = create(:transaction, activity: activity)
-    other_transaction = create(:transaction, activity: other_activity)
+  context "when the user is a fund manager" do
+    let(:user) { create(:fund_manager, organisation: organisation) }
 
-    visit organisations_path
-    click_link organisation.name
-    click_link activity.title
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: organisation) }
+      let(:other_activity) { create(:fund_activity, organisation: organisation) }
 
-    expect(page).to have_content(transaction.reference)
-    expect(page).to_not have_content(other_transaction.reference)
+      scenario "only transactions belonging to this activity are shown on the Activity#show page" do
+        transaction = create(:transaction, activity: activity)
+        other_transaction = create(:transaction, activity: other_activity)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link activity.title
+
+        expect(page).to have_content(transaction.reference)
+        expect(page).to_not have_content(other_transaction.reference)
+      end
+
+      scenario "transaction information is shown on the page" do
+        transaction = create(:transaction, activity: activity)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link activity.title
+
+        transaction_details_are_present(transaction)
+      end
+    end
+
+    context "when the activity is a programme" do
+      let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+      let(:activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+
+      scenario "transaction information is shown on the page" do
+        transaction = create(:transaction, activity: activity)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link fund_activity.title
+        click_link activity.title
+
+        transaction_details_are_present(transaction)
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+      let(:programme_activity) { create(:programme_activity, activity: fund_activity) }
+      let(:activity) { create(:project_activity, activity: programme_activity, organisation: organisation) }
+
+      scenario "transaction information is shown on the page" do
+        transaction = create(:transaction, activity: activity)
+
+        visit organisations_path
+        click_link organisation.name
+        click_link fund_activity.title
+        click_link programme_activity.title
+        click_link activity.title
+
+        transaction_details_are_present(transaction)
+      end
+    end
   end
 
-  scenario "transaction information is shown on the page" do
-    transaction = create(:transaction, activity: activity)
-    transaction_presenter = TransactionPresenter.new(transaction)
+  context "when the user is a delivery partner" do
+    let(:user) { create(:delivery_partner, organisation: organisation) }
 
-    visit organisations_path
-    click_link organisation.name
-    click_link activity.title
+    context "when the activity is a programme" do
+      let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+      let(:activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+
+      scenario "transaction information is not shown on the page" do
+        transaction = create(:transaction, activity: activity)
+
+        visit organisation_path(organisation)
+        click_link fund_activity.title
+        click_link activity.title
+
+        expect(page).to_not have_content(transaction.reference)
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:fund_activity) { create(:fund_activity, organisation: organisation) }
+      let(:programme_activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+      let(:activity) { create(:project_activity, activity: programme_activity, organisation: organisation) }
+
+      scenario "transaction information is shown on the page" do
+        transaction = create(:transaction, activity: activity)
+
+        visit organisation_path(organisation)
+        click_link fund_activity.title
+        click_link programme_activity.title
+        click_link activity.title
+
+        transaction_details_are_present(transaction)
+      end
+    end
+  end
+
+  def transaction_details_are_present(transaction)
+    transaction_presenter = TransactionPresenter.new(transaction)
 
     expect(page).to have_content(transaction_presenter.reference)
     expect(page).to have_content(transaction_presenter.description)

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(activity_back_path(programme_activity)).to eq organisation_activity_path(fund_activity.organisation, fund_activity)
       end
     end
+
+    context "when the activity is a project level" do
+      it "returns the programme path" do
+        fund_activity = create(:activity, level: :fund)
+        programme_activity = create(:activity, level: :programme)
+        project_activity = create(:activity, level: :project)
+        fund_activity.activities << programme_activity
+        programme_activity.activities << project_activity
+
+        expect(activity_back_path(project_activity)).to eq organisation_activity_path(programme_activity.organisation, programme_activity)
+      end
+    end
   end
 
   describe "#step_is_complete_or_next?" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Activity, type: :model do
         fund_activity = create(:activity, level: :fund)
         _other_activiy = create(:activity, level: :programme)
 
-        expect(Activity.funds).to eq [fund_activity]
+        expect(Activity.fund).to eq [fund_activity]
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe Activity, type: :model do
         programme_activity = create(:activity, level: :programme)
         _other_activiy = create(:activity, level: :fund)
 
-        expect(Activity.programmes).to eq [programme_activity]
+        expect(Activity.programme).to eq [programme_activity]
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Activity, type: :model do
         project_activity = create(:activity, level: :project)
         _other_activity = create(:activity, level: :programme)
 
-        expect(Activity.projects).to eq [project_activity]
+        expect(Activity.project).to eq [project_activity]
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Activity, type: :model do
         expect(Activity.programmes).to eq [programme_activity]
       end
     end
+
+    describe ".projects" do
+      it "only returns project level activities" do
+        project_activity = create(:activity, level: :project)
+        _other_activity = create(:activity, level: :programme)
+
+        expect(Activity.projects).to eq [project_activity]
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -42,17 +42,44 @@ RSpec.describe ActivityPolicy do
       described_class::Scope.new(user, Activity.all).resolve
     end
 
-    it { is_expected.to forbid_action(:index) }
-    it { is_expected.to forbid_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to permit_action(:index) }
     it { is_expected.to forbid_action(:destroy) }
 
     context "with activities from my own organisation" do
       let(:user) { create(:delivery_partner, organisation: organisation) }
+      let(:project) { create(:project_activity, organisation: organisation) }
+      let(:programme) { create(:programme_activity, organisation: organisation) }
 
-      it "does not include activity in resolved scope" do
-        expect(resolved_scope).not_to include(activity)
+      context "with a fund activity" do
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to forbid_new_and_create_actions }
+        it { is_expected.to forbid_edit_and_update_actions }
+      end
+
+      context "with a programme activity" do
+        let(:activity) { programme }
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to forbid_new_and_create_actions }
+        it { is_expected.to forbid_edit_and_update_actions }
+      end
+
+      context "with a project activity" do
+        let(:activity) { project }
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_new_and_create_actions }
+        it { is_expected.to permit_edit_and_update_actions }
+      end
+
+      it "includes fund activities in resolved scope" do
+        expect(resolved_scope).to include(activity)
+      end
+
+      it "includes project activities in resolved scope" do
+        expect(resolved_scope).to include(project)
+      end
+
+      it "includes programme activities in resolved scope" do
+        expect(resolved_scope).to include(programme)
       end
     end
 

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -26,9 +26,26 @@ RSpec.describe ActivityPolicy do
 
     it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:destroy) }
+
+    context "with a fund activity" do
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+    end
+
+    context "with a programme activity" do
+      let(:activity) { create(:programme_activity, organisation: organisation) }
+
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+    end
+
+    context "with a project activity" do
+      let(:activity) { create(:project_activity, organisation: organisation) }
+
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+    end
 
     it "includes activity in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.all).resolve

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe TransactionPolicy do
         resolved_scope = described_class::Scope.new(user, Transaction.all).resolve
         expect(resolved_scope).not_to include(transaction)
       end
+
+      context "for project level activities in the user's organisation" do
+        let(:user) { create(:delivery_partner, organisation: organisation) }
+        let(:activity) { create(:project_activity, organisation: organisation) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_new_and_create_actions }
+        it { is_expected.to permit_edit_and_update_actions }
+
+        it "includes transaction in resolved scope" do
+          resolved_scope = described_class::Scope.new(user, Transaction.all).resolve
+          expect(resolved_scope).to include(transaction)
+        end
+      end
     end
   end
 end

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe CreateProjectActivity do
+  let(:organisation) { create(:organisation) }
+  let(:programme) { create(:programme_activity) }
+
+  describe "#call" do
+    let(:result) { described_class.new(organisation_id: organisation.id, programme_id: programme.id).call }
+
+    it "sets the Organisation" do
+      expect(result.organisation).to eq(organisation)
+    end
+
+    it "sets the parent Activity to the programme" do
+      expect(result.activity).to eq(programme)
+    end
+
+    it "sets the initial wizard_status" do
+      expect(result.wizard_status).to eq("identifier")
+    end
+
+    it "sets the Activity level to 'project'" do
+      expect(result.level).to eq("project")
+    end
+
+    it "sets the funding organisation details" do
+      expect(result.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(result.funding_organisation_reference).to eq("GB-GOV-13")
+      expect(result.funding_organisation_type).to eq("10")
+    end
+
+    it "sets the accountable organisation details" do
+      expect(result.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(result.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(result.accountable_organisation_type).to eq("10")
+    end
+  end
+end

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe CreateProjectActivity do
   let(:organisation) { create(:organisation) }
   let(:programme) { create(:programme_activity) }
+  let(:user) { create(:fund_manager) }
 
   describe "#call" do
-    let(:result) { described_class.new(organisation_id: organisation.id, programme_id: programme.id).call }
+    let(:result) { described_class.new(organisation_id: organisation.id, programme_id: programme.id, user: user).call }
 
     it "sets the Organisation" do
       expect(result.organisation).to eq(organisation)
@@ -33,6 +34,20 @@ RSpec.describe CreateProjectActivity do
       expect(result.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
       expect(result.accountable_organisation_reference).to eq("GB-GOV-13")
       expect(result.accountable_organisation_type).to eq("10")
+    end
+
+    context "when the user is a delivery partner" do
+      let(:user) { create(:delivery_partner) }
+
+      it "sets the extending organisation to the user's organisation" do
+        expect(result.extending_organisation).to eq(user.organisation)
+      end
+    end
+
+    context "when the user is a fund manager" do
+      it "does not set the extending organisation" do
+        expect(result.extending_organisation).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Needs https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/182/commits/033fd5e436ef6dfdb3de47f301286094aaa1a3db to be merged before tests will pass!

## Changes in this PR

Trello: https://trello.com/c/kOKYJ1UE/270-users-can-create-a-project-level-c-activity

Project (level C) activities can be added.

This PR required a lot of changes to the things Delivery partners are allowed to see. Previously, DPs could not view fund or programme activities, but they need to be able to navigate through those activities to create a project "under" a programme. 

DPs can now see a "read only" view of funds and programmes, and cannot add budgets or transactions to those activities. But they can create & update project level activities, and add budgets & transactions to projects.

As a side-effect of doing this work, budgets can now be added to fund level activities (https://trello.com/c/RsLTbcF2/280-users-can-add-a-budget-to-a-fund)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
