### PR TITLE
(296) Date fields accept 0

### DIFF
--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -30,9 +30,14 @@ class Staff::ActivityFormsController < Staff::BaseController
     @activity = Activity.find(params[:activity_id])
     authorize @activity
 
-    @activity.assign_attributes(activity_params)
-    update_wizard_status
+    begin
+      @activity.assign_attributes(activity_params)
+    rescue ActiveRecord::MultiparameterAssignmentErrors
+      flash[:error] = I18n.t("activerecord.errors.models.activity.attributes.generic_date.invalid")
+      return render_wizard
+    end
 
+    update_wizard_status
     render_wizard @activity
   end
 

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -1,6 +1,5 @@
 class Staff::ActivityFormsController < Staff::BaseController
   include Wicked::Wizard
-  include DateHelper
   include ActivityHelper
 
   FORM_STEPS = [

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -1,6 +1,5 @@
 class Staff::BudgetsController < Staff::BaseController
   include Secured
-  include DateHelper
 
   def new
     @activity = Activity.find(activity_id)

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -2,7 +2,6 @@
 
 class Staff::TransactionsController < Staff::BaseController
   include Secured
-  include DateHelper
 
   def new
     @activity = Activity.find(activity_id)

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -63,6 +63,8 @@ en:
             actual_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Actual start date must not be in the future
+            generic_date:
+              invalid: One or more of the entered dates is invalid
             planned_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
             planned_start_date:

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -119,9 +119,20 @@ RSpec.feature "Users can create a fund level activity" do
 
         expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
 
+        # Don't provide dates
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content "Planned start date can't be blank"
         expect(page).to have_content "Planned end date can't be blank"
+
+        # Dates cannot contain 0
+        fill_in "activity[planned_start_date(3i)]", with: 1
+        fill_in "activity[planned_start_date(2i)]", with: 0
+        fill_in "activity[planned_start_date(1i)]", with: 2010
+        fill_in "activity[planned_end_date(3i)]", with: 0
+        fill_in "activity[planned_end_date(2i)]", with: 12
+        fill_in "activity[planned_end_date(1i)]", with: 2010
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "One or more of the entered dates is invalid"
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature "Users can create a fund level activity" do
         expect(page).to have_content "Planned start date can't be blank"
         expect(page).to have_content "Planned end date can't be blank"
 
-        # Dates cannot contain 0
+        # Dates cannot contain only a zero
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 0
         fill_in "activity[planned_start_date(1i)]", with: 2010
@@ -132,7 +132,8 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[planned_end_date(2i)]", with: 12
         fill_in "activity[planned_end_date(1i)]", with: 2010
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "One or more of the entered dates is invalid"
+        expect(page).to have_content "Planned start date can't be blank"
+        expect(page).to have_content "Planned end date can't be blank"
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -21,5 +21,10 @@ RSpec.describe DateHelper, type: :helper do
       params = {day: "40", month: "13", year: "2020"}
       expect(helper.format_date(params)).to eq(nil)
     end
+
+    it "returns nil when given a zero parameter" do
+      params = {day: "40", month: "0", year: "2020"}
+      expect(helper.format_date(params)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/c9DkwHY9/296-bug-dates-accept-0

We noticed Papertrail recording `ActiveRecord::MultiparameterAssignmentErrors` when a user input `0` into any of the three inputs on any date field (generated via `govuk_date_field`)

Rails will attempt to coerce any values from a `date_field` view helper into a date. If any of those values are 0, the coercion will fail with `ActiveRecord::MultiparameterAssignmentErrors`

Unfortunately, because this coercion happens *before* the values are assigned to the model, we cannot catch them with a validator on the model and return errors on the attributes in question.

Taking a cue from https://thoughtbot.com/blog/ruby-on-fails we are catching the 
`ActiveRecord::MultiparameterAssignmentErrors` in `ActivityFormsController` and adding a generic flash error message to let the user know one or more of the entered dates was not valid. This is less than ideal but better than what we had before. 

## Screenshots of UI changes

<img width="1103" alt="Screenshot 2020-03-10 at 10 25 47" src="https://user-images.githubusercontent.com/1089521/76303931-679cf480-62ba-11ea-8fe2-382fbd3e9584.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
