### PR TITLE
Pull request links to IATI validator documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@
 - [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
 - [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
 - [ ] Do any environment variables need amending or adding?
-- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
+- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)


### PR DESCRIPTION
## Changes in this PR

Before this change, when clicking the link from a GitHub pull request it broke.

The link path was:
https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/doc/xml-validation.md

Notice the `/pull/doc/`? I assume the relative syntax we've got works from the context of the app but doesn't work from the context of a pull request?

Here's an old pull request where you can test the bug https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/189

An absolute link is prone to breaking if we change our master branch or move the file. In which case a pointer to documentation that exists is still useful even if the link breaks.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
