### PR TITLE
(436) Lists of Activities, Transactions and Budgets do not change based on the last updated time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,8 @@
 
 ## Unreleased changes
 
+- Activities are ordered by `created_at` date, oldest first
+- Transactions are ordered by `date`, newest first
+- Budgets are ordered by `period_start_date`, newest first
+
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -11,7 +11,7 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity = Activity.find(id)
     authorize @activity
 
-    @activities = @activity.activities.map { |activity| ActivityPresenter.new(activity) }
+    @activities = @activity.activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
 
     @transactions = policy_scope(Transaction).where(activity: @activity)
     @budgets = policy_scope(Budget).where(activity: @activity)

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -13,7 +13,7 @@ class Staff::ActivitiesController < Staff::BaseController
 
     @activities = @activity.activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
 
-    @transactions = policy_scope(Transaction).where(activity: @activity)
+    @transactions = policy_scope(Transaction).where(activity: @activity).order("date DESC")
     @budgets = policy_scope(Budget).where(activity: @activity)
 
     respond_to do |format|

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -14,7 +14,7 @@ class Staff::ActivitiesController < Staff::BaseController
     @activities = @activity.activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
 
     @transactions = policy_scope(Transaction).where(activity: @activity).order("date DESC")
-    @budgets = policy_scope(Budget).where(activity: @activity)
+    @budgets = policy_scope(Budget).where(activity: @activity).order("period_start_date DESC")
 
     respond_to do |format|
       format.html do

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,10 +11,10 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    fund_activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation)
+    fund_activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation).order("created_at ASC")
     @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
 
-    programme_activities = policy_scope(Activity.programmes)
+    programme_activities = policy_scope(Activity.programmes).order("created_at ASC")
     @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
   end
 

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -64,7 +64,7 @@
           = submit_tag t("page_content.organisation.button.create_fund"), class: "govuk-button"
 
       - if policy(:fund).index?
-        %ul.govuk-list.govuk-list--bullet
+        %ul.govuk-list.govuk-list--bullet.funds
           - @fund_activities.each do |activity|
             %li
               = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
@@ -75,7 +75,7 @@
             = t("page_content.organisation.programmes")
 
         - if policy(:programme).index?
-          %ul.govuk-list.govuk-list--bullet
+          %ul.govuk-list.govuk-list--bullet.programmes
             - @programme_activities.each do |activity|
               %li
                 = link_to activity.display_title, organisation_activity_path(current_user.organisation, activity)

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -1,5 +1,5 @@
 - unless budgets.empty?
-  %table.govuk-table.transactions
+  %table.govuk-table.budgets
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -26,6 +26,24 @@ RSpec.feature "Users can view an organisation" do
 
         expect(page).to_not have_content(I18n.t("generic.link.back"))
       end
+
+      scenario "can see a list of fund activities" do
+        fund = create(:fund_activity, organisation: user.organisation)
+
+        visit organisation_path(user.organisation)
+
+        expect(page).to have_content(fund.title)
+      end
+
+      scenario "fund activities are ordered by created_at (oldest first)" do
+        fund_1 = create(:fund_activity, organisation: user.organisation, created_at: Date.yesterday)
+        fund_2 = create(:fund_activity, organisation: user.organisation, created_at: Date.today)
+
+        visit organisation_path(user.organisation)
+
+        expect(page.find("ul.funds li:first-child")).to have_content(fund_1.title)
+        expect(page.find("ul.funds li:last-child")).to have_content(fund_2.title)
+      end
     end
 
     context "viewing another organisation" do
@@ -68,6 +86,24 @@ RSpec.feature "Users can view an organisation" do
       visit organisation_path(organisation)
 
       expect(page).to_not have_content(I18n.t("generic.link.back"))
+    end
+
+    scenario "can see a list of programme activities" do
+      programme = create(:programme_activity, organisation: organisation)
+
+      visit organisation_path(organisation)
+
+      expect(page).to have_content(programme.title)
+    end
+
+    scenario "programme activities are ordered by created_at (oldest first)" do
+      programme_1 = create(:programme_activity, organisation: organisation, created_at: Date.yesterday)
+      programme_2 = create(:programme_activity, organisation: organisation, created_at: Date.today)
+
+      visit organisation_path(organisation)
+
+      expect(page.find("ul.programmes li:first-child")).to have_content(programme_1.title)
+      expect(page.find("ul.programmes li:last-child")).to have_content(programme_2.title)
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -23,6 +23,20 @@ RSpec.feature "Users can view budgets on an activity page" do
         expect(page).to have_content(budget_presenter.currency)
         expect(page).to have_content(budget_presenter.value)
       end
+
+      scenario "budgets are shown in period date order, newest first" do
+        fund_activity = create(:fund_activity, organisation: user.organisation)
+        budget_1 = create(:budget, activity: fund_activity, period_start_date: Date.today, period_end_date: Date.tomorrow)
+        budget_2 = create(:budget, activity: fund_activity, period_start_date: 1.year.ago, period_end_date: Date.yesterday)
+        budget_3 = create(:budget, activity: fund_activity, period_start_date: 2.years.ago, period_end_date: 1.year.ago)
+
+        visit organisation_path(user.organisation)
+
+        click_link fund_activity.title
+        expect(page.find(:xpath, "//table[@class = 'govuk-table budgets']/tbody/tr[1]")[:id]).to eq(budget_1.id)
+        expect(page.find(:xpath, "//table[@class = 'govuk-table budgets']/tbody/tr[2]")[:id]).to eq(budget_2.id)
+        expect(page.find(:xpath, "//table[@class = 'govuk-table budgets']/tbody/tr[3]")[:id]).to eq(budget_3.id)
+      end
     end
   end
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -38,5 +38,17 @@ RSpec.feature "Users can view transactions on an activity page" do
       expect(page).to have_content(transaction_presenter.providing_organisation_name)
       expect(page).to have_content(transaction_presenter.receiving_organisation_name)
     end
+
+    scenario "the transactions are shown in date order, newest first" do
+      transaction_1 = create(:transaction, activity: activity, date: Date.today)
+      transaction_2 = create(:transaction, activity: activity, date: Date.yesterday)
+
+      visit organisation_path(user.organisation)
+
+      click_link activity.title
+
+      expect(page.find("table.transactions tbody tr:first-child")[:id]).to eq(transaction_1.id)
+      expect(page.find("table.transactions tbody tr:last-child")[:id]).to eq(transaction_2.id)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/VgXDUp9B/436-lists-of-activities-transactions-and-budgets-do-not-change-based-on-the-last-updated-time

During user testing, users noticed that the lists of budgets & transactions shown on the activity pages changed their order after being edited. The transactions & budgets were being sorted by `last_updated` which is going to change whenever a record is updated. 

Also, activities themselves are listed on the organisation page and "parent" activity pages in order of `last_updated`

This PR orders these entities in different ways:

- Activities are ordered oldest first (`created_at ASC`)
- Budgets are ordered by `period_start_date`, newest first (`period_start_date DESC`)
- Transactions are ordered by `date`, newest first (`date DESC`)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
