### PR TITLE
WIP - Sector step improve content design

### DIFF
--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,4 +1,4 @@
 = render layout: "wrapper" do |f|
   %h1.govuk-heading-xl= t("form.activity.step.page_title.sector")
 
-  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name, label: { size: 'm' }
+  = f.govuk_collection_select :sector, yaml_to_objects_with_description(entity: "activity", type: "sector"), :code, :name, label: { size: 'm', text: I18n.t("activerecord.attributes.activity.sector", level: f.object.level)  }, hint_text: t("helpers.hint.activity.sector.html", level: f.object.level)

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,2 +1,4 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name, label: { tag: 'h1', size: 'xl' }
+  %h1.govuk-heading-xl= t("form.activity.step.page_title.sector")
+
+  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name, label: { size: 'm' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
         year: Year
       organisation:
         hint: The organisation this activity is associated with
+      step:
+        page_title:
+          sector: Purpose code
       submit: Continue
       update:
         success: Activity successfully updated
@@ -190,7 +193,7 @@ en:
       recipient_region:
         label: Recipient region
       sector:
-        label: Sector
+        label: The focus of your programme or project
       status:
         label: Status
       tied_status:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,7 +193,7 @@ en:
       recipient_region:
         label: Recipient region
       sector:
-        label: The focus of your programme or project
+        label: The focus of your %{level}
       status:
         label: Status
       tied_status:
@@ -277,7 +277,7 @@ en:
         purpose: Purpose
         purpose_level: Purpose of %{level}
         region: Recipient region
-        sector: Sector
+        sector: Purpose code
         status: Status
         tied_status: Tied status
     budget:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -14,7 +14,7 @@ en:
           programme: Programme
         recipient_country: Recipient country
         recipient_region: Recipient region
-        sector: Sector
+        sector: The focus of your programme or project
         status: Status
         tied_status: Tied status
         title: Title
@@ -116,7 +116,7 @@ en:
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity.
         sector:
-          html: Classify the purpose of this activity. <a href='http://reference.iatistandard.org/203/codelists/Sector/' target='_blank'>Please provide the sector appropriate to you from this list</a>.
+          html: What area of the economy or society is your project helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank'>CRS purpose codes.</a>.
         status: This is the stage your %{level} is currently at
         tied_status: This is the tied status of your %{level}
         title: A short, human-readable title that contains a meaningful summary of the activity.

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -14,7 +14,7 @@ en:
           programme: Programme
         recipient_country: Recipient country
         recipient_region: Recipient region
-        sector: The focus of your programme or project
+        sector: The focus of your %{level}
         status: Status
         tied_status: Tied status
         title: Title
@@ -116,7 +116,7 @@ en:
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity.
         sector:
-          html: What area of the economy or society is your project helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank'>CRS purpose codes.</a>.
+          html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank'>CRS purpose codes.</a>
         status: This is the stage your %{level} is currently at
         tied_status: This is the tied status of your %{level}
         title: A short, human-readable title that contains a meaningful summary of the activity.

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a sector
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Sector can't be blank"
+        expect(page).to have_content "The focus of your programme or project can't be blank"
 
         select "Education policy and administrative management", from: "activity[sector]"
         click_button I18n.t("form.activity.submit")

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a sector
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "The focus of your programme or project can't be blank"
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
 
         select "Education policy and administrative management", from: "activity[sector]"
         click_button I18n.t("form.activity.submit")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -38,9 +38,8 @@ module FormHelpers
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.sector")
-    expect(page).to have_content "The focus of your programme or project"
-    expect(page).to have_content "What area of the economy or society is your project helping? For example, research, education or SME development. Choose one of the CRS purpose codes"
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
+    expect(page).to have_content "The focus of your #{level}"
     select sector, from: "activity[sector]"
     click_button I18n.t("form.activity.submit")
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -39,7 +39,8 @@ module FormHelpers
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.sector")
-    expect(page).to have_content "Classify the purpose of this activity. Please provide the sector appropriate to you from this list."
+    expect(page).to have_content "The focus of your programme or project"
+    expect(page).to have_content "What area of the economy or society is your project helping? For example, research, education or SME development. Choose one of the CRS purpose codes"
     select sector, from: "activity[sector]"
     click_button I18n.t("form.activity.submit")
 


### PR DESCRIPTION
trello: https://trello.com/c/GL8qRPuM

Implemented content design suggestions for the sector step in creating an activity.

The page title and heading 1 has changed to be ‘Purpose code’. Also there’s a more descriptive content for the label and hint text.

These suggestions are made after several rounds of testing with users, from which we’ve learnesd that a ‘Sector’ is not descriptive or indicative to the users, and they are more familiar with using ‘Purpose codes’.

As next we’re planning to replace the very long list of select options with a 3 digit code level categories list, and after that to present the user with a more specific sector list after choosing the main category. Before we implement this we need to test this approach first.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

![Screenshot 2020-03-19 at 12 12 51](https://user-images.githubusercontent.com/2632224/77077902-c74b7c00-69ed-11ea-8077-b7e88ce14bc2.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
