### PR TITLE
(318) Activitity XML includes reporting org in identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,4 @@
 - Users can view implementing organisations in the Activity XML
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
+- Activity XML includes 'iati-identifier' which is includes the reporting organisation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
 - Activity XML includes 'iati-identifier' which is includes the reporting organisation
+- Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -22,7 +22,9 @@ class Staff::ActivitiesController < Staff::BaseController
         @budget_presenters = @budgets.map { |budget| BudgetPresenter.new(budget) }
         @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
       end
-      format.xml
+      format.xml do |format|
+        @activity_xml_presenter = ActivityXmlPresenter.new(@activity)
+      end
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -101,4 +101,10 @@ class Activity < ApplicationRecord
   def has_implementing_organisations?
     implementing_organisations.any?
   end
+
+  def parent_activities
+    return [activity] if programme?
+    return [activity.activity, activity] if project?
+    []
+  end
 end

--- a/app/presenters/activity_xml_presenter.rb
+++ b/app/presenters/activity_xml_presenter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ActivityXmlPresenter < SimpleDelegator
+  def iati_identifier
+    "#{reporting_organisation_reference}-#{identifier}"
+  end
+end

--- a/app/presenters/activity_xml_presenter.rb
+++ b/app/presenters/activity_xml_presenter.rb
@@ -2,6 +2,8 @@
 
 class ActivityXmlPresenter < SimpleDelegator
   def iati_identifier
-    "#{reporting_organisation_reference}-#{identifier}"
+    parent_activities.each_with_object([reporting_organisation_reference]) { |parent, parent_identifiers|
+      parent_identifiers << parent.identifier
+    }.push(identifier).join("-")
   end
 end

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -8,6 +8,7 @@ class CreateFundActivity
   def call
     activity = Activity.new
     activity.organisation = Organisation.find(organisation_id)
+    activity.reporting_organisation_reference = activity.organisation.iati_reference
 
     activity.wizard_status = "identifier"
     activity.level = :fund

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -9,6 +9,8 @@ class CreateProgrammeActivity
   def call
     activity = Activity.new
     activity.organisation = Organisation.find(organisation_id)
+    activity.reporting_organisation_reference = activity.organisation.iati_reference
+
     fund = Activity.find(fund_id)
     fund.activities << activity
 

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -13,6 +13,7 @@ class CreateProjectActivity
 
     activity = Activity.new
     activity.organisation = reporting_organisation
+    activity.reporting_organisation_reference = reporting_organisation.iati_reference
 
     programme = Activity.find(programme_id)
     programme.activities << activity

--- a/app/views/staff/activities/show.xml.haml
+++ b/app/views/staff/activities/show.xml.haml
@@ -1,4 +1,4 @@
 !!! XML
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
-  = render partial: "staff/shared/xml/activity", locals: { activity: @activity, transactions: @transactions, budgets: @budgets }
+  = render partial: "staff/shared/xml/activity", locals: { activity: @activity_xml_presenter, transactions: @transactions, budgets: @budgets }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,5 +1,5 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
-  %iati-identifier= activity.identifier
+  %iati-identifier= activity.iati_identifier
   %reporting-org{"type" => activity.organisation.organisation_type, "ref" => activity.organisation.iati_reference }
     %narrative= activity.organisation.name
   %title

--- a/db/migrate/20200225155754_add_reporter_reference_to_activity.rb
+++ b/db/migrate/20200225155754_add_reporter_reference_to_activity.rb
@@ -1,0 +1,5 @@
+class AddReporterReferenceToActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :reporting_organisation_reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_141519) do
+ActiveRecord::Schema.define(version: 2020_02_25_155754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_141519) do
     t.string "accountable_organisation_reference"
     t.string "accountable_organisation_type"
     t.uuid "extending_organisation_id"
+    t.string "reporting_organisation_reference"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -19,6 +19,9 @@ FactoryBot.define do
     wizard_status { "complete" } # wizard is complete
 
     association :organisation, factory: :organisation
+    before(:create) do |activity|
+      activity.reporting_organisation_reference = activity.organisation.iati_reference
+    end
 
     factory :fund_activity do
       level { :fund }

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -49,6 +49,7 @@ FactoryBot.define do
     end
 
     factory :project_activity do
+      activity factory: :programme_activity
       level { :project }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -1,9 +1,7 @@
 FactoryBot.define do
-  sequence(:identifier) { |n| "GB-GOV-13-GCRF-#{n}" }
-
   factory :activity do
     title { Faker::Lorem.sentence }
-    identifier
+    identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     description { Faker::Lorem.paragraph }
     sector { "11110" }
     status { "2" }

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,22 +1,18 @@
 FactoryBot.define do
-  sequence(:iati_reference) { |n| "GB-GOV-#{n}" }
-
   factory :organisation do
     name { Faker::Company.name }
-    iati_reference
+    iati_reference { "GB-GOV-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     organisation_type { "10" }
     default_currency { "GBP" }
     language_code { "en" }
 
     factory :delivery_partner_organisation do
-      iati_reference
       service_owner { false }
     end
 
     factory :beis_organisation do
       name { "Department for Business, Energy and Industrial Strategy" }
       service_owner { true }
-      iati_reference
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Users can view an activity as XML" do
 
       context "when the activity is a fund activity" do
         let(:activity) { create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
@@ -16,6 +17,7 @@ RSpec.feature "Users can view an activity as XML" do
 
       context "when the activity is a programme activity" do
         let(:activity) { create(:programme_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
@@ -23,6 +25,7 @@ RSpec.feature "Users can view an activity as XML" do
 
       context "when the activity is a project activity" do
         let(:activity) { create(:project_activity_with_implementing_organisations, organisation: organisation) }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -187,6 +187,39 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#parent_activities" do
+    context "when the activity is a fund" do
+      it "returns an empty array" do
+        result = build(:fund_activity).parent_activities
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns the fund" do
+        programme = create(:programme_activity)
+        fund = programme.activity
+
+        result = programme.parent_activities
+
+        expect(result.first.id).to eq(fund.id)
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns the fund and then the programme" do
+        project = create(:project_activity)
+        programme = project.activity
+        fund = programme.activity
+
+        result = project.parent_activities
+
+        expect(result.first.id).to eq(fund.id)
+        expect(result.second.id).to eq(programme.id)
+      end
+    end
+  end
+
   describe "#wizard_complete?" do
     it "is true if the wizard has been completed" do
       activity = build(:activity, wizard_status: :complete)

--- a/spec/presenters/activity_xml_presenter_spec.rb
+++ b/spec/presenters/activity_xml_presenter_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActivityXmlPresenter do
+  describe "#iati_identifier" do
+    it "returns a composite identifier formed with the reporting organisation" do
+      fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation_reference: "GB-GOV-13")
+      expect(described_class.new(fund).iati_identifier).to eql("GB-GOV-13-GCRF-1")
+    end
+    end
+  end
+end

--- a/spec/presenters/activity_xml_presenter_spec.rb
+++ b/spec/presenters/activity_xml_presenter_spec.rb
@@ -4,10 +4,38 @@ require "rails_helper"
 
 RSpec.describe ActivityXmlPresenter do
   describe "#iati_identifier" do
-    it "returns a composite identifier formed with the reporting organisation" do
-      fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation_reference: "GB-GOV-13")
-      expect(described_class.new(fund).iati_identifier).to eql("GB-GOV-13-GCRF-1")
+    context "when the activity is a fund" do
+      it "returns a composite identifier formed with the reporting organisation" do
+        fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation_reference: "GB-GOV-13")
+        expect(described_class.new(fund).iati_identifier).to eql("GB-GOV-13-GCRF-1")
+      end
     end
+
+    context "when the activity is a programme" do
+      context "when the reporting organisation is a government organisation" do
+        it "returns an identifier with the reporting organisation, fund and programme" do
+          government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
+          programme = create(:programme_activity, organisation: government_organisation)
+          fund = programme.activity
+
+          expect(described_class.new(programme).iati_identifier)
+            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}")
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when the reporting organisation is a government organisation" do
+        it "returns an identifier with the reporting organisation, fund, programme and project" do
+          government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
+          project = create(:project_activity, organisation: government_organisation)
+          programme = project.activity
+          fund = programme.activity
+
+          expect(described_class.new(project).iati_identifier)
+            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}")
+        end
+      end
     end
   end
 end

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe CreateFundActivity do
       expect(result.organisation).to eq(organisation)
     end
 
+    it "saves the reporting organisation reference" do
+      expect(result.reporting_organisation_reference).to eq(organisation.iati_reference)
+    end
+
     it "sets the initial wizard_status" do
       expect(result.wizard_status).to eq("identifier")
     end

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe CreateProgrammeActivity do
       expect(result.organisation).to eq(organisation)
     end
 
+    it "saves the reporting organisation reference" do
+      expect(result.reporting_organisation_reference).to eq(organisation.iati_reference)
+    end
+
     it "sets the parent Activity to the fund" do
       expect(result.activity).to eq(fund)
     end

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe CreateProjectActivity do
       expect(result.organisation).to eq delivery_partner_organisation
     end
 
+    it "saves the reporting organisation reference" do
+      expect(result.reporting_organisation_reference).to eq(delivery_partner_organisation.iati_reference)
+    end
+
     it "sets the parent Activity to the fund" do
       expect(result.activity).to eq(programme)
     end

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -5,9 +5,12 @@ RSpec.shared_examples "valid activity XML" do
   end
 
   it "contains the activity XML" do
+    iati_activity_identifier = "#{activity.reporting_organisation_reference}-#{activity.identifier}"
+
     visit organisation_activity_path(organisation, activity, format: :xml)
+
     expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
-    expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.identifier)
+    expect(xml.at("iati-activity/iati-identifier").text).to eq(iati_activity_identifier)
   end
 
   it "contains the funding organisation XML" do

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -5,33 +5,31 @@ RSpec.shared_examples "valid activity XML" do
   end
 
   it "contains the activity XML" do
-    iati_activity_identifier = "#{activity.reporting_organisation_reference}-#{activity.identifier}"
-
     visit organisation_activity_path(organisation, activity, format: :xml)
 
-    expect(xml.at("iati-activity/@default-currency").text).to eq(activity.default_currency)
-    expect(xml.at("iati-activity/iati-identifier").text).to eq(iati_activity_identifier)
+    expect(xml.at("iati-activity/@default-currency").text).to eq(activity_presenter.default_currency)
+    expect(xml.at("iati-activity/iati-identifier").text).to eq(activity_presenter.iati_identifier)
   end
 
   it "contains the funding organisation XML" do
     visit organisation_activity_path(organisation, activity, format: :xml)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity_presenter.funding_organisation_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity_presenter.funding_organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity_presenter.funding_organisation_name)
   end
 
   it "contains the accountable organisation XML" do
     visit organisation_activity_path(organisation, activity, format: :xml)
-    expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity.accountable_organisation_reference)
-    expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity.accountable_organisation_type)
-    expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity.accountable_organisation_name)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/@ref").text).to eq(activity_presenter.accountable_organisation_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/@type").text).to eq(activity_presenter.accountable_organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '2']/narrative").text).to eq(activity_presenter.accountable_organisation_name)
   end
 
   it "contains the extending organisation XML" do
     visit organisation_activity_path(organisation, activity, format: :xml)
-    expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity.extending_organisation.iati_reference)
-    expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity.extending_organisation.organisation_type)
-    expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity.extending_organisation.name)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/@ref").text).to eq(activity_presenter.extending_organisation.iati_reference)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/@type").text).to eq(activity_presenter.extending_organisation.organisation_type)
+    expect(xml.at("iati-activity/participating-org[@role = '3']/narrative").text).to eq(activity_presenter.extending_organisation.name)
   end
 
   it "contains the implementing organisations XML" do


### PR DESCRIPTION
## Changes in this PR

The `iati-identifier` field that is output in the Activity XML has had 2 updates.

1. It now includes the reporting organisation reference to that it passes the validator. This change involved an important decision on how we deal with changes to organisation iati references against the requirement by IATI for these to always remain unchanged. Feedback would be great on this, more info in the commit!
2. It can include up 2 to more prefixes to the activity identifier part itself. This maps our internal hierarchy and how we ask for identifiers at the different levels back to what BEIS currently publish to IATI. This change is more controversial as it's not required to produce valid IATI but it is required to keep it consistent with BEIS publishing. I've left more info on the commit that added this.

A new `ActivityXmlPresenter` was added along the way to make it easier to add and test the presentational logic around identifiers only in the context of where we show it in XML. 

## Screenshots of UI changes

![Screenshot 2020-02-27 at 13 26 00](https://user-images.githubusercontent.com/912473/75449621-312fb300-5965-11ea-8eba-dfd705ace96b.png)

![Screenshot 2020-02-27 at 13 26 00](https://user-images.githubusercontent.com/912473/75450015-f417f080-5965-11ea-9190-5031c1abf3a4.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
