### PR TITLE
Feature/145 budgets can be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,4 +48,6 @@
 - Users who belong to delivery partners see a list of programmes on their organisation page
 - Users are authorised based on the organisations they belong to
 - Users can add budgets to activities at all levels
+- Users can edit a budget
+
 

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -28,7 +28,37 @@ class Staff::BudgetsController < Staff::BaseController
     end
   end
 
+  def edit
+    @budget = Budget.find(id)
+    authorize @budget
+
+    @activity = Activity.find(activity_id)
+  end
+
+  def update
+    @budget = Budget.find(id)
+    @activity = Activity.find(activity_id)
+    @budget.activity = @activity
+    authorize @budget
+
+    @budget.assign_attributes(budget_params)
+    @budget.value = monetary_value
+    @budget.period_start_date = format_date(period_start_date)
+    @budget.period_end_date = format_date(period_end_date)
+
+    if @budget.save
+      flash[:notice] = I18n.t("form.budget.update.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :edit
+    end
+  end
+
   private
+
+  def id
+    params[:id]
+  end
 
   def activity_id
     params[:activity_id]

--- a/app/presenters/budget_presenter.rb
+++ b/app/presenters/budget_presenter.rb
@@ -18,4 +18,8 @@ class BudgetPresenter < SimpleDelegator
     return if super.blank?
     I18n.l(super)
   end
+
+  def value
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
 end

--- a/app/views/staff/budgets/edit.html.haml
+++ b/app/views/staff/budgets/edit.html.haml
@@ -1,0 +1,11 @@
+=content_for :page_title_prefix, t("page_title.budget.edit")
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.edit")
+
+      = form_with model: @budget, url: activity_budget_path(@activity) do |f|
+        = render partial: "form", locals: { f: f }

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -23,3 +23,4 @@
           %td.govuk-table__cell= budget.period_end_date
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
+            = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.activity, budget))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,8 @@ en:
         label: Period start date
       status:
         label: Status
+      update:
+        success: Budget successfully updated
       value:
         label: Value
     fund:
@@ -244,6 +246,7 @@ en:
         status: Status
         tied_status: Tied status
     budget:
+      edit: Edit budget
       new: Create budget
     errors:
       auth0:

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe "Users can edit a budget" do
+  before { authenticate!(user: user) }
+
+  context "when signed in as BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    scenario "a budget can be successfully edited" do
+      fund_activity = create(:fund_activity, organisation: user.organisation)
+      programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+      budget = create(:budget, activity: programme_activity, budget_type: "original", value: "10")
+
+      visit organisation_activity_path(user.organisation, programme_activity)
+      within("##{budget.id}") do
+        click_on I18n.t("generic.link.edit")
+      end
+
+      fill_in "budget[value]", with: "20"
+      choose("budget[budget_type]", option: "updated")
+      click_on I18n.t("generic.button.submit")
+
+      expect(page).to have_content(I18n.t("form.budget.update.success"))
+      expect(page).to have_content("20.00")
+      expect(page).to have_content("Updated")
+    end
+
+    scenario "validation errors work as expected" do
+      fund_activity = create(:fund_activity, organisation: user.organisation)
+      programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+      budget = create(:budget, activity: programme_activity, value: "10")
+
+      visit organisation_activity_path(user.organisation, programme_activity)
+      within("##{budget.id}") do
+        click_on I18n.t("generic.link.edit")
+      end
+
+      fill_in "budget[value]", with: ""
+      fill_in "budget[period_start_date(3i)]", with: ""
+      fill_in "budget[period_start_date(2i)]", with: ""
+      fill_in "budget[period_start_date(1i)]", with: ""
+      click_on I18n.t("generic.button.submit")
+
+      expect(page).to have_content("There is a problem")
+      expect(page).to have_content("can't be blank")
+    end
+  end
+end

--- a/spec/presenters/budget_presenter_spec.rb
+++ b/spec/presenters/budget_presenter_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe BudgetPresenter do
-  let(:budget) { build_stubbed(:budget, period_start_date: "2020-02-02", period_end_date: "2021-01-01") }
+  let(:budget) { build_stubbed(:budget, period_start_date: "2020-02-02", period_end_date: "2021-01-01", value: "20") }
 
   describe "#budget_type" do
     it "returns the I18n string for the budget_type" do
@@ -24,6 +24,12 @@ RSpec.describe BudgetPresenter do
   describe "#period_end_date" do
     it "returns the localised date for the period_end_date" do
       expect(described_class.new(budget).period_end_date).to eq("1 Jan 2021")
+    end
+  end
+
+  describe "#value" do
+    it "returns the value to two decimal places with a currency symbol" do
+      expect(described_class.new(budget).value).to eq("£20.00")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/S16pkVHn/145-budgets-can-be-edited

Budgets can be edited. Much like transactions, budgets are displayed in a table with an `Edit` link. The link takes the user to a form where all attributes of the budget can be edited. 

We have also added a small formatter for the budget value. Previously, values were being shown to one decimal place if there were no fractions (e.g. 20 became 20.0); as these are monetary values it makes sense to display them to two decimal places.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
