### PR TITLE
Show the user's organisation name in the users#index page

### DIFF
--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -1,7 +1,7 @@
 class Staff::UsersController < Staff::BaseController
   def index
     authorize :user, :index?
-    @users = policy_scope(User).includes([:organisation])
+    @users = policy_scope(User).includes(:organisation).order("organisations.name")
   end
 
   def show

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -1,7 +1,7 @@
 class Staff::UsersController < Staff::BaseController
   def index
     authorize :user, :index?
-    @users = policy_scope(User)
+    @users = policy_scope(User).includes([:organisation])
   end
 
   def show

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -19,7 +19,7 @@
         %td.govuk-table__cell= user.name
         %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
-        %td.govuk-table__cell= user.organisation.name
+        %td.govuk-table__cell.organisation= user.organisation.name
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -8,6 +8,8 @@
       %th.govuk-table__header
         = t("user.email")
       %th.govuk-table__header
+        = t("user.organisation")
+      %th.govuk-table__header
         = t("user.active")
       %th.govuk-table__header
 
@@ -17,6 +19,7 @@
         %td.govuk-table__cell= user.name
         %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
+        %td.govuk-table__cell= user.organisation.name
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "BEIS users can can view other users" do
     expect(page).to have_content(I18n.t("page_title.users.index"))
     expect(page).to have_content(another_user.name)
     expect(page).to have_content(another_user.email)
+    expect(page).to have_content(another_user.organisation.name)
     expect(page).to have_content(I18n.t("form.user.active.true"))
 
     # Navigate to the individual user page

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -39,6 +39,30 @@ RSpec.feature "BEIS users can can view other users" do
     expect(page).to have_content(another_user.email)
   end
 
+  scenario "users are grouped by their organisation name in alphabetical order" do
+    a_organisation = create(:organisation, name: "A Organisation")
+    b_organisation = create(:organisation, name: "B Organisation")
+
+    a1_user = create(:administrator, organisation: a_organisation)
+    a2_user = create(:administrator, organisation: a_organisation)
+    b1_user = create(:administrator, organisation: b_organisation)
+    b2_user = create(:administrator, organisation: b_organisation)
+
+    # Navigate from the landing page
+    visit organisation_path(user.organisation)
+    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+
+    expected_array = [
+      a1_user.organisation.name,
+      a2_user.organisation.name,
+      b1_user.organisation.name,
+      b2_user.organisation.name,
+      user.organisation.name,
+    ].sort
+
+    expect(page.all("td.organisation").collect(&:text)).to match_array(expected_array)
+  end
+
   scenario "an inactive user can be viewed" do
     another_user = create(:inactive_user)
 


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/nD7e6PG9/415-add-organisation-name-to-the-user-list

Show the user's organisation name in the user list. Group the users by their organisation name.

## Screenshots of UI changes

<img width="1109" alt="Screenshot 2020-03-05 at 13 42 18" src="https://user-images.githubusercontent.com/1089521/75987059-276afa00-5ee7-11ea-883e-1ebae3081486.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
