### PR TITLE
Purpose of activity is now dynamic

### DIFF
--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
-  %h1.govuk-heading-xl= @page_title
+  %h1.govuk-heading-xl= t("page_title.activity_form.show.purpose_level", level: f.object.level)
 
   = f.govuk_text_field :title
   = f.govuk_text_area :description, rows: 5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,7 +267,8 @@ en:
         finance: Finance
         flow: Flow
         identifier: Your unique identifier
-        purpose: Purpose of activity
+        purpose: Purpose
+        purpose_level: Purpose of %{level}
         region: Recipient region
         sector: Sector
         status: Status

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can create a fund level activity" do
       visit organisation_path(user.organisation)
       click_on(I18n.t("page_content.organisation.button.create_fund"))
 
-      fill_in_activity_form
+      fill_in_activity_form(level: "fund")
 
       expect(page).to have_content I18n.t("form.fund.create.success")
     end
@@ -88,7 +88,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[identifier]", with: "foo"
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
+        expect(page).to have_content "Purpose of fund"
 
         # Don't provide a title and description
         click_button I18n.t("form.activity.submit")

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can create a programme activity" do
       click_on fund.title
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
-      fill_in_activity_form
+      fill_in_activity_form(level: "programme")
 
       expect(page).to have_content I18n.t("form.programme.create.success")
     end
@@ -26,7 +26,7 @@ RSpec.feature "Users can create a programme activity" do
       click_on fund.title
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
-      fill_in_activity_form(identifier: identifier)
+      fill_in_activity_form(identifier: identifier, level: "programme")
 
       activity = Activity.find_by(identifier: identifier)
       expect(activity.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
@@ -42,7 +42,7 @@ RSpec.feature "Users can create a programme activity" do
       click_on fund.title
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
-      fill_in_activity_form(identifier: identifier)
+      fill_in_activity_form(identifier: identifier, level: "programme")
 
       activity = Activity.find_by(identifier: identifier)
       expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can create a project" do
 
         click_on(I18n.t("page_content.organisation.button.create_project"))
 
-        fill_in_activity_form
+        fill_in_activity_form(level: "project")
 
         expect(page).to have_content I18n.t("form.project.create.success")
         expect(programme.activities.count).to eq 1

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -21,7 +21,8 @@ module FormHelpers
     flow: "ODA",
     finance: "Standard grant",
     aid_type: "General budget support",
-    tied_status: "Untied"
+    tied_status: "Untied",
+    level: "fund"
   )
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.identifier")
@@ -29,7 +30,7 @@ module FormHelpers
     fill_in "activity[identifier]", with: identifier
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose")
+    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose_level", level: level)
     expect(page).to have_content I18n.t("activerecord.attributes.activity.title")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.description")
     fill_in "activity[title]", with: title


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/OWw5dOUE

Addressing the feedback from user research, during the creation of an activity the form step for 'Purpose' needed to be dynamically populated with the level of the activity. That would work as a reminder for users that what they are creating is either a fund, a programme or a project.

In order to achieve this, I have added that activity level to the yaml file so it could be displayed in the view for the purpose step. After doing that and checking all the tests were passing and the view on the browser was actually what I wanted to be, I realised that the page title on the browser tab was displaying
`Purpose of %{level}` (see image attached at the bottom of this section) instead of being dynamically populated. I believe this page title comes from a meta tag that it is common to the entire application. I think changing this meta tag would be too disruptive and complicated for this small tweak, so I decided that the best option would be to create another entry on the yaml file for `page_title.activity_form.show.purpose_level` where I could specify the level of the activity and pass that to the view and the tests. This allows me to leave `page_title.activity_form.show.purpose` as only 'Purpose' so the browser tab will not display a literal interpolation anymore. I am aware this is only _a_ way of doing it but not necessarily the right way, so suggestions on this will be appreciated.

<img width="1239" alt="Screenshot 2020-03-09 at 17 42 38" src="https://user-images.githubusercontent.com/48016017/76306707-53a7c180-62bf-11ea-9052-1d2d7c0fe402.png">


## Screenshots of UI changes

### Before

<img width="1197" alt="Screenshot 2020-03-10 at 10 54 14" src="https://user-images.githubusercontent.com/48016017/76306490-e4ca6880-62be-11ea-8caa-1ca24a271201.png">

### After

<img width="1197" alt="Screenshot 2020-03-10 at 10 16 39" src="https://user-images.githubusercontent.com/48016017/76306529-f3b11b00-62be-11ea-99e5-544f5efdbd37.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
