### PR TITLE
Fix/ci stops failing to download cloudfoundary plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 language: minimal
 services:
 - docker
@@ -10,7 +11,16 @@ jobs:
     env:
     - RAILS_ENV=test
     script: |
-      set -eu
+      set -e
+      echo "==== testing terrafrom ===="
+      git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+      export PATH="$HOME/.tfenv/bin:$PATH"
+      tfenv install
+      /bin/bash install-terraform-provider-for-cf.sh
+      terraform init terraform
+      terraform fmt  -diff -check -recursive terraform
+      terraform validate terraform
+      echo "==== linting our shell scripts ===="
       docker network create test
       docker run -d --name pg --network test -p 5432:5432 postgres:11.6
       docker run -d \
@@ -30,15 +40,6 @@ jobs:
         app/test /bin/bash -c "tail -f /dev/null"
       docker exec test-container rake
       docker exec test-container bundle exec brakeman
-      echo "==== testing terrafrom ===="
-      git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-      export PATH="$HOME/.tfenv/bin:$PATH"
-      tfenv install
-      bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
-      terraform init terraform
-      terraform fmt  -diff -check -recursive terraform
-      terraform validate terraform
-      echo "==== linting our shell scripts ===="
       bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
       set +eu
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,18 +42,6 @@ jobs:
       bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
       set +eu
 deploy:
-- provider: heroku
-  api_key:
-    secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
-  on:
-    branch: develop
-  app: beis-roda-staging
-- provider: heroku
-  api_key:
-    secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
-  on:
-    branch: master
-  app: beis-roda-production
 - provider: script
   script: bash travis-docker-push.sh
   on:

--- a/deploy-terraform.sh
+++ b/deploy-terraform.sh
@@ -59,11 +59,7 @@ fi
 export PATH="$HOME/.tfenv/bin:$PATH"
 tfenv install
 
-# install the cloudfoundry provider if it isnt already
-if [ ! -e ~/.terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry ]
-then
-bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
-fi
+/bin/bash install-terraform-provider-for-cf.sh
 
 # CF_PASSWORD, CF_USER, AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID
 # must be set for the following commands to run

--- a/install-terraform-provider-for-cf.sh
+++ b/install-terraform-provider-for-cf.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# script to install the Terraform plugin for CloudFoundry
+# https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#manually
+set -e
+
+# install the cloudfoundry provider if it isnt already
+if [ ! -e ~/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry ]
+then
+  echo "installing Cloudfoundry Terraform plugin"
+
+  echo "1"
+  mkdir -p ~/.terraform.d/plugins/linux_amd64
+  echo "2"
+  chmod +x ~/.terraform.d/plugins/linux_amd64
+  echo "3"
+  curl -O https://github.com/cloudfoundry-community/terraform-provider-cf/releases/download/v0.11.0/terraform-provider-cloudfoundry_linux_amd64 \
+    -o ~/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  echo "4"
+  chmod +x ~/.terraform.d/plugins/linux_amd64
+  echo "5"
+
+
+  echo "finished downloading Cloudfoundry Terraform plugin"
+fi


### PR DESCRIPTION
## Changes in this PR

- stop deploying to Heroku as we no longer have Heroku environments and their output in Travis was misleading the debugging
- install CF Terraform plugin manually instead of automatically, following the CF documentation https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#manually

This change is not fully testable on a local environment since Travis will be the one to download this package and subsequent Terraform commands on real environments. We could spin up a new environment to test this if we're concerned enough to take the time.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
