### PR TITLE
(301) Budget dates are validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,4 @@
 - Activity XML includes 'iati-identifier' which is includes the reporting organisation
 - Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme
 - BEIS users (administrators) can mark other users as active or inactive
+- Budget start and end dates are validated according to IATI standard

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -10,6 +10,8 @@ class Budget < ApplicationRecord
   validates :value, inclusion: 1..99_999_999_999.00
   validates :period_start_date, :period_end_date, date_within_boundaries: true
 
+  validates_with BudgetDatesValidator, if: -> { period_start_date.present? && period_end_date.present? }
+
   BUDGET_TYPES = {original: "original", updated: "updated"}
   STATUSES = {indicative: "indicative", committed: "committed"}
 end

--- a/app/validators/budget_dates_validator.rb
+++ b/app/validators/budget_dates_validator.rb
@@ -1,0 +1,22 @@
+class BudgetDatesValidator < ActiveModel::Validator
+  def validate(record)
+    unless dates_not_more_than_365_days_apart?(record.period_start_date, record.period_end_date)
+      record.errors.add :period_end_date,
+        I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+    end
+
+    unless start_date_not_after_end_date?(record.period_start_date, record.period_end_date)
+      record.errors.add :period_start_date, I18n.t("activerecord.errors.models.budget.attributes.period_start_date.not_after_end_date")
+    end
+  end
+
+  private
+
+  def dates_not_more_than_365_days_apart?(start_date, end_date)
+    end_date - 365.days <= start_date
+  end
+
+  def start_date_not_after_end_date?(start_date, end_date)
+    start_date <= end_date
+  end
+end

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -71,8 +71,10 @@ en:
           attributes:
             period_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+              within_365_days_of_start_date: The period end date must be no more than 365 days after the period start date
             period_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+              not_after_end_date: The period start date cannot be after the period end date
         transaction:
           attributes:
             date:
@@ -116,7 +118,7 @@ en:
           html: "<a href='http://reference.iatistandard.org/203/codelists/TiedStatus/' target='_blank'>See the IATI tied status page for descriptions.</a>"
         title: A short, human-readable title that contains a meaningful summary of the activity.
       budget:
-        period_end_date: For example, 12 3 2021
+        period_end_date: Period end date must not be more than one year after the period start date. For example, 11 3 2021
         period_start_date: For example, 11 3 2020
       implementing_organisation:
         reference:

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe "Users can create a budget" do
     fill_in "budget[period_start_date(3i)]", with: "01"
     fill_in "budget[period_start_date(2i)]", with: "01"
     fill_in "budget[period_start_date(1i)]", with: "2020"
-    fill_in "budget[period_end_date(3i)]", with: "01"
-    fill_in "budget[period_end_date(2i)]", with: "01"
-    fill_in "budget[period_end_date(1i)]", with: "2021"
+    fill_in "budget[period_end_date(3i)]", with: "31"
+    fill_in "budget[period_end_date(2i)]", with: "12"
+    fill_in "budget[period_end_date(1i)]", with: "2020"
     select "Pound Sterling", from: "budget[currency]"
     fill_in "budget[value]", with: "1000.00"
     click_button I18n.t("generic.button.submit")

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -59,4 +59,24 @@ RSpec.describe Budget do
       expect(budget).to_not be_valid
     end
   end
+
+  context "when the period start and period end dates are blank" do
+    it "does not perform budget date validation" do
+      budget = build(:budget, period_start_date: "", period_end_date: "")
+
+      budget.valid?
+
+      expect(budget.errors[:period_end_date]).not_to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+    end
+  end
+
+  context "when the period start and period end dates are invalid" do
+    it "performs budget date validation" do
+      budget = build(:budget, period_start_date: Date.today, period_end_date: Date.today + 366.days)
+
+      budget.valid?
+
+      expect(budget.errors[:period_end_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+    end
+  end
 end

--- a/spec/validators/budget_date_validator_spec.rb
+++ b/spec/validators/budget_date_validator_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe BudgetDatesValidator do
+  subject { build(:budget) }
+
+  context "when the start date is the same as the end date" do
+    it "is valid" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = Date.today
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the start date is before the end date" do
+    it "is valid" do
+      subject.period_start_date = Date.yesterday
+      subject.period_end_date = Date.today
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the start date is after the end date" do
+    it "is not valid" do
+      subject.period_start_date = Date.tomorrow
+      subject.period_end_date = Date.today
+
+      expect(subject).not_to be_valid
+    end
+
+    it "adds an error message to the :period_start_date" do
+      subject.period_start_date = Date.tomorrow
+      subject.period_end_date = Date.today
+
+      subject.valid?
+      expect(subject.errors.messages[:period_start_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_start_date.not_after_end_date")
+    end
+  end
+
+  context "when the dates are within 365 days of each other" do
+    it "is valid" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = subject.period_start_date + 6.months
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the dates are exactly 365 days apart from each other" do
+    it "is valid" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = subject.period_start_date + 365.days
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the dates are more than 365 days apart" do
+    it "is invalid" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = subject.period_start_date + 366.days
+
+      expect(subject).not_to be_valid
+    end
+
+    it "adds an error message to the :period_end_date" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = subject.period_start_date + 366.days
+
+      subject.valid?
+      expect(subject.errors.messages[:period_end_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

The IATI standard requires that budget start and end dates be validated
as follows:

- start date must not be after end date
- end date not more than one year after start date

http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/budget/

We spent some time attempting to make a generic validator for these two
validations but in the end decided that a validator specifically for
budget was the simplest and most elegant solution until we need to reuse
this validation criteria.

We decided that as the validation requirements are clearly defined by
IATI, by wrapping them up in a validator we keep all of the elements to
carry out the validation together in one place.

The interface and associated challenges that went with a generic solution felt quite messy to us and we were not happy with the result. we much preferred this simple and explicit implementation.

We check that the object being validated has the interface required (duck typing?) but we were not sure if/how we should test this. We also considered if this validation should live inside the budget model but decided it encapsulated enough descreet behaviour to be it's own class.

We had some interesting thoughts about how changes to our objects interfaces could allow this class to validate other types - as the dates represent a period that has a start and end, when other objects have the same requirement, simply using the same column names would result in a reusable class, the validator doesn't care that the object is a budget, simply that it has a start and end date.

## Screenshots of UI changes
![Screenshot_2020-02-28 Create budget — Report Official Development Assistance(1)](https://user-images.githubusercontent.com/480578/75527465-d05ab600-5a0a-11ea-9bb8-e3663f23dd00.png)

![Screenshot_2020-02-28 Create budget — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/75527521-d3ee3d00-5a0a-11ea-9a27-6e448b9033f0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
