### PR TITLE
(496) Organisation factory only create one BEIS

### DIFF
--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -12,7 +12,15 @@ FactoryBot.define do
 
     factory :beis_organisation do
       name { "Department for Business, Energy and Industrial Strategy" }
+      iati_reference { "GB-GOV-13" }
       service_owner { true }
+      initialize_with do
+        Organisation.find_or_create_by(
+          name: name,
+          iati_reference: iati_reference,
+          service_owner: service_owner
+        )
+      end
     end
   end
 end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Factory" do
+  describe "Activity Factory" do
+    context "when multiple beis_organisation factories are created" do
+      it "only creates 1 record" do
+        create_list(:beis_organisation, 2)
+
+        result = Organisation.where(
+          name: "Department for Business, Energy and Industrial Strategy",
+          iati_reference: "GB-GOV-13",
+          service_owner: true
+        )
+
+        expect(result.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This change fixes a known interimittent test failure and potential others we aren't currently aware of.

The test that we know fails: `spec/services/create_project_activity_spec.rb:42`

After a number of refactorings the final change we're proposing to fix this is problem is one to the Organisation Factory as a whole. It should ensure that only 1 BEIS organisation can ever be created within the context of any one test. The main advantage of this approach is that fewer tests have to repeat the precise setup steps required to create an activity with valid parent activities. More information is attached on the commit.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
