### PR TITLE
Chore/Use a server-side session store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ jobs:
     script: |
       docker network create test
       docker run -d --name pg --network test -p 5432:5432 postgres:11.6
+      docker run -d --name redis --network test -p 6379:6379 redis:4.0.14
       docker run -d \
         --name test-container \
         --network test \
         -e RAILS_ENV=test \
         -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
         -e DATABASE_URL=postgres://postgres@pg:5432/roda_test \
+        -e REDIS_URL=redis://redis:6379 \
         -e TRAVIS="$TRAVIS" \
         -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" \
         -e TRAVIS_BRANCH="$TRAVIS_BRANCH" \

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "pundit"
 gem "rollbar"
 gem "rails", "~> 6.0.2"
 gem "redis"
+gem "redis-rails"
+gem "redis-store"
 gem "redis-namespace"
 gem "sassc", "~> 2.0.1" # Downgrade to fix https://github.com/sass/sassc-ruby/issues/133
 gem "sass-rails", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,8 +295,24 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.3)
+    redis-actionpack (5.2.0)
+      actionpack (>= 5, < 7)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.2.0)
+      activesupport (>= 3, < 7)
+      redis-store (>= 1.3, < 2)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
+    redis-rack (2.1.2)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.8.2)
+      redis (>= 4, < 5)
     regexp_parser (1.6.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -459,6 +475,8 @@ DEPENDENCIES
   rails_layout
   redis
   redis-namespace
+  redis-rails
+  redis-store
   rollbar
   rspec-rails
   sass-rails (~> 6.0)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,12 @@
+redis_url = ENV.fetch("REDIS_URL", nil)
+return if redis_url.nil?
+
+redis_uri = URI(redis_url)
+Rails.application.config.session_store :redis_store,
+  servers: {
+    host: redis_uri.host,
+    port: redis_uri.port,
+    db: 1,
+    namespace: "roda:session",
+  },
+  expire_after: 12.hours

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -9,4 +9,7 @@ Rails.application.config.session_store :redis_store,
     db: 1,
     namespace: "roda:session",
   },
-  expire_after: 12.hours
+  expire_after: 12.hours,
+  threadsafe: true,
+  signed: true,
+  secure: true

--- a/doc/architecture/decisions/0017-use-a-server-side-session-store.md
+++ b/doc/architecture/decisions/0017-use-a-server-side-session-store.md
@@ -1,0 +1,38 @@
+# 17. use-a-server-side-session-store
+
+Date: 2020-02-28
+
+## Status
+
+Accepted
+
+## Context
+
+We are proactively checking that we are securing the service before it goes live to real users. Using past experience and penetration feedback the subject of where we store our sessions has previously been approved that we store the data server side, rather than leaving reusable tokens in people's browsers and trusting in the cookie's encryption.
+
+https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
+https://guides.rubyonrails.org/security.html#session-storage
+
+dxw have used both active record and redis stores in the past using the following gems:
+
+- https://github.com/rails/activerecord-session_store
+- https://github.com/redis-store/redis-store/
+- https://github.com/roidrage/redis-session-store
+
+
+## Decision
+
+Use Redis as a server-side session store using https://github.com/redis-store/redis-store/.
+
+## Consequences
+
+User sessions will now be stored in a private Redis database without encryption.
+
+Using Redis over ActiveRecord has a couple of small advantages:
+ - Redis does not require a rake task that is scheduled by a separate process like cron to remove old sessions, it is instead a configuration option for Redis 
+ - Sessions would not contribute to the usage of postgres database which is expecting to be heavily used
+ - Destroying all sessions in the case of an incident is a much safer option using redis-cli than it would be to hop onto a production rails console and manually delete rows from only a single table, this would be a much more dangerous operation if important data was available from within the same context 
+
+There may be some advantages of using the Rails maintained activerecord-session_store that we miss out on as Rails changes. Since it is maintained by the Rails core team this is a likely benefit.
+
+The redis gem we are using is maintained by the core Redis team, is actively maintained too and offers us an easy path into performing any caching at an application level in the future.


### PR DESCRIPTION
## Changes in this PR

* Before this change the Rails default is to use an encrypted cookie on each users browser: https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
* This is a problem because :
    > Session cookies do not invalidate themselves and can be maliciously reused. It may be a good idea to have your application invalidate old session cookies using a stored timestamp. - https://guides.rubyonrails.org/security.html#session-storage
* In this change we replace the session store with Redis
* This change fixes a common CookieOverflow error that occurs when too much data is stored in the session, also referenced here: https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
* This change does not encrypt the session data (although it is Marshalled)
https://redis.io/topics/security and instead relies on the network layers to firewall redis with ACL etc so that it is not open to the public.

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
