### PR TITLE
(466) Enable BEIS users to see all Budgets and Transactions that belong to an Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,5 +86,6 @@
 - Iterate the form content for the sector field by renaming it to "focus area"
 - Enable host whitelisting (Rails 6 feature) to mitigate poisoned host header attacks
 - Anonymize user's IP addresses before logging them outside the application, by removing the last octet of the address. Also use Rollbar's built-in IP address anonymizer.
+- BEIS users can view Transactions & Budgets on a project, but not create or edit them
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -18,8 +18,8 @@ class Staff::ActivitiesController < Staff::BaseController
 
     respond_to do |format|
       format.html do
-        @transaction_presenters = @transactions.map { |transaction| TransactionPresenter.new(transaction) }
-        @budget_presenters = @budgets.map { |budget| BudgetPresenter.new(budget) }
+        @transaction_presenters = @transactions.includes(:activity).map { |transaction| TransactionPresenter.new(transaction) }
+        @budget_presenters = @budgets.includes(:activity).map { |budget| BudgetPresenter.new(budget) }
         @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
       end
       format.xml do |_format|

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -10,9 +10,9 @@ class Staff::BudgetsController < Staff::BaseController
   end
 
   def create
-    authorize :budget, :create?
-
     @activity = Activity.find(activity_id)
+    authorize @activity
+
     result = CreateBudget.new(activity: @activity).call(attributes: budget_params)
 
     if result.success?

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -12,9 +12,9 @@ class Staff::TransactionsController < Staff::BaseController
   end
 
   def create
-    authorize :transaction, :create?
-
     @activity = Activity.find(activity_id)
+    authorize @activity
+
     result = CreateTransaction.new(activity: @activity)
       .call(attributes: transaction_params)
     @transaction = result.object

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -4,11 +4,15 @@ class BudgetPolicy < ApplicationPolicy
   end
 
   def create?
-    true
+    Pundit.policy!(user, record.activity).create?
   end
 
   def update?
-    true
+    Pundit.policy!(user, record.activity).update?
+  end
+
+  def destroy?
+    Pundit.policy!(user, record.activity).destroy?
   end
 
   class Scope < Scope

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -17,8 +17,12 @@ class BudgetPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      activities = Activity.where(organisation_id: user.organisation)
-      scope.where(activity_id: activities)
+      if user.organisation.service_owner?
+        scope.all
+      else
+        activities = Activity.where(organisation_id: user.organisation)
+        scope.where(activity_id: activities)
+      end
     end
   end
 end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -4,11 +4,15 @@ class TransactionPolicy < ApplicationPolicy
   end
 
   def create?
-    true
+    Pundit.policy!(user, record.activity).create?
   end
 
   def update?
-    true
+    Pundit.policy!(user, record.activity).update?
+  end
+
+  def destroy?
+    Pundit.policy!(user, record.activity).destroy?
   end
 
   class Scope < Scope

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -17,8 +17,12 @@ class TransactionPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      activities = Activity.where(organisation_id: user.organisation)
-      scope.where(activity_id: activities)
+      if user.organisation.service_owner?
+        scope.all
+      else
+        activities = Activity.where(organisation_id: user.organisation)
+        scope.where(activity_id: activities)
+      end
     end
   end
 end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -24,7 +24,7 @@
   - if @activity.programme?
     = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
 
-  - if @activity.project? && policy(:project).create?
+  - if @activity.project?
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 

--- a/app/views/staff/shared/activities/_budgets.html.haml
+++ b/app/views/staff/shared/activities/_budgets.html.haml
@@ -3,5 +3,6 @@
     %h2.govuk-heading-m
       = t("page_content.activity.budgets")
 
-    = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
+    - if policy(activity).create?
+      = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/budgets/table', locals: { budgets: budget_presenters }

--- a/app/views/staff/shared/activities/_transactions.html.haml
+++ b/app/views/staff/shared/activities/_transactions.html.haml
@@ -2,6 +2,6 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.transactions")
-
-    = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
+    - if policy(activity).create?
+      = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/transactions/table', locals: { transactions: transaction_presenters }

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -26,4 +26,5 @@
           %td.govuk-table__cell= budget.currency
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
-            = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.activity_id, budget))
+            - if policy(budget).create?
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.activity_id, budget))

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -32,4 +32,5 @@
           %td.govuk-table__cell= transaction.providing_organisation_name
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
-            = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.activity_id, transaction))
+            - if policy(transaction).create?
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.activity_id, transaction))

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -65,6 +65,36 @@ RSpec.feature "Users can view an activity as XML" do
 
         it_behaves_like "valid activity XML"
       end
+
+      context "when the activity has budgets" do
+        let(:activity) { create(:project_activity, organisation: organisation) }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "only includes budgets which belong to the activity" do
+          _budget = create(:budget, activity: activity)
+          _other_budget = create(:budget, activity: create(:activity))
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/budget").count).to eq(1)
+        end
+      end
+
+      context "when the activity has transactions" do
+        let(:activity) { create(:project_activity, organisation: organisation) }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "only includes transactions which belong to the activity" do
+          _transaction = create(:transaction, activity: activity)
+          _other_transaction = create(:transaction, activity: create(:activity))
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/transaction").count).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -3,18 +3,95 @@ require "rails_helper"
 RSpec.describe BudgetPolicy do
   let(:user) { create(:administrator) }
   let(:activity) { create(:activity, organisation: user.organisation) }
+  let(:other_activity) { create(:activity, organisation: create(:organisation)) }
   let(:budget) { create(:budget, activity: activity) }
+  let!(:other_budget) { create(:budget, activity: other_activity) }
 
   subject { described_class.new(user, budget) }
 
-  it { is_expected.to permit_action(:index) }
-  it { is_expected.to permit_action(:show) }
-  it { is_expected.to permit_new_and_create_actions }
-  it { is_expected.to permit_edit_and_update_actions }
-  it { is_expected.to permit_action(:destroy) }
+  context "as a BEIS user" do
+    let(:user) { create(:beis_user) }
 
-  it "includes budget in resolved scope" do
-    resolved_scope = described_class::Scope.new(user, Budget.all).resolve
-    expect(resolved_scope).to include(budget)
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes all budgets in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Budget.all).resolve
+      expect(resolved_scope).to include(budget)
+      expect(resolved_scope).to include(other_budget)
+    end
+  end
+
+  context "as a non-BEIS user" do
+    let(:user) { build_stubbed(:delivery_partner_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      subject { described_class.new(user, budget) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes only budgets that belong to the user's organisation in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Budget.all).resolve
+      expect(resolved_scope).to include(budget)
+      expect(resolved_scope).to_not include(other_budget)
+    end
   end
 end

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -2,19 +2,94 @@ require "rails_helper"
 
 RSpec.describe TransactionPolicy do
   let(:user) { create(:administrator) }
-  let(:activity) { create(:activity, organisation: user.organisation) }
   let(:transaction) { create(:transaction, activity: activity) }
+  let(:activity) { create(:activity, organisation: user.organisation) }
+  let(:other_activity) { create(:activity, organisation: create(:organisation)) }
+  let!(:other_transaction) { create(:transaction, activity: other_activity) }
 
-  subject { described_class.new(user, transaction) }
+  context "as a BEIS user" do
+    let(:user) { create(:beis_user) }
 
-  it { is_expected.to permit_action(:index) }
-  it { is_expected.to permit_action(:show) }
-  it { is_expected.to permit_new_and_create_actions }
-  it { is_expected.to permit_edit_and_update_actions }
-  it { is_expected.to permit_action(:destroy) }
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
 
-  it "includes activity in resolved scope" do
-    resolved_scope = described_class::Scope.new(user, Transaction.all).resolve
-    expect(resolved_scope).to include(transaction)
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes all transactions in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Transaction.all).resolve
+      expect(resolved_scope).to include(transaction)
+      expect(resolved_scope).to include(other_transaction)
+    end
+  end
+
+  context "as a delivery partner user" do
+    let(:user) { build_stubbed(:delivery_partner_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      subject { described_class.new(user, transaction) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes only transactions the belong to the user's organisation in resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Transaction.all).resolve
+      expect(resolved_scope).to include(transaction)
+      expect(resolved_scope).to_not include(other_transaction)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
Trello: https://trello.com/c/Xnef9CW2/466-bug-beis-users-do-not-see-transations-or-budgets-that-are-not-associated-with-their-organisation

Regardless of which organisation the Budgets or Transactions belong to, BEIS users
should be able to see them.

This ticket was raised because BEIS users could not see Budgets and Transactions
in the downloaded IATI XML, because the Budgets/Transactions did not belong to the
user's organisation.

Now, in the Activity XML BEIS users can see all budgets and transactions that belong to
the Activity.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
