### PR TITLE
(297) Choosing a Sector for an Activity presents the user with duplicate options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,4 @@
 - BEIS users (administrators) can mark other users as active or inactive
 - Budget start and end dates are validated according to IATI standard
 - BEIS users can view projects (read-only) and download them as XML via a button
+- Codelist dropdowns do not contain values which have been marked as "status: withdrawn" by IATI

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -5,7 +5,11 @@ module CodelistHelper
     data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
 
-    objects = data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"]) }.sort_by(&:name)
+    objects = data.collect { |item|
+      next if item["status"] == "withdrawn"
+      OpenStruct.new(name: item["name"], code: item["code"])
+    }.compact.sort_by(&:name)
+
     if with_empty_item
       empty_item = OpenStruct.new(name: "", code: "")
       objects.unshift(empty_item)

--- a/spec/fixtures/codelist_with_withdrawn_items.yml
+++ b/spec/fixtures/codelist_with_withdrawn_items.yml
@@ -1,0 +1,22 @@
+---
+data:
+  - code: '11111'
+    category: '151'
+    name: Withdrawn code 1
+    description: Some fake data for a withdrawn code
+    status: withdrawn
+  - code: '22222'
+    category: '151'
+    name: Withdrawn code 2
+    description: Some fake data for a withdrawn code
+    status: withdrawn
+  - code: '33333'
+    category: '151'
+    name: Withdrawn code 3
+    description: Some fake data for a withdrawn code
+    status: withdrawn
+  - code: '44444'
+    category: '151'
+    name: Active code
+    description: Some fake data for an active code
+    status: active

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe CodelistHelper, type: :helper do
           expect(list.first.name).to eq("Active code")
         end
       end
+
+      it "does not add any duplicate-named items to the list" do
+        list = helper.yaml_to_objects(
+          entity: "activity",
+          type: "sector",
+          with_empty_item: false
+        )
+        grouped_by_name = list.group_by { |item| item["name"] }
+        duplicate_groups = grouped_by_name.values.select { |a| a.size > 1 }.flatten
+        expect(duplicate_groups.count).to eql(0)
+      end
     end
 
     describe "#currency_select_options" do

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe CodelistHelper, type: :helper do
           with_empty_item: false
         ).last).to eq(OpenStruct.new(name: "Zloty", code: "PLN"))
       end
+
+      context "when there are three 'withdrawn' items and one 'active' item" do
+        let(:fake_yaml) { YAML.safe_load(File.read("#{Rails.root}/spec/fixtures/codelist_with_withdrawn_items.yml")) }
+        before do
+          allow(helper).to receive(:load_yaml).and_return(fake_yaml["data"])
+        end
+
+        it "only adds the 'active' item to the final list" do
+          list = helper.yaml_to_objects(
+            entity: "activity",
+            type: "sector",
+            with_empty_item: false
+          )
+
+          expect(list.count).to eq(1)
+          expect(list.first.name).to eq("Active code")
+        end
+      end
     end
 
     describe "#currency_select_options" do

--- a/vendor/data/codelists/IATI/2_03/activity/sector.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/sector.yml
@@ -1858,7 +1858,7 @@ data:
     status: active
   - code: '43040'
     category: '430'
-    name: Rural development
+    name: Rural development (planning)
     description: Integrated rural development projects; e.g. regional development planning;
       promotion of decentralised and multi-sectoral competence for planning, co-ordination
       and management; implementation of regional development and measures (including


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/ozGnGd0z/297-choosing-a-sector-for-an-activity-presents-the-user-with-duplicate-options

When creating an activity, we noticed that some of the Sector options were duplicated.

It soon became apparent that some of the codelist items from IATI are marked as "status: withdrawn". IATI marks items as withdrawn to indicate they are deprecated: https://support.iatistandard.org/hc/en-us/articles/214390846-Add-a-withdrawn-flag-to-code-names-to-indicate-deprecation

First, we amended the CodelistHelper to only put codelist items into the dropdowns if they are not marked as withdrawn. 

However, we still had two duplicates - two entries for "Rural development" which were marked as "status: active". Following discussion with the service owner, we decided to amend one of the names on the codelist until IATI can advice us further. This means we no longer have any duplicates in the dropdown list for sector. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
