### PR TITLE
Add database constraints to ensure data integrity

### DIFF
--- a/db/migrate/20200408173214_add_foreign_key_constraints.rb
+++ b/db/migrate/20200408173214_add_foreign_key_constraints.rb
@@ -1,0 +1,19 @@
+class AddForeignKeyConstraints < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :activities, :organisations, on_delete: :restrict
+
+    # Already exists
+    # add_foreign_key :activities, :activities, column: "activity_id", on_delete: :restrict
+
+    # Already exists
+    # add_foreign_key :activities, :organisations, column: "extending_organisation_id"
+
+    # Column doesn't exist in this branch
+    # add_foreign_key :activities, :organisations, column: "reporting_organisation_id"
+
+    add_foreign_key :transactions, :activities, on_delete: :cascade
+    add_foreign_key :budgets, :activities, on_delete: :cascade
+
+    add_foreign_key :users, :organisations, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_31_111947) do
+ActiveRecord::Schema.define(version: 2020_04_08_173214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -122,4 +122,8 @@ ActiveRecord::Schema.define(version: 2020_03_31_111947) do
   add_foreign_key "activities", "activities"
   add_foreign_key "activities", "organisations", column: "extending_organisation_id"
   add_foreign_key "activities", "organisations", column: "reporting_organisation_id"
+  add_foreign_key "activities", "organisations", on_delete: :restrict
+  add_foreign_key "budgets", "activities", on_delete: :cascade
+  add_foreign_key "transactions", "activities", on_delete: :cascade
+  add_foreign_key "users", "organisations", on_delete: :restrict
 end


### PR DESCRIPTION
TL;DR Data integrity is a good thing and protects us from accidents
and unexpected consequences of future logic we may add. Rails 
doesn't steer us as clearly as it could. We should add database level 
constraints **alongside** the Rails model logic to all existing 
associations, rather than removing existing associations and relying 
solely on Rails Model logic.

---

We reached a point where we noticed we had created foreign key
constraints for only 2 relationships. This problem came to the
surface during our work to practice restoring production data
to other environments[1]. We ended up taking a different approach
to copying the database across to complete the work. We left this
issue to one side.

Soon after we noticed we were adding a new association and were
choosing to add a foreign key constraint[2]. It now felt like the
time to decide one way or another what approach we were going to
take as at least we wanted a consistent approach.

Rails talk about Referential Integrity[3] by saying that intelligence
about database logic lives in the model and not the database, so using
foreign keys constraints isn't commonly used. It then goes onto say that
using them is a way to ensure data integrity. Having data integrity is
surely a valuable property of a database but we also want to follow the
"Rails way".

I believe we should use foreign key constraints to ensure our database
is protected against future changes that cause unexpected consequences.
These could take the form of running data migration scripts and calling
`delete` instead of `destroy` - which calls the model after_delete
callbacks. The impact of any such mistake would be a flurry of errors
where users are unable to view activities as their organisation has been
deleted. Since organisation is a required association the codebase is
built to rely on this association being present. This example applies to
our other records such as activities, users, transactions and budgets.

By contrast the only downside to having better data integrity seems to be
the cost of ensuring that these contraints are added for new associations.

A note on my use of `on_delete:`, it defaults to `:restrict` however I
thought it would be clearer to the reader to be explicit. I've used
cascade for tables that make no sense without it's parent like
transactions and budgets. If for unforeseen reasons we allow activities
to be deleted in future, transactions and budgets should also be
deleted.

I tried 2 gems to automate this task. Both failed for various reasons
that I can only assume after an hour of debugging is the fact we're on
Rails 6. One aspect I liked of the Immigrant gem was that it had a rake
task we could call in order to ensure we were checking for constraints
in our test suite, ensuring we don't end up with missing constraints in
the future. Perhaps we should build our own?

- https://github.com/jenseng/immigrant
- https://github.com/kevincolemaninc/yeet_dba

I went through the schema and our existing associations one by one and
created a new add_foreign_key constraint in a single migration.
Hopefully I've caught them all.

I have run this migration on top of a production database locally and it
works. This change is better done sooner than later as we cannot guarantee that
this will always remain the case. If the database does get into a state
where these constraints can't be added retroactively we might have quite
the job on our hands to manually unpick the missing integrity -
something that would be valuable to avoid.

[1] https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/297
[2] https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/303#discussion_r404812946
[3] https://guides.rubyonrails.org/active_record_migrations.html#active-record-and-referential-integrity

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
