### PR TITLE
Activities at the identification step but without an identifier can be updated again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.6.3"
 gem "auth0", "~> 4.9"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "coffee-rails", "~> 5.0"
+gem "data_migrate"
 gem "govuk_design_system_formbuilder", github: "dxw/govuk_design_system_formbuilder", branch: "i18n"
 gem "haml-rails"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    data_migrate (6.3.0)
+      rails (>= 5.0)
     database_cleaner (1.8.3)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -438,6 +440,7 @@ DEPENDENCIES
   climate_control
   coffee-rails (~> 5.0)
   coveralls
+  data_migrate
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -4,6 +4,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   include ActivityHelper
 
   FORM_STEPS = [
+    :blank,
     :identifier,
     :purpose,
     :sector,
@@ -25,6 +26,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     authorize @activity
 
     case step
+    when :blank
+      skip_step
     when :region
       skip_step if @activity.recipient_country?
     when :country

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,6 +2,7 @@ class Activity < ApplicationRecord
   STANDARD_GRANT_FINANCE_CODE = "110"
 
   validates :identifier, presence: true, if: :identifier_step?
+  validates_uniqueness_of :identifier, if: :identifier_step?
   validates :title, :description, presence: true, if: :purpose_step?
   validates :sector, presence: true, if: :sector_step?
   validates :status, presence: true, if: :status_step?
@@ -11,7 +12,6 @@ class Activity < ApplicationRecord
   validates :flow, presence: true, if: :flow_step?
   validates :aid_type, presence: true, if: :aid_type_step?
   validates :tied_status, presence: true, if: :tied_status_step?
-  validates_uniqueness_of :identifier
   validates :planned_start_date, :planned_end_date, presence: true, if: :dates_step?
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -10,7 +10,7 @@ class CreateFundActivity
     activity.organisation = Organisation.find(organisation_id)
     activity.reporting_organisation_reference = activity.organisation.iati_reference
 
-    activity.wizard_status = "identifier"
+    activity.wizard_status = "blank"
     activity.level = :fund
 
     activity.funding_organisation_name = "HM Treasury"

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -14,7 +14,7 @@ class CreateProgrammeActivity
     fund = Activity.find(fund_id)
     fund.child_activities << activity
 
-    activity.wizard_status = "identifier"
+    activity.wizard_status = "blank"
     activity.level = :programme
 
     activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -18,7 +18,7 @@ class CreateProjectActivity
     programme = Activity.find(programme_id)
     programme.child_activities << activity
 
-    activity.wizard_status = "identifier"
+    activity.wizard_status = "blank"
     activity.level = :project
 
     activity.funding_organisation_name = service_owner.name

--- a/db/data/20200402172606_change_wizard_step_for_all_activities_without_identifier_to_blank.rb
+++ b/db/data/20200402172606_change_wizard_step_for_all_activities_without_identifier_to_blank.rb
@@ -1,0 +1,11 @@
+class ChangeWizardStepForAllActivitiesWithoutIdentifierToBlank < ActiveRecord::Migration[6.0]
+  def up
+    activities = Activity.where(wizard_status: :identifier, identifier: nil)
+    activities.update_all(wizard_status: :blank)
+  end
+
+  def down
+    activities = Activity.where(wizard_status: :blank, identifier: nil)
+    activities.update_all(wizard_status: :identifier)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20200402172606)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -29,7 +29,14 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "validations" do
-    describe "constraints" do
+    context "when identifier is blank" do
+      subject { build(:activity, identifier: nil, wizard_status: :identifier) }
+      it { should validate_presence_of(:identifier) }
+    end
+
+    context "when identifier is not unique" do
+      before(:each) { create(:activity, identifier: "GB-GOV-13", wizard_status: :identifier) }
+      subject { build(:activity, identifier: "GB-GOV-13", wizard_status: :identifier) }
       it { should validate_uniqueness_of(:identifier) }
     end
 
@@ -182,6 +189,14 @@ RSpec.describe Activity, type: :model do
     context "when saving in the update_extending_organisation context" do
       subject { build(:activity) }
       it { should validate_presence_of(:extending_organisation_id).on(:update_extending_organisation) }
+    end
+
+    context "when the wizard status is blank" do
+      it "allows updates to be made to other fields set on creation" do
+        blank_activity = create(:activity, funding_organisation_name: "old", wizard_status: :blank)
+        blank_activity.funding_organisation_name = "new"
+        expect(blank_activity.valid?).to eq(true)
+      end
     end
   end
 

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CreateFundActivity do
     end
 
     it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("identifier")
+      expect(result.wizard_status).to eq("blank")
     end
 
     it "sets the activity level to 'fund'" do

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CreateProgrammeActivity do
     end
 
     it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("identifier")
+      expect(result.wizard_status).to eq("blank")
     end
 
     it "sets the Activity level to 'programme'" do

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CreateProjectActivity do
     end
 
     it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("identifier")
+      expect(result.wizard_status).to eq("blank")
     end
 
     it "sets the Activity level to 'project'" do


### PR DESCRIPTION
## Changes in this PR

This change has been driven by the review of this [pull request](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/303) that was seeking to use `save(validate: false)` to solve a problem where data couldn't be saved normally. 

On investigation we found activities that existed on the `identifier` step but did not have a value. When `save` was called on these records to correct data that was set during the initial creation (see changes to the services) it would fail due to the `identifier` field validations being run even though the value was still `nil`. We were unable to update fields set by the system.

I think the `identifier` step is used since it's the first 'real' step to the form.

I've added a new form step to capture the state where an activity is created but no fields have been provided - I've called this `blank`. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
