### PR TITLE
CI runs don't error when a database already exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ jobs:
         -e CI=true \
         --env-file .env.example \
         app/test /bin/bash -c "tail -f /dev/null"
-      docker exec test-container rake db:setup
       docker exec test-container rake
       docker exec test-container bundle exec brakeman
       echo "==== testing terrafrom ===="


### PR DESCRIPTION
## Changes in this PR

Remove CI error caused by running `rake db:setup` when a database already exists. Whilst it doesn't seem to exit the testing process it does produce noise so when something does go wrong we see this error and aren't confident what's related and what's not.

It seems that the docker-entrypoint was already running prepare and these 2 invocations of the same command were treading on each others toes!

## Screenshots of UI changes

### Before

![Screenshot 2020-03-06 at 16 17 40](https://user-images.githubusercontent.com/912473/76101405-4a201000-5fc6-11ea-82f6-829417e6adbd.png)

### After

![Screenshot 2020-03-06 at 16 52 10](https://user-images.githubusercontent.com/912473/76104227-e2b88f00-5fca-11ea-9289-260033decd46.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
