### PR TITLE
(319) Budgets collect currency information much like Transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,5 +49,5 @@
 - Users are authorised based on the organisations they belong to
 - Users can add budgets to activities at all levels
 - Users can edit a budget
-
+- Users can add currency information to budgets and see the currency in the budget XML
 

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -65,7 +65,7 @@ class Staff::BudgetsController < Staff::BaseController
   end
 
   def budget_params
-    params.require(:budget).permit(:budget_type, :status, :value)
+    params.require(:budget).permit(:budget_type, :status, :value, :currency)
   end
 
   def monetary_value

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -1,7 +1,12 @@
 class Budget < ApplicationRecord
   belongs_to :activity
 
-  validates_presence_of :budget_type, :status, :period_start_date, :period_end_date, :value
+  validates_presence_of :budget_type,
+    :status,
+    :period_start_date,
+    :period_end_date,
+    :value,
+    :currency
   validates :value, inclusion: 1..99_999_999_999.00
   validates :period_start_date, :period_end_date, date_within_boundaries: true
 

--- a/app/presenters/budget_presenter.rb
+++ b/app/presenters/budget_presenter.rb
@@ -22,4 +22,9 @@ class BudgetPresenter < SimpleDelegator
   def value
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
+
+  def currency
+    return if super.blank?
+    I18n.t("generic.default_currency.#{super.downcase}")
+  end
 end

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -13,6 +13,10 @@
           legend: { text: t("form.budget.period_start_date.label"), size: "s" }
 = f.govuk_date_field :period_end_date,
           legend: { text: t("form.budget.period_end_date.label"), size: "s" }
+= f.govuk_collection_select :currency,
+                               currency_select_options,
+                               :code,
+                               :name
 = f.govuk_text_field :value
 
 = f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -11,6 +11,8 @@
         %th.govuk-table__header
           =t("form.budget.period_end_date.label")
         %th.govuk-table__header
+          =t("form.budget.currency.label")
+        %th.govuk-table__header
           =t("form.budget.value.label")
         %th.govuk-table__header
 
@@ -21,6 +23,7 @@
           %td.govuk-table__cell= budget.status
           %td.govuk-table__cell= budget.period_start_date
           %td.govuk-table__cell= budget.period_end_date
+          %td.govuk-table__cell= budget.currency
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.activity, budget))

--- a/app/views/staff/shared/xml/_budget.xml.haml
+++ b/app/views/staff/shared/xml/_budget.xml.haml
@@ -1,5 +1,5 @@
 %budget{"type" => budget.budget_type, "status" => budget.status}
   %period-start{"iso-date" => budget.period_start_date}/
   %period-end{"iso-date" => budget.period_end_date}/
-  %value{"value-date" => budget.period_start_date}= budget.value.to_s
+  %value{"value-date" => budget.period_start_date, "currency" => budget.currency}= budget.value.to_s
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
         label: Budget type
       create:
         success: Budget successfully created
+      currency:
+        label: Currency
       period_end_date:
         label: Period end date
       period_start_date:

--- a/db/migrate/20200224141519_add_currency_to_budgets.rb
+++ b/db/migrate/20200224141519_add_currency_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToBudgets < ActiveRecord::Migration[6.0]
+  def change
+    add_column :budgets, :currency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_161657) do
+ActiveRecord::Schema.define(version: 2020_02_24_141519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_02_13_161657) do
     t.date "period_start_date"
     t.date "period_end_date"
     t.decimal "value", precision: 13, scale: 2
+    t.string "currency"
     t.index ["activity_id"], name: "index_budgets_on_activity_id"
   end
 

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     period_start_date { Date.today }
     period_end_date { Date.tomorrow }
     value { 110.01 }
+    currency { "gbp" }
     association :activity
   end
 end

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe "Users can create a budget" do
     fill_in "budget[period_end_date(3i)]", with: "01"
     fill_in "budget[period_end_date(2i)]", with: "01"
     fill_in "budget[period_end_date(1i)]", with: "2021"
+    select "Pound Sterling", from: "budget[currency]"
     fill_in "budget[value]", with: "1000.00"
     click_button I18n.t("generic.button.submit")
   end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         expect(page).to have_content(budget_presenter.status)
         expect(page).to have_content(budget_presenter.period_start_date)
         expect(page).to have_content(budget_presenter.period_end_date)
+        expect(page).to have_content(budget_presenter.currency)
         expect(page).to have_content(budget_presenter.value)
       end
     end
@@ -45,6 +46,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         expect(page).to have_content(budget_presenter.status)
         expect(page).to have_content(budget_presenter.period_start_date)
         expect(page).to have_content(budget_presenter.period_end_date)
+        expect(page).to have_content(budget_presenter.currency)
         expect(page).to have_content(budget_presenter.value)
       end
     end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Budget do
     it { should validate_presence_of(:period_start_date) }
     it { should validate_presence_of(:period_end_date) }
     it { should validate_presence_of(:value) }
+    it { should validate_presence_of(:currency) }
   end
 
   context "value must be between 1 and 99,999,999,999.00 (100 billion minus one)" do

--- a/spec/presenters/budget_presenter_spec.rb
+++ b/spec/presenters/budget_presenter_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe BudgetPresenter do
       expect(described_class.new(budget).value).to eq("£20.00")
     end
   end
+
+  describe "#currency" do
+    it "returns the I18n string for the currency" do
+      expect(described_class.new(budget).currency).to eq("Pound Sterling")
+    end
+  end
 end

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -43,6 +43,7 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/budget/@type").text).to eq("1")
     expect(xml.at("iati-activity/budget/@status").text).to eq("1")
     expect(xml.at("iati-activity/budget/value").text).to eq(budget.value.to_s)
+    expect(xml.at("iati-activity/budget/value/@currency").text).to eq(budget.currency)
     expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
     expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
   end


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/hVAX9Jrc/319-budgets-should-collect-a-currency-like-transactions

Collect the currency information for a Budget using the generic currency
codelist.

Output the budget currency in the XML.

## Screenshots of UI changes

<img width="706" alt="Screenshot 2020-02-24 at 14 32 38" src="https://user-images.githubusercontent.com/1089521/75162446-79589680-5715-11ea-8d51-2dd1f2a13e5e.png">


<img width="939" alt="Screenshot 2020-02-24 at 14 35 46" src="https://user-images.githubusercontent.com/1089521/75162435-7493e280-5715-11ea-8349-8738e438777a.png">



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
