### PR TITLE
Fix flakey user helper

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -3,6 +3,6 @@
 module UserHelper
   def organisation_check_box_options
     @organisation_check_box_options ||=
-      Organisation.all.map { |o| [o.name, o.id] }
+      Organisation.sorted_by_name.map { |o| [o.name, o.id] }
   end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe UserHelper, type: :helper do
   describe "#organisation_check_box_options" do
-    it "returns an array of all organisations" do
-      first_organisation = create(:organisation)
-      second_organisation = create(:organisation)
+    it "returns an array of all organisations in alphabetical order" do
+      first_organisation = create(:organisation, name: "A Organisation")
+      second_organisation = create(:organisation, name: "Z Organisation")
 
       expect(helper.organisation_check_box_options)
         .to match([


### PR DESCRIPTION
This spec failed a couple of times but mostly passes so I took a look
over it.

As we cannot guarantee the order entities from an `all` query the match
could fail if the order came back differently, which we have no control
over.

We could've used `match_array` if the order didn't matter, but I think
it makes sense that, where this is used, the organisations are listed in
alphabetical order.

I've changed the implementation to use the existing `sorted_by_name`
scope, which gives us the organisations in alphabetical order.

I also tweaked the spec now that the order matters.