### PR TITLE
(316) Transactions cannot be set to a future date

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,5 +12,5 @@ class Transaction < ApplicationRecord
     :receiving_organisation_name,
     :receiving_organisation_type
   validates :value, inclusion: 1..99_999_999_999.00
-  validates :date, date_within_boundaries: true
+  validates :date, date_not_in_future: true
 end

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -18,4 +18,9 @@ class TransactionPresenter < SimpleDelegator
     return if super.blank?
     I18n.t("transaction.disbursement_channel.#{super}")
   end
+
+  def value
+    return if super.blank?
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
 end

--- a/app/validators/date_not_in_future_validator.rb
+++ b/app/validators/date_not_in_future_validator.rb
@@ -1,0 +1,16 @@
+class DateNotInFutureValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value
+
+    if in_future?(value)
+      record.errors.add(
+        attribute,
+        I18n.t("activerecord.errors.models.#{record.class.name.downcase}.attributes.#{attribute}.not_in_future")
+      )
+    end
+  end
+
+  def in_future?(date)
+    date > Time.zone.today
+  end
+end

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -71,6 +71,7 @@ en:
           attributes:
             date:
               between: Date must be between %{min} years ago and %{max} years in the future
+              not_in_future: Date must not be in the future
             value:
               inclusion: Value must be between 1 and 99,999,999,999.00
         user:

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     identifier
     description { Faker::Lorem.paragraph }
-    sector { "99" }
+    sector { "11110" }
     status { "2" }
     planned_start_date { Date.today }
     planned_end_date { Date.tomorrow }

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     context "Date validation" do
-      scenario "When the date is more than 25 years in the future" do
+      scenario "When the date is in the future" do
         activity = create(:fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
@@ -142,10 +142,10 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2100, expectations: false)
 
-        expect(page).to have_content "Date must be between 10 years ago and 25 years in the future"
+        expect(page).to have_content "Date must not be in the future"
       end
 
-      scenario "When the date is more than 10 years in the past" do
+      scenario "When the date is in the past" do
         activity = create(:fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
@@ -156,7 +156,8 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 1900, expectations: false)
 
-        expect(page).to have_content "Date must be between 10 years ago and 25 years in the future"
+        expect(page).to_not have_content "Date must not be in the future"
+        expect(page).to have_content I18n.t("form.transaction.create.success")
       end
 
       scenario "When the date is nil" do
@@ -170,7 +171,7 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(date_day: "", date_month: "", date_year: "", expectations: false)
 
-        expect(page).to_not have_content "Date must be between 10 years ago and 25 years in the future"
+        expect(page).to have_content "Date can't be blank"
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(value: "123,000,000", expectations: false)
 
-        expect(page).to have_content "123000000"
+        expect(page).to have_content "£123,000,000"
       end
     end
 

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Users can edit a transaction" do
         transaction_type: "Expenditure",
         date_day: "1",
         date_month: "1",
-        date_year: "2021",
+        date_year: "2020",
         value: "2000.51",
         disbursement_channel: "Aid in kind: Donors manage funds themselves",
         currency: "US Dollar"

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -39,20 +39,19 @@ RSpec.describe Transaction, type: :model do
     end
   end
 
-  context "date must be between 10 years ago and 25 years from now" do
-    it "does not allow a date more than 10 years ago" do
-      transaction = build(:transaction, activity: activity, date: 11.years.ago)
-      expect(transaction.valid?).to be_falsey
-      expect(transaction.errors[:date]).to include "Date must be between 10 years ago and 25 years in the future"
+  context "date must not be in the future" do
+    it "allows a date in the past" do
+      transaction = build(:transaction, activity: activity, date: 1.year.ago)
+      expect(transaction.valid?).to be true
     end
 
-    it "does not allow a date more than 25 years in the future" do
-      transaction = build(:transaction, activity: activity, date: 26.years.from_now)
-      expect(transaction.valid?).to be_falsey
-      expect(transaction.errors[:date]).to include "Date must be between 10 years ago and 25 years in the future"
+    it "does not allow a date in the future" do
+      transaction = build(:transaction, activity: activity, date: 1.year.from_now)
+      expect(transaction.valid?).to be false
+      expect(transaction.errors[:date]).to include "Date must not be in the future"
     end
 
-    it "allows a date between 10 years ago and 25 years in the future" do
+    it "allows today's date" do
       transaction = build(:transaction, activity: activity, date: Date.today)
       expect(transaction.valid?).to be true
     end

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -27,4 +27,10 @@ RSpec.describe TransactionPresenter do
       expect(described_class.new(transaction).disbursement_channel).to eq("Money is disbursed through central Ministry of Finance or Treasury")
     end
   end
+
+  describe "#value" do
+    it "returns the value to two decimal places with a currency symbol" do
+      expect(described_class.new(transaction).value).to eq("£110.01")
+    end
+  end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -170,7 +170,7 @@ module FormHelpers
           month: date_month,
           day: date_day
         )
-        expect(page).to have_content(value)
+        expect(page).to have_content(ActionController::Base.helpers.number_to_currency(value, unit: "£"))
         expect(page).to have_content(disbursement_channel)
         expect(page).to have_content(currency)
         expect(page).to have_content(providing_organisation.name)

--- a/spec/validators/date_not_in_future_validator_spec.rb
+++ b/spec/validators/date_not_in_future_validator_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe DateNotInFutureValidator do
+  subject do
+    Class.new {
+      include ActiveModel::Validations
+      attr_accessor :date
+      validates :date, date_not_in_future: true
+
+      def self.name
+        "Transaction"
+      end
+    }.new
+  end
+
+  describe "#valid?" do
+    context "when date is nil" do
+      it "is valid" do
+        subject.date = nil
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context "when date is today" do
+      it "is valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.date = Date.new(2004, 11, 24)
+        expect(subject.valid?).to be true
+
+        travel_back
+      end
+    end
+
+    context "when date is in the past" do
+      it "is valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.date = Date.new(2003, 1, 1)
+        expect(subject.valid?).to be true
+
+        travel_back
+      end
+    end
+
+    context "when date is in the future" do
+      it "is not valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.date = Date.new(2005, 1, 1)
+        expect(subject.valid?).to be false
+
+        travel_back
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/6XaRLaol/316-transactions-cannot-be-set-to-a-future-date

When testing with the IATI validator we realised that Transactions with a date in the future are not valid according to the IATI standard. This PR adds validations to the Transaction model which means a transaction cannot be saved if its date is in the future.

## Screenshots of UI changes

<img width="661" alt="Screenshot 2020-02-24 at 12 23 21" src="https://user-images.githubusercontent.com/1089521/75152237-7bfcc100-5700-11ea-9679-67655fa5e2a4.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
