### PR TITLE
Old activities that are beyond the country/region step can be updated again.

### DIFF
--- a/db/data/20200402180246_add_geography_data.rb
+++ b/db/data/20200402180246_add_geography_data.rb
@@ -1,0 +1,11 @@
+class AddGeographyData < ActiveRecord::Migration[6.0]
+  def up
+    activities_with_only_regions = Activity.where(recipient_country: nil).where.not(recipient_region: nil)
+    activities_with_only_regions.update_all(geography: :recipient_region)
+  end
+
+  def down
+    activities_with_only_regions = Activity.where(recipient_country: nil).where.not(recipient_region: nil)
+    activities_with_only_regions.update_all(geography: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20200402172606)
+DataMigrate::Data.define(version: 20200402180246)


### PR DESCRIPTION
Based on https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/310 which installs the data-migrate gem. Please merge that first.

## Changes in this PR

When we added the `geography` field we didn't set values on our environments. None of our 35 activities on production have a value for geography. https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/249/files

An impact of this is that activities that are at the country step or beyond can no longer be edited.

Using a rake script we update the geography to `recipient_region` for all actiivty records that have a region but not a country.

Whilst no activities currently have a country on production. This is not guaranteed to be the case by the time this task is run, so there is a guard to ignore those records. New activities that set a country should set the geography field correctly in any case.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
