### PR TITLE
Stop running the test script when a command errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
     env:
     - RAILS_ENV=test
     script: |
+      set -eu
       docker network create test
       docker run -d --name pg --network test -p 5432:5432 postgres:11.6
       docker run -d \
@@ -39,6 +40,7 @@ jobs:
       terraform validate terraform
       echo "==== linting our shell scripts ===="
       bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
+      set +eu
 deploy:
 - provider: heroku
   api_key:


### PR DESCRIPTION
## Changes in this PR

Using `set -e` at the top of the script ensures that if one of the
following commands errors the script will stop and return an exit code
of not zero which will let CI know that something has failed.

Otherwise a command will fail during the script but Travis thinks
everything is green.

Also set `u` so if a variable is unbound it will also error out.