### PR TITLE
Extract env vars from VCAP_SERVICES

### DIFF
--- a/config/initializers/vcap_services.rb
+++ b/config/initializers/vcap_services.rb
@@ -1,0 +1,2 @@
+require "vcap_parser"
+VcapParser.load_service_environment_variables!

--- a/lib/vcap_parser.rb
+++ b/lib/vcap_parser.rb
@@ -1,0 +1,28 @@
+# Class to parse the VCAP_SERVICES environment variable.
+# Cloud Foundry provides an environment variable called VCAP_SERVICES which
+# contains JSON.
+# The JSON provides details of services bound to the application.
+# We parse this to generate environment variables to be used by Rails.
+class VcapParser
+  def self.load_service_environment_variables!
+    return if ENV["VCAP_SERVICES"].blank?
+
+    vcap_json = JSON.parse(ENV["VCAP_SERVICES"])
+    # Turn user provided service credentials into environment variables
+    vcap_json.fetch("user-provided", []).each do |service|
+      service["credentials"].each_pair do |key, value|
+        ENV[key] = value
+      end
+    end
+
+    load_redis_config(
+      vcap_json.fetch("redis", []).first
+    )
+  end
+
+  def self.load_redis_config(redis_config)
+    return unless redis_config
+    # Generate a REDIS_URL from the redis service uri
+    ENV["REDIS_URL"] = redis_config.fetch("credentials").fetch("uri")
+  end
+end

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe VcapParser do
+  describe ".load_service_environment_variables!" do
+    it "loads service level environment variables to the ENV" do
+      vcap_json = '
+        {
+           "user-provided": [
+            {
+             "credentials": {
+              "ENV1": "ENV1VALUE",
+              "ENV2": "ENV2VALUE"
+             }
+            }
+           ]
+         }
+      '
+      ClimateControl.modify VCAP_SERVICES: vcap_json do
+        VcapParser.load_service_environment_variables!
+        expect(ENV["ENV2"]).to eq("ENV2VALUE")
+      end
+    end
+
+    it "loads redis URL to the ENV" do
+      vcap_json = '
+        {
+          "redis": [
+           {
+              "credentials": {
+                "uri": "rediss://x:REDACTED@HOST:6379"
+              }
+            }
+          ]
+        }
+      '
+      ClimateControl.modify VCAP_SERVICES: vcap_json do
+        VcapParser.load_service_environment_variables!
+        expect(ENV["REDIS_URL"]).to eq("rediss://x:REDACTED@HOST:6379")
+      end
+    end
+
+    it "does not error if VCAP_SERVICES is not set" do
+      ClimateControl.modify VCAP_SERVICES: nil do
+        expect { VcapParser.load_service_environment_variables! }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

GPaaS provides a VCAP_SERVICES environment variable which contains JSON
with information about services bound to the application.

From the JSON we need to extract the REDIS_URL and any other environment
variables we have put into a user provided service.

This is based on the work we had done for CCS RMI
https://github.com/dxw/DataSubmissionServiceAPI/pull/376 and others