### PR TITLE
Validate that iati references are prefixed with the correct structure

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,7 +3,10 @@ class Organisation < ApplicationRecord
   has_many :funds
 
   validates_presence_of :name, :organisation_type, :language_code, :default_currency
-  validates :iati_reference, uniqueness: {case_sensitive: false}, presence: true
+  validates :iati_reference,
+    uniqueness: {case_sensitive: false},
+    presence: true,
+    format: {with: /\A[a-zA-Z]{2,}-[a-zA-Z]{3}-.+\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")}
 
   scope :sorted_by_name, -> { order(name: :asc) }
   scope :delivery_partners, -> { sorted_by_name.where(service_owner: false) }

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -80,6 +80,10 @@ en:
             period_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_after_end_date: The period start date cannot be after the period end date
+        organisation:
+          attributes:
+            iati_reference:
+              format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
         transaction:
           attributes:
             date:

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -9,6 +9,40 @@ RSpec.describe Organisation, type: :model do
     it { should validate_presence_of(:iati_reference) }
 
     it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
+
+    describe "#iati_reference" do
+      it "returns true if it does matches a known structure XX-XXX-" do
+        organisation = build(:organisation, iati_reference: "GB-GOV-13")
+        result = organisation.valid?
+        expect(result).to eq(true)
+      end
+
+      it "returns true if it does match an unexpected value of the same XX-XXX- structure" do
+        organisation = build(:organisation, iati_reference: "GB-COH-1234567asdfghj")
+        result = organisation.valid?
+        expect(result).to eq(true)
+      end
+
+      it "returns true if the country code is 3 characters long" do
+        organisation = build(:organisation, iati_reference: "CZH-COH-111")
+        result = organisation.valid?
+        expect(result).to eq(true)
+      end
+
+      it "returns false if it doesn't match the structure XX-XXX-" do
+        organisation = build(:organisation, iati_reference: "1234")
+        result = organisation.valid?
+        expect(result).to eq(false)
+      end
+
+      it "returns an error message if it is invalid" do
+        organisation = build(:organisation, iati_reference: "1234")
+        organisation.valid?
+        expect(organisation.errors.messages[:iati_reference]).to include(
+          I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")
+        )
+      end
+    end
   end
 
   describe "associations" do


### PR DESCRIPTION
## Changes in this PR

I noticed this bug when restoring production data to the pentest environment. UKSA have an invalid identifier of 1234. This makes publishing their data to IATI invalid.

Following the IATI guidance on organisation identifiers: http://reference.iatistandard.org/203/organisation-identifiers/#two-components-of-iati-organisation-identifiers. This change validates that the "namespace" code exists as a prefix and is separated by a hyphen.

Whilst IATI do say that each component of the namespace code MAY also include a hyphen the real world examples we have seen for BEIS do not. It feels like we can layer on this logic later if required.

## Screenshots of UI changes

![Screenshot 2020-03-26 at 18 15 49](https://user-images.githubusercontent.com/912473/77682927-8c1def80-6f8f-11ea-96e5-43ce1fe014dc.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
