### PR TITLE
Remove TRAVIS_BRANCH from docker tag

### DIFF
--- a/travis-docker-push.sh
+++ b/travis-docker-push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TAG="${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
+TAG="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker build -t "thedxw/beis-report-official-development-assistance:$TRAVIS_BRANCH" .
 docker tag "thedxw/beis-report-official-development-assistance:$TRAVIS_BRANCH" "thedxw/beis-report-official-development-assistance:$TAG"


### PR DESCRIPTION
## Changes in this PR

You can not have a '/' in a docker tag because it uses it to separate org
and repo

```
invalid argument "thedxw/beis-report-official-development-assistance:feature/287-create-ability-to-make-a-user-eg-delivery-partner-inactive-in-the-application" for "-t, --tag" flag: invalid reference format
```

We often use '/' in branch names which causes this error.

We are using this tag to make sure we have a unique tag for deployments
so TRAVIS_BUILD_NUMBER and TRAVIS_COMMIT will suffice.