### PR TITLE
(417) Allow BEIS users to download projects as XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@
 - Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme
 - BEIS users (administrators) can mark other users as active or inactive
 - Budget start and end dates are validated according to IATI standard
+- BEIS users can view projects (read-only) and download them as XML via a button

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -22,8 +22,9 @@ class Staff::ActivitiesController < Staff::BaseController
         @budget_presenters = @budgets.map { |budget| BudgetPresenter.new(budget) }
         @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
       end
-      format.xml do |format|
+      format.xml do |_format|
         @activity_xml_presenter = ActivityXmlPresenter.new(@activity)
+        response.headers["Content-Disposition"] = "attachment; filename=\"#{@activity_xml_presenter.iati_identifier}.xml\""
       end
     end
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -19,6 +19,10 @@ class ProjectPolicy < ApplicationPolicy
     false
   end
 
+  def download?
+    beis_user?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -30,3 +30,5 @@
 
   - if @activity.project?
     = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
+    - if policy(:project).download?
+      = link_to t("generic.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -21,7 +21,7 @@
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 
-  - if @activity.programme? && policy(:project).create?
+  - if @activity.programme?
     = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
 
   - if @activity.project? && policy(:project).create?

--- a/app/views/staff/shared/activities/_projects.html.haml
+++ b/app/views/staff/shared/activities/_projects.html.haml
@@ -2,6 +2,6 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.projects")
-
-    = button_to t("page_content.organisation.button.create_project"), organisation_fund_programme_projects_path(current_user.organisation, activity.parent_activity, activity), class: "govuk-button"
+    - if policy(:project).create?
+      = button_to t("page_content.organisation.button.create_project"), organisation_fund_programme_projects_path(current_user.organisation, activity.parent_activity, activity), class: "govuk-button"
     = render partial: '/staff/shared/projects/table', locals: { projects: activities }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
         success: User successfully updated
   generic:
     button:
+      download_as_xml: Download as XML
       menu: Menu
       submit: Submit
     link:

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -33,4 +33,31 @@ RSpec.feature "Users can view a project" do
       end
     end
   end
+
+  context "when the user belongs to BEIS" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    scenario "can view a project but not create one" do
+      project = create(:project_activity)
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content project.title
+      expect(page).to_not have_content I18n.t("page_content.organisation.button.create_project")
+    end
+
+    scenario "can download a project as XML" do
+      fund = create(:fund_activity)
+      programme = create(:programme_activity)
+      fund.activities << programme
+      project = create(:project_activity, organisation: user.organisation)
+      programme.activities << project
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content project.title
+      expect(page).to_not have_content I18n.t("page_content.organisation.button.create_project")
+    end
+  end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to permit_action(:download) }
 
     it "includes activity in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.all).resolve
@@ -29,6 +30,7 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to permit_new_and_create_actions }
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to forbid_action(:download) }
 
     it "includes activity in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.all).resolve


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/AEowjwGK/417-add-a-button-to-make-it-easier-for-beis-users-ie-dan-sparks-to-export-xml-data-on-a-per-project-basis

Allow BEIS users to download a project activity XML via the click of a button.

Because previously BEIS users were not able to view projects, we have allowed them to access projects on a read-only basis (they can view but not create/update them). BEIS users can navigate to the project page and click "Download as XML" to download the IATI XML for the project.

Non-BEIS users cannot see the "Download as XML" button.

## Screenshots of UI changes

<img width="1011" alt="Screenshot 2020-03-05 at 15 46 31" src="https://user-images.githubusercontent.com/1089521/75998348-9866dd80-5ef8-11ea-9ff1-2a217bd00f90.png">



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
