### PR TITLE
Migration does not fail by trying to update blank activity records on production

### DIFF
--- a/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
+++ b/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb
@@ -5,7 +5,7 @@ class AddReportingOrgAssociationToActivity < ActiveRecord::Migration[6.0]
     ActiveRecord::Base.transaction do
       service_owner = Organisation.find_by_service_owner(true)
 
-      Activity.all.each do |activity|
+      Activity.where.not(wizard_status: :blank).each do |activity|
         organisation = activity.organisation
         activity.reporting_organisation = if organisation.is_government?
           service_owner
@@ -23,7 +23,7 @@ class AddReportingOrgAssociationToActivity < ActiveRecord::Migration[6.0]
     add_column :activities, :reporting_organisation_reference, :string
 
     ActiveRecord::Base.transaction do
-      activities = Activity.where.not(reporting_organisation_id: nil)
+      activities = Activity.where.not(reporting_organisation_id: nil, wizard_status: :blank)
 
       activities.each do |activity|
         activity.reporting_organisation_reference = activity.reporting_organisation.iati_reference


### PR DESCRIPTION

## Changes in this PR

This was fine locally, and on staging but luckily I was testing this against my local database that has production data in and it blew up!

```
== 20200331111947 AddReportingOrgAssociationToActivity: migrating =============
-- add_reference(:activities, :reporting_organisation, {:type=>:uuid, :foreign_key=>{:to_table=>:organisations}})
   -> 0.0220s
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:
Validation failed: Your unique identifier Your unique identifier has already been taken
/Users/tomhipkin/sites/beis/beis-report-overseas-development-assistance/db/migrate/20200331111947_add_reporting_org_association_to_activity.rb:15:in `block (2 levels) in up'
```
This was happening as I had 2 activities with an identifier of `nil`.

Before this change is deployed and run on production let's add a guard for this into the migration.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
