### PR TITLE
Fix update activity message not working for projects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,8 @@ en:
     project:
       create:
         success: Project successfully created
+      update:
+        success: Project successfully updated
     transaction:
       create:
         success: Transaction successfully created

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,9 +1,10 @@
 RSpec.feature "Users can edit an activity" do
   include ActivityHelper
 
+  before { authenticate!(user: user) }
+
   context "when the activity is a fund" do
     let(:user) { create(:beis_user) }
-    before { authenticate!(user: user) }
 
     context "when the activity only has an identifier (and is incomplete)" do
       it "shows edit link on the identifier, and add link on only the next step" do
@@ -97,9 +98,25 @@ RSpec.feature "Users can edit an activity" do
   end
 
   context "when the activity is a programme" do
+    context "when the user is a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "shows an update success message" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        within(".title") do
+          click_on(I18n.t("generic.link.edit"))
+        end
+
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content(I18n.t("form.programme.update.success"))
+      end
+    end
+
     context "when the user is NOT a BEIS user" do
       let(:user) { create(:delivery_partner_user) }
-      before { authenticate!(user: user) }
 
       scenario "the user should not be shown edit/add actions" do
         activity = create(:programme_activity, :at_purpose_step, organisation: user.organisation)
@@ -108,6 +125,25 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).not_to have_content("Edit")
         expect(page).not_to have_content("Add")
+      end
+    end
+  end
+
+  context "when the activity is a project" do
+    context "when the user is a delivery_partner_user" do
+      let(:user) { create(:delivery_partner_user) }
+
+      it "shows an update success message" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        within(".title") do
+          click_on(I18n.t("generic.link.edit"))
+        end
+
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content(I18n.t("form.project.update.success"))
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Small fix that I noticed in previous work that I didn't want to push into the same pull request. 

We could probably refactor these flash messages to reuse the same locale by allowing variables to be passed in but that felt improvement like like a rabbit hole and a step too far.

## Screenshots of UI changes

### Before

![Screenshot 2020-02-28 at 11 24 15](https://user-images.githubusercontent.com/912473/75549896-a0baa680-5a28-11ea-8446-6ab7a46094d6.png)

### After

![Screenshot 2020-02-28 at 12 48 56](https://user-images.githubusercontent.com/912473/75549938-b4fea380-5a28-11ea-8a50-7849ba66ade6.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
