### PR TITLE
(296) Date fields accept 0

### DIFF
--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -1,6 +1,5 @@
 class Staff::BudgetsController < Staff::BaseController
   include Secured
-  include DateHelper
 
   def new
     @activity = Activity.find(activity_id)

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -2,7 +2,6 @@
 
 class Staff::TransactionsController < Staff::BaseController
   include Secured
-  include DateHelper
 
   def new
     @activity = Activity.find(activity_id)

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -120,6 +120,17 @@ RSpec.feature "Users can create a fund level activity" do
         expect(page).to have_content "Planned start date can't be blank"
         expect(page).to have_content "Planned end date can't be blank"
 
+        # Dates cannot contain only a zero
+        fill_in "activity[planned_start_date(3i)]", with: 1
+        fill_in "activity[planned_start_date(2i)]", with: 0
+        fill_in "activity[planned_start_date(1i)]", with: 2010
+        fill_in "activity[planned_end_date(3i)]", with: 0
+        fill_in "activity[planned_end_date(2i)]", with: 12
+        fill_in "activity[planned_end_date(1i)]", with: 2010
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "Planned start date can't be blank"
+        expect(page).to have_content "Planned end date can't be blank"
+
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12
         fill_in "activity[planned_start_date(1i)]", with: 2010

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -21,5 +21,10 @@ RSpec.describe DateHelper, type: :helper do
       params = {day: "40", month: "13", year: "2020"}
       expect(helper.format_date(params)).to eq(nil)
     end
+
+    it "returns nil when given a zero parameter" do
+      params = {day: "40", month: "0", year: "2020"}
+      expect(helper.format_date(params)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/c9DkwHY9/296-bug-dates-accept-0

We noticed Papertrail recording ActiveRecord::MultiparameterAssignmentErrors when a user input 0 into any of the three inputs on any date field (generated via govuk_date_field)

Rails will attempt to coerce any values from a date_field view helper into a date. If any of those values are 0, the coercion will fail with ActiveRecord::MultiparameterAssignmentErrors

Unfortunately, because this coercion happens before the values are assigned to the model, we cannot catch them with a validator on the model and return errors on the attributes in question.

After trying several solutions, we have extended DateHelper (which was being included in several controllers but not actually being used!) to catch and reject any dates which contain a zero in any of the 3 date parameters. 

In the controller, we update all the attributes via mass assignment, *except* date parameters. The date parameters are then passed to DateHelper and checked for correctness (all fields present, no only-zeros in any of the fields).

 Dates which are invalid are then validated on the UI as if they had been entered as blank.

## Screenshots of UI changes

<img width="616" alt="Screenshot 2020-03-12 at 11 42 06" src="https://user-images.githubusercontent.com/1089521/76518152-846e2f00-6456-11ea-9bbb-26a5890fb209.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
