### PR TITLE
(286) Show actual Auth0 error when user creation fails

### DIFF
--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -27,7 +27,7 @@ class Staff::UsersController < Staff::BaseController
         flash.now[:notice] = I18n.t("form.user.create.success")
         redirect_to user_path(@user.reload.id)
       else
-        flash.now[:error] = I18n.t("form.user.create.failed")
+        flash.now[:error] = I18n.t("form.user.create.failed", error: result.error_message)
         render :new
       end
     else

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,4 +1,4 @@
-Result = Struct.new(:success, :object) {
+Result = Struct.new(:success, :object, :error_message) {
   def success?
     success == true
   end

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -16,12 +16,22 @@ class CreateUser
         CreateUserInAuth0.new(user: user).call
       rescue Auth0::Exception => e
         result.success = false
-        Rails.logger.error("Error adding user #{user.email} to Auth0 during CreateUser with #{e.message}.")
+        result.error_message = extract_auth0_error_message(e)
+        Rails.logger.error("Error adding user #{user.email} to Auth0 during CreateUser with: #{result.error_message}")
         raise ActiveRecord::Rollback
       end
     end
 
     SendWelcomeEmail.new(user: user).call if user.persisted?
     result
+  end
+
+  private def extract_auth0_error_message(result)
+    begin
+      message = JSON.parse(result.message)["message"]
+    rescue JSON::ParserError
+      message = I18n.t("generic.error.unknown")
+    end
+    message
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,7 @@ en:
         label: Activate user
         'true': 'Yes'
       create:
-        failed: The service is experiencing issues creating new users and the team has been alerted to the problem.
+        failed: 'The service failed to create the new user. The error received was: %{error}'
         success: User successfully created
       organisation:
         hint: What organisation does this user belong to?
@@ -129,6 +129,8 @@ en:
       download_as_xml: Download as XML
       menu: Menu
       submit: Submit
+    error:
+      unknown: Unknown error
     link:
       add: Add
       back: Back

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
             click_button I18n.t("generic.button.submit")
           }.not_to change { User.count }
 
-          expect(page).to have_content(I18n.t("form.user.create.failed"))
+          expect(page).to have_content(I18n.t("form.user.create.failed", error: "The user already exists."))
         end
       end
 

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -10,10 +10,10 @@ module Auth0Helpers
       .to_return(status: 200, body: "{\"user_id\":\"#{auth0_identifier}\"}")
   end
 
-  def stub_auth0_create_user_request_failure(email:)
+  def stub_auth0_create_user_request_failure(email:, body: "{\"message\":\"The user already exists.\"}")
     stub_request(:post, "https://testdomain/api/v2/users")
       .with(body: hash_including(email: email))
-      .to_return(status: 500, body: "")
+      .to_return(status: 500, body: body)
   end
 
   def stub_auth0_post_password_change(auth0_identifier: anything)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/falHEEs2/286-address-bug-when-email-address-has-already-been-used-to-create-a-user-in-auth0

Previously, we were showing a generic error message when user creation failed in
Auth0. Now, we will attempt to parse the error message received from Auth0 and
show it to the user. If the error message is unparseable, a generic error will
be shown.

## Screenshots of UI changes

<img width="1141" alt="Screenshot 2020-03-06 at 11 43 06" src="https://user-images.githubusercontent.com/1089521/76080836-b6d3e400-5f9f-11ea-9182-a1c110b7aa19.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
