### PR TITLE
(fix) CI and local tests use the same env vars

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,4 @@ DOMAIN=test.local
 DATABASE_URL=postgres://postgres@localhost:5432/roda_test
 NOTIFY_KEY=abc
 NOTIFY_WELCOME_EMAIL_TEMPLATE=123
+REDIS_URL=redis://localhost:6379

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         -e COVERALLS_SERVICE_NAME=travis-ci \
         -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" \
         -e CI=true \
-        --env-file .env.example \
+        --env-file .env.test \
         app/test /bin/bash -c "tail -f /dev/null"
       docker exec test-container rake
       docker exec test-container bundle exec brakeman

--- a/spec/requests/users_can_sign_out_spec.rb
+++ b/spec/requests/users_can_sign_out_spec.rb
@@ -2,14 +2,12 @@ require "rails_helper"
 
 RSpec.describe "signing out of Auth0", type: :request do
   scenario "success" do
-    allow(ENV).to receive(:[]).with("BULLET_DEBUG").and_return("false")
-    allow(ENV).to receive(:[]).with("AUTH0_CLIENT_ID").and_return("123456")
-    allow(ENV).to receive(:[]).with("AUTH0_DOMAIN").and_return("test.auth0")
-    host! "test.local"
-    mock_successful_authentication
+    ClimateControl.modify AUTH0_DOMAIN: "test.auth0", AUTH0_CLIENT_ID: "123456", BULLET_DEBUG: "false" do
+      host! "test.local"
+      mock_successful_authentication
+      get "/sign_out"
 
-    get "/sign_out"
-
-    expect(request).to redirect_to("https://test.auth0/v2/logout?returnTo=http%3A%2F%2Ftest.local%2F&client_id=123456")
+      expect(request).to redirect_to("https://test.auth0/v2/logout?returnTo=http%3A%2F%2Ftest.local%2F&client_id=123456")
+    end
   end
 end


### PR DESCRIPTION
This work came out of seeing the tests fail in CI with seed 10466,
running the same seed locally, the tests passed.

Trying to figure out what was different it became apparent that in CI
the `.env.example` variables are loaded and locally the `.env.test`
variables are loaded.

One of the differences was that REDIS_URL is not defined in .env.test
whereas it is in .env.example.

Adding the REDIS_URL to the .env.test file results in seed 10466 failing
locally, which confirms the issue.

This could be fixed two ways but the decision was made to change CI to
use the .env.test variables and add the REDIS_URL in. This means
developers will need to run redis locally now in order to run the test
suite, but also means CI and the local tests run in the same environment
- this feels like a good trade-off.

With both local and CI test failing the same the actual failing test was
examined:

`spec/requests/users_can_sign_out_spec.rb`

This failure seems to relate to test order as the spec will pass with
other seeds. Seed 10466 runs this spec first.

This looks to be the only spec that stubs the env variables.

Stubbing the entire ENV means that other parts of the code that might
use the ENV will fail, and indeed this was the case.

As the the Code Climate gem is already used, it make sense to use it
here to only stub the env variables needed for the test rather than the
whole thing.

## NOTE
Developers must run redis locally to run the test suite once this is merged.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
