### PR TITLE
Chore/add google analytic environment vars to gpaas

### DIFF
--- a/deploy-terraform.sh
+++ b/deploy-terraform.sh
@@ -27,6 +27,9 @@ then
   export TF_VAR_rollbar_access_token="$ROLLBAR_ACCESS_TOKEN"
   export TF_VAR_domain="$PROD_DOMAIN"
   export TF_VAR_papertrail_destination="$PROD_PAPERTRAIL_DESTINATION"
+  export TF_VAR_google_tag_manager_container_id="$PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID"
+  export TF_VAR_google_tag_manager_environment_auth="$PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH"
+  export TF_VAR_google_tag_manager_environment_preview="$PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW"
 elif [ "$TRAVIS_BRANCH" = develop ]
 then
   echo "creating staging env vars for terraform"
@@ -41,6 +44,9 @@ then
   export TF_VAR_rollbar_access_token="$ROLLBAR_ACCESS_TOKEN"
   export TF_VAR_domain="$STAGING_DOMAIN"
   export TF_VAR_papertrail_destination="$STAGING_PAPERTRAIL_DESTINATION"
+  export TF_VAR_google_tag_manager_container_id="$STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID"
+  export TF_VAR_google_tag_manager_environment_auth="$STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH"
+  export TF_VAR_google_tag_manager_environment_preview="$STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW"
 else
   # we dont want to deploy anywhere else but staging or production
   echo "Not Deploying: we only deploy to staging and production"

--- a/doc/manage-environment-variables.md
+++ b/doc/manage-environment-variables.md
@@ -1,0 +1,38 @@
+# Manage environment variables
+
+Environment variables are passed to live environments through Terraform by either Travis or a manual deployment.
+
+## Adding a new environment variable
+
+1. Introduce the new variable to Terraform by adding to `terraform/variables.tf`:
+    ```
+    variable "google_tag_manager_environment_preview" {
+      type = string
+      description = "Google Tag Manager preview identifier"
+    }
+    ```
+1. Inject the new variables to the app and/or worker (if in doubt add to both):
+    ```
+    resource "cloudfoundry_app" "beis-roda-app" {
+      environment = {
+        …
+        "GOOGLE_TAG_MANAGER_CONTAINER_ID" = var.google_tag_manager_container_id
+        …
+    ```
+1. Reference the new variable in our `deploy-terraform.sh` script in **2 places**, one for each environment. Changing the prefix to match the environment name that the variable should be applied to:
+    ```
+    if [ "$TRAVIS_BRANCH" = master ]
+      export TF_VAR_google_tag_manager_environment_preview="$PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW"
+    if [ "$TRAVIS_BRANCH" = develop ]
+      export TF_VAR_google_tag_manager_environment_preview="$STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW"
+    ```
+1. Add 2 new environment variables to Travis matching those names from the previous step. [Travis settings can be managed here.](https://travis-ci.org/UKGovernmentBEIS/beis-report-official-development-assistance/settings)
+1. Once all steps are complete and merged, the next time Travis deploys either staging and production those environment variables will be made available to the app
+1. Add those variables to our environment file in the RODA 1Password vault as they cannot be read back out of Travis
+
+## Deploying changes to environment variables
+
+There are currently 2 mechanisms available:
+
+1. Automated deployments through Travis
+1. Manual deployments made locally where the environment variables are provided from a local `.tfvars` file. See [the Terraform README](/terraform/README.md#Manual-Deployment) for more information.

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -12,18 +12,21 @@ resource "cloudfoundry_app" "beis-roda-app" {
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-postgres.id }
   service_binding { service_instance = cloudfoundry_user_provided_service.papertrail.id }
   environment = {
-    "RAILS_LOG_TO_STDOUT"           = "true"
-    "RAILS_SERVE_STATIC_FILES"      = "enabled"
-    "RAILS_ENV"                     = "production"
-    "SECRET_KEY_BASE"               = var.secret_key_base
-    "DOMAIN"                        = var.domain
-    "AUTH0_CLIENT_ID"               = var.auth0_client_id
-    "AUTH0_CLIENT_SECRET"           = var.auth0_client_secret
-    "AUTH0_DOMAIN"                  = var.auth0_domain
-    "NOTIFY_KEY"                    = var.notify_key
-    "NOTIFY_WELCOME_EMAIL_TEMPLATE" = var.notify_welcome_email_template
-    "ROLLBAR_ENV"                   = "paas-${var.environment}"
-    "ROLLBAR_ACCESS_TOKEN"          = var.rollbar_access_token
+    "RAILS_LOG_TO_STDOUT"                    = "true"
+    "RAILS_SERVE_STATIC_FILES"               = "enabled"
+    "RAILS_ENV"                              = "production"
+    "SECRET_KEY_BASE"                        = var.secret_key_base
+    "DOMAIN"                                 = var.domain
+    "AUTH0_CLIENT_ID"                        = var.auth0_client_id
+    "AUTH0_CLIENT_SECRET"                    = var.auth0_client_secret
+    "AUTH0_DOMAIN"                           = var.auth0_domain
+    "NOTIFY_KEY"                             = var.notify_key
+    "NOTIFY_WELCOME_EMAIL_TEMPLATE"          = var.notify_welcome_email_template
+    "ROLLBAR_ENV"                            = "paas-${var.environment}"
+    "ROLLBAR_ACCESS_TOKEN"                   = var.rollbar_access_token
+    "GOOGLE_TAG_MANAGER_CONTAINER_ID"        = var.google_tag_manager_container_id
+    "GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH"    = var.google_tag_manager_environment_auth
+    "GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW" = var.google_tag_manager_environment_preview
   }
   # routes need to be declared with the app for blue green deployments to work
   routes { route = cloudfoundry_route.beis-roda-route.id }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,3 +52,18 @@ variable "domain" {
   type        = string
   description = "Domain used in email links"
 }
+
+variable "google_tag_manager_container_id" {
+  type        = string
+  description = "Google Tag Manager container identifier"
+}
+
+variable "google_tag_manager_environment_auth" {
+  type        = string
+  description = "Google Tag Manager authentication variable"
+}
+
+variable "google_tag_manager_environment_preview" {
+  type        = string
+  description = "Google Tag Manager preview identifier"
+}


### PR DESCRIPTION
## Changes in this PR

I noticed that Google analytic variables hadn't been added in the migration to GPaaS so this change re-adds support for them in our new environments.

As it's the first time I'm doing this I've documented the steps I've taken.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [x] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
