### PR TITLE
Production release #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
 
-## Unreleased changes
+## [release-2] - 2020-03-12
 
 - Activity status is now shown as radio buttons with hints
 - Activity XML includes 'iati-identifier' which is includes the reporting organisation
@@ -67,4 +67,6 @@
 - Codelist dropdowns do not contain values which have been marked as "status: withdrawn" by IATI
 - Redis version increased from 3.x to 4.x now that GPaaS supports it
 
-<!-- [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1 -->
+## Unreleased changes
+
+[release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased changes
+## [release-1] - 2020-03-04
 
 - Add Google Tag Manager in place of templated Google Analytics code
 - Ensure missing I18n strings cause tests to fail
@@ -55,6 +55,9 @@
 - Users can view implementing organisations in the Activity XML
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
+
+## Unreleased changes
+
 - Activity status is now shown as radio buttons with hints
 - Activity XML includes 'iati-identifier' which is includes the reporting organisation
 - Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme
@@ -63,3 +66,5 @@
 - BEIS users can view projects (read-only) and download them as XML via a button
 - Codelist dropdowns do not contain values which have been marked as "status: withdrawn" by IATI
 - Redis version increased from 3.x to 4.x now that GPaaS supports it
+
+<!-- [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1 -->


### PR DESCRIPTION
- Activity status is now shown as radio buttons with hints
- Activity XML includes 'iati-identifier' which is includes the reporting organisation
- Activity XML includes 'iati-identifier' with an identifier that consists of all present levels of hierarchy: fund and/or programme
- BEIS users (administrators) can mark other users as active or inactive
- Budget start and end dates are validated according to IATI standard
- BEIS users can view projects (read-only) and download them as XML via a button
- Codelist dropdowns do not contain values which have been marked as "status: withdrawn" by IATI
- Redis version increased from 3.x to 4.x now that GPaaS supports it

I will be replacing the old redis instance manually when this is merged since automatica replacement was not possible.

We need to merge this branch into develop and then into master to ensure the release commits are available downstream. Without these release commits on the develop branch, release 3 will have the same problem as I had with a missing release 1 commit to compare against. I think using pull requests is safer that anyone merging and pushing to master locally. We will need to update the documentation for deployments.

Please merge this before https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/269