### PR TITLE
Release 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 - Users can report either recipient_country or recipient_region data which is
   include in the xml
 
-## Unreleased changes
+## [release-3] - 2020-04-02
 
 - Activities are ordered by `created_at` date, oldest first
 - Transactions are ordered by `date`, newest first
@@ -90,4 +90,9 @@
 - Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
 - Add feedback form link to phase banner
 
-[release-2]: https://github.com/dxw/DataSubmissionService/compare/release-2...release-1
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...HEAD
+[release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3
+[release-2]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-1...release-2
+


### PR DESCRIPTION
- Activities are ordered by `created_at` date, oldest first
- Transactions are ordered by `date`, newest first
- Budgets are ordered by `period_start_date`, newest first
- Remove transaction description from the transaction display table, to improve the activity page UI
- Organisation and User management links are in the site header navigation
- Organisations are managed from the /organisation page
- Organisation show page re-organised to show more information including funds,
  programmes and projects for the relevant users
- Make it clearer that Programme should have an extending organisation in order
  for delivery partners to report on the programme
- fix cookie error by switching session storage to Redis
- Activity aid type is now selected by radio button, not a dropdown select box
- Iterate the form content for the sector field by renaming it to "focus area"
- Enable host whitelisting (Rails 6 feature) to mitigate poisoned host header attacks
- Anonymize user's IP addresses before logging them outside the application, by removing the last octet of the address. Also use Rollbar's built-in IP address anonymizer.
- BEIS users can view Transactions & Budgets on a project, but not create or edit them
- Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
- Add feedback form link to phase banner

We have fixed the links for release-2 and added an `unreleased` link.