### PR TITLE
Fix/369 create activity accessibility improvements

### DIFF
--- a/app/views/staff/activity_forms/_wrapper.html.haml
+++ b/app/views/staff/activity_forms/_wrapper.html.haml
@@ -4,7 +4,6 @@
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %h1.govuk-heading-xl= @page_title
 
       = form_for @activity, url: wizard_path do |f|
         = yield f

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :aid_type, yaml_to_objects(entity: "activity", type: "aid_type"), :code, :name
+  = f.govuk_collection_select :aid_type, yaml_to_objects(entity: "activity", type: "aid_type"), :code, :name, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/country.html.haml
+++ b/app/views/staff/activity_forms/country.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :recipient_region, region_select_options, :code, :name, options: { selected: f.object.recipient_region || region_select_options.first.code }
+  = f.govuk_collection_select :recipient_region, region_select_options, :code, :name, options: { selected: f.object.recipient_region || region_select_options.first.code }, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/dates.html.haml
+++ b/app/views/staff/activity_forms/dates.html.haml
@@ -1,4 +1,6 @@
 = render layout: "wrapper" do |f|
+  %h1.govuk-heading-xl= @page_title
+
   = f.govuk_date_field :planned_start_date
   = f.govuk_date_field :planned_end_date
   = f.govuk_date_field :actual_start_date

--- a/app/views/staff/activity_forms/finance.html.haml
+++ b/app/views/staff/activity_forms/finance.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :finance, yaml_to_objects(entity: "activity", type: "finance"), :code, :name
+  = f.govuk_collection_select :finance, yaml_to_objects(entity: "activity", type: "finance"), :code, :name, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }
+  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code },  label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/identifier.html.haml
+++ b/app/views/staff/activity_forms/identifier.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_text_field :identifier
+  = f.govuk_text_field :identifier, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,3 +1,5 @@
 = render layout: "wrapper" do |f|
+  %h1.govuk-heading-xl= @page_title
+
   = f.govuk_text_field :title
   = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name
+  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :status, yaml_to_objects(entity: "activity", type: "status"), :code, :name
+  = f.govuk_collection_select :status, yaml_to_objects(entity: "activity", type: "status"), :code, :name, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :tied_status, tied_status_select_options, :code, :name, options: { selected: f.object.tied_status || tied_status_select_options.first.code }
+  = f.govuk_collection_select :tied_status, tied_status_select_options, :code, :name, options: { selected: f.object.tied_status || tied_status_select_options.first.code }, label: { tag: 'h1', size: 'xl' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
         flow: Flow
         identifier: Your unique identifier
         purpose: Purpose of activity
+        region: Recipient region
         sector: Sector
         status: Status
         tied_status: Tied status

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -121,7 +121,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Dates are not mandatory so we can move through this step
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.region")
 
         # Region has a default and can't be set to blank so we skip
         select "Developing countries, unspecified", from: "activity[recipient_region]"

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -24,7 +24,6 @@ module FormHelpers
     tied_status: "Untied"
   )
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.identifier")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.identifier")
     expect(page).to have_content I18n.t("helpers.hint.activity.identifier")
     fill_in "activity[identifier]", with: identifier
@@ -37,13 +36,11 @@ module FormHelpers
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.sector")
     expect(page).to have_content "Classify the purpose of this activity. Please provide the sector appropriate to you from this list."
     select sector, from: "activity[sector]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.status")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.status")
     expect(page).to have_content "IATI activity status. See IATI for detailed descriptions."
 
@@ -74,31 +71,26 @@ module FormHelpers
 
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.country")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.recipient_region")
     expect(page).to have_content "A supranational geopolitical region that will benefit from this activity. Find the region code from the IATI region list."
     select recipient_region, from: "activity[recipient_region]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.flow")
     expect(page).to have_content "IATI descriptions of each flow type can be found here."
     select flow, from: "activity[flow]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.finance")
     expect(page).to have_content I18n.t("helpers.hint.activity.finance")
     select finance, from: "activity[finance]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.aid_type")
     expect(page).to have_content "A code for the vocabulary aid-type classifications. IATI descriptions can be found here."
     select aid_type, from: "activity[aid_type]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.tied_status")
     expect(page).to have_content "See the IATI tied status page for descriptions."
 


### PR DESCRIPTION
## Changes in this PR

### Accessibility improvements that include removing duplication of page titles and labels for the 'Create activity' journey

- We should use labels as page title to avoid duplication of content when we follow the one thing per page approach. So we wrapped labels in a h1 tag in most of the steps.

- We’re following the gov.uk guidline
https://design-system.service.gov.uk/get-started/labels-legends-headings/

- For cases where we should use a filedset with a legend there is temporary fix, because there are issues trying to render an h1 legend for a filedset. It doesn't work at the moment.

- Once we have removed page title heading from the form wrapper, we need to output it on the fieldset pages (for dates and purpose). The 'h1' is inside the form which is not ideal, but we’re workinng on fixing this.

- Remove page title from activity tests, because we no longer use page title and only rely on the label being set as h1

- Added recipent region to the translation

- We have switched to use labels as headings in most of the form steps for creating activity, but we are still using page title in our tests.

TODO / TO CONSIDER:

Having two seperate translation files for the app and form might make things difficult once we start changing a lot of content [I guess], so we should probably update some of the tests to refer and expect the content in the form transaltion.


## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
