### PR TITLE
(Fix) Parse ENV["DOMAIN"] to retrieve host name for use in config.hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,7 +121,7 @@ Rails.application.configure do
 
   # See https://github.com/rails/rails/issues/29893
   # This whitelists the hosts the application can trust when using `url_for` and related helpers
-  config.hosts = [
-    ENV["DOMAIN"],
-  ]
+  hosts = []
+  hosts << URI(ENV["DOMAIN"])&.host if ENV["DOMAIN"].present?
+  config.hosts = hosts.compact
 end


### PR DESCRIPTION

## Changes in this PR

In https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/286
we enabled Rails 6 host whitelisting. Unfortunately in that PR we used the
ENV["DOMAIN"] variable as the host, but this contains a full URI and not just
the host name. This PR parses the DOMAIN variable to extract only the host for
use in `config.host`

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
