### PR TITLE
Recipient country list reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,10 +82,11 @@
 - Make it clearer that Programme should have an extending organisation in order
   for delivery partners to report on the programme
 - fix cookie error by switching session storage to Redis
-- Activity aid type is now selected by radio button, not a dropdown select box  
+- Activity aid type is now selected by radio button, not a dropdown select box
 - Iterate the form content for the sector field by renaming it to "focus area"
 - Enable host whitelisting (Rails 6 feature) to mitigate poisoned host header attacks
 - Anonymize user's IP addresses before logging them outside the application, by removing the last octet of the address. Also use Rollbar's built-in IP address anonymizer.
 - BEIS users can view Transactions & Budgets on a project, but not create or edit them
+- Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
@@ -13,29 +13,14 @@ data:
 - code: AF
   name: Afghanistan
   status: active
-- code: AX
-  name: Åland Islands
-  status: active
 - code: AL
   name: Albania
   status: active
 - code: DZ
   name: Algeria
   status: active
-- code: AS
-  name: American Samoa
-  status: active
-- code: AD
-  name: Andorra
-  status: active
 - code: AO
   name: Angola
-  status: active
-- code: AI
-  name: Anguilla
-  status: active
-- code: AQ
-  name: Antarctica
   status: active
 - code: AG
   name: Antigua and Barbuda
@@ -46,35 +31,14 @@ data:
 - code: AM
   name: Armenia
   status: active
-- code: AW
-  name: Aruba
-  status: active
-- code: AU
-  name: Australia
-  status: active
-- code: AT
-  name: Austria
-  status: active
 - code: AZ
   name: Azerbaijan
-  status: active
-- code: BS
-  name: Bahamas (the)
-  status: active
-- code: BH
-  name: Bahrain
   status: active
 - code: BD
   name: Bangladesh
   status: active
-- code: BB
-  name: Barbados
-  status: active
 - code: BY
   name: Belarus
-  status: active
-- code: BE
-  name: Belgium
   status: active
 - code: BZ
   name: Belize
@@ -82,17 +46,11 @@ data:
 - code: BJ
   name: Benin
   status: active
-- code: BM
-  name: Bermuda
-  status: active
 - code: BT
   name: Bhutan
   status: active
 - code: BO
   name: Bolivia (Plurinational State of)
-  status: active
-- code: BQ
-  name: Bonaire, Sint Eustatius and Saba
   status: active
 - code: BA
   name: Bosnia and Herzegovina
@@ -100,20 +58,8 @@ data:
 - code: BW
   name: Botswana
   status: active
-- code: BV
-  name: Bouvet Island
-  status: active
 - code: BR
   name: Brazil
-  status: active
-- code: IO
-  name: British Indian Ocean Territory (the)
-  status: active
-- code: BN
-  name: Brunei Darussalam
-  status: active
-- code: BG
-  name: Bulgaria
   status: active
 - code: BF
   name: Burkina Faso
@@ -127,14 +73,8 @@ data:
 - code: CM
   name: Cameroon
   status: active
-- code: CA
-  name: Canada
-  status: active
 - code: CV
   name: Cabo Verde
-  status: active
-- code: KY
-  name: Cayman Islands (the)
   status: active
 - code: CF
   name: Central African Republic (the)
@@ -142,17 +82,8 @@ data:
 - code: TD
   name: Chad
   status: active
-- code: CL
-  name: Chile
-  status: active
 - code: CN
   name: China
-  status: active
-- code: CX
-  name: Christmas Island
-  status: active
-- code: CC
-  name: Cocos (Keeling) Islands (the)
   status: active
 - code: CO
   name: Colombia
@@ -166,32 +97,14 @@ data:
 - code: CD
   name: Congo (the Democratic Republic of the)
   status: active
-- code: CK
-  name: Cook Islands (the)
-  status: active
 - code: CR
   name: Costa Rica
   status: active
 - code: CI
   name: Côte d'Ivoire
   status: active
-- code: HR
-  name: Croatia
-  status: active
 - code: CU
   name: Cuba
-  status: active
-- code: CW
-  name: Curaçao
-  status: active
-- code: CY
-  name: Cyprus
-  status: active
-- code: CZ
-  name: Czechia
-  status: active
-- code: DK
-  name: Denmark
   status: active
 - code: DJ
   name: Djibouti
@@ -217,35 +130,11 @@ data:
 - code: ER
   name: Eritrea
   status: active
-- code: EE
-  name: Estonia
-  status: active
 - code: ET
   name: Ethiopia
   status: active
-- code: FK
-  name: Falkland Islands (the) [Malvinas]
-  status: active
-- code: FO
-  name: Faroe Islands (the)
-  status: active
 - code: FJ
   name: Fiji
-  status: active
-- code: FI
-  name: Finland
-  status: active
-- code: FR
-  name: France
-  status: active
-- code: GF
-  name: French Guiana
-  status: active
-- code: PF
-  name: French Polynesia
-  status: active
-- code: TF
-  name: French Southern Territories (the)
   status: active
 - code: GA
   name: Gabon
@@ -256,35 +145,14 @@ data:
 - code: GE
   name: Georgia
   status: active
-- code: DE
-  name: Germany
-  status: active
 - code: GH
   name: Ghana
-  status: active
-- code: GI
-  name: Gibraltar
-  status: active
-- code: GR
-  name: Greece
-  status: active
-- code: GL
-  name: Greenland
   status: active
 - code: GD
   name: Grenada
   status: active
-- code: GP
-  name: Guadeloupe
-  status: active
-- code: GU
-  name: Guam
-  status: active
 - code: GT
   name: Guatemala
-  status: active
-- code: GG
-  name: Guernsey
   status: active
 - code: GN
   name: Guinea
@@ -298,23 +166,8 @@ data:
 - code: HT
   name: Haiti
   status: active
-- code: HM
-  name: Heard Island and McDonald Islands
-  status: active
-- code: VA
-  name: Holy See (the)
-  status: active
 - code: HN
   name: Honduras
-  status: active
-- code: HK
-  name: Hong Kong
-  status: active
-- code: HU
-  name: Hungary
-  status: active
-- code: IS
-  name: Iceland
   status: active
 - code: IN
   name: India
@@ -328,26 +181,8 @@ data:
 - code: IQ
   name: Iraq
   status: active
-- code: IE
-  name: Ireland
-  status: active
-- code: IM
-  name: Isle of Man
-  status: active
-- code: IL
-  name: Israel
-  status: active
-- code: IT
-  name: Italy
-  status: active
 - code: JM
   name: Jamaica
-  status: active
-- code: JP
-  name: Japan
-  status: active
-- code: JE
-  name: Jersey
   status: active
 - code: JO
   name: Jordan
@@ -370,17 +205,11 @@ data:
 - code: XK
   name: Kosovo
   status: active
-- code: KW
-  name: Kuwait
-  status: active
 - code: KG
   name: Kyrgyzstan
   status: active
 - code: LA
   name: Lao People's Democratic Republic (the)
-  status: active
-- code: LV
-  name: Latvia
   status: active
 - code: LB
   name: Lebanon
@@ -393,18 +222,6 @@ data:
   status: active
 - code: LY
   name: Libya
-  status: active
-- code: LI
-  name: Liechtenstein
-  status: active
-- code: LT
-  name: Lithuania
-  status: active
-- code: LU
-  name: Luxembourg
-  status: active
-- code: MO
-  name: Macao
   status: active
 - code: MK
   name: North Macedonia
@@ -424,23 +241,14 @@ data:
 - code: ML
   name: Mali
   status: active
-- code: MT
-  name: Malta
-  status: active
 - code: MH
   name: Marshall Islands (the)
-  status: active
-- code: MQ
-  name: Martinique
   status: active
 - code: MR
   name: Mauritania
   status: active
 - code: MU
   name: Mauritius
-  status: active
-- code: YT
-  name: Mayotte
   status: active
 - code: MX
   name: Mexico
@@ -450,9 +258,6 @@ data:
   status: active
 - code: MD
   name: Moldova (the Republic of)
-  status: active
-- code: MC
-  name: Monaco
   status: active
 - code: MN
   name: Mongolia
@@ -481,18 +286,6 @@ data:
 - code: NP
   name: Nepal
   status: active
-- code: NL
-  name: Netherlands (the)
-  status: active
-- code: AN
-  name: NETHERLAND ANTILLES
-  status: withdrawn
-- code: NC
-  name: New Caledonia
-  status: active
-- code: NZ
-  name: New Zealand
-  status: active
 - code: NI
   name: Nicaragua
   status: active
@@ -505,26 +298,11 @@ data:
 - code: NU
   name: Niue
   status: active
-- code: NF
-  name: Norfolk Island
-  status: active
-- code: MP
-  name: Northern Mariana Islands (the)
-  status: active
-- code: 'NO'
-  name: Norway
-  status: active
-- code: OM
-  name: Oman
-  status: active
 - code: PK
   name: Pakistan
   status: active
 - code: PW
   name: Palau
-  status: active
-- code: PS
-  name: Palestine, State of
   status: active
 - code: PA
   name: Panama
@@ -541,50 +319,14 @@ data:
 - code: PH
   name: Philippines (the)
   status: active
-- code: PN
-  name: Pitcairn
-  status: active
-- code: PL
-  name: Poland
-  status: active
-- code: PT
-  name: Portugal
-  status: active
-- code: PR
-  name: Puerto Rico
-  status: active
-- code: QA
-  name: Qatar
-  status: active
-- code: RE
-  name: Réunion
-  status: active
-- code: RO
-  name: Romania
-  status: active
-- code: RU
-  name: Russian Federation (the)
-  status: active
 - code: RW
   name: Rwanda
-  status: active
-- code: BL
-  name: Saint Barthélemy
   status: active
 - code: SH
   name: Saint Helena, Ascension and Tristan da Cunha
   status: active
-- code: KN
-  name: Saint Kitts and Nevis
-  status: active
 - code: LC
   name: Saint Lucia
-  status: active
-- code: MF
-  name: Saint Martin (French part)
-  status: active
-- code: PM
-  name: Saint Pierre and Miquelon
   status: active
 - code: VC
   name: Saint Vincent and the Grenadines
@@ -592,14 +334,8 @@ data:
 - code: WS
   name: Samoa
   status: active
-- code: SM
-  name: San Marino
-  status: active
 - code: ST
   name: Sao Tome and Principe
-  status: active
-- code: SA
-  name: Saudi Arabia
   status: active
 - code: SN
   name: Senegal
@@ -607,23 +343,8 @@ data:
 - code: RS
   name: Serbia
   status: active
-- code: SC
-  name: Seychelles
-  status: active
 - code: SL
   name: Sierra Leone
-  status: active
-- code: SG
-  name: Singapore
-  status: active
-- code: SX
-  name: Sint Maarten (Dutch part)
-  status: active
-- code: SK
-  name: Slovakia
-  status: active
-- code: SI
-  name: Slovenia
   status: active
 - code: SB
   name: Solomon Islands
@@ -634,14 +355,8 @@ data:
 - code: ZA
   name: South Africa
   status: active
-- code: GS
-  name: South Georgia and the South Sandwich Islands
-  status: active
 - code: SS
   name: South Sudan
-  status: active
-- code: ES
-  name: Spain
   status: active
 - code: LK
   name: Sri Lanka
@@ -652,23 +367,11 @@ data:
 - code: SR
   name: Suriname
   status: active
-- code: SJ
-  name: Svalbard and Jan Mayen
-  status: active
 - code: SZ
   name: Eswatini
   status: active
-- code: SE
-  name: Sweden
-  status: active
-- code: CH
-  name: Switzerland
-  status: active
 - code: SY
   name: Syrian Arab Republic
-  status: active
-- code: TW
-  name: Taiwan (Province of China)
   status: active
 - code: TJ
   name: Tajikistan
@@ -691,9 +394,6 @@ data:
 - code: TO
   name: Tonga
   status: active
-- code: TT
-  name: Trinidad and Tobago
-  status: active
 - code: TN
   name: Tunisia
   status: active
@@ -703,9 +403,6 @@ data:
 - code: TM
   name: Turkmenistan
   status: active
-- code: TC
-  name: Turks and Caicos Islands (the)
-  status: active
 - code: TV
   name: Tuvalu
   status: active
@@ -714,21 +411,6 @@ data:
   status: active
 - code: UA
   name: Ukraine
-  status: active
-- code: AE
-  name: United Arab Emirates (the)
-  status: active
-- code: GB
-  name: United Kingdom of Great Britain and Northern Ireland (the)
-  status: active
-- code: US
-  name: United States of America (the)
-  status: active
-- code: UM
-  name: United States Minor Outlying Islands (the)
-  status: active
-- code: UY
-  name: Uruguay
   status: active
 - code: UZ
   name: Uzbekistan
@@ -742,17 +424,8 @@ data:
 - code: VN
   name: Viet Nam
   status: active
-- code: VG
-  name: Virgin Islands (British)
-  status: active
-- code: VI
-  name: Virgin Islands (U.S.)
-  status: active
 - code: WF
   name: Wallis and Futuna
-  status: active
-- code: EH
-  name: Western Sahara
   status: active
 - code: YE
   name: Yemen


### PR DESCRIPTION
Trello: https://trello.com/c/R1sH0nhV

## Changes in this PR

When creating an activity, in the recipient country step there was a list including all the countries on the ISO list.

Following advice from users regarding this list being too extensive and including countries that ODA do not consider recipients, I have reduced the list of countries leaving only the ones that ODA report as recipients.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
