### PR TITLE
Run data migrations automatically after migrating the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ To manage sensitive environment variables:
 
 [Our release process is documented locally](/doc/deployment-process.md).
 
+## Migrations
+
+### Schema
+
+We use conventional Rails migrations to make changes to the schema. This includes setting or changing relevant data.
+
+Schema migrations are applied automatically on deployment via the docker-entrypoint.sh.
+
+### Data / One-off tasks
+
+We use the [data-migrate](https://github.com/ilyakatz/data-migrate) gem to make changes to data that do not require schema changes.
+
+This can be useful if we need to fix missing data fields or improve the quality of data. For example upcasing all values of a certain field at the same time as adding in validation for the same.
+
+Data migrations are applied automatically on deployment via the docker-entrypoint.sh.
+
 ## Access
 
 ### Staging

--- a/doc/architecture/decisions/0019-use-data-migrations-to-update-live-data.md
+++ b/doc/architecture/decisions/0019-use-data-migrations-to-update-live-data.md
@@ -1,0 +1,41 @@
+# 19. use-data-migrations-to-update-live-data
+
+Date: 2020-04-09
+
+## Status
+
+Accepted
+
+## Context
+
+We need a way to modify existing data on live environments. A good example of this is the new field we made called `geography`. We made is a required field but missed the fact that existing data needed to be migrated based on the value of `recipient_region`. We missed this and needed to take action to correct the mistake on each environment.
+
+We want to avoid having unstructured access to rails consoles on live environments to de-risk the process where possible.
+
+We want to avoid the fact we have to remember to run a manual action before or after a deployment to snure they aren't forgotten.
+
+Using conventional rails migrations as the mechanism for only change data is an option. Though we may wish to change the schema without changing the data migrations. Tieing these 2 responsibilities into the same mechanism seems like it could back us into a corner later.
+
+We would like to document the actions we perform through our code. This would help us understand and debug the state of the service. 
+
+## Decision
+
+Use the data-migrate gem[1] when we need to make changes to data without touching the schema.
+
+Changes to the schema can still include changes relevant to data within the db:migrate. If we were to add the geography feature again, we would add the new column and set the value as a single transaction.
+
+Include the `rake data:migrate` step in the deployment process so it is automatically run after `rake db:migrate`.  
+
+[1] https://github.com/ilyakatz/data-migrate
+
+## Consequences
+
+Changing data on real environments has an automated process.
+
+The team can rollback from data migrations if they need to.
+
+Data migrations and "one-off tasks" are preserved and documented within the code base.
+
+It may be unclear when to use data migrations and when to use db migrations despite including this in the README.
+
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,10 @@ setup_database()
   echo "Preparing database…"
   bundle exec rake db:prepare
   echo "Finished database setup."
+
+  echo "Running data migrations…"
+  bundle exec rake data:migrate
+  echo "Finished running data migrations."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi


### PR DESCRIPTION
## Changes in this PR

Doing this automatically will ensure we don't forget to run these data:migrate tasks by hand. Something we did on the first try - oops.

Using the docker entrypoint ensures the command will be run automatically on all environments.

When we deploy we bring up 2 new applications in the form of docker containers. This sometimes causes a race condition. The first container to call the `rake db:migrate` will block the second and a concurrent migration can error. I think this error will prevent the new data:migrate step from being executed and will remove the change of a data migration being run before the database migration has been applied.

This can be applied by using rake db:migrate:with_data to do both in one. Our use of prepare which improved the reliability of our database set up. Before this we were having to catch rails database errors! I think it's worth keeping `prepare` and adding a separate command afterwards.

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
