### PR TITLE
(WIP) CI uses docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,25 @@
 language: minimal
-services:
-- docker
 before_install:
-- docker build . --target test --build-arg RAILS_ENV=test -t app/test
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker -v
 jobs:
   include:
   - stage: Test
-    name: Build and test the current version of the application using Docker
-    env:
-    - RAILS_ENV=test
+    name: Build and test the current version of the application using Docker compose
     script: |
-      set -eu
-      docker network create test
-      docker run -d --name pg --network test -p 5432:5432 postgres:11.6
-      docker run -d --name redis --network test -p 6379:6379 redis:4.0.14
-      docker run -d \
-        --name test-container \
-        --network test \
-        -e RAILS_ENV=test \
-        -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
-        -e DATABASE_URL=postgres://postgres@pg:5432/roda_test \
-        -e REDIS_URL=redis://redis:6379 \
-        -e TRAVIS="$TRAVIS" \
-        -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" \
-        -e TRAVIS_BRANCH="$TRAVIS_BRANCH" \
-        -e TRAVIS_PULL_REQUEST="$TRAVIS_PULL_REQUEST" \
-        -e COVERALLS_SERVICE_NAME=travis-ci \
-        -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" \
-        -e CI=true \
-        --env-file .env.test \
-        app/test /bin/bash -c "tail -f /dev/null"
-      docker exec test-container bundle exec rake
-      docker exec test-container bundle exec brakeman
+      echo "==== build image ===="
+      DOCKER_BUILDKIT=1
+      IMAGE_NAME="thedxw/beis-report-official-development-assistance"
+      VERSION="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
+      DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from "$IMAGE_NAME" --tag "$IMAGE_NAME" .
+      docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:test"
+      docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${VERSION}"
+      echo "==== testing app ===="
+      docker-compose -f docker-compose.ci.yml up --detach
+      docker exec app-container /bin/bash -c "bundle exec rails default"
       echo "==== testing terrafrom ===="
       cd terraform
       git clone https://github.com/tfutils/tfenv.git ~/.tfenv

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+services:
+  app:
+    image: thedxw/beis-report-official-development-assistance:test
+    container_name: app-container
+    depends_on:
+      - redis
+      - db
+    environment:
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      DATABASE_URL: postgres://postgres:password@db:5432/roda_test
+      REDIS_URL: redis://redis:6379
+      DOMAIN: test.local
+      NOTIFY_KEY: abc
+      NOTIFY_WELCOME_EMAIL_TEMPLATE: 123
+      RAILS_ENV: test
+      TRAVIS: "$TRAVIS"
+      TRAVIS_JOB_ID: "$TRAVIS_JOB_ID"
+      TRAVIS_BRANCH: "$TRAVIS_BRANCH"
+      TRAVIS_PULL_REQUEST: "$TRAVIS_PULL_REQUEST"
+      COVERALLS_SERVICE_NAME: travis-ci
+      COVERALLS_REPO_TOKEN: "$COVERALLS_REPO_TOKEN"
+      CI: "true"
+  db:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: password
+  redis:
+    image: redis

--- a/travis-docker-push.sh
+++ b/travis-docker-push.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 TAG="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build --target web -t "thedxw/beis-report-official-development-assistance:$TAG" .
 docker push "thedxw/beis-report-official-development-assistance:$TAG"


### PR DESCRIPTION
## Changes in this PR
This is an attempt to use `docker-compose` in CI to build and run the tests. The motivation for this is seeing the test suite fail in CI becasue Redis is not available.

The way we were using `docker run` could potentially cause a race condition where the tests run before Redis has started.

Whilst switching to docker-comopse [cannot remove the risk](https://docs.docker.com/compose/startup-order/) it would be interesting to see if this makes any difference. 

The complete fix is to check for redis before moving on to start the application, [wait-for-it](https://github.com/vishnubob/wait-for-it) looks like a zero dependancy way to do that and I may take a look if we think it is worthwhile?

I think we should be able to build the image, run the tests with docker-compose and then push the same image to docker hub for deployment - this would save us building the image twice, but to do that we would have to change our multistage build so `web` is the last stage and we would have to install the testing dependancies on the deployed image, @tahb this is something we have spoken about in the past.

I'd be interested to hear folks views on this?

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
