### PR TITLE
Enable Rails 6 hosts whitelisting to counteract host header poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,5 +84,6 @@
 - fix cookie error by switching session storage to Redis
 - Activity aid type is now selected by radio button, not a dropdown select box  
 - Iterate the form content for the sector field by renaming it to "focus area"
+- Enable host whitelisting (Rails 6 feature) to mitigate poisoned host header attacks
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,4 +118,10 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.require_master_key = false
+
+  # See https://github.com/rails/rails/issues/29893
+  # This whitelists the hosts the application can trust when using `url_for` and related helpers
+  config.hosts = [
+    ENV["DOMAIN"],
+  ]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,9 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
   end
+
+  config.hosts = [
+    /test.local/,
+    /localhost/,
+  ]
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,6 +83,10 @@ RSpec.configure do |config|
   config.after(:each) do |example|
     ActionMailer::Base.deliveries.clear
   end
+
+  config.before(:each, type: :request) do
+    host! "test.local"
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/host_urls_are_whitelisted_spec.rb
+++ b/spec/requests/host_urls_are_whitelisted_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "host urls are checked against a whitelist", type: :request do
+  scenario "a whitelisted host is accepted and and OK response is received" do
+    get root_path, headers: {"Host" => "test.local"}
+    expect(response).to have_http_status("200")
+  end
+
+  scenario "a bad host is rejected and the request is forbidden" do
+    get root_path, headers: {"Host" => "baddomain.com"}
+    expect(response).to have_http_status("403")
+  end
+end

--- a/spec/requests/users_can_sign_out_spec.rb
+++ b/spec/requests/users_can_sign_out_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe "signing out of Auth0", type: :request do
     allow(ENV).to receive(:[]).with("BULLET_DEBUG").and_return("false")
     allow(ENV).to receive(:[]).with("AUTH0_CLIENT_ID").and_return("123456")
     allow(ENV).to receive(:[]).with("AUTH0_DOMAIN").and_return("test.auth0")
+    host! "test.local"
     mock_successful_authentication
 
     get "/sign_out"
 
-    expect(request).to redirect_to("https://test.auth0/v2/logout?returnTo=http%3A%2F%2Fwww.example.com%2F&client_id=123456")
+    expect(request).to redirect_to("https://test.auth0/v2/logout?returnTo=http%3A%2F%2Ftest.local%2F&client_id=123456")
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 Capybara.asset_host = "http://localhost:3000"
+Capybara.app_host = "http://localhost"


### PR DESCRIPTION

## Changes in this PR
Trello: https://trello.com/c/fKK1MwEE/473-http-host-header-poisoning-id-web-l3

During a recent pen test, our application was found to be vulnerable to a Host
header poisoning attack, in which a "bad" hostname can be injected into the
request headers and passed back to the client, where it may be used to redirect
users (or in any scenario where `url_for` is used or the `location` is passed
back to the client)

Using a built-in feature in Rails 6 https://github.com/rails/rails/pull/33145
we are able to only allow known hostnames to be passed on from a request header
into the application.

## Screenshots of UI changes

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
