### PR TITLE
Sector step renamed to Focus Area for clarity and hint text added to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,5 +83,6 @@
   for delivery partners to report on the programme
 - fix cookie error by switching session storage to Redis
 - Activity aid type is now selected by radio button, not a dropdown select box  
+- Iterate the form content for the sector field by renaming it to "focus area"
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,2 +1,7 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector, yaml_to_objects(entity: "activity", type: "sector"), :code, :name, label: { tag: 'h1', size: 'xl' }
+  = f.govuk_collection_select :sector,
+    yaml_to_objects(entity: "activity", type: "sector", with_empty_item: true),
+    :code,
+    :name,
+    label: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: f.object.level) },
+    hint_text: t("helpers.hint.activity.sector.html", level: f.object.level)

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -36,7 +36,7 @@
 
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
-      = t("page_content.activity.sector.label")
+      = t("page_content.activity.sector.label", level: activity_presenter.level)
     %dd.govuk-summary-list__value
       = activity_presenter.sector
     %dd.govuk-summary-list__actions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,7 +190,7 @@ en:
       recipient_region:
         label: Recipient region
       sector:
-        label: Sector
+        label: Focus area
       status:
         label: Status
       tied_status:
@@ -277,7 +277,7 @@ en:
         purpose: Purpose
         purpose_level: Purpose of %{level}
         region: Recipient region
-        sector: Sector
+        sector: What is the focus area for this %{level}
         status: Status
         tied_status: Tied status
     budget:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -14,7 +14,7 @@ en:
           programme: Programme
         recipient_country: Recipient country
         recipient_region: Recipient region
-        sector: Sector
+        sector: Focus area
         status: Status
         tied_status: Tied status
         title: Title
@@ -116,7 +116,7 @@ en:
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity.
         sector:
-          html: Classify the purpose of this activity. <a href='http://reference.iatistandard.org/203/codelists/Sector/' target='_blank'>Please provide the sector appropriate to you from this list</a>.
+          html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
         status: This is the stage your %{level} is currently at
         tied_status: This is the tied status of your %{level}
         title: A short, human-readable title that contains a meaningful summary of the activity.

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Users can create a fund level activity" do
       visit organisation_path(user.organisation)
       click_on(I18n.t("page_content.organisation.button.create_fund"))
 
-      fill_in_activity_form(identifier: identifier)
+      fill_in_activity_form(identifier: identifier, level: "fund")
 
       activity = Activity.find_by(identifier: identifier)
       expect(activity.funding_organisation_name).to eq("HM Treasury")
@@ -53,7 +53,7 @@ RSpec.feature "Users can create a fund level activity" do
       visit organisation_path(user.organisation)
       click_on(I18n.t("page_content.organisation.button.create_fund"))
 
-      fill_in_activity_form(identifier: identifier)
+      fill_in_activity_form(identifier: identifier, level: "fund")
 
       activity = Activity.find_by(identifier: identifier)
       expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
@@ -67,7 +67,7 @@ RSpec.feature "Users can create a fund level activity" do
       visit organisation_path(user.organisation)
       click_on(I18n.t("page_content.organisation.button.create_fund"))
 
-      fill_in_activity_form(identifier: identifier)
+      fill_in_activity_form(identifier: identifier, level: "fund")
 
       activity = Activity.find_by(identifier: identifier)
       expect(activity.extending_organisation).to eql(user.organisation)
@@ -96,11 +96,11 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[description]", with: Faker::Lorem.paragraph
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
 
         # Don't provide a sector
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Sector can't be blank"
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
 
         select "Education policy and administrative management", from: "activity[sector]"
         click_button I18n.t("form.activity.submit")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -23,7 +23,7 @@ module FormHelpers
     finance: "Standard grant",
     aid_type: "A01",
     tied_status: "5",
-    level: "fund"
+    level:
   )
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.identifier")
@@ -38,8 +38,12 @@ module FormHelpers
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.sector")
-    expect(page).to have_content "Classify the purpose of this activity. Please provide the sector appropriate to you from this list."
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: level)
+    expect(page).to have_content(
+      ActionView::Base.full_sanitizer.sanitize(
+        I18n.t("helpers.hint.activity.sector.html", level: level)
+      )
+    )
     select sector, from: "activity[sector]"
     click_button I18n.t("form.activity.submit")
 


### PR DESCRIPTION
…the form

## Changes in this PR

The form step changes dynamically to include the level of activity being created. Once this contextual guidance has been used to create the activity, the static "Focus area" is used instead of "Sector" through the rest of the service (apart from IATI where sector is used).

"Focus area in {level}" is only used within the form when that concept is introduced to users. Once introduced the theory is that users can link this back when they see the content within the service and the dynamic inclusion becomes redundant. For example, viewing a fund level activity and seeing "Focus area for your fund" in the list of contents

Co-authored-by: Agz <agz@dxw.com>

## Screenshots of UI changes

### Before

![Screenshot 2020-03-19 at 17 02 31](https://user-images.githubusercontent.com/912473/77093871-8cecd980-6a03-11ea-910d-9c8800582472.png)


### After


![Screenshot 2020-03-19 at 17 01 01](https://user-images.githubusercontent.com/912473/77093887-91b18d80-6a03-11ea-963c-0f1ab8de6577.png)
![Screenshot 2020-03-19 at 17 01 48](https://user-images.githubusercontent.com/912473/77093892-924a2400-6a03-11ea-8017-710490e6f98b.png)
![Screenshot 2020-03-19 at 17 02 01](https://user-images.githubusercontent.com/912473/77093883-9118f700-6a03-11ea-8556-8f987ccb825a.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
