### PR TITLE
Activity details take full page width

### DIFF
--- a/app/assets/stylesheets/partials/_definition_list.scss
+++ b/app/assets/stylesheets/partials/_definition_list.scss
@@ -1,0 +1,9 @@
+.activity-page {
+  .activity-details {
+    .govuk-summary-list__actions {
+      @include govuk-media-query($from: desktop) {
+        width: 10%;
+      }
+    }
+  }
+}

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -3,12 +3,12 @@
 = link_to t("generic.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
+    .govuk-grid-column-full
       %h1.govuk-heading-xl
         = @activity.title
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
       = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
 
   - if @activity.fund? && policy(:fund).create?

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -1,4 +1,4 @@
-%dl.govuk-summary-list
+%dl.govuk-summary-list.activity-details
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("page_content.activity.organisation.label")


### PR DESCRIPTION
Trello: https://trello.com/c/oQ88bfcT

We change the activity detail to take full page width, so that if the description is very long it takes less vertical space. 

Also we reduced the width of action links, to help manage the horizontal space better.

We should be striving towards separating information that is less used and important into smaller chunks (perhaps into a side navigation link or a tab) and move up the most used and important information to the top.

## Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot_2020-03-23 Activity Rainforest conservation — Report Official Development Assistance](https://user-images.githubusercontent.com/2632224/77343689-03eae080-6d2a-11ea-9f0d-7aee4c1ad98a.png)

### After

![Screenshot_2020-03-23 Activity Rainforest conservation — Report Official Development Assistance(1)](https://user-images.githubusercontent.com/2632224/77343831-3ac0f680-6d2a-11ea-994d-e5da70b13809.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
