### PR TITLE
Update deployment instructions to include the same manual merge step

### DIFF
--- a/doc/deployment-process.md
+++ b/doc/deployment-process.md
@@ -23,25 +23,39 @@ The heading should link to a Github URL at the bottom of the file, which shows t
 ### Steps
 
 1. Create a release branch and make a pull request
-  * Create a branch from develop for the release called release-X where X is the release number
-  * Update CHANGELOG.md to:
-    document the changes in this release in a bullet point form
-    add a link to the diff at the bottom of the file
-  * Document the changes in the commit message as well
-  * Create a tag for the release in the format release-X
-  * git push --follow-tags <your-branch-name>
-  * Create a pull request to merge that release into master with content from the CHANGELOG.md
-  * Get that pull request reviewed and approved
-2. Review and merge the release pull request
-  * Confirm the release candidate and perform any prerequisites such as environment variables or third-party service configuration
-  * The pull request should be reviewed to confirm that the changes in the release are safe to ship and that CHANGELOG.md accurately reflects the changes included in the release.
-  * Merge the pull request
-3. Announce the release
+    * Create a branch from develop for the release called release-X where X is the release number
+    * Update CHANGELOG.md to:
+      document the changes in this release in a bullet point form
+      add a link to the diff at the bottom of the file
+    * Document the changes in the commit message as well
+    * Create a tag for the release in the format release-X
+    * git push --follow-tags <your-branch-name>
+    * Create a pull request to merge that release into **develop** with content from the CHANGELOG.md
+    * Get that pull request reviewed and approved
+1. Review and merge the release pull request
+    The pull request should be reviewed to confirm that the changes in the release are safe to ship and that CHANGELOG.md accurately reflects the changes included in the release.
+1. Confirm the release candidate and perform any prerequisites
+    * Confirm the release with any relevant people (product owner, delivery manager, etc)
+    * Think about any dependencies that also need considering: dependent parts of the service that also need updating; environment variables that need changing/adding; third-party services that need to be set up/updated
+1. Announce the release
     Let the team know about the release. This is posted in Slack under #beis-roda. Typical form is:
 
     ```
     @here :badger: Release N of RODA going to production :badger:
     ```
+1. Manually merge to master to release
+    Once the release pull request has been merged into the develop branch, the production deploy can be performed by manually merging develop into master:
+    ```
+    git fetch
+    git checkout master
+    git pull
+    git merge origin/develop
+    # Edit the commit message to reference the release number
+    # e.g. "Release 43" or "merge origin/develop for release 43"
+    git push
+    ```
+1. Production smoke test
+    Once the code has been deployed to production, carry out a quick smoke test to confirm that the changes have been successfully deployed.
 
 ## Staging
 


### PR DESCRIPTION
## Changes in this PR

We tried using a hyrid of these instructions and it went wrong.

The release commit that was merged into master wasn't pushed back downstream into develop. When we came to release again our changelog was in the state as if the first release hadn't happened - not ideal.

We like pull requests because they protect us from accidentally doing git merges to the wrong environment which we use for development. That said, having a pull request to deplo and another to push the change back to the downstream involves a frustrating amount of overhead. Getting 2 pull requests, merged in the right order, with 2 reviews. It's complicated and things are likely to go wrong too.

We're going to keep exactly to the deployment process of RMI instead of using a hyrbid https://crown-commercial-service.github.io/ReportMI-service-manual/#/deployments and go from there.

## Screenshots of UI changes

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
