### PR TITLE
(549) Activities can have a previous identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@
 
 ## [unreleased]
 
+- Activities that have an identifier already can use it as the iati-identifier
+  in the xml output
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4
 [release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,5 +1,8 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
-  %iati-identifier= activity.iati_identifier
+  - if activity.previous_identifier?
+    %iati-identifier= activity.previous_identifier
+  - else
+    %iati-identifier= activity.iati_identifier
   %reporting-org{"type" => activity.reporting_organisation.organisation_type, "ref" => activity.reporting_organisation.iati_reference }
     %narrative= activity.reporting_organisation.name
   %title
@@ -19,6 +22,8 @@
     - activity.implementing_organisations.each do |organisation|
       %participating-org{"ref" => organisation.reference, "type" => organisation.organisation_type, "role" => 4}
         %narrative= organisation.name
+  - if activity.previous_identifier?
+    %other-identifier{"ref" => activity.iati_identifier, type: "A1"}
   %activity-status{"code" => activity.status}/
   %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
   - if activity.actual_start_date?

--- a/db/migrate/20200414101829_add_previous_identifier_to_activities.rb
+++ b/db/migrate/20200414101829_add_previous_identifier_to_activities.rb
@@ -1,0 +1,5 @@
+class AddPreviousIdentifierToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :previous_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_133152) do
+ActiveRecord::Schema.define(version: 2020_04_14_101829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_133152) do
     t.string "recipient_country"
     t.string "geography"
     t.uuid "reporting_organisation_id"
+    t.string "previous_identifier"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -7,6 +7,30 @@ RSpec.feature "Users can view an activity as XML" do
     context "when the user belongs to BEIS" do
       before { authenticate!(user: user) }
 
+      context "when the activity has a previous activity identifier" do
+        let(:activity) {
+          create(:fund_activity,
+            organisation: organisation,
+            identifier: "IND-ENT-IFIER",
+            previous_identifier: "PREV-IND-ENT-IFIER")
+        }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "shows the previous identifier as the actvitiy identifier" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.previous_identifier)
+        end
+
+        it "shows the activity identifier as the other identifier" do
+          iati_identifier = ActivityXmlPresenter.new(activity).iati_identifier
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/other-identifier/@ref").text).to eq(iati_identifier)
+        end
+      end
+
       context "when the activity has recipient_region geography" do
         let(:activity) {
           create(:fund_activity,


### PR DESCRIPTION
When an activity has already been published to IATI the identifier must
not change. As we are now standardising the identifier we may have to
use two identifiers for some activities.

As existing activities will be imported, do not expose the previous
identifier attribute to users.

Where an activity has a previous identifier use it as the
`iati-identifier` in the xml and output the new identifier using the
`other-identifier` attribute, see:

http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/other-identifier/

I did wonder if we should include the `owner-org` for the `other-identifier` and set it to BEIS, but I won't let that block this work.

http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/other-identifier/owner-org/

## XML validation
https://stage.dataworkbench.io/validate/e47224d5-0eca-4fd0-8199-6e98032c99aa

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
