### PR TITLE
(353) Switch Tied Status from a select box to a set of radio buttons with h…

### DIFF
--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -17,7 +17,7 @@ module CodelistHelper
     objects
   end
 
-  def yaml_to_status_objects(entity:, type:)
+  def yaml_to_objects_with_description(entity:, type:)
     data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
 

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :status, value: nil
-  = f.govuk_collection_radio_buttons :status, yaml_to_status_objects(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: "Status" }, hint_text: I18n.t("helpers.hint.activity.status", level: f.object.level)
+  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: "Status" }, hint_text: I18n.t("helpers.hint.activity.status", level: f.object.level)

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,2 +1,3 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :tied_status, tied_status_select_options, :code, :name, options: { selected: f.object.tied_status || tied_status_select_options.first.code }, label: { tag: 'h1', size: 'xl' }
+  = f.hidden_field :tied_status
+  = f.govuk_collection_radio_buttons :tied_status, yaml_to_objects_with_description(entity: "activity", type: "tied_status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.tied_status") }, hint_text: I18n.t("helpers.hint.activity.tied_status", level: f.object.level)

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -114,8 +114,7 @@ en:
         sector:
           html: Classify the purpose of this activity. <a href='http://reference.iatistandard.org/203/codelists/Sector/' target='_blank'>Please provide the sector appropriate to you from this list</a>.
         status: This is the stage your %{level} is currently at
-        tied_status:
-          html: "<a href='http://reference.iatistandard.org/203/codelists/TiedStatus/' target='_blank'>See the IATI tied status page for descriptions.</a>"
+        tied_status: This is the tied status of your %{level}
         title: A short, human-readable title that contains a meaningful summary of the activity.
       budget:
         period_end_date: Period end date must not be more than one year after the period start date. For example, 11 3 2021

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -32,9 +32,6 @@ RSpec.feature "Users can create a fund level activity" do
 
       visit activity_step_path(activity, :flow)
       expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.flow
-
-      visit activity_step_path(activity, :tied_status)
-      expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.tied_status
     end
 
     scenario "the activity has the appropriate funding organisation defaults" do
@@ -168,7 +165,7 @@ RSpec.feature "Users can create a fund level activity" do
         expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
 
         # Tied status has a default and can't be set to blank so we skip
-        select "Untied", from: "activity[tied_status]"
+        choose("activity[tied_status]", option: "5")
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content Activity.last.title
       end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
-    describe "#yaml_to_status_objects" do
+    describe "#yaml_to_objects_with_description" do
       it "gracefully handles a missing or incorrect yaml file" do
-        expect(helper.yaml_to_status_objects(entity: "generic", type: "favourite_colours")).to eq([])
+        expect(helper.yaml_to_objects_with_description(entity: "generic", type: "favourite_colours")).to eq([])
       end
 
-      it "formats the data in a yaml file to an array of objects for use in govuk form builder for the Status stage" do
-        expect(helper.yaml_to_status_objects(entity: "activity", type: "status"))
+      it "formats the data in a yaml file to an array of objects for use in govuk form builder, with descriptions" do
+        expect(helper.yaml_to_objects_with_description(entity: "activity", type: "status"))
           .to include(
             OpenStruct.new(name: "Pipeline/identification", code: "1", description: "The activity is being scoped or planned"),
             OpenStruct.new(name: "Implementation", code: "2", description: "The activity is currently being implemented"),
@@ -97,11 +97,11 @@ RSpec.describe CodelistHelper, type: :helper do
       end
 
       it "sorts the data by code order" do
-        expect(helper.yaml_to_status_objects(
+        expect(helper.yaml_to_objects_with_description(
           entity: "activity",
           type: "status"
         ).first).to eq(OpenStruct.new(name: "Pipeline/identification", code: "1", description: "The activity is being scoped or planned"))
-        expect(helper.yaml_to_status_objects(
+        expect(helper.yaml_to_objects_with_description(
           entity: "activity",
           type: "status",
         ).last).to eq(OpenStruct.new(name: "Suspended", code: "6", description: "The activity has been temporarily suspended"))

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -22,7 +22,7 @@ module FormHelpers
     flow: "ODA",
     finance: "Standard grant",
     aid_type: "General budget support",
-    tied_status: "Untied",
+    tied_status: "5",
     level: "fund"
   )
 
@@ -104,9 +104,9 @@ module FormHelpers
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.tied_status")
-    expect(page).to have_content "See the IATI tied status page for descriptions."
+    expect(page).to have_content "This is the tied status of your #{level}"
 
-    select tied_status, from: "activity[tied_status]"
+    choose("activity[tied_status]", option: tied_status)
 
     click_button I18n.t("form.activity.submit")
 
@@ -119,7 +119,7 @@ module FormHelpers
     expect(page).to have_content flow
     expect(page).to have_content finance
     expect(page).to have_content aid_type
-    expect(page).to have_content tied_status
+    expect(page).to have_content I18n.t("activity.tied_status.#{tied_status}")
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,
       month: planned_start_date_month,


### PR DESCRIPTION
…ints

## Changes in this PR

Trello: https://trello.com/c/mibiNC05/353-create-activity-tied-status-change-to-radio-btn-with-hints

As part of this, I have renamed CodelistHelper#yaml_to_status_objects to
CodelistHelper#yaml_to_objects_with_description to make it more generic.

Unfortunately I don't think govuk_collection_radio_buttons takes a default selected
option so we have lost the "Untied" default selection.

## Screenshots of UI changes

<img width="738" alt="Screenshot 2020-03-13 at 11 22 46" src="https://user-images.githubusercontent.com/1089521/76616913-01fc7280-651d-11ea-99bf-3e7869451c65.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
