### PR TITLE
Push docker images to docker hub for every branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ deploy:
   on:
     branch: master
   app: beis-roda-production
+- provider: script
+  script: bash travis-docker-push.sh
+  on:
+    all_branches: true
 env:
   global:
     secure: mBNvcyOEhYVAbbUJL4sXvwU6RM9LgFLAaEq/B5VKhUSOSKWvcYYInk5qWOldMF79aE8mC7JsOi5D4AC6fvPEEU2aM9N5jcvoNyR5FEKg80ltgK8GE8NwrzqjD3shS2IhFtKdBN1PI/vDxAtIJqefQ8eSy2/FwdpN/aB06QDGjEy5ye2dh/A4YH5fAz1W9lncFI8zr7ZdPC5N7FG6DkNCVju9wfqwzyHCQabuJ3iKvq3dxBaRvJgrIi6I2QVHV9ieWARuI5CHgYQWwm2VPVW5vUhrZ3ZaefD5qJZ4Bp+NzlnDH7frCjuDpPrCiNI6wYrbOxj4LFVDAWl9dMYcZ9BY6DNQjeTtSt9qLCgG6csBsTf9RHR5THz3zreChEyf/+iJvBqyh9XdSNj/ZtEDFAM4z4LTsyQy7VlxyjLoO+oYOONzQP/y4EOmELJ7YPvB6bZmazJ2Rpix91svlBmaxtcx63W0aZa8yqqzJ5n6mPdIIBnMQOlNkofUSapaKJRceMcVqHk/5EqjUG7ETTf8eohrfLqrHP/S344NPNCDMHmTIoWd4QL7K9E0IeAinBUOa8RfN4A3SfXvouOPvfZGqCjmciAsQi2r024EqZ/c39xu1BQDLIm+LZ9ThMBimi2u7yZV7W4ijoY7DRae3mgzqGxnHxEmWhtDMWWnEujfR2BM4oY= # Coveralls READ_TOKEN

--- a/travis-docker-push.sh
+++ b/travis-docker-push.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+TAG="${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker build -t "thedxw/beis-report-official-development-assistance:$TRAVIS_BRANCH" .
+docker tag "thedxw/beis-report-official-development-assistance:$TRAVIS_BRANCH" "thedxw/beis-report-official-development-assistance:$TAG"
+docker push "thedxw/beis-report-official-development-assistance:$TRAVIS_BRANCH"
+docker push "thedxw/beis-report-official-development-assistance:$TAG"


### PR DESCRIPTION
## Changes in this PR

We will be deploying to the PaaS using docker images so push an image for
each branch that gets tested in travis and a unique docker tag consisting
of branch, build number and commit.