### PR TITLE
(459) IATI reporting org should be BEIS regardless of the user's organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
   Javascript is available
 - Add privacy policy to site
 - Empty optional dates for `actual start date` and `actual end date` are not included on the activity XML
+- Reporting org in the IATI XML is always BEIS for funds, programmes and projects created by governmental organisations, and the activity's organisation if it is a non-governmental organisation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...HEAD
 [release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@
 
 ## [unreleased]
 
-- Activity to Activity association renamed `child_activities` (from `activities`) to avoid an association name clash with the `public_activity` gem
 - When creating an activity the Finance step has been defaulted to `Standard grant` and omitted from the user journey
 - When creating an activity, the `Tied status` step has been removed from the user journey and it has now a default value of `Untied`, code "5"
 - Progressively enhance the country select element into a combo box when

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -23,6 +23,7 @@ class Activity < ApplicationRecord
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
   has_many :implementing_organisations
+  belongs_to :reporting_organisation, foreign_key: "reporting_organisation_id", class_name: "Organisation"
 
   enum level: {
     fund: "fund",

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,4 +10,8 @@ class Organisation < ApplicationRecord
 
   scope :sorted_by_name, -> { order(name: :asc) }
   scope :delivery_partners, -> { sorted_by_name.where(service_owner: false) }
+
+  def is_government?
+    %w[10 11].include?(organisation_type)
+  end
 end

--- a/app/presenters/activity_xml_presenter.rb
+++ b/app/presenters/activity_xml_presenter.rb
@@ -2,7 +2,7 @@
 
 class ActivityXmlPresenter < SimpleDelegator
   def iati_identifier
-    parent_activities.each_with_object([reporting_organisation_reference]) { |parent, parent_identifiers|
+    parent_activities.each_with_object([reporting_organisation.iati_reference]) { |parent, parent_identifiers|
       parent_identifiers << parent.identifier
     }.push(identifier).join("-")
   end

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -9,6 +9,7 @@ class CreateFundActivity
     activity = Activity.new
     activity.organisation = Organisation.find(organisation_id)
     activity.reporting_organisation = activity.organisation
+    activity.extending_organisation = service_owner
 
     activity.wizard_status = "blank"
     activity.level = :fund
@@ -21,9 +22,13 @@ class CreateFundActivity
     activity.accountable_organisation_reference = "GB-GOV-13"
     activity.accountable_organisation_type = "10"
 
-    activity.extending_organisation = Organisation.find_by!(service_owner: true)
-
     activity.save(validate: false)
     activity
+  end
+
+  private
+
+  def service_owner
+    Organisation.find_by_service_owner(true)
   end
 end

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -8,7 +8,7 @@ class CreateFundActivity
   def call
     activity = Activity.new
     activity.organisation = Organisation.find(organisation_id)
-    activity.reporting_organisation_reference = activity.organisation.iati_reference
+    activity.reporting_organisation = activity.organisation
 
     activity.wizard_status = "blank"
     activity.level = :fund

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -17,15 +17,19 @@ class CreateProgrammeActivity
     activity.wizard_status = "blank"
     activity.level = :programme
 
-    activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
-    activity.funding_organisation_reference = "GB-GOV-13"
-    activity.funding_organisation_type = "10"
+    activity.funding_organisation_name = service_owner.name
+    activity.funding_organisation_reference = service_owner.iati_reference
+    activity.funding_organisation_type = service_owner.organisation_type
 
-    activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
-    activity.accountable_organisation_reference = "GB-GOV-13"
-    activity.accountable_organisation_type = "10"
+    activity.accountable_organisation_name = service_owner.name
+    activity.accountable_organisation_reference = service_owner.iati_reference
+    activity.accountable_organisation_type = service_owner.organisation_type
 
     activity.save(validate: false)
     activity
+  end
+
+  def service_owner
+    Organisation.find_by_service_owner(true)
   end
 end

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -9,7 +9,7 @@ class CreateProgrammeActivity
   def call
     activity = Activity.new
     activity.organisation = Organisation.find(organisation_id)
-    activity.reporting_organisation_reference = activity.organisation.iati_reference
+    activity.reporting_organisation = activity.organisation
 
     fund = Activity.find(fund_id)
     fund.child_activities << activity

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -13,7 +13,7 @@ class CreateProjectActivity
 
     activity = Activity.new
     activity.organisation = reporting_organisation
-    activity.reporting_organisation_reference = reporting_organisation.iati_reference
+    activity.reporting_organisation = reporting_organisation
 
     programme = Activity.find(programme_id)
     programme.child_activities << activity

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -8,18 +8,10 @@ class CreateProjectActivity
   end
 
   def call
-    service_owner = Organisation.find_by(service_owner: true)
-    reporting_organisation = Organisation.find(organisation_id)
-
     activity = Activity.new
-    activity.organisation = reporting_organisation
-
-    if reporting_organisation.is_government?
-      service_owner = Organisation.find_by(service_owner: true)
-      activity.reporting_organisation = service_owner
-    else
-      activity.reporting_organisation = reporting_organisation
-    end
+    activity.organisation = creating_organisation
+    activity.reporting_organisation = reporting_organisation
+    activity.extending_organisation = creating_organisation
 
     programme = Activity.find(programme_id)
     programme.child_activities << activity
@@ -35,8 +27,21 @@ class CreateProjectActivity
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type
 
-    activity.extending_organisation = reporting_organisation
     activity.save(validate: false)
     activity
+  end
+
+  private
+
+  def service_owner
+    Organisation.find_by_service_owner(true)
+  end
+
+  def creating_organisation
+    Organisation.find(organisation_id)
+  end
+
+  def reporting_organisation
+    creating_organisation.is_government? ? service_owner : creating_organisation
   end
 end

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -13,7 +13,13 @@ class CreateProjectActivity
 
     activity = Activity.new
     activity.organisation = reporting_organisation
-    activity.reporting_organisation = reporting_organisation
+
+    if reporting_organisation.is_government?
+      service_owner = Organisation.find_by(service_owner: true)
+      activity.reporting_organisation = service_owner
+    else
+      activity.reporting_organisation = reporting_organisation
+    end
 
     programme = Activity.find(programme_id)
     programme.child_activities << activity

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,7 +1,7 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
   %iati-identifier= activity.iati_identifier
-  %reporting-org{"type" => activity.organisation.organisation_type, "ref" => activity.organisation.iati_reference }
-    %narrative= activity.organisation.name
+  %reporting-org{"type" => activity.reporting_organisation.organisation_type, "ref" => activity.reporting_organisation.iati_reference }
+    %narrative= activity.reporting_organisation.name
   %title
     %narrative= activity.title
   %description{"type" => "1"}

--- a/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
+++ b/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
@@ -12,7 +12,7 @@ class AddReportingOrgAssociationToActivity < ActiveRecord::Migration[6.0]
         else
           organisation
         end
-        activity.save(validate: false)
+        activity.save!
       end
     end
 
@@ -27,7 +27,7 @@ class AddReportingOrgAssociationToActivity < ActiveRecord::Migration[6.0]
 
       activities.each do |activity|
         activity.reporting_organisation_reference = activity.reporting_organisation.iati_reference
-        activity.save(validate: false)
+        activity.save!
       end
     end
 

--- a/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
+++ b/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
@@ -1,0 +1,36 @@
+class AddReportingOrgAssociationToActivity < ActiveRecord::Migration[6.0]
+  def up
+    add_reference :activities, :reporting_organisation, type: :uuid, foreign_key: {to_table: :organisations}
+
+    ActiveRecord::Base.transaction do
+      service_owner = Organisation.find_by_service_owner(true)
+
+      Activity.all.each do |activity|
+        organisation = activity.organisation
+        activity.reporting_organisation = if organisation.is_government?
+          service_owner
+        else
+          organisation
+        end
+        activity.save(validate: false)
+      end
+    end
+
+    remove_column :activities, :reporting_organisation_reference, :string
+  end
+
+  def down
+    add_column :activities, :reporting_organisation_reference, :string
+
+    ActiveRecord::Base.transaction do
+      activities = Activity.where.not(reporting_organisation_id: nil)
+
+      activities.each do |activity|
+        activity.reporting_organisation_reference = activity.reporting_organisation.iati_reference
+        activity.save(validate: false)
+      end
+    end
+
+    remove_reference :activities, :reporting_organisation, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_31_085103) do
+ActiveRecord::Schema.define(version: 2020_03_31_111947) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,13 +42,14 @@ ActiveRecord::Schema.define(version: 2020_03_31_085103) do
     t.string "accountable_organisation_reference"
     t.string "accountable_organisation_type"
     t.uuid "extending_organisation_id"
-    t.string "reporting_organisation_reference"
     t.string "recipient_country"
     t.string "geography"
+    t.uuid "reporting_organisation_id"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
+    t.index ["reporting_organisation_id"], name: "index_activities_on_reporting_organisation_id"
   end
 
   create_table "budgets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -119,4 +121,5 @@ ActiveRecord::Schema.define(version: 2020_03_31_085103) do
 
   add_foreign_key "activities", "activities"
   add_foreign_key "activities", "organisations", column: "extending_organisation_id"
+  add_foreign_key "activities", "organisations", column: "reporting_organisation_id"
 end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -19,9 +19,7 @@ FactoryBot.define do
     wizard_status { "complete" } # wizard is complete
 
     association :organisation, factory: :organisation
-    before(:create) do |activity|
-      activity.reporting_organisation_reference = activity.organisation.iati_reference
-    end
+    association :reporting_organisation, factory: :beis_organisation
 
     factory :fund_activity do
       level { :fund }
@@ -33,6 +31,7 @@ FactoryBot.define do
       accountable_organisation_type { "10" }
 
       association :extending_organisation, factory: :beis_organisation
+      association :reporting_organisation, factory: :beis_organisation
     end
 
     factory :programme_activity do
@@ -46,6 +45,7 @@ FactoryBot.define do
       accountable_organisation_type { "10" }
 
       association :extending_organisation, factory: :beis_organisation
+      association :reporting_organisation, factory: :beis_organisation
     end
 
     factory :project_activity do
@@ -59,6 +59,7 @@ FactoryBot.define do
       accountable_organisation_type { "10" }
 
       association :extending_organisation, factory: :beis_organisation
+      association :reporting_organisation, factory: :delivery_partner_organisation
 
       factory :project_activity_with_implementing_organisations do
         transient do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:child_activities).with_foreign_key("activity_id") }
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
     it { should have_many(:implementing_organisations) }
+    it { should belong_to(:reporting_organisation).with_foreign_key("reporting_organisation_id") }
   end
 
   describe "#parent_activity" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -105,4 +105,21 @@ RSpec.describe Organisation, type: :model do
       expect(delivery_partners).not_to include(beis_organisation)
     end
   end
+
+  describe "#is_government?" do
+    it "should be true for a Government organisation_type" do
+      organisation = create(:organisation, organisation_type: 10)
+      expect(organisation.is_government?).to eq true
+    end
+
+    it "should be true for a Government organisation_type" do
+      organisation = create(:organisation, organisation_type: 11)
+      expect(organisation.is_government?).to eq true
+    end
+
+    it "should be false for an NGO organisation_type" do
+      organisation = create(:organisation, organisation_type: 21)
+      expect(organisation.is_government?).to eq false
+    end
+  end
 end

--- a/spec/presenters/activity_xml_presenter_spec.rb
+++ b/spec/presenters/activity_xml_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActivityXmlPresenter do
   describe "#iati_identifier" do
     context "when the activity is a fund" do
       it "returns a composite identifier formed with the reporting organisation" do
-        fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation_reference: "GB-GOV-13")
+        fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation: create(:beis_organisation))
         expect(described_class.new(fund).iati_identifier).to eql("GB-GOV-13-GCRF-1")
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe ActivityXmlPresenter do
       context "when the reporting organisation is a government organisation" do
         it "returns an identifier with the reporting organisation, fund, programme and project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
-          project = create(:project_activity, organisation: government_organisation)
+          project = create(:project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
           programme = project.activity
           fund = programme.activity
 

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CreateFundActivity do
     end
 
     it "saves the reporting organisation reference" do
-      expect(result.reporting_organisation_reference).to eq(organisation.iati_reference)
+      expect(result.reporting_organisation.iati_reference).to eq(organisation.iati_reference)
     end
 
     it "sets the initial wizard_status" do

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateProgrammeActivity do
     end
 
     it "saves the reporting organisation reference" do
-      expect(result.reporting_organisation_reference).to eq(organisation.iati_reference)
+      expect(result.reporting_organisation.iati_reference).to eq(organisation.iati_reference)
     end
 
     it "sets the parent Activity to the fund" do

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CreateProjectActivity do
   let(:beis) { create(:beis_organisation) }
-  let(:delivery_partner_organisation) { create(:delivery_partner_organisation) }
+  let(:delivery_partner_organisation) { create(:delivery_partner_organisation, organisation_type: 10) }
   let(:user) { create(:administrator, organisation: delivery_partner_organisation) }
   let(:programme) { create(:programme_activity, organisation: beis) }
 
@@ -15,8 +15,18 @@ RSpec.describe CreateProjectActivity do
       expect(result.organisation).to eq delivery_partner_organisation
     end
 
-    it "saves the reporting organisation reference" do
-      expect(result.reporting_organisation.iati_reference).to eq(delivery_partner_organisation.iati_reference)
+    context "when the organisation is a Government organisation" do
+      it "uses the service owner as the reporting organisation" do
+        expect(result.reporting_organisation.iati_reference).to eq(beis.iati_reference)
+      end
+    end
+
+    context "when the organisation is a non-governmental organisation" do
+      let(:delivery_partner_organisation) { create(:delivery_partner_organisation, organisation_type: 21) }
+
+      it "saves the reporting organisation" do
+        expect(result.reporting_organisation.iati_reference).to eq(delivery_partner_organisation.iati_reference)
+      end
     end
 
     it "sets the parent Activity to the fund" do

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CreateProjectActivity do
     end
 
     it "saves the reporting organisation reference" do
-      expect(result.reporting_organisation_reference).to eq(delivery_partner_organisation.iati_reference)
+      expect(result.reporting_organisation.iati_reference).to eq(delivery_partner_organisation.iati_reference)
     end
 
     it "sets the parent Activity to the fund" do

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -11,6 +11,13 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/iati-identifier").text).to eq(activity_presenter.iati_identifier)
   end
 
+  it "contains the reporting organisation XML" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+    expect(xml.at("iati-activity/reporting-org/@ref").text).to eq(activity_presenter.reporting_organisation.iati_reference)
+    expect(xml.at("iati-activity/reporting-org/@type").text).to eq(activity_presenter.reporting_organisation.organisation_type)
+    expect(xml.at("iati-activity/reporting-org/narrative").text).to eq(activity_presenter.reporting_organisation.name)
+  end
+
   it "contains the funding organisation XML" do
     visit organisation_activity_path(organisation, activity, format: :xml)
     expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity_presenter.funding_organisation_reference)


### PR DESCRIPTION
Trello: https://trello.com/c/CfLUXjCa/459-iati-reporting-org-should-be-beis-regardless-of-the-users-organisation

Funds and programmes should have their reporting org set as BEIS

Projects created by UKSA (our current only delivery partner, and a government organisation) should have their reporting org set as BEIS

Other future DPs will have themselves set as their reporting org (for now).

**NOTE** This PR includes a rake task (can be added as a data migration) to be run on deployment to production.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
