### PR TITLE
(433) Changes to the front page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,5 +75,6 @@
 - Transactions are ordered by `date`, newest first
 - Budgets are ordered by `period_start_date`, newest first
 - Remove transaction description from the transaction display table, to improve the activity page UI
+- Organisation and User management links are in the site header navigation
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,5 +79,7 @@
 - Organisations are managed from the /organisation page
 - Organisation show page re-organised to show more information including funds,
   programmes and projects for the relevant users
+- Make it clearer that Programme should have an extending organisation in order
+  for delivery partners to report on the programme
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,5 +76,6 @@
 - Budgets are ordered by `period_start_date`, newest first
 - Remove transaction description from the transaction display table, to improve the activity page UI
 - Organisation and User management links are in the site header navigation
+- Organisations are managed from the /organisation page
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,5 +77,7 @@
 - Remove transaction description from the transaction display table, to improve the activity page UI
 - Organisation and User management links are in the site header navigation
 - Organisations are managed from the /organisation page
+- Organisation show page re-organised to show more information including funds,
+  programmes and projects for the relevant users
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/controllers/public/visitors_controller.rb
+++ b/app/controllers/public/visitors_controller.rb
@@ -1,4 +1,5 @@
 class Public::VisitorsController < Public::BaseController
   def index
+    redirect_to organisation_path(current_user.organisation) if current_user&.active?
   end
 end

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -11,11 +11,15 @@ class Staff::OrganisationsController < Staff::BaseController
     authorize organisation
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
+
     fund_activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation).order("created_at ASC")
     @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
 
-    programme_activities = policy_scope(Activity.programmes).order("created_at ASC")
+    programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).order("created_at ASC")
     @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
+
+    project_activites = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).order("created_at ASC")
+    @project_activities = project_activites.map { |activity| ActivityPresenter.new(activity) }
   end
 
   def new

--- a/app/policies/programme_policy.rb
+++ b/app/policies/programme_policy.rb
@@ -21,7 +21,11 @@ class ProgrammePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.all
+      if user.organisation.service_owner?
+        scope.all
+      else
+        scope.where(extending_organisation: user.organisation)
+      end
     end
   end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -25,7 +25,11 @@ class ProjectPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.all
+      if user.organisation.service_owner?
+        scope.all
+      else
+        scope.where(organisation: user.organisation)
+      end
     end
   end
 end

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -1,7 +1,15 @@
 %nav
   %ul{class: 'govuk-header__navigation', aria: { label: "Top Level Navigation"}}
-    -if defined?(current_user) && current_user
+    -if defined?(current_user) && current_user.active?
 
       %li{ class: navigation_item_class(organisation_path(current_user.organisation)) }
         %a{ href: organisation_path(current_user.organisation), class: 'govuk-header__link' }
           = t("page_title.home")
+
+      - if policy(Organisation).index?
+        %li{ class: navigation_item_class(organisations_path) }
+          = link_to t("page_title.organisation.index"), organisations_path, class: "govuk-header__link"
+
+      - if policy(User).index?
+        %li{ class: navigation_item_class(users_path) }
+          = link_to t("page_title.users.index"), users_path, class: "govuk-header__link"

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -1,0 +1,20 @@
+
+%table.govuk-table.organisations
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("activerecord.attributes.organisation.name")
+      %th.govuk-table__header
+        =t("activerecord.attributes.organisation.iati_reference")
+      %th.govuk-table__header
+
+  %tbody.govuk-table__body
+    - organisations.each do |organisation|
+      %tr.govuk-table__row{id: organisation.id}
+        %td.govuk-table__cell= organisation.name
+        %td.govuk-table__cell= organisation.iati_reference
+        %td.govuk-table__cell
+          - if policy(organisation).show?
+            = a11y_action_link(t("generic.link.show"), organisation_path(organisation), organisation.name)
+          - if policy(organisation).edit?
+            = a11y_action_link(t("generic.link.edit"), edit_organisation_path(organisation), organisation.name)

--- a/app/views/staff/organisations/index.html.haml
+++ b/app/views/staff/organisations/index.html.haml
@@ -1,9 +1,8 @@
 =content_for :page_title_prefix, t("page_title.organisation.index")
 
-= link_to t("generic.link.back"), organisation_path(current_user.organisation), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
+    .govuk-grid-column-full
       %h1.govuk-heading-xl
         = t("page_title.organisation.index")
 
@@ -11,7 +10,4 @@
         = link_to(I18n.t("page_content.organisations.button.create"), new_organisation_path, class: "govuk-button")
 
       - if @organisations
-        %ul.govuk-list.govuk-list--bullet
-          - @organisations.each do |organisation|
-            %li
-              = link_to organisation.name, organisation_path(organisation.id)
+        = render partial: "staff/organisations/table", locals: { organisations: @organisations }

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -12,14 +12,7 @@
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m Details
 
-      - if policy(Organisation).update?
-        = link_to t("page_content.organisation.button.edit"), edit_organisation_path(@organisation_presenter), class: "govuk-button"
       %dl.govuk-summary-list
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
-            = t("page_content.organisation.name.label")
-          %dd.govuk-summary-list__value
-            = @organisation_presenter.name
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("page_content.organisation.iati_reference.label")

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -41,17 +41,6 @@
           %dd.govuk-summary-list__value
             = t("generic.default_currency.#{@organisation_presenter.default_currency}")
 
-    .govuk-grid-column-one-third
-      - if policy(User).index?
-        %h3.govuk-heading-m
-          = t("page_content.dashboard.header.manage_users")
-        = link_to t("page_content.dashboard.button.manage_users"), users_path, class: "govuk-button"
-
-      - if policy(Organisation).index?
-        %h3.govuk-heading-m
-          = t("page_content.dashboard.header.manage_organisations")
-        = link_to t("page_content.dashboard.button.manage_organisations"), organisations_path, class: "govuk-button"
-
   .govuk-grid-row
     .govuk-grid-column-two-thirds
 

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -8,9 +8,38 @@
       %h1.govuk-heading-xl
         = @organisation_presenter.name
 
+  - if policy(:fund).index? & @organisation_presenter.service_owner?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.organisation.funds")
+
+        - if policy(:fund).create?
+          = form_tag(organisation_funds_path(@organisation_presenter), method: "post") do
+            = submit_tag t("page_content.organisation.button.create_fund"), class: "govuk-button"
+
+        = render partial: "staff/shared/funds/table", locals: { funds: @fund_activities }
+
+  - if policy(:programme).index?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.organisation.programmes")
+
+        = render partial: "staff/shared/programmes/table", locals: { programmes: @programme_activities }
+
+  - if policy(:project).index?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.organisation.projects")
+
+        = render partial: "staff/shared/projects/table", locals: { projects: @project_activities }
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %h2.govuk-heading-m Details
+      %h2.govuk-heading-m
+        = t("page_content.organisation.details")
 
       %dl.govuk-summary-list
         .govuk-summary-list__row
@@ -34,30 +63,5 @@
           %dd.govuk-summary-list__value
             = t("generic.default_currency.#{@organisation_presenter.default_currency}")
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-
-      - if policy(:fund).index?
-        %h2.govuk-heading-m
-          = t("page_content.organisation.funds")
-
-      - if policy(:fund).create?
-        = form_tag(organisation_funds_path(@organisation_presenter), method: "post") do
-          = submit_tag t("page_content.organisation.button.create_fund"), class: "govuk-button"
-
-      - if policy(:fund).index?
-        %ul.govuk-list.govuk-list--bullet.funds
-          - @fund_activities.each do |activity|
-            %li
-              = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
-
-      - unless current_user.organisation.service_owner?
-        - if policy(:programme).index?
-          %h2.govuk-heading-m
-            = t("page_content.organisation.programmes")
-
-        - if policy(:programme).index?
-          %ul.govuk-list.govuk-list--bullet.programmes
-            - @programme_activities.each do |activity|
-              %li
-                = link_to activity.display_title, organisation_activity_path(current_user.organisation, activity)
+      - if policy(:organisation).edit?
+        = link_to t("page_content.organisation.button.edit_details"), edit_organisation_path(@organisation_presenter), class: "govuk-button"

--- a/app/views/staff/shared/activities/_extending_organisation.html.haml
+++ b/app/views/staff/shared/activities/_extending_organisation.html.haml
@@ -2,6 +2,8 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.extending_organisation.heading")
+    %p.govuk-hint
+      = t("page_content.activity.extending_organisation.hint")
 
     -if activity.extending_organisation.present?
       %p.govuk-body

--- a/app/views/staff/shared/funds/_table.html.haml
+++ b/app/views/staff/shared/funds/_table.html.haml
@@ -1,0 +1,16 @@
+%table.govuk-table.funds
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t("page_content.organisation.funds")
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("activerecord.attributes.activity.title")
+
+      %th.govuk-table__header
+        = t("page_content.activity.identitfier.label")
+
+  %tbody.govuk-table__body
+    - funds.each do |fund|
+      %tr.govuk-table__row{id: fund.id}
+        %td.govuk-table__cell= link_to fund.display_title, organisation_activity_path(fund.organisation, fund), class: "govuk-link govuk-link--no-visited-state"
+        %td.govuk-table__cell= fund.identifier

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -1,0 +1,18 @@
+%table.govuk-table.programmes
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t("page_content.organisation.programmes")
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("activerecord.attributes.activity.title")
+      %th.govuk-table__header
+        = t("page_content.activity.identitfier.label")
+      %th.govuk-table__header
+        =t("activerecord.attributes.activity.programme.fund")
+
+  %tbody.govuk-table__body
+    - programmes.each do |programme|
+      %tr.govuk-table__row{id: programme.id}
+        %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
+        %td.govuk-table__cell= programme.identifier
+        %td.govuk-table__cell= programme.parent_activity.title

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -1,11 +1,19 @@
 - unless projects.empty?
-  %table.govuk-table.transactions
+  %table.govuk-table.projects
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.organisation.projects")
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header
           =t("activerecord.attributes.activity.title")
+        %th.govuk-table__header
+          = t("page_content.activity.identitfier.label")
+        %th.govuk-table__header
+          =t("activerecord.attributes.activity.project.programme")
 
     %tbody.govuk-table__body
       - projects.each do |project|
         %tr.govuk-table__row{id: project.id}
-          %td.govuk-table__cell= link_to project.title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
+          %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
+          %td.govuk-table__cell= project.identifier
+          %td.govuk-table__cell= project.parent_activity.title

--- a/app/views/staff/users/index.html.haml
+++ b/app/views/staff/users/index.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.home")
 
-= link_to t("generic.link.back"), organisation_path(current_user.organisation), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,13 +207,6 @@ en:
     budgets:
       button:
         create: Create budget
-    dashboard:
-      button:
-        manage_organisations: Manage organisations
-        manage_users: Manage users
-      header:
-        manage_organisations: Organisations
-        manage_users: Users
     errors:
       auth0:
         failed:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
         button:
           edit: Choose extending organisation
         heading: Extending organisation
+        hint: The extending organisation will be able to create and report project information against this programme
       finance:
         label: Finance
       flow:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,8 +222,10 @@ en:
         create_programme: Create programme
         create_project: Create project
         edit: Edit organisation
+        edit_details: Edit details
       default_currency:
         label: Default currency
+      details: Organisation details
       funds: Funds
       iati_reference:
         label: IATI reference
@@ -232,8 +234,10 @@ en:
       name:
         label: Name
       programmes: Programmes
+      projects: Projects
       type:
         label: Type
+    organisation_details: Organisation details
     organisations:
       button:
         create: Create organisation

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -8,6 +8,10 @@ en:
         finance: Finance
         flow: Flow
         identifier: Your unique identifier
+        programme:
+          fund: Fund
+        project:
+          programme: Programme
         recipient_country: Recipient country
         recipient_region: Recipient region
         sector: Sector

--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -3,4 +3,34 @@ feature "Home page" do
     visit root_path
     expect(page).to have_content(I18n.t("app.title"))
   end
+
+  context "when signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    scenario "they are redirected to their organisation show page" do
+      visit root_path
+      expect(page.current_path).to eq organisation_path(user.organisation)
+    end
+  end
+
+  context "when signed in as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "they are redirected to their organisation show page" do
+      visit root_path
+      expect(page.current_path).to eq organisation_path(user.organisation)
+    end
+  end
+
+  context "when signed in as a user who is not active" do
+    let(:user) { create(:delivery_partner_user, active: false) }
+    before { authenticate!(user: user) }
+
+    scenario "they are shown the start page" do
+      visit root_path
+      expect(page).to have_button(I18n.t("generic.link.sign_in"))
+    end
+  end
 end

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "BEIS users can create organisations" do
 
   scenario "successfully creating an organisation" do
     visit organisation_path(user.organisation)
-    click_link I18n.t("page_content.dashboard.button.manage_organisations")
+    click_link I18n.t("page_title.organisation.index")
     click_link I18n.t("page_content.organisations.button.create")
 
     expect(page).to have_content(I18n.t("page_title.organisation.new"))
@@ -31,7 +31,7 @@ RSpec.feature "BEIS users can create organisations" do
 
   scenario "presence validation works as expected" do
     visit organisation_path(user.organisation)
-    click_link I18n.t("page_content.dashboard.button.manage_organisations")
+    click_link I18n.t("page_title.organisation.index")
     click_link I18n.t("page_content.organisations.button.create")
 
     expect(page).to have_content(I18n.t("page_title.organisation.new"))

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "BEIS users can editing other users" do
     # Navigate from the landing page
     visit organisation_path(user.organisation)
 
-    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+    click_on(I18n.t("page_title.users.index"))
 
     # Navigate to the users page
     expect(page).to have_content(I18n.t("page_title.users.index"))
@@ -51,7 +51,7 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on "Manage users"
+    click_on I18n.t("page_title.users.index")
 
     expect(page).to have_content(user.name)
 
@@ -68,7 +68,7 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on "Manage users"
+    click_on I18n.t("page_title.users.index")
     find("tr", text: user.name).click_link("Edit")
 
     choose I18n.t("form.user.active.inactive")
@@ -83,7 +83,7 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on "Manage users"
+    click_on I18n.t("page_title.users.index")
     find("tr", text: user.name).click_link("Edit")
 
     choose I18n.t("form.user.active.active")

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(I18n.t("page_content.dashboard.button.manage_users"))
+      click_on(I18n.t("page_title.users.index"))
 
       # Navigate to the users page
       expect(page).to have_content(I18n.t("page_title.users.index"))

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -20,15 +20,5 @@ RSpec.feature "BEIS users can view other organisations" do
       expect(page).to have_content(user.organisation.name)
       expect(page).to have_content(another_organisation.name)
     end
-
-    scenario "can go back to the previous page" do
-      authenticate!(user: user)
-
-      visit organisations_path
-
-      click_on I18n.t("generic.link.back")
-
-      expect(page).to have_current_path(organisation_path(user.organisation))
-    end
   end
 end

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "BEIS users can can view other users" do
 
     # Navigate from the landing page
     visit organisation_path(user.organisation)
-    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+    click_on(I18n.t("page_title.users.index"))
 
     # Navigate to the users page
     expect(page).to have_content(I18n.t("page_title.users.index"))
@@ -50,7 +50,7 @@ RSpec.feature "BEIS users can can view other users" do
 
     # Navigate from the landing page
     visit organisation_path(user.organisation)
-    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+    click_on(I18n.t("page_title.users.index"))
 
     expected_array = [
       a1_user.organisation.name,
@@ -68,7 +68,7 @@ RSpec.feature "BEIS users can can view other users" do
 
     # Navigate from the landing page
     visit organisation_path(user.organisation)
-    click_on(I18n.t("page_content.dashboard.button.manage_users"))
+    click_on(I18n.t("page_title.users.index"))
 
     # The details include whether the user is active
     expect(page).to have_content(I18n.t("form.user.active.false"))

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -1,0 +1,133 @@
+feature "Organisation show page" do
+  let(:delivery_partner_user) { create(:delivery_partner_user) }
+  let(:beis_user) { create(:beis_user) }
+
+  let(:fund) { create(:fund_activity, organisation: beis_user.organisation) }
+  let(:programme) do
+    create(:programme_activity,
+      activity: fund,
+      organisation: beis_user.organisation,
+      extending_organisation: delivery_partner_user.organisation)
+  end
+  let!(:project) { create(:project_activity, activity: programme, organisation: delivery_partner_user.organisation) }
+  let!(:another_programme) { create(:programme_activity) }
+  let!(:another_project) { create(:project_activity) }
+
+  context "when signed in as a BEIS user" do
+    context "when viewing the BEIS oganisation" do
+      before do
+        authenticate!(user: beis_user)
+        visit organisation_path(beis_user.organisation)
+      end
+
+      scenario "they see a list of all funds" do
+        within("##{fund.id}") do
+          expect(page).to have_link fund.title, href: organisation_activity_path(fund.organisation, fund)
+          expect(page).to have_content fund.title
+          expect(page).to have_content fund.identifier
+        end
+      end
+
+      scenario "they see a create fund button" do
+        expect(page).to have_button I18n.t("page_content.organisation.button.create_fund")
+      end
+
+      scenario "they see a list of all programmes" do
+        within("##{programme.id}") do
+          expect(page).to have_link programme.title, href: organisation_activity_path(programme.organisation, programme)
+          expect(page).to have_content programme.identifier
+          expect(page).to have_content programme.parent_activity.title
+        end
+
+        within("##{another_programme.id}") do
+          expect(page).to have_link another_programme.title, href: organisation_activity_path(another_programme.organisation, another_programme)
+          expect(page).to have_content another_programme.identifier
+          expect(page).to have_content another_programme.parent_activity.title
+        end
+      end
+
+      scenario "they see a list of all projects" do
+        within("##{project.id}") do
+          expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
+          expect(page).to have_content project.identifier
+          expect(page).to have_content project.parent_activity.title
+        end
+
+        within("##{another_project.id}") do
+          expect(page).to have_link another_project.title, href: organisation_activity_path(another_project.organisation, another_project)
+          expect(page).to have_content another_project.identifier
+          expect(page).to have_content another_project.parent_activity.title
+        end
+      end
+
+      scenario "they see the organisation details" do
+        expect(page).to have_content beis_user.organisation.name
+        expect(page).to have_content beis_user.organisation.iati_reference
+      end
+
+      scenario "they see a edit details button" do
+        expect(page).to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
+      end
+    end
+
+    context "when viewing a delivery partners organisation" do
+      scenario "they do not see funds or the create fund button" do
+        visit organisation_path(delivery_partner_user.organisation)
+
+        expect(page).not_to have_button I18n.t("page_content.organisation.button.create_fund")
+        expect(page).not_to have_content "Funds"
+      end
+    end
+  end
+
+  context "when signed in as a delivery partner user" do
+    before do
+      authenticate!(user: delivery_partner_user)
+      visit organisation_path(delivery_partner_user.organisation)
+    end
+
+    scenario "they do not see a list of funds" do
+      expect(page).not_to have_table "Funds"
+    end
+
+    scenario "they do not see a create fund button" do
+      expect(page).not_to have_button I18n.t("page_content.organisation.button.create_fund")
+    end
+
+    scenario "they see a list of all the programmes for which they are the extending organisation" do
+      within("##{programme.id}") do
+        expect(page).to have_link programme.title, href: organisation_activity_path(programme.organisation, programme)
+        expect(page).to have_content programme.identifier
+        expect(page).to have_content programme.parent_activity.title
+      end
+    end
+
+    scenario "they do not see progammes they are not the extending organisation of" do
+      expect(page).not_to have_content another_programme.identifier
+    end
+
+    scenario "they see a list of all their projects" do
+      within("##{project.id}") do
+        expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
+        expect(page).to have_content project.identifier
+        expect(page).to have_content project.parent_activity.title
+      end
+    end
+
+    scenario "the list of projects is ordered by created_at (oldest first)" do
+      yet_another_project = create(:project_activity, organisation: delivery_partner_user.organisation, created_at: Date.yesterday)
+
+      visit organisation_path(delivery_partner_user.organisation)
+
+      expect(page.find("table.projects  tbody tr:first-child")[:id]).to have_content(yet_another_project.id)
+      expect(page.find("table.projects  tbody tr:last-child")[:id]).to have_content(project.id)
+    end
+    scenario "they do not see projects that they are not the reporting organisation of" do
+      expect(page).not_to have_content another_project.identifier
+    end
+
+    scenario "they do not see the edit detials button" do
+      expect(page).not_to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)
+    end
+  end
+end

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -64,7 +64,10 @@ RSpec.describe "Users can create a budget" do
     context "on a programme level activity" do
       scenario "they cannot create budgets" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity,
+          activity: fund_activity,
+          organisation: user.organisation,
+          extending_organisation: user.organisation)
 
         visit organisation_path(user.organisation)
         click_on(programme_activity.title)
@@ -77,8 +80,12 @@ RSpec.describe "Users can create a budget" do
     context "on a project level activity" do
       scenario "successfully creates a budget" do
         fund_activity = create(:fund_activity)
-        programme_activity = create(:programme_activity, activity: fund_activity)
-        project_activity = create(:project_activity, activity: programme_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity,
+          activity: fund_activity,
+          extending_organisation: user.organisation)
+        project_activity = create(:project_activity,
+          activity: programme_activity,
+          organisation: user.organisation)
 
         visit organisation_path(user.organisation)
 

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can create a project" do
 
     context "when viewing a programme" do
       scenario "a new project can be added to the programme" do
-        programme = create(:programme_activity)
+        programme = create(:programme_activity, extending_organisation: user.organisation)
 
         visit organisation_path(user.organisation)
 

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -182,7 +182,10 @@ RSpec.feature "Users can create a transaction" do
 
     scenario "they cannot create transactions on a programme" do
       fund_activity = create(:fund_activity, organisation: user.organisation)
-      programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+      programme_activity = create(:programme_activity,
+        activity: fund_activity,
+        organisation: user.organisation,
+        extending_organisation: user.organisation)
 
       visit organisation_path(user.organisation)
       click_on(programme_activity.title)

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can edit organisations" do
     authenticate!(user: create(:administrator, organisation: beis_organisation))
 
     visit organisation_path(beis_organisation)
-    click_link I18n.t("page_content.dashboard.button.manage_organisations")
+    click_link I18n.t("page_title.organisation.index")
     click_link another_organisation.name
     click_link I18n.t("page_content.organisation.button.edit")
 
@@ -35,7 +35,7 @@ RSpec.feature "Users can edit organisations" do
   def successfully_edit_an_organisation
     visit organisation_path(beis_organisation)
 
-    click_link I18n.t("page_content.dashboard.button.manage_organisations")
+    click_link I18n.t("page_title.organisation.index")
 
     click_link another_organisation.name
     click_link I18n.t("page_content.organisation.button.edit")

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -21,8 +21,9 @@ RSpec.feature "Users can edit organisations" do
 
     visit organisation_path(beis_organisation)
     click_link I18n.t("page_title.organisation.index")
-    click_link another_organisation.name
-    click_link I18n.t("page_content.organisation.button.edit")
+    within("##{another_organisation.id}") do
+      click_link I18n.t("generic.link.edit")
+    end
 
     expect(page).to have_content(I18n.t("page_title.organisation.edit"))
     fill_in "organisation[name]", with: ""
@@ -37,8 +38,9 @@ RSpec.feature "Users can edit organisations" do
 
     click_link I18n.t("page_title.organisation.index")
 
-    click_link another_organisation.name
-    click_link I18n.t("page_content.organisation.button.edit")
+    within("##{another_organisation.id}") do
+      click_link I18n.t("generic.link.edit")
+    end
 
     expect(page).to have_content(I18n.t("page_title.organisation.edit"))
     fill_in "organisation[name]", with: "My New Organisation"

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -52,16 +52,20 @@ RSpec.feature "Users can view an organisation" do
       scenario "can see the other organisation's page" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")
-        click_link other_organisation.name
-
+        within("##{other_organisation.id}") do
+          click_link I18n.t("generic.link.show")
+        end
         expect(page).to have_content(other_organisation.name)
       end
 
       scenario "can go back to the previous page" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")
-        click_link other_organisation.name
 
+        within("##{other_organisation.id}") do
+          click_link I18n.t("generic.link.show")
+        end
+        expect(page).to have_content(other_organisation.name)
         click_on I18n.t("generic.link.back")
 
         expect(page).to have_current_path(organisations_path)

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -41,8 +41,8 @@ RSpec.feature "Users can view an organisation" do
 
         visit organisation_path(user.organisation)
 
-        expect(page.find("ul.funds li:first-child")).to have_content(fund_1.title)
-        expect(page.find("ul.funds li:last-child")).to have_content(fund_2.title)
+        expect(page.find("table.funds  tbody tr:first-child")[:id]).to have_content(fund_1.id)
+        expect(page.find("table.funds  tbody tr:last-child")[:id]).to have_content(fund_2.id)
       end
     end
 
@@ -93,7 +93,9 @@ RSpec.feature "Users can view an organisation" do
     end
 
     scenario "can see a list of programme activities" do
-      programme = create(:programme_activity, organisation: organisation)
+      programme = create(:programme_activity,
+        organisation: organisation,
+        extending_organisation: organisation)
 
       visit organisation_path(organisation)
 
@@ -101,13 +103,19 @@ RSpec.feature "Users can view an organisation" do
     end
 
     scenario "programme activities are ordered by created_at (oldest first)" do
-      programme_1 = create(:programme_activity, organisation: organisation, created_at: Date.yesterday)
-      programme_2 = create(:programme_activity, organisation: organisation, created_at: Date.today)
+      programme_1 = create(:programme_activity,
+        organisation: organisation,
+        created_at: Date.yesterday,
+        extending_organisation: organisation)
+      programme_2 = create(:programme_activity,
+        organisation: organisation,
+        created_at: Date.today,
+        extending_organisation: organisation)
 
       visit organisation_path(organisation)
 
-      expect(page.find("ul.programmes li:first-child")).to have_content(programme_1.title)
-      expect(page.find("ul.programmes li:last-child")).to have_content(programme_2.title)
+      expect(page.find("table.programmes  tbody tr:first-child")[:id]).to have_content(programme_1.id)
+      expect(page.find("table.programmes  tbody tr:last-child")[:id]).to have_content(programme_2.id)
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Users can view an organisation" do
 
       scenario "can see the other organisation's page" do
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_content.dashboard.button.manage_organisations")
+        click_link I18n.t("page_title.organisation.index")
         click_link other_organisation.name
 
         expect(page).to have_content(other_organisation.name)
@@ -59,7 +59,7 @@ RSpec.feature "Users can view an organisation" do
 
       scenario "can go back to the previous page" do
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_content.dashboard.button.manage_organisations")
+        click_link I18n.t("page_title.organisation.index")
         click_link other_organisation.name
 
         click_on I18n.t("generic.link.back")

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -43,10 +43,9 @@ RSpec.feature "Users can view fund level activities" do
 
   context "when the activity is partially complete and doesn't have a title" do
     scenario "it to show a meaningful link to the activity" do
-      activity = create(:activity, :at_purpose_step, organisation: user.organisation, title: nil)
+      activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation, title: nil)
 
       visit organisation_path(user.organisation)
-
       expect(page).to have_content("Untitled (#{activity.id})")
     end
   end

--- a/spec/features/staff/users_can_view_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_view_programme_level_activity_spec.rb
@@ -12,10 +12,8 @@ RSpec.feature "Users can view programme level activites" do
 
       visit organisation_path(user.organisation)
 
-      expect(page).to have_content I18n.t("page_content.organisation.funds")
-      expect(page).not_to have_content I18n.t("page_content.organisation.programmes")
+      expect(page).to have_content I18n.t("page_content.organisation.programmes")
 
-      click_on fund_activity.title
       click_on programme_activity.title
 
       page_displays_an_activity(activity_presenter: ActivityPresenter.new(programme_activity))
@@ -39,7 +37,8 @@ RSpec.feature "Users can view programme level activites" do
       fund_activity = create(:fund_activity, organisation: user.organisation)
       programme_activity = create(:programme_activity,
         organisation: user.organisation,
-        activity: fund_activity)
+        activity: fund_activity,
+        extending_organisation: user.organisation)
 
       visit organisation_path(user.organisation)
       expect(page).not_to have_content I18n.t("page_content.organisation.funds")

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -1,0 +1,40 @@
+RSpec.feature "Users can view the site navigation" do
+  context "when the user is not signed in" do
+    it "does not show the navigation" do
+      activity = create(:activity)
+
+      visit organisation_path(activity.organisation)
+
+      expect(page).not_to have_css ".govuk-header__navigation"
+      expect(page).not_to have_link organisation_path(activity.organisation)
+    end
+  end
+
+  context "when the user is signed in as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    it "shows the appropriate naviation" do
+      visit organisation_path(user.organisation)
+
+      expect(page).to have_css ".govuk-header__navigation"
+      expect(page).to have_link I18n.t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).not_to have_link I18n.t("page_title.organisation.index"), href: organisations_path
+      expect(page).not_to have_link I18n.t("page_title.users.index"), href: users_path
+    end
+  end
+
+  context "when the user is signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    it "shows the appropriate naviation" do
+      visit organisation_path(user.organisation)
+
+      expect(page).to have_css ".govuk-header__navigation"
+      expect(page).to have_link I18n.t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).to have_link I18n.t("page_title.organisation.index"), href: organisations_path
+      expect(page).to have_link I18n.t("page_title.users.index"), href: users_path
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ProjectPolicy do
-  subject { described_class.new(user, activity) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+  let(:project) { create(:project_activity, organisation: organisation) }
+  let(:another_project) { create(:project_activity) }
 
-  let(:organisation) { create(:organisation) }
-  let(:activity) { create(:project_activity, organisation: organisation) }
+  subject { described_class.new(user, Activity.project) }
 
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
@@ -16,14 +17,14 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to permit_action(:download) }
 
-    it "includes activity in resolved scope" do
-      resolved_scope = described_class::Scope.new(user, Activity.all).resolve
-      expect(resolved_scope).to include(activity)
+    it "includes all projects in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Activity.project).resolve
+      expect(resolved_scope).to contain_exactly(project, another_project)
     end
   end
 
   context "as a user that does NOT belong to BEIS" do
-    let(:user) { build_stubbed(:delivery_partner_user) }
+    let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
 
     it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:show) }
@@ -32,9 +33,10 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to forbid_action(:download) }
 
-    it "includes activity in resolved scope" do
-      resolved_scope = described_class::Scope.new(user, Activity.all).resolve
-      expect(resolved_scope).to eq(Activity.all)
+    it "includes only projects that the users organisation is reporting the project in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Activity.project).resolve
+      expect(resolved_scope).to include project
+      expect(resolved_scope).not_to include another_project
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
This PR aims to take some steps to making the 'front page' (the page users see upon signing in) more useful and clearer.

- The manage organisation and user links have been moved to the header navigation
- The manage organisation page has been updated to include a table of organisations with show and edit links

For BEIS users the front page shows:

- all funds
- a create fund button
- all programmes
- all projects
- the organisation details (BEIS in this case)
- an edit organisation button

We know this is only a short term fix for BEIS users and that these list will begin to get very long, very quickly!

For delivery partner users the front page shows:

- programmes that the delivery partner is the extending organisation of
- projects that the delivery partner is the associated organistion of
- the organisation details

Because of these changes quite a few feature specs needed to be updated inline with this new UI.

We also felt we wanted to make it clear the impact not setting the extending organisation on a programme would have, so added a hint to that part of the page.

The programme and policy scopes now limit which entities a user will see, however developers must set the right `policy_scope_class` to use the scopes, see the `organisation_controller#show`.

## Screenshots of UI changes

BEIS user front page:
![Screenshot_2020-03-16 Organisation Department for Business, Energy Industrial Strategy — Report Official Development Assist](https://user-images.githubusercontent.com/480578/76782362-156f3e00-67a8-11ea-85fd-a50476feebe4.png)

Delivery partner user front page:
![Screenshot_2020-03-16 Organisation UK Space Agency — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/76782378-1c964c00-67a8-11ea-92e4-e5e4b23ee34e.png)

Organisation management:
![Screenshot_2020-03-16 Organisations — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/76782396-215b0000-67a8-11ea-9c80-7aa058a75ee4.png)

User management:
![Screenshot_2020-03-16 Home — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/76782406-25871d80-67a8-11ea-95c9-686eebfaa7d2.png)

Extending organisation hint text:
![Screenshot_2020-03-16 Activity Programme — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/76782425-2b7cfe80-67a8-11ea-8abf-60ee7be134a2.png)

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
