### PR TITLE
Run data migrations on start before schema migrations

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,13 +5,13 @@ echo "Starting docker entrypoint…"
 
 setup_database()
 {
-  echo "Preparing database…"
-  bundle exec rake db:prepare
-  echo "Finished database setup."
-
   echo "Running data migrations…"
   bundle exec rake data:migrate
   echo "Finished running data migrations."
+
+  echo "Preparing database…"
+  bundle exec rake db:prepare
+  echo "Finished database setup."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi


### PR DESCRIPTION
## Changes in this PR

We found that deploying a batch of code to production that the master branch was much further behind in terms of outstanding schema changes. This meant that a data migration that required a much earlier schema change worked locally and on staging, but failed on production.

As schema changes should include the required and relevant data changes we think we can switch the ordering.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
