### PR TITLE
Empty optional dates are not included in XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Progressively enhance the country select element into a combo box when
   Javascript is available
 - Add privacy policy to site
+- Empty optional dates for `actual start date` and `actual end date` are not included on the activity XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...HEAD
 [release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -21,9 +21,11 @@
         %narrative= organisation.name
   %activity-status{"code" => activity.status}/
   %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
-  %activity-date{"iso-date" => activity.actual_start_date, type: "2"}/
+  - if activity.actual_start_date?
+    %activity-date{"iso-date" => activity.actual_start_date, type: "2"}/
   %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
-  %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
+  - if activity.actual_end_date?
+    %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
   - if activity.recipient_region?
     %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}/
   - if activity.recipient_country?

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -42,6 +42,26 @@ RSpec.feature "Users can view an activity as XML" do
         end
       end
 
+      context "when the activity does not have actual dates (optional dates)" do
+        let(:activity) {
+          create(:fund_activity,
+            organisation: organisation,
+            identifier: "IND-ENT-IFIER",
+            actual_start_date: nil,
+            actual_end_date: nil)
+        }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "does not include empty optional dates" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          optional_start_date = xml.at("iati-activity/activity-date[@type = '2']")
+          optional_end_date = xml.at("iati-activity/activity-date[@type = '4']")
+
+          expect(optional_start_date).to be_nil
+          expect(optional_end_date).to be_nil
+        end
+      end
+
       context "when the activity is a fund activity" do
         let(:activity) { create(:fund_activity, organisation: organisation, identifier: "IND-ENT-IFIER") }
         let(:activity_presenter) { ActivityXmlPresenter.new(activity) }


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/2LJYjzhh

This PR fixes a bug we detected while validating XMLs of activities on the IATI validator. When a user creates an activity, they're prompted to input start dates and end dates as part of the journey. The `planned dates` are mandatory, but the `actual dates` are optional. 

Before this change, the XML file would include the fields for the optional dates (`actual_start_date` and `actual_end_date`) even when these dates have been left blank by the user. This situation would case the IATI validator to throw an error on validation of this XML file, as it would encounter two fields with not data on them. Now, the optional dates fields that are left blank by the user will not be included on the XML and the validation will not fail as a result. 

I added tests to assert this functionality and I have checked several XML files agains IATI validator. They have all passed validation.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
