### PR TITLE
make terraform testing more reliable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,18 +44,6 @@ jobs:
       bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
       set +eu
 deploy:
-- provider: heroku
-  api_key:
-    secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
-  on:
-    branch: develop
-  app: beis-roda-staging
-- provider: heroku
-  api_key:
-    secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
-  on:
-    branch: master
-  app: beis-roda-production
 - provider: script
   script: bash travis-docker-push.sh
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,15 @@ jobs:
       docker exec test-container rake
       docker exec test-container bundle exec brakeman
       echo "==== testing terrafrom ===="
+      cd terraform
       git clone https://github.com/tfutils/tfenv.git ~/.tfenv
       export PATH="$HOME/.tfenv/bin:$PATH"
       tfenv install
-      ./install-terraform-provider-for-cf.sh
-      terraform init terraform
-      terraform fmt  -diff -check -recursive terraform
-      terraform validate terraform
+      ../install-terraform-provider-for-cf.sh
+      terraform init
+      terraform fmt  -diff -check -recursive
+      terraform validate
+      cd ..
       echo "==== linting our shell scripts ===="
       bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
       set +eu

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       git clone https://github.com/tfutils/tfenv.git ~/.tfenv
       export PATH="$HOME/.tfenv/bin:$PATH"
       tfenv install
-      bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
+      ./install-terraform-provider-for-cf.sh
       terraform init terraform
       terraform fmt  -diff -check -recursive terraform
       terraform validate terraform

--- a/deploy-terraform.sh
+++ b/deploy-terraform.sh
@@ -59,11 +59,7 @@ fi
 export PATH="$HOME/.tfenv/bin:$PATH"
 tfenv install
 
-# install the cloudfoundry provider if it isnt already
-if [ ! -e ~/.terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry ]
-then
-bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
-fi
+../install-terraform-provider-for-cf.sh
 
 # CF_PASSWORD, CF_USER, AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID
 # must be set for the following commands to run

--- a/install-terraform-provider-for-cf.sh
+++ b/install-terraform-provider-for-cf.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# script to install the Terraform plugin for CloudFoundry
+# https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#manually
+set -e
+
+# install the cloudfoundry provider if it isnt already
+if [ ! -e ~/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry ]
+then
+  echo "installing Cloudfoundry Terraform plugin"
+
+  mkdir -p ~/.terraform.d/plugins/linux_amd64
+  curl -L https://github.com/cloudfoundry-community/terraform-provider-cf/releases/download/v0.11.0/terraform-provider-cloudfoundry_linux_amd64 \
+    -o ~/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  chmod u+x  ~/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+
+
+  echo "finished downloading Cloudfoundry Terraform plugin"
+fi


### PR DESCRIPTION
## Changes in this PR

- use our own script to download the cloud foundry terraform provider
- do terraform testing in the terraform directory
- remove the heroku deploys
 
