### PR TITLE
(471) Unknown Auth0 error messages are not displayed

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -15,7 +15,12 @@ class Auth0Controller < ApplicationController
   end
 
   def failure
-    # show a failure page or redirect to an error page
-    @error_message = request.params["message"]
+    message = request.params["message"]
+    @error_message = t message.to_sym,
+      scope: "page_content.errors.auth0.error_messages",
+      raise: true
+  rescue I18n::MissingTranslationData
+    Rollbar.log(:info, "Unknown response from Auth0", message)
+    @error_message = t("page_content.errors.auth0.error_messages.generic")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,9 @@ en:
         create: Create budget
     errors:
       auth0:
+        error_messages:
+          generic: There was a problem signing you in.
+          invalid_credentials: Invalid credentials
         failed:
           explanation: Your request to sign in failed
           prompt: Try signing in again and if you continue to have this issue please contact support.


### PR DESCRIPTION
This work came out of the Pentest which was performed on the service in
March 2020.

An attacker could inject their own error message into a fake
Auth0 response and get the user to inteact with a bogus service.

By checking the error message is something we know and understand and
then displaying our own error message instead we prevent this attack.

If we see a unknown error message, we log to Rollbar so we can learn
what errors we are seeing and display a generic error message.

As ever, I struggled to find a good home for the locales that display
the errors, I went for a location that already had 'errors' and 'auth0'
over creating more separation.

I reworded some of the specs to better reflect what is under test.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
