### PR TITLE
(270) Users can report project level activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@
 - Date inputs in forms for creating activity, transaction and a budget have a hint text
 - Transaction provider and receiver IATI references are exposed in the XML if present
 - Users can report project level activities
+- Users can add budgets to project level activities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@
 - Fund managers can set and change the extending organisation
 - Date inputs in forms for creating activity, transaction and a budget have a hint text
 - Transaction provider and receiver IATI references are exposed in the XML if present
+- Users can report project level activities

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -9,7 +9,7 @@ class Staff::BudgetsController < Staff::BaseController
 
     authorize @budget
 
-    unless @activity.is_programme_level?
+    unless @activity.is_programme_level? | @activity.is_project_level?
       flash[:warning] = I18n.t("page_title.errors.budget.not_possible")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     end

--- a/app/controllers/staff/projects_controller.rb
+++ b/app/controllers/staff/projects_controller.rb
@@ -1,0 +1,8 @@
+class Staff::ProjectsController < Staff::ActivitiesController
+  def create
+    @activity = CreateProjectActivity.new(user: current_user, organisation_id: params["organisation_id"], programme_id: params["programme_id"]).call
+    authorize @activity
+
+    redirect_to activity_step_path(@activity.id, @activity.wizard_status)
+  end
+end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -13,6 +13,6 @@ module ActivityHelper
 
   def activity_back_path(activity)
     return organisation_path(activity.organisation) if activity.is_fund_level?
-    return organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity) if activity.is_programme_level?
+    organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity)
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -20,7 +20,8 @@ class Activity < ApplicationRecord
   enum level: {
     fund: "fund",
     programme: "programme",
-  }
+    project: "project",
+  }, _prefix: :is, _suffix: :level
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
@@ -67,14 +68,6 @@ class Activity < ApplicationRecord
 
   def default_currency
     organisation.default_currency
-  end
-
-  def is_fund_level?
-    level == "fund"
-  end
-
-  def is_programme_level?
-    level == "programme"
   end
 
   def parent_activity

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -1,0 +1,34 @@
+class CreateProjectActivity
+  attr_accessor :user, :organisation_id, :programme_id
+
+  def initialize(user:, organisation_id:, programme_id:)
+    self.organisation_id = organisation_id
+    self.programme_id = programme_id
+    self.user = user
+  end
+
+  def call
+    reporting_organisation = Organisation.find(organisation_id)
+
+    activity = Activity.new
+    activity.organisation = reporting_organisation
+
+    programme = Activity.find(programme_id)
+    programme.activities << activity
+
+    activity.wizard_status = "identifier"
+    activity.level = :project
+
+    activity.funding_organisation_name = reporting_organisation.name
+    activity.funding_organisation_reference = reporting_organisation.iati_reference
+    activity.funding_organisation_type = reporting_organisation.organisation_type
+
+    activity.accountable_organisation_name = reporting_organisation.name
+    activity.accountable_organisation_reference = reporting_organisation.iati_reference
+    activity.accountable_organisation_type = reporting_organisation.organisation_type
+
+    activity.extending_organisation = user.organisation
+    activity.save(validate: false)
+    activity
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -35,6 +35,14 @@
 
         = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisation_path(@activity), class: "govuk-button")
 
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.activity.projects")
+
+        = render partial: '/staff/shared/projects/table', locals: { projects: @activities }
+        = button_to t("page_content.organisation.button.create_project"), organisation_fund_programme_projects_path(@activity.organisation, @activity.parent_activity, @activity), class: "govuk-button"
+
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-m

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -51,7 +51,7 @@
       = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(@activity), class: "govuk-button")
       = render partial: '/staff/shared/transactions/table', locals: { transactions: @transaction_presenters }
 
-  - if @activity.is_programme_level?
+  - if @activity.is_programme_level? | @activity.is_project_level?
     .govuk-grid-row
       .govuk-grid-column-full
         %h2.govuk-heading-m

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -1,0 +1,11 @@
+- unless projects.empty?
+  %table.govuk-table.transactions
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("activerecord.attributes.activity.title")
+
+    %tbody.govuk-table__body
+      - projects.each do |project|
+        %tr.govuk-table__row{id: project.id}
+          %td.govuk-table__cell= link_to project.title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,9 @@ en:
         success: Programme successfully created
       update:
         success: Programme successfully updated
+    project:
+      create:
+        success: Project successfully created
     transaction:
       create:
         success: Transaction successfully created
@@ -151,6 +154,7 @@ en:
         label: Planned end date
       planned_start_date:
         label: Planned start date
+      projects: Projects
       recipient_region:
         label: Recipient region
       sector:
@@ -192,6 +196,7 @@ en:
         choose_extending_organisation: Choose extending organisation
         create_fund: Create fund
         create_programme: Create programme
+        create_project: Create project
         edit: Edit organisation
       default_currency:
         label: Default currency

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:destroy]
       resources :funds, only: [:create] do
-        resources :programmes, only: [:create]
+        resources :programmes, only: [:create] do
+          resources :projects, only: [:create]
+        end
       end
     end
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -43,6 +43,16 @@ FactoryBot.define do
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
     end
+
+    factory :project_activity do
+      level { :project }
+      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      funding_organisation_reference { "GB-GOV-13" }
+      funding_organisation_type { "10" }
+      accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      accountable_organisation_reference { "GB-GOV-13" }
+      accountable_organisation_type { "10" }
+    end
   end
 
   trait :at_identifier_step do

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -1,87 +1,34 @@
 RSpec.describe "Users can create a budget" do
-  let(:organisation) { create(:organisation, name: "UKSA") }
+  let(:organisation) { create(:delivery_partner_organisation, name: "UKSA") }
 
-  context "when the user is not logged in" do
-    it "redirects the user to the root path" do
-      activity = create(:activity)
-      page.set_rack_session(userinfo: nil)
-      visit new_activity_budget_path(activity)
-      expect(current_path).to eq(root_path)
-    end
-  end
+  let!(:fund_activity) { create(:activity, organisation: organisation) }
+  let!(:programme_activity) { create(:programme_activity, activity: fund_activity, organisation: organisation) }
+  let!(:project_activity) { create(:project_activity, activity: programme_activity, organisation: organisation) }
 
-  context "on a programme" do
-    let!(:fund_activity) { create(:activity, organisation: organisation) }
-    let!(:programme_activity) do
-      create(:programme_activity,
-        activity: fund_activity,
-        organisation: organisation)
-    end
+  context "when signed in as an administrator" do
+    let(:fund_manager) { create(:administrator, organisation: organisation) }
 
-    context "as a fund manager" do
-      let(:fund_manager) { create(:fund_manager, organisation: organisation) }
+    before { authenticate!(user: fund_manager) }
 
-      before { authenticate!(user: fund_manager) }
+    scenario "sees validation errors for missing attributes" do
+      visit organisation_path(organisation)
 
-      scenario "successfully creates a budget" do
-        visit organisation_path(organisation)
-        click_on(fund_activity.title)
-        click_on(programme_activity.title)
+      click_on(fund_activity.title)
+      click_on(programme_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+      click_on(I18n.t("page_content.budgets.button.create"))
 
-        choose("budget[budget_type]", option: "original")
-        choose("budget[status]", option: "indicative")
-        fill_in "budget[period_start_date(3i)]", with: "01"
-        fill_in "budget[period_start_date(2i)]", with: "01"
-        fill_in "budget[period_start_date(1i)]", with: "2020"
-        fill_in "budget[period_end_date(3i)]", with: "01"
-        fill_in "budget[period_end_date(2i)]", with: "01"
-        fill_in "budget[period_end_date(1i)]", with: "2021"
-        fill_in "budget[value]", with: "1000.00"
-        click_button I18n.t("generic.button.submit")
+      click_button I18n.t("generic.button.submit")
 
-        expect(page).to have_content(I18n.t("form.budget.create.success"))
-      end
-
-      scenario "sees validation errors for missing attributes" do
-        visit organisation_path(organisation)
-
-        click_on(fund_activity.title)
-        click_on(programme_activity.title)
-
-        click_on(I18n.t("page_content.budgets.button.create"))
-
-        click_button I18n.t("generic.button.submit")
-
-        expect(page).to have_content("There is a problem")
-        expect(page).to have_content("Budget type can't be blank")
-        expect(page).to have_content("Status can't be blank")
-        expect(page).to have_content("Period start date can't be blank")
-        expect(page).to have_content("Period end date can't be blank")
-        expect(page).to have_content("Value is not included in the list")
-      end
+      expect(page).to have_content("There is a problem")
+      expect(page).to have_content("Budget type can't be blank")
+      expect(page).to have_content("Status can't be blank")
+      expect(page).to have_content("Period start date can't be blank")
+      expect(page).to have_content("Period end date can't be blank")
+      expect(page).to have_content("Value is not included in the list")
     end
 
-    context "as a delivery partner" do
-      let(:delivery_partner) { create(:delivery_partner, organisation: organisation) }
-
-      before { authenticate!(user: delivery_partner) }
-
-      scenario "cannot create a budget on a programme" do
-        visit new_activity_budget_path(programme_activity)
-
-        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
-      end
-    end
-  end
-
-  context "on a fund" do
-    context "as a fund manager" do
-      let(:fund_manager) { create(:fund_manager, organisation: organisation) }
-
-      before { authenticate!(user: fund_manager) }
-
+    context "on a fund level project" do
       scenario "cannot create a budget on a fund" do
         fund_activity = create(:fund_activity, organisation: organisation)
         visit new_activity_budget_path(fund_activity)
@@ -90,17 +37,71 @@ RSpec.describe "Users can create a budget" do
       end
     end
 
-    context "as a delivery partner" do
-      let(:delivery_partner) { create(:delivery_partner, organisation: organisation) }
+    context "on a programme level activity" do
+      scenario "successfully creates a budget" do
+        visit organisation_path(organisation)
+        click_on(fund_activity.title)
+        click_on(programme_activity.title)
 
-      before { authenticate!(user: delivery_partner) }
+        click_on(I18n.t("page_content.budgets.button.create"))
 
-      scenario "cannot create a budget on a fund" do
-        fund_activity = create(:fund_activity, organisation: organisation)
-        visit new_activity_budget_path(fund_activity)
+        fill_in_and_submit_budget_form
 
-        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+        expect(page).to have_content(I18n.t("form.budget.create.success"))
       end
     end
+
+    context "on a project level activity" do
+      scenario "successfully creates a budget" do
+        visit organisation_path(organisation)
+        click_on(fund_activity.title)
+        click_on(programme_activity.title)
+        click_on(project_activity.title)
+
+        click_on(I18n.t("page_content.budgets.button.create"))
+
+        fill_in_and_submit_budget_form
+
+        expect(page).to have_content(I18n.t("form.budget.create.success"))
+      end
+    end
+  end
+
+  context "when signed in as a delivery partner" do
+    let(:delivery_partner) { create(:delivery_partner, organisation: organisation) }
+
+    before { authenticate!(user: delivery_partner) }
+
+    scenario "cannot create a budget on a fund" do
+      fund_activity = create(:fund_activity, organisation: organisation)
+      visit new_activity_budget_path(fund_activity)
+
+      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+    end
+
+    scenario "cannot create a budget on a programme" do
+      visit new_activity_budget_path(programme_activity)
+
+      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+    end
+
+    scenario "cannot create a budget on a project" do
+      visit new_activity_budget_path(project_activity)
+
+      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+    end
+  end
+
+  def fill_in_and_submit_budget_form
+    choose("budget[budget_type]", option: "original")
+    choose("budget[status]", option: "indicative")
+    fill_in "budget[period_start_date(3i)]", with: "01"
+    fill_in "budget[period_start_date(2i)]", with: "01"
+    fill_in "budget[period_start_date(1i)]", with: "2020"
+    fill_in "budget[period_end_date(3i)]", with: "01"
+    fill_in "budget[period_end_date(2i)]", with: "01"
+    fill_in "budget[period_end_date(1i)]", with: "2021"
+    fill_in "budget[value]", with: "1000.00"
+    click_button I18n.t("generic.button.submit")
   end
 end

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -1,0 +1,30 @@
+RSpec.feature "Users can create a project" do
+  let(:beis) { create(:beis_organisation) }
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+
+  context "when an administrator" do
+    before { authenticate!(user: create(:administrator, organisation: delivery_partner)) }
+
+    context "when viewing a programme" do
+      scenario "a new project can be added to the programme" do
+        fund = create(:fund_activity, organisation: beis)
+        programme = create(:programme_activity, organisation: beis)
+        fund.activities << programme
+
+        visit organisation_activity_path(programme.organisation, programme)
+
+        expect(page).to have_content programme.title
+        click_on(I18n.t("page_content.organisation.button.create_project"))
+
+        fill_in_activity_form
+
+        expect(page).to have_content I18n.t("form.project.create.success")
+        expect(programme.activities.count).to eq 1
+
+        project = programme.activities.last
+
+        expect(project.organisation).to eq beis
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_edit_an_actviity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_actviity_spec.rb
@@ -1,10 +1,10 @@
-RSpec.feature "Fund managers can edit a fund level activity" do
+RSpec.feature "Users can edit an activity" do
   include ActivityHelper
 
-  let(:organisation) { create(:organisation, name: "UKSA") }
+  let(:organisation) { create(:delivery_partner_organisation) }
 
-  context "when the user is a fund_manager" do
-    before { authenticate!(user: create(:fund_manager, organisation: organisation)) }
+  context "when the user is an administrator" do
+    before { authenticate!(user: create(:administrator, organisation: organisation)) }
 
     context "when the activity only has an identifier (and is incomplete)" do
       it "shows edit link on the identifier, and add link on only the next step" do

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -1,0 +1,38 @@
+RSpec.feature "Users can view a project" do
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+  let(:beis) { create(:beis_organisation) }
+
+  context "when an signed in as an administrator" do
+    before { authenticate!(user: create(:administrator, organisation: beis)) }
+
+    scenario "can view a project" do
+      fund = create(:fund_activity, organisation: beis)
+      programme = create(:programme_activity, organisation: beis)
+      fund.activities << programme
+      project = create(:project_activity, organisation: delivery_partner)
+      programme.activities << project
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content project.title
+    end
+
+    context "when viewing a programme" do
+      scenario "links to the programmes projects" do
+        fund = create(:fund_activity, organisation: beis)
+        programme = create(:programme_activity, organisation: beis)
+        fund.activities << programme
+        project = create(:project_activity, organisation: delivery_partner)
+        programme.activities << project
+
+        visit organisation_activity_path(programme.organisation, programme)
+
+        expect(page).to have_content programme.title
+
+        click_on project.title
+
+        expect(page).to have_content project.title
+      end
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -155,6 +155,16 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#is_project_level?" do
+    it "returns true when the activity is at the project level" do
+      activity = Activity.new(level: :project)
+      expect(activity.is_project_level?).to eq true
+
+      activity = Activity.new(level: :fund)
+      expect(activity.is_project_level?).to eq false
+    end
+  end
+
   describe "#parent_activity" do
     it "returns the parent activity or nil if there is not one" do
       fund_activity = create(:activity, level: :fund)

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe CreateProjectActivity do
+  let(:beis) { create(:beis_organisation) }
+  let(:delivery_partner_organisation) { create(:delivery_partner_organisation) }
+  let(:delivery_partner_user) { create(:delivery_partner, organisation: delivery_partner_organisation) }
+  let(:programme) { create(:programme_activity, organisation: beis) }
+
+  describe "#call" do
+    let(:result) {
+      described_class.new(user: delivery_partner_user, organisation_id: beis.id, programme_id: programme.id).call
+    }
+
+    it "sets the Organisation to that of the parent programme i.e. BEIS" do
+      expect(result.organisation).to eq beis
+    end
+
+    it "sets the parent Activity to the fund" do
+      expect(result.activity).to eq(programme)
+    end
+
+    it "sets the initial wizard_status" do
+      expect(result.wizard_status).to eq("identifier")
+    end
+
+    it "sets the Activity level to 'project'" do
+      expect(result.level).to eq("project")
+    end
+
+    it "sets the funding organisation details" do
+      expect(result.funding_organisation_name).to eq beis.name
+      expect(result.funding_organisation_reference).to eq beis.iati_reference
+      expect(result.funding_organisation_type).to eq beis.organisation_type
+    end
+
+    it "sets the accountable organisation details" do
+      expect(result.accountable_organisation_name).to eq beis.name
+      expect(result.accountable_organisation_reference).to eq beis.iati_reference
+      expect(result.accountable_organisation_type).to eq beis.organisation_type
+    end
+
+    it "sets the extending organisation to that of signed in delivery partner" do
+      expect(result.extending_organisation).to eq delivery_partner_organisation
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
In #184 although @lozette amazing work and determination got us a working feature, the team were concerned about the debt we were building up around user roles and authorisation.

In order to deliver a this feature we decided to re-scope the work and remove the authorisation altogether. By doing so any user signed in to the service can be thought of as an 'Administator' for the moment and can perform create, update and edit actions on all activity levels.

We know we have work to do to authorise users and activities, but we can deliver this feature in a managable chunk of work that raises little debt and can be reviewed easily.

All the work here is taken from @lozette previous work.

This PR enables users to:

- create any number of projects as children of a programme
- view the details of the projects
- once viewing the project, edit the details
- add transactions and budgets to the projects
- view the transations and budgets of the projects

## Screenshots of UI changes
A programme level activity with no projects
![Screenshot_2020-02-18 Activity A Programme — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/74735833-66435380-5249-11ea-8a40-716ba6bbf684.png)

The same programme with a project added
![Screenshot_2020-02-18 Activity A Programme — Report Official Development Assistance(1)](https://user-images.githubusercontent.com/480578/74735847-6cd1cb00-5249-11ea-9e5d-da4c0d7cdb77.png)

The project level activity view showing add budgets and transations
![Screenshot_2020-02-18 Activity Project 01 — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/74735885-7c511400-5249-11ea-91c0-161318c9fc0f.png)

The project level activity with transation and budget added
![Screenshot_2020-02-18 Activity Project 01 — Report Official Development Assistance(1)](https://user-images.githubusercontent.com/480578/74735902-84a94f00-5249-11ea-9dd6-d84faf58a6ea.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
