### PR TITLE
(465) Add link to feedback form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,5 +88,6 @@
 - Anonymize user's IP addresses before logging them outside the application, by removing the last octet of the address. Also use Rollbar's built-in IP address anonymizer.
 - BEIS users can view Transactions & Budgets on a project, but not create or edit them
 - Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
+- Add feedback form link to phase banner
 
 [release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -64,7 +64,7 @@
           %strong.govuk-tag.govuk-phase-banner__content__tag
             beta
           %span.govuk-phase-banner__text
-            This is a new service
+            = t("page_content.feedback.html")
 
       = render 'layouts/messages'
       = yield

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,8 @@ en:
       not_authorised:
         explanation: Whilst you have successfully signed in you have not been authorised to see this page.
       support_prompt: If you believe this to be in error, please contact the person who invited you to the service.
+    feedback:
+      html: This is a new service – your <a href="https://docs.google.com/forms/d/e/1FAIpQLSfk9abTLRNZdB9tPdtoF_t_1z7q6uPQiZks8NfzGeqg-8UQtQ/viewform" class="govuk-link">feedback</a> will help us to improve it.
     organisation:
       button:
         choose_extending_organisation: Choose extending organisation

--- a/spec/features/public/visitors/users_can_provide_feedback_spec.rb
+++ b/spec/features/public/visitors/users_can_provide_feedback_spec.rb
@@ -1,0 +1,7 @@
+RSpec.feature "Users can provide feedback" do
+  scenario "by following a link to the feedback form in the site phase banner" do
+    visit root_path
+
+    expect(page).to have_link("feedback", href: "https://docs.google.com/forms/d/e/1FAIpQLSfk9abTLRNZdB9tPdtoF_t_1z7q6uPQiZks8NfzGeqg-8UQtQ/viewform")
+  end
+end


### PR DESCRIPTION
## Changes in this PR

To allow users of the service to provide feedback. Following the GOVUK
pattern, of a link in the phase banned at the top of the site.

## Screenshots of UI changes

### After
![Screenshot_2020-03-27 Home — Report Official Development Assistance](https://user-images.githubusercontent.com/480578/77741431-cc6f8300-700c-11ea-939a-b434c43a2ef7.png)
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
