### PR TITLE
Feature/478 users no longer select tied status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,11 +89,12 @@
 - BEIS users can view Transactions & Budgets on a project, but not create or edit them
 - Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
 - Add feedback form link to phase banner
-- Activity to Activity association renamed `child_activities` (from `activities`) to avoid an association name clash with the `public_activity` gem
 
 ## [unreleased]
 
+- Activity to Activity association renamed `child_activities` (from `activities`) to avoid an association name clash with the `public_activity` gem
 - When creating an activity the Finance step has been defaulted to `Standard grant` and omitted from the user journey
+- When creating an activity, the `Tied status` step has been removed from the user journey and it has now a default value of `Untied`, code "5"
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...HEAD
 [release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -15,7 +15,6 @@ class Staff::ActivityFormsController < Staff::BaseController
     :country,
     :flow,
     :aid_type,
-    :tied_status,
   ]
 
   steps(*FORM_STEPS)
@@ -80,7 +79,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     params.require(:activity).permit(:identifier, :sector, :title, :description, :status,
       :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date,
       :geography, :recipient_region, :recipient_country, :flow,
-      :aid_type, :tied_status)
+      :aid_type)
   end
 
   def finish_wizard_path

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -44,11 +44,6 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
   end
 
-  def tied_status_radio_options
-    objects = yaml_to_objects_with_description(entity: "activity", type: "tied_status")
-    objects.sort_by! { |item| item.code }.reverse
-  end
-
   def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,6 @@
 class Activity < ApplicationRecord
   STANDARD_GRANT_FINANCE_CODE = "110"
+  UNTIED_TIED_STATUS_CODE = "5"
 
   validates :identifier, presence: true, if: :identifier_step?
   validates_uniqueness_of :identifier, if: :identifier_step?
@@ -11,7 +12,7 @@ class Activity < ApplicationRecord
   validates :recipient_country, presence: true, if: :country_step?
   validates :flow, presence: true, if: :flow_step?
   validates :aid_type, presence: true, if: :aid_type_step?
-  validates :tied_status, presence: true, if: :tied_status_step?
+  validates_uniqueness_of :identifier
   validates :planned_start_date, :planned_end_date, presence: true, if: :dates_step?
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
@@ -39,6 +40,10 @@ class Activity < ApplicationRecord
 
   def finance
     STANDARD_GRANT_FINANCE_CODE
+  end
+
+  def tied_status
+    UNTIED_TIED_STATUS_CODE
   end
 
   private def identifier_step?
@@ -79,10 +84,6 @@ class Activity < ApplicationRecord
 
   private def aid_type_step?
     wizard_status == "aid_type" || wizard_complete?
-  end
-
-  private def tied_status_step?
-    wizard_status == "tied_status" || wizard_complete?
   end
 
   def wizard_complete?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -56,11 +56,6 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.flow.#{super}")
   end
 
-  def tied_status
-    return if super.blank?
-    I18n.t("activity.tied_status.#{super}")
-  end
-
   def call_to_action(attribute)
     send(attribute).present? ? "edit" : "add"
   end

--- a/app/views/staff/activity_forms/tied_status.html.haml
+++ b/app/views/staff/activity_forms/tied_status.html.haml
@@ -1,3 +1,0 @@
-= render layout: "wrapper" do |f|
-  = f.hidden_field :tied_status
-  = f.govuk_collection_radio_buttons :tied_status, tied_status_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.tied_status") }, hint_text: I18n.t("helpers.hint.activity.tied_status", level: f.object.level)

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -135,12 +135,3 @@
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
         = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("page_content.activity.aid_type.label"))
-
-  .govuk-summary-list__row.tied_status
-    %dt.govuk-summary-list__key
-      = t("page_content.activity.tied_status.label")
-    %dd.govuk-summary-list__value
-      = activity_presenter.tied_status
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :tied_status)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:tied_status)}"), activity_step_path(activity_presenter, :tied_status), t("page_content.activity.tied_status.label"))

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -620,10 +620,6 @@ en:
       '4': Post-completion
       '5': Cancelled
       '6': Suspended
-    tied_status:
-      '3': Partially tied
-      '4': Tied
-      '5': Untied
   generic:
     default_currency:
       aed: UAE Dirham

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,8 +191,6 @@ en:
         label: Focus area
       status:
         label: Status
-      tied_status:
-        label: Tied status
       title:
         label: Title
       transactions: Transactions
@@ -278,7 +276,6 @@ en:
         region: Recipient region
         sector: What is the focus area for this %{level}
         status: Status
-        tied_status: Tied status
     budget:
       edit: Edit budget
       new: Create budget

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -15,7 +15,6 @@ en:
         recipient_region: Recipient region
         sector: Focus area
         status: Status
-        tied_status: Tied status
         title: Title
       budget:
         budget_type:
@@ -120,7 +119,6 @@ en:
         sector:
           html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
         status: This is the stage your %{level} is currently at
-        tied_status: This is the tied status of your %{level}
         title: A short, human-readable title that contains a meaningful summary of the activity.
       budget:
         period_end_date: Period end date must not be more than one year after the period start date. For example, 11 3 2021

--- a/db/migrate/20200331085103_remove_tied_status_from_activities.rb
+++ b/db/migrate/20200331085103_remove_tied_status_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveTiedStatusFromActivities < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :activities, :tied_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_145039) do
-
+ActiveRecord::Schema.define(version: 2020_03_31_085103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,7 +31,6 @@ ActiveRecord::Schema.define(version: 2020_03_30_145039) do
     t.string "recipient_region"
     t.string "flow"
     t.string "aid_type"
-    t.string "tied_status"
     t.string "wizard_status"
     t.string "level"
     t.uuid "activity_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
     recipient_country { nil }
     flow { "10" }
     aid_type { "A01" }
-    tied_status { "3" }
     level { :fund }
 
     wizard_status { "complete" } # wizard is complete
@@ -89,7 +88,6 @@ FactoryBot.define do
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
-    tied_status { nil }
   end
 
   trait :at_purpose_step do
@@ -107,7 +105,6 @@ FactoryBot.define do
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
-    tied_status { nil }
   end
 
   trait :at_region_step do
@@ -115,7 +112,6 @@ FactoryBot.define do
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
-    tied_status { nil }
   end
 
   trait :at_geography_step do
@@ -124,7 +120,6 @@ FactoryBot.define do
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
-    tied_status { nil }
   end
 
   trait :nil_wizard_status do

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -162,12 +162,6 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose("activity[aid_type]", option: "A01")
         click_button I18n.t("form.activity.submit")
-
-        expect(page).to have_content I18n.t("page_title.activity_form.show.tied_status")
-
-        # Tied status has a default and can't be set to blank so we skip
-        choose("activity[tied_status]", option: "5")
-        click_button I18n.t("form.activity.submit")
         expect(page).to have_content Activity.last.title
       end
     end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -253,12 +253,4 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("generic.link.back"))
-
-  within(".tied_status") do
-    click_on(I18n.t("generic.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :tied_status)
-    )
-  end
-  click_on(I18n.t("generic.link.back"))
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "flow")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "tied_status")).to be(false)
       end
     end
 
@@ -74,7 +73,6 @@ RSpec.describe ActivityHelper, type: :helper do
       it "returns false for the next fields" do
         activity = build(:activity, :at_region_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "tied_status")).to be(false)
       end
     end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -135,12 +135,5 @@ RSpec.describe CodelistHelper, type: :helper do
           .to eq(OpenStruct.new(name: "ODA", code: "10"))
       end
     end
-
-    describe "#tied_status_radio_options" do
-      it "returns an array of tied_status objects with Untied (5) first in the list" do
-        expect(helper.tied_status_radio_options.first.name)
-          .to eq("Untied")
-      end
-    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -173,11 +173,6 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:flow) }
     end
 
-    context "when tied_status is blank" do
-      subject { build(:activity, tied_status: nil, wizard_status: :tied_status) }
-      it { should validate_presence_of(:tied_status) }
-    end
-
     context "when the wizard_status is complete" do
       subject { build(:activity, wizard_status: "complete") }
       it { should validate_presence_of(:title) }
@@ -190,7 +185,6 @@ RSpec.describe Activity, type: :model do
       it { should_not validate_presence_of(:actual_end_date) }
       it { should validate_presence_of(:geography) }
       it { should validate_presence_of(:flow) }
-      it { should validate_presence_of(:tied_status) }
     end
 
     context "when saving in the update_extending_organisation context" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#tied_status" do
+    it "always returns Untied, code '5'" do
+      activity = Activity.new
+      expect(activity.tied_status).to eq "5"
+    end
+  end
+
   describe "scopes" do
     describe ".funds" do
       it "only returns fund level activities" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -189,24 +189,6 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#tied_status" do
-    context "when the tied_status exists" do
-      it "returns the locale value for the code" do
-        activity = build(:activity, tied_status: "3")
-        result = described_class.new(activity).tied_status
-        expect(result).to eql("Partially tied")
-      end
-    end
-
-    context "when the activity does not have a tied_status set" do
-      it "returns nil" do
-        activity = build(:activity, tied_status: nil)
-        result = described_class.new(activity)
-        expect(result.tied_status).to be_nil
-      end
-    end
-  end
-
   describe "#call_to_action" do
     it "returns 'edit' if the desired attribute is present" do
       activity = build(:activity, title: "My title")

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -12,6 +12,5 @@ module ActivityHelpers
     expect(page).to have_content activity_presenter.recipient_region
     expect(page).to have_content activity_presenter.flow
     expect(page).to have_content activity_presenter.aid_type
-    expect(page).to have_content activity_presenter.tied_status
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -21,7 +21,6 @@ module FormHelpers
     recipient_region: "Developing countries, unspecified",
     flow: "ODA",
     aid_type: "A01",
-    tied_status: "5",
     level:
   )
 
@@ -101,14 +100,6 @@ module FormHelpers
     choose("activity[aid_type]", option: aid_type)
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.tied_status")
-    expect(page).to have_content "This is the tied status of your #{level}"
-    expect(page.find("div.govuk-radios div.govuk-radios__item:first-child input")[:value]).to eq("5")
-
-    choose("activity[tied_status]", option: tied_status)
-
-    click_button I18n.t("form.activity.submit")
-
     expect(page).to have_content identifier
     expect(page).to have_content title
     expect(page).to have_content description
@@ -117,7 +108,6 @@ module FormHelpers
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
     expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")
-    expect(page).to have_content I18n.t("activity.tied_status.#{tied_status}")
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,
       month: planned_start_date_month,

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -53,6 +53,12 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/default-finance-type/@code").text).to eq("110")
   end
 
+  it "contains the default value for Tied Status" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    expect(xml.at("iati-activity/default-tied-status/@code").text).to eq("5")
+  end
+
   it "contains the transaction XML" do
     transaction = create(:transaction, activity: activity)
     visit organisation_activity_path(organisation, activity, format: :xml)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/qFZMNyvN

After discussion with service users, they informed us that the only category they use for `Tied status` is `Untied`, hence there is no need for a form step with different options when they create activities. This is unlikely to change in the future so we are confident that removing this step will only be beneficial for the users as they will be able to complete the journey quicker without affecting the quality of the documentation they create.

To achieve this, I introduced a default value of "5" ("Untied") for `Tied status` on activity model, as a constant, and removed the form step from the controller and views. The Spec files no longer test for the presence of this form step or a value been given by the user. I have also made tests to assert the default value will be always added to the XML file.

I have deleted the `tied_status` column from the DB as it serves no purpose anymore.

In order to make sure documentation will not be altered by this change, I have tested several XML files I created on different activity levels and check them on the IATI XML validator. All of them passed the test validator.

## Screenshots of UI changes

### Before

<img width="1228" alt="Screenshot 2020-03-25 at 09 07 20" src="https://user-images.githubusercontent.com/48016017/77557006-1d6a6480-6eb1-11ea-999f-ee46955607c7.png">

### After

<img width="1228" alt="Screenshot 2020-03-25 at 15 17 39" src="https://user-images.githubusercontent.com/48016017/77557138-4f7bc680-6eb1-11ea-9345-df2cfde5d6b2.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
