### PR TITLE
Make sure "Untied" is first in the list of tied_status options

### DIFF
--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -44,9 +44,9 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
   end
 
-  def tied_status_select_options
-    objects = yaml_to_objects(entity: "activity", type: "tied_status", with_empty_item: false)
-    objects.unshift(OpenStruct.new(name: "Untied", code: "5")).uniq
+  def tied_status_radio_options
+    objects = yaml_to_objects_with_description(entity: "activity", type: "tied_status")
+    objects.sort_by! { |item| item.code }.reverse
   end
 
   def load_yaml(entity:, type:)

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :tied_status
-  = f.govuk_collection_radio_buttons :tied_status, yaml_to_objects_with_description(entity: "activity", type: "tied_status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.tied_status") }, hint_text: I18n.t("helpers.hint.activity.tied_status", level: f.object.level)
+  = f.govuk_collection_radio_buttons :tied_status, tied_status_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.tied_status") }, hint_text: I18n.t("helpers.hint.activity.tied_status", level: f.object.level)

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -135,5 +135,12 @@ RSpec.describe CodelistHelper, type: :helper do
           .to eq(OpenStruct.new(name: "ODA", code: "10"))
       end
     end
+
+    describe "#tied_status_radio_options" do
+      it "returns an array of tied_status objects with Untied (5) first in the list" do
+        expect(helper.tied_status_radio_options.first.name)
+          .to eq("Untied")
+      end
+    end
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -105,6 +105,7 @@ module FormHelpers
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.tied_status")
     expect(page).to have_content "This is the tied status of your #{level}"
+    expect(page.find("div.govuk-radios div.govuk-radios__item:first-child input")[:value]).to eq("5")
 
     choose("activity[tied_status]", option: tied_status)
 


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/mibiNC05/353-create-activity-tied-status-change-to-radio-btn-with-hints

As per a discussion with the service owner, as we cannot have a default selected
optino with radio buttons, we are putting "Untied" first in the tied_status
options to help users realise it is the preferred option for ODA.

## Screenshots of UI changes

<img width="742" alt="Screenshot 2020-03-17 at 12 06 49" src="https://user-images.githubusercontent.com/1089521/76854899-d85a8880-6847-11ea-8a27-af52a545c66e.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
