### PR TITLE
Create tmp/pids so that puma can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ COPY . $INSTALL_PATH
 
 RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
 
+# create tmp/pids
+RUN mkdir -p tmp/pids
+
 # db setup
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
## Changes in this PR

On the PaaS when puma attempts to start it will try to write a pid to
`tmp/pids/server.pid` if it can't it will error and stop.

```
   2020-02-20T15:05:47.77+0000 [APP/PROC/WEB/0] ERR bundler: failed to load command: puma (/usr/local/bundle/ruby/2.6.0/bin/puma)
   2020-02-20T15:05:47.77+0000 [APP/PROC/WEB/0] ERR Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid
```