### PR TITLE
Fix Docker start script so that containers start OK when the database…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,17 +5,9 @@ echo "Starting docker entrypoint…"
 
 setup_database()
 {
-  echo "Checking database setup is up-to-date…"
-  # Rails will throw an error if no database exists"
-  #   PG::ConnectionBad: FATAL:  database "roda-development" does not exist
-  if rake db:migrate:status &> /dev/null; then
-    echo "Database found, running db:migrate…"
-    rake db:migrate
-  else
-    echo "No database found, running db:create db:schema:load…"
-    rake db:create db:schema:load
-  fi
-  echo "Finished database setup"
+  echo "Preparing database…"
+  rake db:prepare
+  echo "Finished database setup."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi


### PR DESCRIPTION
… is new


## Changes in this PR

With the previous version of the code when a new container started rake was being instructed to create a new database, assuming one did not exist. For real environments such as Heroku and GPaaS, the provisioning of a database resource creates the database for us and then provides the DATABASE_URL. This causes the container to crash as it fails to create a database where one already exists.

I presume this was once used when containers were used locally for convenience. For this app we are not running with docker in development.

We recently found this problem when resetting our Heroku database and we've now noticed it again when setting up a new environment on GPaaS.

Given we know databases are always provisioned outside of the Docker context (either by hand or by infrastructure as code) then we do not need the docker entrypoint to handle this responsibility.

Rails 6 introduces a new command that handles the problem this code was trying to fix. The fact that if no database exists the database command errors. Here's a blog post that explains the situation and what rake db:prepare brings: https://blog.saeloun.com/2019/04/11/rails-6-rails-db-prepare.html

I think we can use this command to create the database, run the seed file (we have guarded this from being run outside of development) and then any migrations safely.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
