### PR TITLE
Add hint text to date form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@
 - Fund activities store extending organisation details
 - Sign in button works when JS is disabled
 - Fund managers can set and change the extending organisation
+- Date inputs in forms for creating activity, transaction and a budget have a hint text

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -87,12 +87,16 @@ en:
         role: Role
     hint:
       activity:
+        actual_end_date: For example, 2 12 2020
+        actual_start_date: For example, 11 4 2020
         aid_type:
           html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidTypeVocabulary/' target='_blank'>IATI descriptions can be found here.</a>
         finance: DAC/CRS transaction classification used to distinguish financial instruments, e.g. grants or loans.
         flow:
           html: "<a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>IATI descriptions of each flow type can be found here.</a>"
         identifier: Reference to link this to your internal systems so it can be found again later.
+        planned_end_date: For example, 28 11 2020
+        planned_start_date: For example, 27 3 2020
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity. <a href='http://reference.iatistandard.org/203/codelists/Region/' target='_blank'>Find the region code from the IATI region list.</a>
         sector:
@@ -102,3 +106,8 @@ en:
         tied_status:
           html: "<a href='http://reference.iatistandard.org/203/codelists/TiedStatus/' target='_blank'>See the IATI tied status page for descriptions.</a>"
         title: A short, human-readable title that contains a meaningful summary of the activity.
+      budget:
+        period_end_date: For example, 12 3 2021
+        period_start_date: For example, 11 3 2020
+      transaction:
+        date: For example, 27 3 2020


### PR DESCRIPTION
Added hint text to date form fields for an activity, budget and a transaction.

During our testing the date form fields turned out to be not clear on what values are expected for the month part. It wasn’t clear that the date input expects a number and not a month name.

Now with a hint text this should be more descriptive.

Next todo’s:
There should be more hint text work around dates added to include guidance around planned and actual dates

## Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot_2020-02-13 Dates — Report Official Development Assistance](https://user-images.githubusercontent.com/2632224/74434665-c35e9400-4e5a-11ea-956c-c8d0378665e0.png)

### After

![Screenshot_2020-02-13 Dates — Report Official Development Assistance(1)](https://user-images.githubusercontent.com/2632224/74434691-d2dddd00-4e5a-11ea-80cb-9fd01792a189.png)

![Screenshot_2020-02-13 New transaction — Report Official Development Assistance](https://user-images.githubusercontent.com/2632224/74434704-d8d3be00-4e5a-11ea-9bc0-f1a349decd21.png)

![Screenshot_2020-02-13 Create budget — Report Official Development Assistance](https://user-images.githubusercontent.com/2632224/74434717-dffacc00-4e5a-11ea-905b-8864b3e3bf3c.png)



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
