### PR TITLE
(287) BEIS users can mark other users (i.e. delivery partner users) as active or inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,4 @@
 - Actual start and end dates must not be in the future
 - Activity XML includes 'iati-identifier' which is includes the reporting organisation
 - Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme
+- BEIS users (administrators) can mark other users as active or inactive

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -5,7 +5,7 @@ class Auth0Controller < ApplicationController
     session[:userinfo] = request.env["omniauth.auth"]
 
     # Redirect to the URL you want after successful auth
-    if current_user.organisation
+    if current_user.active && current_user.organisation
       redirect_to organisation_path(current_user.organisation)
     else
       render "pages/errors/not_authorised",

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -17,6 +17,7 @@ class Staff::UsersController < Staff::BaseController
 
   def create
     @user = User.new(user_params)
+    @user.active = params[:user][:active]
     authorize @user
     @organisations = policy_scope(Organisation)
 
@@ -46,6 +47,7 @@ class Staff::UsersController < Staff::BaseController
     @organisations = policy_scope(Organisation)
 
     @user.assign_attributes(user_params)
+    @user.active = params[:user][:active]
 
     if @user.valid?
       result = UpdateUser.new(user: @user, organisation: organisation).call

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -25,4 +25,11 @@ module FormHelper
       Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.budget.status.#{name}")) }
     end
   end
+
+  def user_active_options
+    [
+      OpenStruct.new(id: "true", name: t("form.user.active.active")),
+      OpenStruct.new(id: "false", name: t("form.user.active.inactive")),
+    ]
+  end
 end

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -8,6 +8,8 @@
       %th.govuk-table__header
         = t("user.email")
       %th.govuk-table__header
+        = t("user.active.label")
+      %th.govuk-table__header
 
   %tbody.govuk-table__body
     - users.each do |user|
@@ -15,6 +17,7 @@
         %td.govuk-table__cell= user.name
         %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
+        %td.govuk-table__cell= t("user.active.#{user.active}")
         %td.govuk-table__cell
           = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")
           = a11y_action_link(I18n.t("generic.link.edit"), edit_user_path(user), user.name)

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -8,7 +8,7 @@
       %th.govuk-table__header
         = t("user.email")
       %th.govuk-table__header
-        = t("user.active.label")
+        = t("user.active")
       %th.govuk-table__header
 
   %tbody.govuk-table__body
@@ -17,7 +17,7 @@
         %td.govuk-table__cell= user.name
         %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
-        %td.govuk-table__cell= t("user.active.#{user.active}")
+        %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")
           = a11y_action_link(I18n.t("generic.link.edit"), edit_user_path(user), user.name)

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -22,4 +22,11 @@
         = t("page_content.users.new.no_organisations.cta")
         = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
 
+  = f.govuk_collection_radio_buttons :active,
+      user_active_options,
+      :id,
+      :name,
+      legend: { tag: :h2 , text: t("form.user.active.label")},
+      hint_text: t("form.user.active.hint")
+
   = f.govuk_submit t("form.user.submit")

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -36,3 +36,8 @@
             = t("user.identifier")
           %dd.govuk-summary-list__value
             = @user.identifier
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("user.active.label")
+          %dd.govuk-summary-list__value
+            = t("user.active.#{@user.active}")

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -38,6 +38,6 @@
             = @user.identifier
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            = t("user.active.label")
+            = t("user.active")
           %dd.govuk-summary-list__value
-            = t("user.active.#{@user.active}")
+            = t("form.user.active.#{@user.active}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,10 +106,12 @@ en:
         success: Transaction sucessfully updated
     user:
       active:
-        active: Active
-        hint: Is this user active or inactive? Inactive users cannot log in.
-        inactive: Inactive
-        label: Active?
+        active: Activate
+        'false': 'No'
+        hint: Is this user activated or deactivated? Deactivated users cannot log in.
+        inactive: Deactivate
+        label: Activate user
+        'true': 'Yes'
       create:
         failed: The service is experiencing issues creating new users and the team has been alerted to the problem.
         success: User successfully created
@@ -291,10 +293,7 @@ en:
     formats:
       default: "%Y-%m-%d"
   user:
-    active:
-      'false': Inactive
-      label: Active?
-      'true': Active
+    active: Active?
     email: Email address
     identifier: Auth0 identifier
     name: Full name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,11 @@ en:
       update:
         success: Transaction sucessfully updated
     user:
+      active:
+        active: Active
+        hint: Is this user active or inactive? Inactive users cannot log in.
+        inactive: Inactive
+        label: Active?
       create:
         failed: The service is experiencing issues creating new users and the team has been alerted to the problem.
         success: User successfully created
@@ -286,6 +291,10 @@ en:
     formats:
       default: "%Y-%m-%d"
   user:
+    active:
+      'false': Inactive
+      label: Active?
+      'true': Active
     email: Email address
     identifier: Auth0 identifier
     name: Full name

--- a/db/migrate/20200303120754_add_active_status_to_users.rb
+++ b/db/migrate/20200303120754_add_active_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveStatusToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_155754) do
+ActiveRecord::Schema.define(version: 2020_03_03_120754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_155754) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "role"
     t.uuid "organisation_id"
+    t.boolean "active", default: true
     t.index ["identifier"], name: "index_users_on_identifier"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["role"], name: "index_users_on_role"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     role { :administrator }
+    active { true }
 
     organisation
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     factory :delivery_partner_user do
       organisation factory: :delivery_partner_organisation
     end
+
+    factory :inactive_user do
+      active { false }
+    end
   end
 end

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -62,4 +62,33 @@ RSpec.feature "BEIS users can editing other users" do
 
     expect(user.reload.role).to eql("administrator")
   end
+
+  scenario "an active user can be deactivated" do
+    administrator_user = create(:beis_user)
+    authenticate!(user: administrator_user)
+
+    visit organisation_path(administrator_user.organisation)
+    click_on "Manage users"
+    find("tr", text: user.name).click_link("Edit")
+
+    choose I18n.t("form.user.active.inactive")
+    click_on I18n.t("generic.button.submit")
+
+    expect(user.reload.active).to be false
+  end
+
+  scenario "an inactive user can be reactivated" do
+    administrator_user = create(:beis_user)
+    user = create(:inactive_user)
+    authenticate!(user: administrator_user)
+
+    visit organisation_path(administrator_user.organisation)
+    click_on "Manage users"
+    find("tr", text: user.name).click_link("Edit")
+
+    choose I18n.t("form.user.active.active")
+    click_on I18n.t("generic.button.submit")
+
+    expect(user.reload.active).to be true
+  end
 end

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "BEIS users can can view other users" do
     authenticate!(user: user)
   end
 
-  scenario "a user can be viewed" do
+  scenario "an active user can be viewed" do
     another_user = create(:administrator)
 
     # Navigate from the landing page
@@ -26,6 +26,7 @@ RSpec.feature "BEIS users can can view other users" do
     expect(page).to have_content(I18n.t("page_title.users.index"))
     expect(page).to have_content(another_user.name)
     expect(page).to have_content(another_user.email)
+    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
 
     # Navigate to the individual user page
     within(".users") do
@@ -35,6 +36,24 @@ RSpec.feature "BEIS users can can view other users" do
     expect(page).to have_content(I18n.t("page_title.users.show"))
     expect(page).to have_content(another_user.name)
     expect(page).to have_content(another_user.email)
+  end
+
+  scenario "an inactive user can be viewed" do
+    another_user = create(:inactive_user)
+
+    # Navigate from the landing page
+    visit organisation_path(user.organisation)
+    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+
+    # The details include whether the user is active
+    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
+
+    # Navigate to the individual user page
+    within(".users") do
+      find("tr", text: another_user.name).click_link("Show")
+    end
+
+    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
   end
 
   scenario "can go back to the previous page" do

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "BEIS users can can view other users" do
     expect(page).to have_content(I18n.t("page_title.users.index"))
     expect(page).to have_content(another_user.name)
     expect(page).to have_content(another_user.email)
-    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
+    expect(page).to have_content(I18n.t("form.user.active.true"))
 
     # Navigate to the individual user page
     within(".users") do
@@ -46,14 +46,14 @@ RSpec.feature "BEIS users can can view other users" do
     click_on(I18n.t("page_content.dashboard.button.manage_users"))
 
     # The details include whether the user is active
-    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
+    expect(page).to have_content(I18n.t("form.user.active.false"))
 
     # Navigate to the individual user page
     within(".users") do
       find("tr", text: another_user.name).click_link("Show")
     end
 
-    expect(page).to have_content(I18n.t("user.active.#{another_user.active}"))
+    expect(page).to have_content(I18n.t("form.user.active.false"))
   end
 
   scenario "can go back to the previous page" do

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -100,4 +100,23 @@ RSpec.feature "Users can sign in with Auth0" do
       expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.prompt"))
     end
   end
+
+  context "when the user has been deactivated" do
+    scenario "the user cannot log in and sees an informative message" do
+      user = create(:delivery_partner_user, active: false, identifier: "deactivated-user")
+      mock_successful_authentication(
+        uid: "deactivated-user", name: user.name, email: user.email
+      )
+
+      visit dashboard_path
+
+      within ".app-header__user-links" do
+        expect(page).to have_content(I18n.t("generic.link.sign_in"))
+        click_on I18n.t("generic.link.sign_in")
+      end
+
+      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+      expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/L6bIzPW7/287-create-ability-to-make-a-user-eg-delivery-partner-inactive-in-the-application

BEIS users can mark other users as active or inactive. The GOVUK design system prefers yes/no type options to be presented as radio buttons as opposed to a single checkbox, for clarity (see https://govuk-form-builder.netlify.com/form-elements/checkboxes/#generating-a-single-checkbox )

An inactive user will still have an Auth0 account, they just cannot access the RODA service.

## Screenshots of UI changes

<img width="1052" alt="Screenshot 2020-03-03 at 14 57 39" src="https://user-images.githubusercontent.com/1089521/75787992-7ab24080-5d5f-11ea-86a6-f827ce1d32bb.png">

<img width="621" alt="Screenshot 2020-03-03 at 14 58 04" src="https://user-images.githubusercontent.com/1089521/75788007-7e45c780-5d5f-11ea-954d-6225bec1edb4.png">

<img width="993" alt="Screenshot 2020-03-03 at 14 58 24" src="https://user-images.githubusercontent.com/1089521/75788016-81d94e80-5d5f-11ea-921d-5e93655d6130.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
