### PR TITLE
(435) Remove transaction description from the display table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,5 +74,6 @@
 - Activities are ordered by `created_at` date, oldest first
 - Transactions are ordered by `date`, newest first
 - Budgets are ordered by `period_start_date`, newest first
+- Remove transaction description from the transaction display table, to improve the activity page UI
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -5,8 +5,6 @@
         %th.govuk-table__header
           = t("activerecord.attributes.transaction.reference")
         %th.govuk-table__header
-          = t("activerecord.attributes.transaction.description")
-        %th.govuk-table__header
           = t("activerecord.attributes.transaction.transaction_type")
         %th.govuk-table__header
           = t("activerecord.attributes.transaction.date")
@@ -26,7 +24,6 @@
       - transactions.each do |transaction|
         %tr.govuk-table__row{id: transaction.id}
           %td.govuk-table__cell= transaction.reference
-          %td.govuk-table__cell= transaction.description
           %td.govuk-table__cell= transaction.transaction_type
           %td.govuk-table__cell= transaction.date
           %td.govuk-table__cell= transaction.currency

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -29,7 +29,6 @@ RSpec.feature "Users can view transactions on an activity page" do
       click_link activity.title
 
       expect(page).to have_content(transaction_presenter.reference)
-      expect(page).to have_content(transaction_presenter.description)
       expect(page).to have_content(transaction_presenter.transaction_type)
       expect(page).to have_content(transaction_presenter.date)
       expect(page).to have_content(transaction_presenter.currency)

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -167,7 +167,6 @@ module FormHelpers
     if expectations
       within ".transactions" do
         expect(page).to have_content(reference)
-        expect(page).to have_content(description)
         expect(page).to have_content(transaction_type)
         expect(page).to have_content localise_date_from_input_fields(
           year: date_year,


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/YqtDTWv2/435-transaction-descriptions-are-not-included-in-the-table

To improve the look of the activity page, we have decided to remove the
transaction description from the transaction display table, as it can be very
long and disrupt the activity page UI.

## Screenshots of UI changes

### After

<img width="1103" alt="Screenshot 2020-03-16 at 16 41 13" src="https://user-images.githubusercontent.com/1089521/76780448-f7eca500-67a4-11ea-9169-684c326fad1a.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
