### PR TITLE
(281) Add Budgets to XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,5 @@
 - Transaction provider and receiver IATI references are exposed in the XML if present
 - Users can report project level activities
 - Users can add budgets to project level activities
+- Users can view Budgets in the Activity XML
+

--- a/app/presenters/budget_xml_presenter.rb
+++ b/app/presenters/budget_xml_presenter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class BudgetXmlPresenter < SimpleDelegator
+  XML_BUDGET_TYPES = {"original" => 1, "updated" => 2}
+  XML_STATUSES = {"indicative" => 1, "committed" => 2}
+
+  def period_start_date
+    return if super.blank?
+    I18n.l(super, format: :iati)
+  end
+
+  def period_end_date
+    return if super.blank?
+    I18n.l(super, format: :iati)
+  end
+
+  def value
+    super.to_s
+  end
+
+  def budget_type
+    return if super.blank?
+    XML_BUDGET_TYPES[super]
+  end
+
+  def status
+    return if super.blank?
+    XML_STATUSES[super]
+  end
+end

--- a/app/views/staff/activities/show.xml.haml
+++ b/app/views/staff/activities/show.xml.haml
@@ -1,4 +1,4 @@
 !!! XML
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
-  = render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions }
+  = render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions, budgets: @budgets }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -26,6 +26,10 @@
   %default-finance-type{"code" => "#{activity.finance}"}/
   %default-aid-type{"code" => "#{activity.aid_type}"}/
   %default-tied-status{"code" => "#{activity.tied_status}"}/
+  - if budgets
+    - budgets.each do |budget|
+      = render partial: "staff/shared/xml/budget", locals: { budget: budget }
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }
+

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -28,7 +28,7 @@
   %default-tied-status{"code" => activity.tied_status}/
   - if budgets
     - budgets.each do |budget|
-      = render partial: "staff/shared/xml/budget", locals: { budget: budget }
+      = render partial: "staff/shared/xml/budget", locals: { budget: BudgetXmlPresenter.new(budget) }
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,10 +1,10 @@
-%iati-activity{"default-currency" => "#{activity.default_currency}", "xml:lang" => activity.organisation.language_code }
+%iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
   %iati-identifier= activity.identifier
   %reporting-org{"type" => activity.organisation.organisation_type, "ref" => activity.organisation.iati_reference }
     %narrative= activity.organisation.name
   %title
     %narrative= activity.title
-  %description{type: "1"}
+  %description{"type" => "1"}
     %narrative= activity.description
   - if activity.has_funding_organisation?
     %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
@@ -15,17 +15,17 @@
   - if activity.has_extending_organisation?
     %participating-org{"ref" => activity.extending_organisation.iati_reference, "type" => activity.extending_organisation.organisation_type, "role" => 3}
       %narrative= activity.extending_organisation.name
-  %activity-status{code: "#{activity.status}"}/
-  %activity-date{"iso-date" => "#{activity.planned_start_date}", type: "1"}/
-  %activity-date{"iso-date" => "#{activity.actual_start_date}", type: "2"}/
-  %activity-date{"iso-date" => "#{activity.planned_end_date}", type: "3"}/
-  %activity-date{"iso-date" => "#{activity.actual_end_date}", type: "4"}/
-  %recipient-region{"code" => "#{activity.recipient_region}"}/
-  %sector{"vocabulary" => "1", "code" => "#{activity.sector}"}/
-  %default-flow-type{"code" => "#{activity.flow}"}/
-  %default-finance-type{"code" => "#{activity.finance}"}/
-  %default-aid-type{"code" => "#{activity.aid_type}"}/
-  %default-tied-status{"code" => "#{activity.tied_status}"}/
+  %activity-status{"code" => activity.status}/
+  %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
+  %activity-date{"iso-date" => activity.actual_start_date, type: "2"}/
+  %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
+  %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
+  %recipient-region{"code" => activity.recipient_region}/
+  %sector{"vocabulary" => "1", "code" => activity.sector}/
+  %default-flow-type{"code" => activity.flow}/
+  %default-finance-type{"code" => activity.finance}/
+  %default-aid-type{"code" => activity.aid_type}/
+  %default-tied-status{"code" => activity.tied_status}/
   - if budgets
     - budgets.each do |budget|
       = render partial: "staff/shared/xml/budget", locals: { budget: budget }

--- a/app/views/staff/shared/xml/_budget.xml.haml
+++ b/app/views/staff/shared/xml/_budget.xml.haml
@@ -1,5 +1,5 @@
 %budget{"type" => budget.budget_type, "status" => budget.status}
-  %period-start{"iso-date" => l(budget.period_start_date, format: :iati)}/
-  %period-end{"iso-date" => l(budget.period_end_date, format: :iati)}/
+  %period-start{"iso-date" => budget.period_start_date}/
+  %period-end{"iso-date" => budget.period_end_date}/
   %value{"value-date" => budget.period_start_date}= budget.value.to_s
 

--- a/app/views/staff/shared/xml/_budget.xml.haml
+++ b/app/views/staff/shared/xml/_budget.xml.haml
@@ -1,0 +1,5 @@
+%budget{"type" => budget.budget_type, "status" => budget.status}
+  %period-start{"iso-date" => l(budget.period_start_date, format: :iati)}/
+  %period-end{"iso-date" => l(budget.period_end_date, format: :iati)}/
+  %value{"value-date" => budget.period_start_date}= budget.value.to_s
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   date:
     formats:
       default: "%-d %b %Y"
+      iati: "%Y-%m-%d"
   form:
     activity:
       create:

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -42,6 +42,8 @@ FactoryBot.define do
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
+
+      association :extending_organisation, factory: :beis_organisation
     end
 
     factory :project_activity do
@@ -52,6 +54,8 @@ FactoryBot.define do
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
+
+      association :extending_organisation, factory: :beis_organisation
     end
   end
 

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Users can view an activity as XML" do
           expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
           expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
         end
-     end
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -1,73 +1,98 @@
-RSpec.feature "Users can download an activity as XML" do
-  before do
-    authenticate!(user: user)
-  end
-
-  let(:organisation) { create(:beis_organisation) }
-  let(:delivery_partner) { create(:organisation) }
-  let(:activity) do
-    create(:activity,
-      planned_start_date: Date.today,
-      planned_end_date: Date.tomorrow,
-      organisation: organisation,
-      extending_organisation: delivery_partner)
-  end
-  let(:user) { create(:administrator, organisation: organisation) }
-
-  context "when the user is not logged in" do
-    it "redirects the user to the root path" do
-      page.set_rack_session(userinfo: nil)
-      visit organisation_activity_path(activity.organisation, activity)
-      expect(current_path).to eq(root_path)
-    end
-  end
-
+# TODO: This data will eventually need to be public so that IATI can retrieve it
+RSpec.feature "Users can view an activity as XML" do
   context "when the user belongs to the organisation the activity is part of" do
-    it "returns an XML response" do
-      visit organisation_activity_path(activity.organisation, activity, format: :xml)
+    let(:organisation) { create(:organisation) }
 
-      xml = Nokogiri::XML::Document.parse(page.body)
+    context "when the user is a fund manager" do
+      before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
 
-      expect(xml.at("iati-identifier").text).to eq(activity.identifier)
-      expect(xml.at("reporting-org/@ref").text).to eq(activity.organisation.iati_reference)
-      expect(xml.at("reporting-org/@type").text).to eq(activity.organisation.organisation_type)
-      expect(xml.at("reporting-org/narrative").text).to eq(organisation.name)
-      expect(xml.at("title/narrative").text).to eq(activity.title)
-      expect(xml.at("description/narrative").text).to eq(activity.description)
-      expect(xml.at("activity-status/@code").text).to eq(activity.status)
-      expect(xml.at("activity-date[@type = '1']/@iso-date").text).to eq(activity.planned_start_date.strftime("%Y-%m-%d"))
-      expect(xml.at("activity-date[@type = '2']/@iso-date").text).to eq(activity.actual_start_date.strftime("%Y-%m-%d"))
-      expect(xml.at("activity-date[@type = '3']/@iso-date").text).to eq(activity.planned_end_date.strftime("%Y-%m-%d"))
-      expect(xml.at("activity-date[@type = '4']/@iso-date").text).to eq(activity.actual_end_date.strftime("%Y-%m-%d"))
-      expect(xml.at("recipient-region/@code").text).to eq(activity.recipient_region)
-      expect(xml.at("sector[@vocabulary = '1']/@code").text).to eq(activity.sector)
-      expect(xml.at("default-flow-type/@code").text).to eq(activity.flow)
-      expect(xml.at("default-finance-type/@code").text).to eq(activity.finance)
-      expect(xml.at("default-tied-status/@code").text).to eq(activity.tied_status)
-    end
-  end
+      context "when the activity is a fund activity" do
+        let(:activity) { create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
-  context "when an activity has a transaction" do
-    it "returns an XML response with the transaction included" do
-      transaction = create(:transaction, activity: activity)
-      visit organisation_activity_path(activity.organisation, activity, format: :xml)
+        it "contains a top-level activities element with the IATI version" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activities/@version").text).to eq(IATI_VERSION.tr("_", "."))
+        end
 
-      xml = Nokogiri::XML::Document.parse(page.body)
+        it "contains the activity XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
+          expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+        end
 
-      expect(xml.at("transaction/@ref").text).to eq(transaction.reference)
-      expect(xml.at("transaction-type/@code").text).to eq(transaction.transaction_type)
-      expect(xml.at("transaction-date/@iso-date").text).to eq(transaction.date.strftime("%Y-%m-%d"))
-      expect(xml.at("value/@currency").text).to eq(transaction.currency)
-      expect(xml.at("value/@value-date").text).to eq(transaction.date.strftime("%Y-%m-%d"))
-      expect(xml.at("value").text).to eq(transaction.value.to_s)
-      expect(xml.at("transaction/description/narrative").text).to eq(transaction.description)
-      expect(xml.at("provider-org/@type").text).to eq(transaction.providing_organisation_type)
-      expect(xml.at("provider-org/@ref").text).to eq(transaction.providing_organisation_reference)
-      expect(xml.at("provider-org/narrative").text).to eq(transaction.providing_organisation_name)
-      expect(xml.at("receiver-org/@type").text).to eq(transaction.receiving_organisation_type)
-      expect(xml.at("receiver-org/@ref").text).to eq(transaction.receiving_organisation_reference)
-      expect(xml.at("receiver-org/narrative").text).to eq(transaction.receiving_organisation_name)
-      expect(xml.at("disbursement-channel/@code").text).to eq(transaction.disbursement_channel)
+        it "contains the funding organisation XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+        end
+
+        it "contains the accountable organisation XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
+        end
+
+        it "contains the extending organisation XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation.iati_reference)
+          expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation.organisation_type)
+          expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation.name)
+        end
+
+        it "contains the transaction XML" do
+          transaction = create(:transaction, activity: activity)
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
+        end
+
+        it "contains the budget XML" do
+          budget = create(:budget, activity: activity)
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/budget/@type").text).to eq(budget.budget_type)
+          expect(xml.at("iati-activity/budget/@status").text).to eq(budget.status)
+          expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
+          expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
+          expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
+        end
+      end
+
+      context "when the activity is a programme activity" do
+        let(:activity) { create(:programme_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "contains the activity XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
+          expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+        end
+
+        it "contains the funding organisation XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
+          expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+        end
+
+        it "contains the accountable organisation XML" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
+          expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
+        end
+
+        it "contains the budget XML" do
+          budget = create(:budget, activity: activity)
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/budget/@type").text).to eq(budget.budget_type)
+          expect(xml.at("iati-activity/budget/@status").text).to eq(budget.status)
+          expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
+          expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
+          expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
+        end
+     end
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -10,88 +10,14 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) { create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
-        it "contains a top-level activities element with the IATI version" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activities/@version").text).to eq(IATI_VERSION.tr("_", "."))
-        end
-
-        it "contains the activity XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
-          expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
-        end
-
-        it "contains the funding organisation XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
-        end
-
-        it "contains the accountable organisation XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
-        end
-
-        it "contains the extending organisation XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation.iati_reference)
-          expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation.organisation_type)
-          expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation.name)
-        end
-
-        it "contains the transaction XML" do
-          transaction = create(:transaction, activity: activity)
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
-        end
-
-        it "contains the budget XML" do
-          budget = create(:budget, activity: activity)
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/budget/@type").text).to eq("1")
-          expect(xml.at("iati-activity/budget/@status").text).to eq("1")
-          expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
-          expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
-          expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
-        end
+        it_behaves_like "valid activity XML"
       end
 
       context "when the activity is a programme activity" do
         let(:activity) { create(:programme_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
-        it "contains the activity XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
-          expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
-        end
-
-        it "contains the funding organisation XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
-          expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
-        end
-
-        it "contains the accountable organisation XML" do
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
-          expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
-        end
-
-        it "contains the budget XML" do
-          budget = create(:budget, activity: activity)
-          visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/budget/@type").text).to eq("1")
-          expect(xml.at("iati-activity/budget/@status").text).to eq("1")
-          expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
-          expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
-          expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
-        end
+        it_behaves_like "valid activity XML"
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -51,8 +51,8 @@ RSpec.feature "Users can view an activity as XML" do
         it "contains the budget XML" do
           budget = create(:budget, activity: activity)
           visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/budget/@type").text).to eq(budget.budget_type)
-          expect(xml.at("iati-activity/budget/@status").text).to eq(budget.status)
+          expect(xml.at("iati-activity/budget/@type").text).to eq("1")
+          expect(xml.at("iati-activity/budget/@status").text).to eq("1")
           expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
           expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
           expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
@@ -86,8 +86,8 @@ RSpec.feature "Users can view an activity as XML" do
         it "contains the budget XML" do
           budget = create(:budget, activity: activity)
           visit organisation_activity_path(organisation, activity, format: :xml)
-          expect(xml.at("iati-activity/budget/@type").text).to eq(budget.budget_type)
-          expect(xml.at("iati-activity/budget/@status").text).to eq(budget.status)
+          expect(xml.at("iati-activity/budget/@type").text).to eq("1")
+          expect(xml.at("iati-activity/budget/@status").text).to eq("1")
           expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
           expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
           expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))

--- a/spec/presenters/budget_presenter_spec.rb
+++ b/spec/presenters/budget_presenter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BudgetPresenter do
     end
   end
 
-  describe "#period_start_date" do
+  describe "#period_end_date" do
     it "returns the localised date for the period_end_date" do
       expect(described_class.new(budget).period_end_date).to eq("1 Jan 2021")
     end

--- a/spec/presenters/budget_xml_presenter_spec.rb
+++ b/spec/presenters/budget_xml_presenter_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BudgetXmlPresenter do
+  describe "#period_start_date" do
+    context "when the period_start_date is blank" do
+      it "returns nil" do
+        budget = build(:budget, period_start_date: "")
+        expect(described_class.new(budget).period_start_date).to be_nil
+      end
+    end
+
+    context "when the period_start_date exists" do
+      it "returns an IATI-formatted date" do
+        budget = build(:budget, period_start_date: Date.today)
+        expect(described_class.new(budget).period_start_date).to eq(Date.today.strftime("%Y-%m-%d"))
+      end
+    end
+  end
+
+  describe "#period_end_date" do
+    context "when the period_end_date is blank" do
+      it "returns nil" do
+        budget = build(:budget, period_end_date: "")
+        expect(described_class.new(budget).period_end_date).to be_nil
+      end
+    end
+
+    context "when the period_end_date exists" do
+      it "returns an IATI-formatted date" do
+        budget = build(:budget, period_end_date: Date.tomorrow)
+        expect(described_class.new(budget).period_end_date).to eq(Date.tomorrow.strftime("%Y-%m-%d"))
+      end
+    end
+  end
+
+  describe "#budget_type" do
+    context "when the budget_type is blank" do
+      it "returns nil" do
+        budget = build(:budget, budget_type: "")
+        expect(described_class.new(budget).budget_type).to be_nil
+      end
+    end
+
+    context "when the budget_type exists" do
+      it "returns the type in IATI format" do
+        budget = build(:budget, budget_type: "original")
+        expect(described_class.new(budget).budget_type).to eq(1)
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when the status is blank" do
+      it "returns nil" do
+        budget = build(:budget, status: "")
+        expect(described_class.new(budget).status).to be_nil
+      end
+    end
+
+    context "when the status exists" do
+      it "returns the status in IATI format" do
+        budget = build(:budget, status: "indicative")
+        expect(described_class.new(budget).budget_type).to eq(1)
+      end
+    end
+  end
+
+  describe "#value" do
+    it "returns the value as a string" do
+      budget = build(:budget, value: 21.01)
+      expect(described_class.new(budget).value).to eq("21.01")
+    end
+  end
+end

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml_spec.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml_spec.rb
@@ -1,0 +1,49 @@
+RSpec.shared_examples "valid activity XML" do
+  it "contains a top-level activities element with the IATI version" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activities/@version").text).to eq(IATI_VERSION.tr("_", "."))
+  end
+
+  it "contains the activity XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
+    expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+  end
+
+  it "contains the funding organisation XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+  end
+
+  it "contains the accountable organisation XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
+  end
+
+  it "contains the extending organisation XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation.iati_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation.organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation.name)
+  end
+
+  it "contains the transaction XML" do
+    transaction = create(:transaction, activity: activity)
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
+  end
+
+  it "contains the budget XML" do
+    budget = create(:budget, activity: activity)
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/budget/@type").text).to eq("1")
+    expect(xml.at("iati-activity/budget/@status").text).to eq("1")
+    expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
+    expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
+    expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/o0YNJlMt/281-add-budgets-to-xml

Budgets are added to the Activity XML as per the IATI standard: http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/budget/

The budget XML passes validation (see https://test-validator.iatistandard.org/view/dqf/files/ba982acc-8187-4885-989c-50bff12c4fd6?isTestfiles=true) but there are some errors in the Activity XML which are not related to budgets.

See also https://trello.com/c/anTHm0iW/301-budget-periods-cannot-be-more-than-1-year

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
