### PR TITLE
Ensure that organisation iati_references are unique at the database level

### DIFF
--- a/db/migrate/20200326173005_add_uniqueness_to_organisation_iati_reference.rb
+++ b/db/migrate/20200326173005_add_uniqueness_to_organisation_iati_reference.rb
@@ -1,0 +1,5 @@
+class AddUniquenessToOrganisationIatiReference < ActiveRecord::Migration[6.0]
+  def change
+    add_index :organisations, :iati_reference, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_160846) do
+ActiveRecord::Schema.define(version: 2020_03_26_173005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2020_03_03_160846) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "service_owner", default: false
     t.string "iati_reference"
+    t.index ["iati_reference"], name: "index_organisations_on_iati_reference", unique: true
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Changes in this PR

During the production database restore to the pentest environment I noticed that if you skip activerecord you can have as many organisations with GB-GOV-13 as you like. This is a pretty important field to be unique for publishing to IATI purposes to lets validate at the database level as well as ActiveRecord.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
