### PR TITLE
Deploy to the PaaS from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
       terraform init terraform
       terraform fmt  -diff -check -recursive terraform
       terraform validate terraform
+      echo "==== linting our shell scripts ===="
+      bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
 deploy:
 - provider: heroku
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,11 @@ deploy:
   script: bash travis-docker-push.sh
   on:
     all_branches: true
+- provider: script
+  script: bash deploy-terraform.sh
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^(develop|master)$
 env:
   global:
     secure: mBNvcyOEhYVAbbUJL4sXvwU6RM9LgFLAaEq/B5VKhUSOSKWvcYYInk5qWOldMF79aE8mC7JsOi5D4AC6fvPEEU2aM9N5jcvoNyR5FEKg80ltgK8GE8NwrzqjD3shS2IhFtKdBN1PI/vDxAtIJqefQ8eSy2/FwdpN/aB06QDGjEy5ye2dh/A4YH5fAz1W9lncFI8zr7ZdPC5N7FG6DkNCVju9wfqwzyHCQabuJ3iKvq3dxBaRvJgrIi6I2QVHV9ieWARuI5CHgYQWwm2VPVW5vUhrZ3ZaefD5qJZ4Bp+NzlnDH7frCjuDpPrCiNI6wYrbOxj4LFVDAWl9dMYcZ9BY6DNQjeTtSt9qLCgG6csBsTf9RHR5THz3zreChEyf/+iJvBqyh9XdSNj/ZtEDFAM4z4LTsyQy7VlxyjLoO+oYOONzQP/y4EOmELJ7YPvB6bZmazJ2Rpix91svlBmaxtcx63W0aZa8yqqzJ5n6mPdIIBnMQOlNkofUSapaKJRceMcVqHk/5EqjUG7ETTf8eohrfLqrHP/S344NPNCDMHmTIoWd4QL7K9E0IeAinBUOa8RfN4A3SfXvouOPvfZGqCjmciAsQi2r024EqZ/c39xu1BQDLIm+LZ9ThMBimi2u7yZV7W4ijoY7DRae3mgzqGxnHxEmWhtDMWWnEujfR2BM4oY= # Coveralls READ_TOKEN

--- a/deploy-terraform.sh
+++ b/deploy-terraform.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# script to deploy terraform
+# exit on error or if a variable is unbound
+set -eu
+
+# create a tag from travis variables
+# this will be the docker tag that gets deployed
+TAG=$TRAVIS_BUILD-$TRAVIS_COMMIT
+
+# set env vars depending on which branch we are on
+# TF_VAR_variable_name gets passed to `terraform`
+# to set variables.
+# The variables starting PROD or STAGING should be exported
+# from your running environment
+
+if [ "$TRAVIS_BRANCH" = master ]
+then
+  echo "creating production env vars for terraform"
+  export TF_VAR_docker_image="$TAG"
+  export TF_VAR_environment="prod"
+  export TF_VAR_secret_key_base="$PROD_SECRET_KEY_BASE"
+  export TF_VAR_auth0_client_id="$PROD_AUTH0_CLIENT_ID"
+  export TF_VAR_auth0_client_secret="$PROD_AUTH0_CLIENT_SECRET"
+  export TF_VAR_auth0_domain="$PROD_AUTH0_DOMAIN"
+  export TF_VAR_notify_key="$PROD_NOTIFY_KEY"
+  export TF_VAR_notify_welcome_email_template="$PROD_NOTIFY_WELCOME_EMAIL_TEMPLATE"
+  export TF_VAR_rollbar_access_token="$ROLLBAR_ACCESS_TOKEN"
+  export TF_VAR_domain="$PROD_DOMAIN"
+  export TF_VAR_papertrail_destination="$PROD_PAPERTRAIL_DESTINATION"
+elif [ "$TRAVIS_BRANCH" = develop ]
+then
+  echo "creating staging env vars for terraform"
+  export TF_VAR_docker_image="$TAG"
+  export TF_VAR_environment="staging"
+  export TF_VAR_secret_key_base="$STAGING_SECRET_KEY_BASE"
+  export TF_VAR_auth0_client_id="$STAGING_AUTH0_CLIENT_ID"
+  export TF_VAR_auth0_client_secret="$STAGING_AUTH0_CLIENT_SECRET"
+  export TF_VAR_auth0_domain="$STAGING_AUTH0_DOMAIN"
+  export TF_VAR_notify_key="$STAGING_NOTIFY_KEY"
+  export TF_VAR_notify_welcome_email_template="$STAGING_NOTIFY_WELCOME_EMAIL_TEMPLATE"
+  export TF_VAR_rollbar_access_token="$ROLLBAR_ACCESS_TOKEN"
+  export TF_VAR_domain="$STAGING_DOMAIN"
+  export TF_VAR_papertrail_destination="$STAGING_PAPERTRAIL_DESTINATION"
+else
+  # we dont want to deploy anywhere else but staging or production
+  echo "Not Deploying: we only deploy to staging and production"
+  exit 0
+fi
+
+echo "deploying $TF_VAR_environment"
+
+cd terraform
+
+# deploy terraform using tfenv
+if [ ! -e ~/.tfenv ]
+then
+git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+fi
+export PATH="$HOME/.tfenv/bin:$PATH"
+tfenv install
+
+# install the cloudfoundry provider if it isnt already
+if [ ! -e ~/.terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry ]
+then
+bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
+fi
+
+# CF_PASSWORD, CF_USER, AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID
+# must be set for the following commands to run
+
+# initialise terraform
+terraform init
+
+# select the correct workspace
+terraform workspace select $TF_VAR_environment
+
+# apply the terraform
+terraform apply -auto-approve
+
+echo "$TF_VAR_environment has been deployed"


### PR DESCRIPTION
## Changes in this PR

Add a script to run terraform which will deploy the app to staging and production
The script will also set up a PaaS space to run the app.
This PR also adds linting of our shell scripts.

This PR relies on https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/233 being merged.

## Next steps

- [x] environment variables need adding to travis via the UI