### PR TITLE
Finance value defaulted and step removed from Create Activity journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,8 @@
 
 ## [unreleased]
 
+- When creating an activity the Finance step has been defaulted to `Standard grant` and omitted from the user journey
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...HEAD
 [release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3
 [release-2]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-1...release-2
-

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -13,7 +13,6 @@ class Staff::ActivityFormsController < Staff::BaseController
     :region,
     :country,
     :flow,
-    :finance,
     :aid_type,
     :tied_status,
   ]
@@ -77,7 +76,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   def activity_params
     params.require(:activity).permit(:identifier, :sector, :title, :description, :status,
       :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date,
-      :geography, :recipient_region, :recipient_country, :flow, :finance,
+      :geography, :recipient_region, :recipient_country, :flow,
       :aid_type, :tied_status)
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,6 @@
 class Activity < ApplicationRecord
+  STANDARD_GRANT_FINANCE_CODE = "110"
+
   validates :identifier, presence: true, if: :identifier_step?
   validates :title, :description, presence: true, if: :purpose_step?
   validates :sector, presence: true, if: :sector_step?
@@ -7,7 +9,6 @@ class Activity < ApplicationRecord
   validates :recipient_region, presence: true, if: :region_step?
   validates :recipient_country, presence: true, if: :country_step?
   validates :flow, presence: true, if: :flow_step?
-  validates :finance, presence: true, if: :finance_step?
   validates :aid_type, presence: true, if: :aid_type_step?
   validates :tied_status, presence: true, if: :tied_status_step?
   validates_uniqueness_of :identifier
@@ -35,6 +36,10 @@ class Activity < ApplicationRecord
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
+
+  def finance
+    STANDARD_GRANT_FINANCE_CODE
+  end
 
   private def identifier_step?
     wizard_status == "identifier" || wizard_complete?
@@ -70,10 +75,6 @@ class Activity < ApplicationRecord
 
   private def flow_step?
     wizard_status == "flow" || wizard_complete?
-  end
-
-  private def finance_step?
-    wizard_status == "finance" || wizard_complete?
   end
 
   private def aid_type_step?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -56,11 +56,6 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.flow.#{super}")
   end
 
-  def finance
-    return if super.blank?
-    I18n.t("activity.finance.#{super}")
-  end
-
   def tied_status
     return if super.blank?
     I18n.t("activity.tied_status.#{super}")

--- a/app/views/staff/activity_forms/finance.html.haml
+++ b/app/views/staff/activity_forms/finance.html.haml
@@ -1,2 +1,0 @@
-= render layout: "wrapper" do |f|
-  = f.govuk_collection_select :finance, yaml_to_objects(entity: "activity", type: "finance"), :code, :name, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -127,15 +127,6 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :flow)
         = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("page_content.activity.flow.label"))
 
-  .govuk-summary-list__row.finance
-    %dt.govuk-summary-list__key
-      = t("page_content.activity.finance.label")
-    %dd.govuk-summary-list__value
-      = activity_presenter.finance
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :finance)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:finance)}"), activity_step_path(activity_presenter, :finance), t("page_content.activity.finance.label"))
-
   .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
       = t("page_content.activity.aid_type.label")

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -17,69 +17,6 @@ en:
       g01: Administrative costs not included elsewhere
       h01: Development awareness
       h02: Refugees in donor countries
-    finance:
-      '110': Standard grant
-      '1100': Guarantees/insurance
-      '111': Subsidies to national private investors
-      '210': Interest subsidy
-      '211': Interest subsidy to national private exporters
-      '310': Capital subscription on deposit basis
-      '311': Capital subscription on encashment basis
-      '410': Aid loan excluding debt reorganisation
-      '411': Investment-related loan to developing countries
-      '412': Loan in a joint venture with the recipient
-      '413': Loan to national private investor
-      '414': Loan to national private exporter
-      '421': Standard loan
-      '422': Reimbursable grant
-      '423': Bonds
-      '424': Asset-backed securities
-      '425': Other debt securities
-      '431': Subordinated loan
-      '432': Preferred equity
-      '433': Other hybrid instruments
-      '451': Non-banks guaranteed export credits
-      '452': Non-banks non-guaranteed portions of guaranteed export credits
-      '453': Bank export credits
-      '510': Common equity
-      '511': Acquisition of equity not part of joint venture in developing countries
-      '512': Other acquisition of equity
-      '520': Shares in collective investment vehicles
-      '530': Reinvested earnings
-      '610': 'Debt forgiveness/conversion: ODA claims (P)'
-      '611': 'Debt forgiveness/conversion: ODA claims (I)'
-      '612': 'Debt forgiveness/conversion: OOF claims (P)'
-      '613': 'Debt forgiveness/conversion: OOF claims (I)'
-      '614': 'Debt forgiveness/conversion: Private claims (P)'
-      '615': 'Debt forgiveness/conversion: Private claims (I)'
-      '616': 'Debt forgiveness: OOF claims (DSR)'
-      '617': 'Debt forgiveness: Private claims (DSR)'
-      '618': 'Debt forgiveness: Other'
-      '620': 'Debt rescheduling: ODA claims (P)'
-      '621': 'Debt rescheduling: ODA claims (I)'
-      '622': 'Debt rescheduling: OOF claims (P)'
-      '623': 'Debt rescheduling: OOF claims (I)'
-      '624': 'Debt rescheduling: Private claims (P)'
-      '625': 'Debt rescheduling: Private claims (I)'
-      '626': 'Debt rescheduling: OOF claims (DSR)'
-      '627': 'Debt rescheduling: Private claims (DSR)'
-      '630': 'Debt rescheduling: OOF claim (DSR – original loan principal)'
-      '631': 'Debt rescheduling: OOF claim (DSR – original loan interest)'
-      '632': 'Debt rescheduling: Private claim (DSR – original loan principal)'
-      '633': 'Debt forgiveness/conversion: export credit claims (P)'
-      '634': 'Debt forgiveness/conversion: export credit claims (I)'
-      '635': 'Debt forgiveness: export credit claims (DSR)'
-      '636': 'Debt rescheduling: export credit claims (P)'
-      '637': 'Debt rescheduling: export credit claims (I)'
-      '638': 'Debt rescheduling: export credit claims (DSR)'
-      '639': 'Debt rescheduling: export credit claim (DSR – original loan principal)'
-      '710': Foreign direct investment
-      '711': Other foreign direct investment, including reinvested earnings
-      '810': Bank bonds
-      '811': Non-bank bonds
-      '910': Other bank securities/claims
-      '911': Other non-bank securities/claims
-      '912': Securities and other instruments issued by multilateral agencies
     flow:
       '10': ODA
       '20': OOF

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,8 +165,6 @@ en:
           edit: Choose extending organisation
         heading: Extending organisation
         hint: The extending organisation will be able to create and report project information against this programme
-      finance:
-        label: Finance
       flow:
         label: Flow
       geography:
@@ -272,7 +270,6 @@ en:
         aid_type: Aid type
         country: Recipient country
         dates: Dates
-        finance: Finance
         flow: Flow
         geography: Will the benefitting recipient be a region or country?
         identifier: Your unique identifier

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -5,7 +5,6 @@ en:
       activity:
         aid_type: Aid type
         description: Description
-        finance: Finance
         flow: Flow
         identifier: Your unique identifier
         programme:
@@ -111,7 +110,6 @@ en:
         actual_start_date: For example, 11 1 2020
         aid_type:
           html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>IATI descriptions can be found here.</a>
-        finance: DAC/CRS transaction classification used to distinguish financial instruments, e.g. grants or loans.
         flow:
           html: "<a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>IATI descriptions of each flow type can be found here.</a>"
         identifier: Reference to link this to your internal systems so it can be found again later.

--- a/db/migrate/20200330145039_remove_finance_from_activities.rb
+++ b/db/migrate/20200330145039_remove_finance_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveFinanceFromActivities < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :activities, :finance, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_26_173005) do
+ActiveRecord::Schema.define(version: 2020_03_30_145039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2020_03_26_173005) do
     t.date "actual_end_date"
     t.string "recipient_region"
     t.string "flow"
-    t.string "finance"
     t.string "aid_type"
     t.string "tied_status"
     t.string "wizard_status"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     recipient_region { "489" }
     recipient_country { nil }
     flow { "10" }
-    finance { "110" }
     aid_type { "A01" }
     tied_status { "3" }
     level { :fund }
@@ -89,7 +88,6 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     flow { nil }
-    finance { nil }
     aid_type { nil }
     tied_status { nil }
   end
@@ -108,7 +106,6 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     flow { nil }
-    finance { nil }
     aid_type { nil }
     tied_status { nil }
   end
@@ -117,7 +114,6 @@ FactoryBot.define do
     wizard_status { "region" }
     recipient_country { nil }
     flow { nil }
-    finance { nil }
     aid_type { nil }
     tied_status { nil }
   end
@@ -127,7 +123,6 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     flow { nil }
-    finance { nil }
     aid_type { nil }
     tied_status { nil }
   end

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -154,15 +154,6 @@ RSpec.feature "Users can create a fund level activity" do
         # Flow has a default and can't be set to blank so we skip
         select "ODA", from: "activity[flow]"
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.finance")
-
-        # Don't select a finance
-        click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Finance can't be blank"
-
-        select "Standard grant", from: "activity[finance]"
-        click_button I18n.t("form.activity.submit")
-
         expect(page).to have_content I18n.t("page_title.activity_form.show.aid_type")
 
         # Don't select an aid type

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -246,14 +246,6 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   end
   click_on(I18n.t("generic.link.back"))
 
-  within(".finance") do
-    click_on(I18n.t("generic.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :finance)
-    )
-  end
-  click_on(I18n.t("generic.link.back"))
-
   within(".aid_type") do
     click_on(I18n.t("generic.link.edit"))
     expect(page).to have_current_path(

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(helper.step_is_complete_or_next?(activity: activity, step: "region")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "flow")).to be(false)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "finance")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "tied_status")).to be(false)
       end
@@ -74,7 +73,6 @@ RSpec.describe ActivityHelper, type: :helper do
 
       it "returns false for the next fields" do
         activity = build(:activity, :at_region_step)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "finance")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "tied_status")).to be(false)
       end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -159,11 +159,6 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:flow) }
     end
 
-    context "when finance is blank" do
-      subject { build(:activity, finance: nil, wizard_status: :finance) }
-      it { should validate_presence_of(:finance) }
-    end
-
     context "when tied_status is blank" do
       subject { build(:activity, tied_status: nil, wizard_status: :tied_status) }
       it { should validate_presence_of(:tied_status) }
@@ -181,7 +176,6 @@ RSpec.describe Activity, type: :model do
       it { should_not validate_presence_of(:actual_end_date) }
       it { should validate_presence_of(:geography) }
       it { should validate_presence_of(:flow) }
-      it { should validate_presence_of(:finance) }
       it { should validate_presence_of(:tied_status) }
     end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  describe "#finance" do
+    it "always returns Standard Grant, code '110'" do
+      activity = Activity.new
+      expect(activity.finance).to eq "110"
+    end
+  end
+
   describe "scopes" do
     describe ".funds" do
       it "only returns fund level activities" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -189,24 +189,6 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#finance" do
-    context "when the finance exists" do
-      it "returns the locale value for the code" do
-        activity = build(:activity, finance: "111")
-        result = described_class.new(activity).finance
-        expect(result).to eql("Subsidies to national private investors")
-      end
-    end
-
-    context "when the activity does not have a finance set" do
-      it "returns nil" do
-        activity = build(:activity, finance: nil)
-        result = described_class.new(activity)
-        expect(result.finance).to be_nil
-      end
-    end
-  end
-
   describe "#tied_status" do
     context "when the tied_status exists" do
       it "returns the locale value for the code" do

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -11,7 +11,6 @@ module ActivityHelpers
     expect(page).to have_content activity_presenter.actual_end_date
     expect(page).to have_content activity_presenter.recipient_region
     expect(page).to have_content activity_presenter.flow
-    expect(page).to have_content activity_presenter.finance
     expect(page).to have_content activity_presenter.aid_type
     expect(page).to have_content activity_presenter.tied_status
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -20,7 +20,6 @@ module FormHelpers
     geography: "recipient_region",
     recipient_region: "Developing countries, unspecified",
     flow: "ODA",
-    finance: "Standard grant",
     aid_type: "A01",
     tied_status: "5",
     level:
@@ -97,11 +96,6 @@ module FormHelpers
     select flow, from: "activity[flow]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.finance")
-    expect(page).to have_content I18n.t("helpers.hint.activity.finance")
-    select finance, from: "activity[finance]"
-    click_button I18n.t("form.activity.submit")
-
     expect(page).to have_content I18n.t("activerecord.attributes.activity.aid_type")
     expect(page).to have_content "A code for the vocabulary aid-type classifications. IATI descriptions can be found here."
     choose("activity[aid_type]", option: aid_type)
@@ -122,7 +116,6 @@ module FormHelpers
     expect(page).to have_content status
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
-    expect(page).to have_content finance
     expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")
     expect(page).to have_content I18n.t("activity.tied_status.#{tied_status}")
     expect(page).to have_content localise_date_from_input_fields(

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -47,6 +47,12 @@ RSpec.shared_examples "valid activity XML" do
     end
   end
 
+  it "contains the default value for Finance" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    expect(xml.at("iati-activity/default-finance-type/@code").text).to eq("110")
+  end
+
   it "contains the transaction XML" do
     transaction = create(:transaction, activity: activity)
     visit organisation_activity_path(organisation, activity, format: :xml)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/yfr1eiz2

Feedback from user research when creating an activity showed that the Finance step could possibly be omitted as the users always document the activities' finance under the "Standard grant" category. After discussion with them and knowing is highly likely they will keep using the same category in the future, we decided to default the finance category to "Standard grant" for every activity in every level and omit this step from the form the user needs to fill in when they create activities. This would reduce the time users take to complete this task too.

I have deleted the Finance step from the controller and the views. I have deleted the references to this step on the Spec files and the yaml files that are not needed anymore. I have also removed the Finance column from the activities table on the DB.
On the XML that is created for IATI, Finance is still there with the default value of code "110" ("Standard grant"). This value comes from a constant on the Activity model. 
I have checked some XMLs on the IATI public validator and they were valid.  

## Screenshots of UI changes

### Before

<img width="1228" alt="Screenshot 2020-03-25 at 09 07 20" src="https://user-images.githubusercontent.com/48016017/77521347-71a62200-6e7a-11ea-958f-4ed83cf74938.png">


### After

<img width="1228" alt="Screenshot 2020-03-24 at 15 52 56" src="https://user-images.githubusercontent.com/48016017/77521390-85ea1f00-6e7a-11ea-941e-8a69f9da48cf.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
