### PR TITLE
(231) Seed the database with delivery partner organisations & BEIS, and common user accounts

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,22 +8,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Generic development user
 if Rails.env.development?
-  organisation_params = FactoryBot.build(
-    :organisation, name: "Department for Business, Energy & Industrial Strategy"
-  ).attributes
-  organisation = Organisation.find_or_create_by(organisation_params)
-
-  user = User.find_or_initialize_by(
-    name: "Generic development user",
-    email: "roda@dxw.com",
-    identifier: "auth0|5dc53e4b85758e0e95b062f0",
-    role: :administrator
-  )
-  user.organisation = organisation
-  user.save
-
-  activity_params = FactoryBot.build(:activity, title: "GCRF", organisation: organisation).attributes
-  Activity.find_or_create_by(activity_params)
+  load File.join(Rails.root, "db", "seeds", "organisations.rb")
+  load File.join(Rails.root, "db", "seeds", "users.rb")
+  load File.join(Rails.root, "db", "seeds", "activity.rb")
 end

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -1,0 +1,3 @@
+beis = Organisation.find_by(service_owner: true)
+activity_params = FactoryBot.build(:activity, title: "GCRF", organisation: beis).attributes
+Activity.find_or_create_by(activity_params)

--- a/db/seeds/organisations.rb
+++ b/db/seeds/organisations.rb
@@ -1,0 +1,13 @@
+require "yaml"
+
+organisations = YAML.safe_load(File.read(File.join(Rails.root, "db", "seeds", "organisations.yml")))
+organisations.each do |organisation|
+  organisation_params = {
+    name: organisation["name"],
+    organisation_type: organisation["type"],
+    language_code: "en",
+    default_currency: "gbp",
+    service_owner: organisation["service_owner"],
+  }
+  Organisation.find_or_create_by(iati_reference: organisation["reference"]).update(organisation_params)
+end

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -30,39 +30,3 @@
   reference: GB-COH-RC000519
   type: 22
   service_owner: false
-- name: UK Research & Innovation
-  reference: GB
-  type: 90
-  service_owner: false
-- name: Biotechnology and Biological Sciences Research Council
-  reference: GB- -PB317
-  type: 0
-  service_owner: false
-- name: Medical Research Council
-  reference: GB- -PB132
-  type: 0
-  service_owner: false
-- name: Science and Technology Facilities Council
-  reference: GB- -PB135
-  type: 0
-  service_owner: false
-- name: Arts and Humanities Research Council
-  reference: GB- -PB123
-  type: 0
-  service_owner: false
-- name: Economic and Social Research Council
-  reference: GB- -PB129
-  type: 0
-  service_owner: false
-- name: Engineering and Physical Sciences Research Council
-  reference: GB- -PB130
-  type: 0
-  service_owner: false
-- name: Natural Environment Research Council
-  reference: GB- -PB133
-  type: 0
-  service_owner: false
-- name: Research England
-  reference: GB- -
-  type: 0
-  service_owner: false

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -1,0 +1,68 @@
+- name: Department for Business, Energy and Industrial Strategy
+  reference: GB-GOV-13
+  type: 10
+  service_owner: true
+- name: UK Space Agency
+  reference: GB-GOV-EA31
+  type: 10
+  service_owner: false
+- name: Met Office
+  reference: GB-GOV-EA46
+  type: 10
+  service_owner: false
+- name: British Council
+  reference: GB-GOV-OT313
+  type: 10
+  service_owner: false
+- name: Academy of Medical Sciences
+  reference: GB-COH-03520281
+  type: 22
+  service_owner: false
+- name: Royal Society
+  reference: GB-COH-RC000519
+  type: 22
+  service_owner: false
+- name: British Academy
+  reference: GB-COH-RC000053
+  type: 22
+  service_owner: false
+- name: Royal Academy of Engineering
+  reference: GB-COH-RC000519
+  type: 22
+  service_owner: false
+- name: UK Research & Innovation
+  reference: GB
+  type: 90
+  service_owner: false
+- name: Biotechnology and Biological Sciences Research Council
+  reference: GB- -PB317
+  type: 0
+  service_owner: false
+- name: Medical Research Council
+  reference: GB- -PB132
+  type: 0
+  service_owner: false
+- name: Science and Technology Facilities Council
+  reference: GB- -PB135
+  type: 0
+  service_owner: false
+- name: Arts and Humanities Research Council
+  reference: GB- -PB123
+  type: 0
+  service_owner: false
+- name: Economic and Social Research Council
+  reference: GB- -PB129
+  type: 0
+  service_owner: false
+- name: Engineering and Physical Sciences Research Council
+  reference: GB- -PB130
+  type: 0
+  service_owner: false
+- name: Natural Environment Research Council
+  reference: GB- -PB133
+  type: 0
+  service_owner: false
+- name: Research England
+  reference: GB- -
+  type: 0
+  service_owner: false

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,0 +1,9 @@
+user = User.find_or_create_by(
+  name: "Generic development user",
+  email: "roda@dxw.com",
+  identifier: "auth0|5dc53e4b85758e0e95b062f0",
+  role: :administrator
+)
+beis = Organisation.find_by(service_owner: true)
+user.organisation = beis
+user.save

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,9 +1,19 @@
-user = User.find_or_create_by(
-  name: "Generic development user",
+administrator = User.find_or_create_by(
+  name: "Administrator",
   email: "roda@dxw.com",
   identifier: "auth0|5dc53e4b85758e0e95b062f0",
   role: :administrator
 )
+delivery_partner = User.find_or_create_by(
+  name: "Delivery Partner",
+  email: "roda+dp@dxw.com",
+  identifier: "auth0|5e5e1ee731555a0cb0ab5a75",
+  role: :administrator
+)
 beis = Organisation.find_by(service_owner: true)
-user.organisation = beis
-user.save
+administrator.organisation = beis
+administrator.save
+
+other_organisation = Organisation.where(service_owner: false).first
+delivery_partner.organisation = other_organisation
+delivery_partner.save


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/pcdbxmEM/320-seed-the-database-with-known-delivery-partners-and-beis-itself

- Reorganise the seeds into individual files for organisation/users/activities
- Run the seeds in order (organisations first, as users & activities depend on them)
- Create the organisations from a YAML file
- Add a second generic delivery partner user (login details in the 1password vault as usual)

One deficiency here is that if we wish to update an organisation's IATI identifier in
the `organisations.yml` file we will have to drop all the organisations and re-seed them.
But I'm not sure of a better attribute to `find_or_create_by` than iati_reference?

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
