### PR TITLE
Reduce the attack footprint by removing unused rails ties

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,20 @@
 
 require_relative "boot"
 
-require "rails/all"
+# Include each railties manually, excluding `active_storage/engine` and `action_mailbox`
+%w[
+  active_record/railtie
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  active_job/railtie
+  action_cable/engine
+  rails/test_unit/railtie
+  sprockets/railtie
+].each do |railtie|
+  require railtie
+rescue LoadError
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
## Changes in this PR

ActiveStorage in default configuration created valid routes that allowed files to be uploaded. We do not intend for files to be uploaded to the application as local files so this can be removed.

If we do want to add file upload in the future we may add this back however it will very likely use a third party document store given the ephemeral nature of Docker containers.

This change also removes action_mailbox routes with allows the application to recieve incoming emails. https://guides.rubyonrails.org/action_mailbox_basics.html This is not appropriate now and I cannot imagine when this would be appropriate.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
