### PR TITLE
Change Activity -> Activity association to `child_activities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - BEIS users can view Transactions & Budgets on a project, but not create or edit them
 - Country list for recipient countries when creating an activity has been reduced to only those ODA uses as recipients.
 - Add feedback form link to phase banner
+- Activity to Activity association renamed `child_activities` (from `activities`) to avoid an association name clash with the `public_activity` gem
 
 ## [unreleased]
 

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -11,7 +11,7 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity = Activity.find(id)
     authorize @activity
 
-    @activities = @activity.activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
+    @activities = @activity.child_activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
 
     @transactions = policy_scope(Transaction).where(activity: @activity).order("date DESC")
     @budgets = policy_scope(Budget).where(activity: @activity).order("period_start_date DESC")

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -17,7 +17,7 @@ class Activity < ApplicationRecord
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation
 
   belongs_to :activity, optional: true
-  has_many :activities, foreign_key: "activity_id"
+  has_many :child_activities, foreign_key: "activity_id", class_name: "Activity"
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
   has_many :implementing_organisations

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -12,7 +12,7 @@ class CreateProgrammeActivity
     activity.reporting_organisation_reference = activity.organisation.iati_reference
 
     fund = Activity.find(fund_id)
-    fund.activities << activity
+    fund.child_activities << activity
 
     activity.wizard_status = "identifier"
     activity.level = :programme

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -16,7 +16,7 @@ class CreateProjectActivity
     activity.reporting_organisation_reference = reporting_organisation.iati_reference
 
     programme = Activity.find(programme_id)
-    programme.activities << activity
+    programme.child_activities << activity
 
     activity.wizard_status = "identifier"
     activity.level = :project

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Users can create a project" do
         fill_in_activity_form(level: "project")
 
         expect(page).to have_content I18n.t("form.project.create.success")
-        expect(programme.activities.count).to eq 1
+        expect(programme.child_activities.count).to eq 1
 
-        project = programme.activities.last
+        project = programme.child_activities.last
 
         expect(project.organisation).to eq user.organisation
       end

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature "Users can view a project" do
     scenario "can view a project" do
       fund = create(:fund_activity)
       programme = create(:programme_activity)
-      fund.activities << programme
+      fund.child_activities << programme
       project = create(:project_activity, organisation: user.organisation)
-      programme.activities << project
+      programme.child_activities << project
 
       visit organisation_activity_path(project.organisation, project)
 
@@ -26,9 +26,9 @@ RSpec.feature "Users can view a project" do
       scenario "links to the programmes projects" do
         fund = create(:fund_activity)
         programme = create(:programme_activity)
-        fund.activities << programme
+        fund.child_activities << programme
         project = create(:project_activity, organisation: user.organisation)
-        programme.activities << project
+        programme.child_activities << project
 
         visit organisation_activity_path(programme.organisation, programme)
 
@@ -65,9 +65,9 @@ RSpec.feature "Users can view a project" do
     scenario "can download a project as XML" do
       fund = create(:fund_activity)
       programme = create(:programme_activity)
-      fund.activities << programme
+      fund.child_activities << programme
       project = create(:project_activity, organisation: user.organisation)
-      programme.activities << project
+      programme.child_activities << project
       project_presenter = ActivityXmlPresenter.new(project)
 
       visit organisation_activity_path(project.organisation, project)

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Users can view fund level activities" do
     scenario "can view and create programme level activities" do
       fund_activity = create(:activity, level: :fund, organisation: user.organisation)
       programme_activity = create(:activity, level: :programme)
-      fund_activity.activities << programme_activity
+      fund_activity.child_activities << programme_activity
       activity_presenter = ActivityPresenter.new(programme_activity)
       visit organisation_activity_path(fund_activity.organisation, fund_activity)
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Activity, type: :model do
   describe "associations" do
     it { should belong_to(:organisation) }
     it { should belong_to(:activity).optional }
-    it { should have_many(:activities).with_foreign_key("activity_id") }
+    it { should have_many(:child_activities).with_foreign_key("activity_id") }
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
     it { should have_many(:implementing_organisations) }
   end
@@ -196,7 +196,7 @@ RSpec.describe Activity, type: :model do
     it "returns the parent activity or nil if there is not one" do
       fund_activity = create(:activity, level: :fund)
       programme_activity = create(:activity, level: :programme)
-      fund_activity.activities << programme_activity
+      fund_activity.child_activities << programme_activity
 
       expect(programme_activity.parent_activity).to eql fund_activity
       expect(fund_activity.parent_activity).to be_nil


### PR DESCRIPTION


## Changes in this PR
Related to: https://trello.com/c/jEaQCbZp/434-user-actions-are-auditable

While implementing `public_activity` gem, we found a name clash with `Activities`

When public_activity records a change against a model, it adds PublicActivity::Activity
records in an association called `activities`. We already had an association
on Activity called `activities`, so this resulted in a naming clash.

In order to move forward with public_activity, we have decided to rename the
Activity -> Activity association to `child_activities`, i.e.

`has_many :child_activities, foreign_key: "activity_id", class_name: "Activity"`

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
