### PR TITLE
IATI reporting-org should be BEIS regardless of the user's organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,5 +88,6 @@
 - Anonymize user's IP addresses before logging them outside the application, by removing the last octet of the address. Also use Rollbar's built-in IP address anonymizer.
 - BEIS users can view Transactions & Budgets on a project, but not create or edit them
 - Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
+- Reporting org in the IATI XML is always BEIS for funds, programmes and projects created by UKSA, despite what the database record says
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,4 +7,8 @@ class Organisation < ApplicationRecord
 
   scope :sorted_by_name, -> { order(name: :asc) }
   scope :delivery_partners, -> { sorted_by_name.where(service_owner: false) }
+
+  def is_government_organisation?
+    %w[10 11].include?(organisation_type)
+  end
 end

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,7 +1,12 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
   %iati-identifier= activity.iati_identifier
-  %reporting-org{"type" => activity.organisation.organisation_type, "ref" => activity.organisation.iati_reference }
-    %narrative= activity.organisation.name
+  - service_owner = Organisation.find_by(service_owner: true)
+  - if activity.organisation.is_government_organisation?
+    %reporting-org{"type" => service_owner.organisation_type, "ref" => service_owner.iati_reference }
+      %narrative= service_owner.name
+  - else
+    %reporting-org{"type" => activity.organisation.organisation_type, "ref" => activity.organisation.iati_reference }
+      %narrative= activity.organisation.name
   %title
     %narrative= activity.title
   %description{"type" => "1"}

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -48,6 +48,14 @@ RSpec.feature "Users can view an activity as XML" do
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
+
+        it "sets BEIS as the reporting org" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/reporting-org/@type").text).to eq("10")
+          expect(xml.at("iati-activity/reporting-org/@ref").text).to eq("GB-GOV-13")
+          expect(xml.at("iati-activity/reporting-org/narrative").text).to eq("Department for Business, Energy and Industrial Strategy")
+        end
       end
 
       context "when the activity is a programme activity" do
@@ -56,6 +64,14 @@ RSpec.feature "Users can view an activity as XML" do
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
+
+        it "sets BEIS as the reporting org" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/reporting-org/@type").text).to eq("10")
+          expect(xml.at("iati-activity/reporting-org/@ref").text).to eq("GB-GOV-13")
+          expect(xml.at("iati-activity/reporting-org/narrative").text).to eq("Department for Business, Energy and Industrial Strategy")
+        end
       end
 
       context "when the activity is a project activity" do
@@ -64,6 +80,30 @@ RSpec.feature "Users can view an activity as XML" do
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
+
+        context "when the delivery partner is a governmental organisation" do
+          let(:organisation) { create(:organisation, name: "UKSA", organisation_type: 10) }
+
+          it "sets BEIS as the reporting org" do
+            visit organisation_activity_path(organisation, activity, format: :xml)
+
+            expect(xml.at("iati-activity/reporting-org/@type").text).to eq("10")
+            expect(xml.at("iati-activity/reporting-org/@ref").text).to eq("GB-GOV-13")
+            expect(xml.at("iati-activity/reporting-org/narrative").text).to eq("Department for Business, Energy and Industrial Strategy")
+          end
+        end
+
+        context "when the delivery partner isa non-governmental organisation" do
+          let(:organisation) { create(:organisation, name: "AMS", organisation_type: 15) }
+
+          it "sets itself as the reporting org" do
+            visit organisation_activity_path(organisation, activity, format: :xml)
+
+            expect(xml.at("iati-activity/reporting-org/@type").text).to eq(organisation.organisation_type)
+            expect(xml.at("iati-activity/reporting-org/@ref").text).to eq(organisation.iati_reference)
+            expect(xml.at("iati-activity/reporting-org/narrative").text).to eq(organisation.name)
+          end
+        end
       end
 
       context "when the activity has budgets" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -71,4 +71,21 @@ RSpec.describe Organisation, type: :model do
       expect(delivery_partners).not_to include(beis_organisation)
     end
   end
+
+  describe "#is_government_organisation?" do
+    it "should be true for a Government organisation_type" do
+      organisation = create(:organisation, organisation_type: 10)
+      expect(organisation.is_government_organisation?).to eq true
+    end
+
+    it "should be true for a Government organisation_type" do
+      organisation = create(:organisation, organisation_type: 11)
+      expect(organisation.is_government_organisation?).to eq true
+    end
+
+    it "should be false for an NGO organisation_type" do
+      organisation = create(:organisation, organisation_type: 21)
+      expect(organisation.is_government_organisation?).to eq false
+    end
+  end
 end


### PR DESCRIPTION


## Changes in this PR
Trello: https://trello.com/c/CfLUXjCa/459-iati-reporting-org-should-be-beis-regardless-of-the-users-organisation

Funds and programmes should have their reporting org set as BEIS

Projects created by UKSA (our current only delivery partner) should have their
reporting org set as BEIS

Other future DPs will have themselves set as their reporting org (for now).

Note that these changes are only in the XML representation of the activity, not
the database record.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
