### PR TITLE
(352) Change activity Aid type into radio buttons with descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,6 @@
 - Make it clearer that Programme should have an extending organisation in order
   for delivery partners to report on the programme
 - fix cookie error by switching session storage to Redis
-
+- Activity aid type is now selected by radio button, not a dropdown select box  
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,2 +1,3 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :aid_type, yaml_to_objects(entity: "activity", type: "aid_type"), :code, :name, label: { tag: 'h1', size: 'xl' }
+  = f.hidden_field :aid_type
+  = f.govuk_collection_radio_buttons :aid_type, yaml_to_objects_with_description(entity: "activity", type: "aid_type"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.aid_type") }, hint_text: I18n.t("helpers.hint.activity.aid_type.html").html_safe?

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -106,7 +106,7 @@ en:
         actual_end_date: For example, 2 2 2020
         actual_start_date: For example, 11 1 2020
         aid_type:
-          html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidTypeVocabulary/' target='_blank'>IATI descriptions can be found here.</a>
+          html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>IATI descriptions can be found here.</a>
         finance: DAC/CRS transaction classification used to distinguish financial instruments, e.g. grants or loans.
         flow:
           html: "<a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>IATI descriptions of each flow type can be found here.</a>"

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -169,7 +169,7 @@ RSpec.feature "Users can create a fund level activity" do
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content "Aid type can't be blank"
 
-        select "General budget support", from: "activity[aid_type]"
+        choose("activity[aid_type]", option: "A01")
         click_button I18n.t("form.activity.submit")
 
         expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -21,7 +21,7 @@ module FormHelpers
     recipient_region: "Developing countries, unspecified",
     flow: "ODA",
     finance: "Standard grant",
-    aid_type: "General budget support",
+    aid_type: "A01",
     tied_status: "5",
     level: "fund"
   )
@@ -100,7 +100,7 @@ module FormHelpers
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.aid_type")
     expect(page).to have_content "A code for the vocabulary aid-type classifications. IATI descriptions can be found here."
-    select aid_type, from: "activity[aid_type]"
+    choose("activity[aid_type]", option: aid_type)
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.tied_status")
@@ -119,7 +119,7 @@ module FormHelpers
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
     expect(page).to have_content finance
-    expect(page).to have_content aid_type
+    expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")
     expect(page).to have_content I18n.t("activity.tied_status.#{tied_status}")
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,


### PR DESCRIPTION
## Changes in this PR
Trello: https://trello.com/c/Uw6dKrtm/352-create-activity-aid-type

In line with other steps on the Create Activity flow, we have switched Aid type in Activity form from a dropdown to a set of radio buttons with hints.

The hint texts are quite long, so there is a further ticket to iterate over the content and make them smaller & in "plain English" https://trello.com/c/fysX1dKR/497-make-aid-type-descriptions-smaller-in-plain-english

## Screenshots of UI changes

<img width="631" alt="Screenshot 2020-03-19 at 10 41 05" src="https://user-images.githubusercontent.com/1089521/77058996-28635780-69ce-11ea-8d79-48d16b0480d3.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
