### PR TITLE
Disable rollbar through a new environment variable

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -9,6 +9,10 @@ Rollbar.configure do |config|
     config.enabled = false
   end
 
+  if ENV.fetch("ROLLBAR_DISABLED", nil).eql?("true")
+    config.enabled = false
+  end
+
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`
   # method to fetch this property. To customize:

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -24,6 +24,7 @@ resource "cloudfoundry_app" "beis-roda-app" {
     "NOTIFY_WELCOME_EMAIL_TEMPLATE"          = var.notify_welcome_email_template
     "ROLLBAR_ENV"                            = "paas-${var.environment}"
     "ROLLBAR_ACCESS_TOKEN"                   = var.rollbar_access_token
+    "ROLLBAR_DISABLED"                       = var.rollbar_disabled
     "GOOGLE_TAG_MANAGER_CONTAINER_ID"        = var.google_tag_manager_container_id
     "GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH"    = var.google_tag_manager_environment_auth
     "GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW" = var.google_tag_manager_environment_preview

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -67,3 +67,9 @@ variable "google_tag_manager_environment_preview" {
   type        = string
   description = "Google Tag Manager preview identifier"
 }
+
+variable "rollbar_disabled" {
+  type        = string
+  description = "Flag to turn off rollbar reporting"
+  default     = "false"
+}

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -25,5 +25,6 @@ resource "cloudfoundry_app" "beis-roda-worker" {
     "NOTIFY_WELCOME_EMAIL_TEMPLATE" = var.notify_welcome_email_template
     "ROLLBAR_ENV"                   = "paas-${var.environment}"
     "ROLLBAR_ACCESS_TOKEN"          = var.rollbar_access_token
+    "ROLLBAR_DISABLED"              = var.rollbar_disabled
   }
 }


### PR DESCRIPTION
## Changes in this PR

Add the ability to turn off reporting as the pen test is raising so many errors that we are going to hit our account limit.

I haven't allowed this flag to be send to production or staging by Travis as I think it will be very rare we ever want to do this. If we did we should probably change this environment variable manually with a manual deploy whilst we fix the root cause. Once a fix is made we can use the normal release process to flip rollbar back on.

This hotfix has already been applied onto the pentest environment so this change is to sync it into our mainstream.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
