### PR TITLE
(269) Activities collect one or more implementing organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,4 @@
 - Users can add currency information to budgets and see the currency in the budget XML
 - Users can report an activities implementing organisation
 - Users can edit a reported implementing organisation
+- Users can view implementing organisations in the Activity XML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,4 +50,4 @@
 - Users can add budgets to activities at all levels
 - Users can edit a budget
 - Users can add currency information to budgets and see the currency in the budget XML
-
+- Users can report an activities implementing organisation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@
 - Users can edit a budget
 - Users can add currency information to budgets and see the currency in the budget XML
 - Users can report an activities implementing organisation
+- Users can edit a reported implementing organisation

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -20,6 +20,7 @@ class Staff::ActivitiesController < Staff::BaseController
       format.html do
         @transaction_presenters = @transactions.map { |transaction| TransactionPresenter.new(transaction) }
         @budget_presenters = @budgets.map { |budget| BudgetPresenter.new(budget) }
+        @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
       end
       format.xml
     end

--- a/app/controllers/staff/implementing_organisations_controller.rb
+++ b/app/controllers/staff/implementing_organisations_controller.rb
@@ -1,0 +1,29 @@
+class Staff::ImplementingOrganisationsController < Staff::BaseController
+  def new
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+
+    @implementing_organisation = ImplementingOrganisation.new
+  end
+
+  def create
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+
+    @implementing_organisation = ImplementingOrganisation.new(implementing_organisation_params)
+
+    if @implementing_organisation.valid?
+      @implementing_organisation.save
+      flash[:notice] = I18n.t("form.implementing_organisation.create.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def implementing_organisation_params
+    params.require(:implementing_organisation).permit(:name, :organisation_type, :reference, :activity_id)
+  end
+end

--- a/app/controllers/staff/implementing_organisations_controller.rb
+++ b/app/controllers/staff/implementing_organisations_controller.rb
@@ -6,6 +6,12 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
     @implementing_organisation = ImplementingOrganisation.new
   end
 
+  def edit
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+    @implementing_organisation = ImplementingOrganisation.find(params[:id])
+  end
+
   def create
     @activity = Activity.find(params[:activity_id])
     authorize @activity
@@ -18,6 +24,22 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :new
+    end
+  end
+
+  def update
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+    @implementing_organisation = ImplementingOrganisation.find(params[:id])
+
+    @implementing_organisation.assign_attributes(implementing_organisation_params)
+
+    if @implementing_organisation.valid?
+      @implementing_organisation.save!
+      flash[:notice] = I18n.t("form.implementing_organisation.update.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :edit
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -91,4 +91,8 @@ class Activity < ApplicationRecord
   def has_extending_organisation?
     extending_organisation.present?
   end
+
+  def has_implementing_organisations?
+    implementing_organisations.any?
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -16,6 +16,7 @@ class Activity < ApplicationRecord
   has_many :activities, foreign_key: "activity_id"
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
+  has_many :implementing_organisations
 
   enum level: {
     fund: "fund",

--- a/app/models/implementing_organisation.rb
+++ b/app/models/implementing_organisation.rb
@@ -1,0 +1,5 @@
+class ImplementingOrganisation < ApplicationRecord
+  validates_presence_of :name, :organisation_type
+
+  belongs_to :activity
+end

--- a/app/presenters/implementing_organisation_presenter.rb
+++ b/app/presenters/implementing_organisation_presenter.rb
@@ -1,0 +1,15 @@
+class ImplementingOrganisationPresenter < SimpleDelegator
+  include CodelistHelper
+
+  def organisation_type
+    return if super.blank?
+    type = organisation_types.find { |type| type.code == super }
+    type.name
+  end
+
+  private
+
+  def organisation_types
+    yaml_to_objects(entity: "organisation", type: "organisation_type", with_empty_item: false)
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -27,3 +27,6 @@
   - if @activity.project? && policy(:project).create?
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
+
+  - if @activity.project?
+    = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }

--- a/app/views/staff/implementing_organisations/edit.html.haml
+++ b/app/views/staff/implementing_organisations/edit.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("page_title.activity.implementing_organisation.edit", name: @activity.title)
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.activity.implementing_organisation.edit")
+
+      = form_with model: @implementing_organisation, url: activity_implementing_organisation_path(@activity, @implementing_organisation) do |f|
+        = f.govuk_error_summary
+        = f.hidden_field :activity_id, value: @activity.id
+        = f.govuk_text_field :name
+        = f.govuk_collection_select :organisation_type,
+                     yaml_to_objects(entity: "organisation", type: "organisation_type"),
+                     :code,
+                     :name
+        = f.govuk_text_field :reference
+        = f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/implementing_organisations/new.html.haml
+++ b/app/views/staff/implementing_organisations/new.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("page_title.activity.implementing_organisation.new", name: @activity.title)
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.activity.implementing_organisation.new")
+
+      = form_with model: @implementing_organisation, url: activity_implementing_organisations_path(@activity) do |f|
+        = f.govuk_error_summary
+        = f.hidden_field :activity_id, value: @activity.id
+        = f.govuk_text_field :name
+        = f.govuk_collection_select :organisation_type,
+                     yaml_to_objects(entity: "organisation", type: "organisation_type"),
+                     :code,
+                     :name
+        = f.govuk_text_field :reference
+        = f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/shared/activities/_implementing_organisations.html.haml
+++ b/app/views/staff/shared/activities/_implementing_organisations.html.haml
@@ -1,0 +1,10 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.implementing_organisation.heading")
+
+    - if @activity.implementing_organisations.present?
+      = render partial: "staff/shared/implementing_organisations/table", locals: { implementing_organisations: @implementing_organisation_presenters }
+
+    - if policy(:project).create?
+      = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(@activity), class: "govuk-button")

--- a/app/views/staff/shared/implementing_organisations/_table.html.haml
+++ b/app/views/staff/shared/implementing_organisations/_table.html.haml
@@ -7,6 +7,7 @@
         =t("activerecord.attributes.implementing_organisation.organisation_type")
       %th.govuk-table__header
         =t("activerecord.attributes.implementing_organisation.reference")
+      %th.govuk-table__header
 
   %tbody.govuk-table__body
     - implementing_organisations.each do |organisation|
@@ -14,3 +15,6 @@
         %td.govuk-table__cell= organisation.name
         %td.govuk-table__cell= organisation.organisation_type
         %td.govuk-table__cell= organisation.reference
+        %td.govuk-table__cell
+          - if policy(:project).edit?
+            = link_to t("generic.link.edit"), edit_activity_implementing_organisation_path(@activity, organisation), class: "govuk-link govuk-link--no-visited-state"

--- a/app/views/staff/shared/implementing_organisations/_table.html.haml
+++ b/app/views/staff/shared/implementing_organisations/_table.html.haml
@@ -1,0 +1,16 @@
+%table.govuk-table.implementing_organisations
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("activerecord.attributes.implementing_organisation.name")
+      %th.govuk-table__header
+        =t("activerecord.attributes.implementing_organisation.organisation_type")
+      %th.govuk-table__header
+        =t("activerecord.attributes.implementing_organisation.reference")
+
+  %tbody.govuk-table__body
+    - implementing_organisations.each do |organisation|
+      %tr.govuk-table__row{id: organisation.id}
+        %td.govuk-table__cell= organisation.name
+        %td.govuk-table__cell= organisation.organisation_type
+        %td.govuk-table__cell= organisation.reference

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -15,6 +15,10 @@
   - if activity.has_extending_organisation?
     %participating-org{"ref" => activity.extending_organisation.iati_reference, "type" => activity.extending_organisation.organisation_type, "role" => 3}
       %narrative= activity.extending_organisation.name
+  - if activity.has_implementing_organisations?
+    - activity.implementing_organisations.each do |organisation|
+      %participating-org{"ref" => organisation.reference, "type" => organisation.organisation_type, "role" => 4}
+        %narrative= organisation.name
   %activity-status{"code" => activity.status}/
   %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
   %activity-date{"iso-date" => activity.actual_start_date, type: "2"}/
@@ -32,4 +36,3 @@
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
     implementing_organisation:
       create:
         success: Implementing organisation successfully created
+      update:
+        success: Implementing organisation successfully updated
     organisation:
       create:
         success: Organisation successfully created
@@ -242,6 +244,7 @@ en:
   page_title:
     activity:
       implementing_organisation:
+        edit: Edit implemening organisation
         new: Add a new implementing organisation
       show: Activity %{name}
     activity_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,8 @@ en:
           link: you can make one now
   page_title:
     activity:
+      implementing_organisation:
+        new: Add a new implementing organisation
       show: Activity %{name}
     activity_form:
       show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en:
         success: Fund successfully created
       update:
         success: Fund successfully updated
+    implementing_organisation:
+      create:
+        success: Implementing organisation successfully created
     organisation:
       create:
         success: Organisation successfully created
@@ -153,6 +156,10 @@ en:
         label: Flow
       identitfier:
         label: Identifier
+      implementing_organisation:
+        button:
+          new: Add implementing organisation
+        heading: Implementing organisations
       organisation:
         label: Organisation
       planned_end_date:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -25,6 +25,10 @@ en:
           indicative: Indicative - A non-binding estimate for the described budget
           one: Status
         value: Value
+      implementing_organisation:
+        name: Organisation name
+        organisation_type: Organisation type
+        reference: IATI refrence (optional)
       organisation:
         default_currency: Default currency
         iati_reference: IATI reference
@@ -112,5 +116,8 @@ en:
       budget:
         period_end_date: For example, 12 3 2021
         period_start_date: For example, 11 3 2020
+      implementing_organisation:
+        reference:
+          html: <a href="http://org-id.guide/" target="_blank" class="govuk-link">Organisation references can be found using this service</a>
       transaction:
         date: For example, 27 3 2020

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     resources :activities, only: [], concerns: [:transactionable, :budgetable] do
       resources :steps, controller: "activity_forms"
       resources :extending_organisations, only: [:edit, :update]
-      resources :implementing_organisations, only: [:new, :create]
+      resources :implementing_organisations, only: [:new, :create, :edit, :update]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     resources :activities, only: [], concerns: [:transactionable, :budgetable] do
       resources :steps, controller: "activity_forms"
       resources :extending_organisations, only: [:edit, :update]
+      resources :implementing_organisations, only: [:new, :create]
     end
   end
 

--- a/db/migrate/20200213143837_create_implementing_organisations.rb
+++ b/db/migrate/20200213143837_create_implementing_organisations.rb
@@ -1,0 +1,11 @@
+class CreateImplementingOrganisations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :implementing_organisations, id: :uuid do |t|
+      t.string :name
+      t.string :reference
+      t.string :organisation_type
+      t.references :activity, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,6 +61,16 @@ ActiveRecord::Schema.define(version: 2020_02_24_141519) do
     t.index ["activity_id"], name: "index_budgets_on_activity_id"
   end
 
+  create_table "implementing_organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "reference"
+    t.string "organisation_type"
+    t.uuid "activity_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_implementing_organisations_on_activity_id"
+  end
+
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "organisation_type"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -57,6 +57,16 @@ FactoryBot.define do
       accountable_organisation_type { "10" }
 
       association :extending_organisation, factory: :beis_organisation
+
+      factory :project_activity_with_implementing_organisations do
+        transient do
+          implementing_organisations_count { 3 }
+        end
+
+        after(:create) do |project_activity, evaluator|
+          create_list(:implementing_organisation, evaluator.implementing_organisations_count, activity: project_activity)
+        end
+      end
     end
   end
 

--- a/spec/factories/implementing_organisation.rb
+++ b/spec/factories/implementing_organisation.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :implementing_organisation do
+    name { Faker::Company.name }
+    reference
+    organisation_type { "10" }
+  end
+end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -1,0 +1,55 @@
+RSpec.feature "Users can manage the implementing organisations" do
+  context "when they are signed in as a delivery partner" do
+    let(:delivery_partner) { create(:organisation) }
+    let(:project) { create(:project_activity, organisation: delivery_partner) }
+
+    before { authenticate!(user: create(:delivery_partner_user, organisation: delivery_partner)) }
+
+    scenario "they can add an implementing organisation" do
+      other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "10", reference: "GB-COH-123456")
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content I18n.t("page_content.activity.implementing_organisation.button.new")
+      click_on I18n.t("page_content.activity.implementing_organisation.button.new")
+
+      expect(page).to have_field I18n.t("activerecord.attributes.implementing_organisation.name")
+      expect(page).to have_select I18n.t("activerecord.attributes.implementing_organisation.organisation_type")
+      expect(page).to have_field I18n.t("activerecord.attributes.implementing_organisation.reference")
+
+      fill_in I18n.t("activerecord.attributes.implementing_organisation.name"), with: other_public_sector_organisation.name
+      select("Other Public Sector", from: I18n.t("activerecord.attributes.implementing_organisation.organisation_type"))
+      fill_in I18n.t("activerecord.attributes.implementing_organisation.reference"), with: other_public_sector_organisation.reference
+      click_on I18n.t("generic.button.submit")
+
+      expect(current_path).to eq organisation_activity_path(project.organisation, project)
+      expect(page).to have_content I18n.t("form.implementing_organisation.create.success")
+
+      expect(page).to have_content other_public_sector_organisation.name
+      expect(page).to have_content other_public_sector_organisation.reference
+    end
+  end
+
+  context "when they are signed in as a BEIS user" do
+    let(:delivery_partner) { create(:organisation) }
+    let(:project) { create(:project_activity, organisation: delivery_partner) }
+
+    before { authenticate!(user: create(:beis_user)) }
+
+    scenario "they can view implementing organisations" do
+      other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
+      project.implementing_organisations << other_public_sector_organisation
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content other_public_sector_organisation.name
+      expect(page).to have_content other_public_sector_organisation.reference
+    end
+
+    scenario "they cannot add implementing organisations" do
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).not_to have_button I18n.t("page_content.activity.implementing_organisation.button.new")
+    end
+  end
+end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -28,6 +28,28 @@ RSpec.feature "Users can manage the implementing organisations" do
       expect(page).to have_content other_public_sector_organisation.name
       expect(page).to have_content other_public_sector_organisation.reference
     end
+
+    scenario "they can edit an implementing organisation" do
+      other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
+      project.implementing_organisations << other_public_sector_organisation
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content other_public_sector_organisation.name
+      expect(page).to have_content other_public_sector_organisation.reference
+
+      within "##{other_public_sector_organisation.id}" do
+        click_on "Edit"
+      end
+
+      expect(find_field(I18n.t("activerecord.attributes.implementing_organisation.name")).value).to eq other_public_sector_organisation.name
+
+      fill_in I18n.t("activerecord.attributes.implementing_organisation.name"), with: "It is a charity"
+      click_on I18n.t("generic.button.submit")
+
+      expect(page).to have_content I18n.t("form.implementing_organisation.update.success")
+      expect(page).to have_content "It is a charity"
+    end
   end
 
   context "when they are signed in as a BEIS user" do
@@ -44,6 +66,15 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       expect(page).to have_content other_public_sector_organisation.name
       expect(page).to have_content other_public_sector_organisation.reference
+    end
+
+    scenario "they cannot edit implementing organisations" do
+      other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
+      project.implementing_organisations << other_public_sector_organisation
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).not_to have_link I18n.t("generic.link.edit"), href: edit_activity_implementing_organisation_path(project, other_public_sector_organisation)
     end
 
     scenario "they cannot add implementing organisations" do

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -20,6 +20,13 @@ RSpec.feature "Users can view an activity as XML" do
 
         it_behaves_like "valid activity XML"
       end
+
+      context "when the activity is a project activity" do
+        let(:activity) { create(:project_activity_with_implementing_organisations, organisation: organisation) }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it_behaves_like "valid activity XML"
+      end
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -208,4 +208,12 @@ RSpec.describe Activity, type: :model do
 
     expect(activity.has_extending_organisation?).to be false
   end
+
+  describe "#has_implementing_organisation?" do
+    it "returns true when there is one or more implementing organisationg" do
+      activity = create(:project_activity_with_implementing_organisations)
+
+      expect(activity.has_implementing_organisations?).to be true
+    end
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Activity, type: :model do
     it { should belong_to(:activity).optional }
     it { should have_many(:activities).with_foreign_key("activity_id") }
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
+    it { should have_many(:implementing_organisations) }
   end
 
   describe "#parent_activity" do

--- a/spec/models/implementing_organisation_spec.rb
+++ b/spec/models/implementing_organisation_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe ImplementingOrganisation, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:organisation_type) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:activity) }
+  end
+end

--- a/spec/presenters/implementing_organisation_presenter_spec.rb
+++ b/spec/presenters/implementing_organisation_presenter_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe ImplementingOrganisationPresenter do
+  describe "#organisation_type" do
+    it "takes the code and changes it to the name of the organisation type" do
+      organisation = ImplementingOrganisation.new(name: "This organisation", organisation_type: "70", reference: "GB-COH-1234566")
+      implementing_organisation_presenter = ImplementingOrganisationPresenter.new(organisation)
+
+      expect(implementing_organisation_presenter.organisation_type).to eq "Private Sector"
+    end
+  end
+end

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -31,6 +31,21 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation.name)
   end
 
+  it "contains the implementing organisations XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    implementing_organisations_xml = xml.xpath("iati-activity/participating-org[@role = '4']")
+    implementing_organisation_refs = activity.implementing_organisations.pluck(:reference)
+    implementing_organisation_types = activity.implementing_organisations.pluck(:organisation_type)
+    implementing_organisation_names = activity.implementing_organisations.pluck(:name)
+
+    implementing_organisations_xml.each do |organisation_xml|
+      expect(implementing_organisation_refs).to include(organisation_xml.at("@ref").text)
+      expect(implementing_organisation_types).to include(organisation_xml.at("@type").text)
+      expect(implementing_organisation_names).to include(organisation_xml.at("narrative").text)
+    end
+  end
+
   it "contains the transaction XML" do
     transaction = create(:transaction, activity: activity)
     visit organisation_activity_path(organisation, activity, format: :xml)


### PR DESCRIPTION
##  Changes in this PR

Trello: https://trello.com/c/VwXXIspE/269-activities-collect-one-or-more-implementing-organisations

@mec did 99% of this PR, I'm just finishing it for him!

Project-level activities can now have multiple implementing organisations. These are expressed in the IATI XML as `participating-org[@role='4']`

Implementing organisations attributes are free-text fields. Because implementers can be any organisation anywhere in the world (not necessarily registered on this platform) we rely on the delivery partners filling in these details themselves.

Validated here: https://test-validator.iatistandard.org/view/dqf/files/4e82520b-38b5-462f-86d8-f020af58c1e2?isTestfiles=true

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](doc/xml-validation.md)
