### PR TITLE
(280) Remove restrictions that stopped a budget from being attached to a fund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,5 @@
 - Consolidate all user roles into 'administrator', removing 'fund_manager' and 'delivery_partner'. All users can temporarily do anything
 - Users who belong to delivery partners see a list of programmes on their organisation page
 - Users are authorised based on the organisations they belong to
+- Users can add budgets to activities at all levels
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,8 +248,6 @@ en:
     errors:
       auth0:
         failed: Sign in failed
-      budget:
-        not_possible: It is not possible to create a budget on this activity type
       not_authorised: You are not authorised
     home: Home
     organisation:

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Users can create a budget" do
 
     context "when the activity is a fund" do
       scenario "successfully creates a budget" do
-        fund_activity = create(:activity, organisation: user.organisation)
+        fund_activity = create(:fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
         click_on(fund_activity.title)

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -9,13 +9,18 @@ RSpec.feature "Users can view budgets on an activity page" do
 
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        _budget = create(:budget)
+        budget = create(:budget, activity: fund_activity)
+        budget_presenter = BudgetPresenter.new(budget)
 
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
 
-        expect(page).to have_content(I18n.t("page_content.activity.budgets"))
+        expect(page).to have_content(budget_presenter.budget_type)
+        expect(page).to have_content(budget_presenter.status)
+        expect(page).to have_content(budget_presenter.period_start_date)
+        expect(page).to have_content(budget_presenter.period_end_date)
+        expect(page).to have_content(budget_presenter.value)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/RsLTbcF2/280-users-can-add-a-budget-to-a-fund

Previously we believed a budget could not be directly attached to a fund. This
turned out not to be true, so we have removed the restrictions which stopped
a budget from being created on a fund.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
