### PR TITLE
Pin sidekiq to 5.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,10 @@ gem "redis"
 gem "redis-namespace"
 gem "sassc", "~> 2.0.1" # Downgrade to fix https://github.com/sass/sassc-ruby/issues/133
 gem "sass-rails", "~> 6.0"
-gem "sidekiq"
+# TODO: currently GPaaS only provides redis 3.2.
+# when redis 4 or above is available use
+# gem "sidekiq", "< 7"
+gem "sidekiq", "5.2.7"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,11 +351,11 @@ GEM
     sexp_processor (4.13.0)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
-    sidekiq (6.0.5)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -465,7 +465,7 @@ DEPENDENCIES
   sassc (~> 2.0.1)
   selenium-webdriver
   shoulda-matchers
-  sidekiq
+  sidekiq (= 5.2.7)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
@@ -481,4 +481,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.0.pre.1
+   2.1.3


### PR DESCRIPTION
## Changes in this PR

GPaaS currently only provides redis 3.2 which is not supported by
sidekiq 6 therefore we should use a version of sidekiq 5.

Sidekiq 5.2.8 is the latest released version but that downgrades rack to
2.0.9. We decided that for the week that we need to use sidekiq 5 we
don't need the patches provided by 5.2.8 and would prefer not to use an
old version of rack therefore we are pinning to 5.2.7

