### PR TITLE
(520) BEIS users only see an organisation's activities on that organisation's show page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Individual Activity update steps are tracked on create & update
 - Content added to start page
 - Links that open in a new window now have a message informing the user of this.
+- BEIS users only see an organisation's activities on that organisation's show page (bug)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -12,15 +12,9 @@ class Staff::OrganisationsController < Staff::BaseController
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
 
-    if organisation.service_owner
-      fund_activities = policy_scope(Activity.funds, policy_scope_class: FundPolicy::Scope).includes(:organisation).order("created_at ASC")
-      programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).order("created_at ASC")
-      project_activities = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).order("created_at ASC")
-    else
-      fund_activities = policy_scope(Activity.funds, policy_scope_class: FundPolicy::Scope).includes(:organisation).where(organisation: organisation).order("created_at ASC")
-      programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).where(extending_organisation: organisation).order("created_at ASC")
-      project_activities = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).where(organisation: organisation).order("created_at ASC")
-    end
+    fund_activities = FindFundActivities.new(organisation: organisation, current_user: current_user).call
+    programme_activities = FindProgrammeActivities.new(organisation: organisation, current_user: current_user).call
+    project_activities = FindProjectActivities.new(organisation: organisation, current_user: current_user).call
 
     @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
     @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -12,14 +12,19 @@ class Staff::OrganisationsController < Staff::BaseController
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
 
-    fund_activities = policy_scope(Activity.funds).includes(:organisation).where(organisation: organisation).order("created_at ASC")
+    if organisation.service_owner
+      fund_activities = policy_scope(Activity.funds, policy_scope_class: FundPolicy::Scope).includes(:organisation).order("created_at ASC")
+      programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).order("created_at ASC")
+      project_activities = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).order("created_at ASC")
+    else
+      fund_activities = policy_scope(Activity.funds, policy_scope_class: FundPolicy::Scope).includes(:organisation).where(organisation: organisation).order("created_at ASC")
+      programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).where(extending_organisation: organisation).order("created_at ASC")
+      project_activities = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).where(organisation: organisation).order("created_at ASC")
+    end
+
     @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
-
-    programme_activities = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope).includes(:organisation).order("created_at ASC")
     @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
-
-    project_activites = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope).includes(:organisation).order("created_at ASC")
-    @project_activities = project_activites.map { |activity| ActivityPresenter.new(activity) }
+    @project_activities = project_activities.map { |activity| ActivityPresenter.new(activity) }
   end
 
   def new

--- a/app/services/find_fund_activities.rb
+++ b/app/services/find_fund_activities.rb
@@ -1,0 +1,22 @@
+class FindFundActivities
+  include Pundit
+
+  attr_accessor :organisation, :current_user
+
+  def initialize(organisation:, current_user:)
+    @organisation = organisation
+    @current_user = current_user
+  end
+
+  def call
+    funds = policy_scope(Activity.funds, policy_scope_class: FundPolicy::Scope)
+      .includes(:organisation)
+      .order("created_at ASC")
+    funds = if organisation.service_owner
+      funds.all
+    else
+      funds.where(organisation_id: organisation.id)
+    end
+    funds
+  end
+end

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -1,0 +1,22 @@
+class FindProgrammeActivities
+  include Pundit
+
+  attr_accessor :organisation, :current_user
+
+  def initialize(organisation:, current_user:)
+    @organisation = organisation
+    @current_user = current_user
+  end
+
+  def call
+    programmes = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope)
+      .includes(:organisation)
+      .order("created_at ASC")
+    programmes = if organisation.service_owner
+      programmes.all
+    else
+      programmes.where(extending_organisation_id: organisation.id)
+    end
+    programmes
+  end
+end

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -1,0 +1,22 @@
+class FindProjectActivities
+  include Pundit
+
+  attr_accessor :organisation, :current_user
+
+  def initialize(organisation:, current_user:)
+    @organisation = organisation
+    @current_user = current_user
+  end
+
+  def call
+    projects = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope)
+      .includes(:organisation)
+      .order("created_at ASC")
+    projects = if organisation.service_owner
+      projects.all
+    else
+      projects.where(organisation_id: organisation.id)
+    end
+    projects
+  end
+end

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Users can view an organisation" do
       end
 
       scenario "does not see activities which belong to a different organisation" do
-        other_programme = create(:programme_activity, organisation: create(:organisation))
+        other_programme = create(:programme_activity, extending_organisation: create(:organisation))
         other_project = create(:project_activity, organisation: create(:organisation))
 
         visit organisation_path(user.organisation)

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -57,6 +57,34 @@ RSpec.feature "Users can view an organisation" do
         expect(page).to have_content(other_organisation.name)
       end
 
+      scenario "sees activities which belong to this organisation" do
+        programme = create(:programme_activity, extending_organisation: other_organisation)
+        project = create(:project_activity, organisation: other_organisation)
+
+        visit organisation_path(user.organisation)
+        click_link I18n.t("page_title.organisation.index")
+        within("##{other_organisation.id}") do
+          click_link I18n.t("generic.link.show")
+        end
+
+        expect(page).to have_content(programme.title)
+        expect(page).to have_content(project.title)
+      end
+
+      scenario "does not see activities which belong to a different organisation" do
+        other_programme = create(:programme_activity, organisation: create(:organisation))
+        other_project = create(:project_activity, organisation: create(:organisation))
+
+        visit organisation_path(user.organisation)
+        click_link I18n.t("page_title.organisation.index")
+        within("##{other_organisation.id}") do
+          click_link I18n.t("generic.link.show")
+        end
+
+        expect(page).to_not have_content(other_programme.title)
+        expect(page).to_not have_content(other_project.title)
+      end
+
       scenario "can go back to the previous page" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")

--- a/spec/services/find_fund_activities_spec.rb
+++ b/spec/services/find_fund_activities_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe FindFundActivities do
+  let(:user) { create(:beis_user) }
+  let(:service_owner) { create(:beis_organisation) }
+  let(:other_organisation) { create(:organisation) }
+
+  let!(:organisation_fund) { create(:fund_activity, organisation: other_organisation) }
+  let!(:other_fund) { create(:fund_activity) }
+
+  describe "#call" do
+    context "when the organisation is the service owner" do
+      it "returns all fund activities" do
+        result = described_class.new(organisation: service_owner, current_user: user).call
+
+        expect(result).to match_array [organisation_fund, other_fund]
+      end
+    end
+
+    context "when the organisation is not the service owner" do
+      it "returns fund activities for this organisation" do
+        result = described_class.new(organisation: other_organisation, current_user: user).call
+
+        expect(result).to match_array [organisation_fund]
+      end
+    end
+  end
+end

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe FindProgrammeActivities do
+  let(:user) { create(:beis_user) }
+  let(:service_owner) { create(:beis_organisation) }
+  let(:other_organisation) { create(:organisation) }
+
+  let!(:extending_organisation_programme) { create(:programme_activity, extending_organisation: other_organisation) }
+  let!(:other_programme) { create(:programme_activity) }
+
+  describe "#call" do
+    context "when the organisation is the service owner" do
+      it "returns all programme activities" do
+        result = described_class.new(organisation: service_owner, current_user: user).call
+
+        expect(result).to match_array [extending_organisation_programme, other_programme]
+      end
+    end
+
+    context "when the organisation is not the service owner" do
+      it "returns programme activities whose extending organisation is this organisation" do
+        result = described_class.new(organisation: other_organisation, current_user: user).call
+
+        expect(result).to match_array [extending_organisation_programme]
+      end
+    end
+  end
+end

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe FindProjectActivities do
+  let(:user) { create(:beis_user) }
+  let(:service_owner) { create(:beis_organisation) }
+  let(:other_organisation) { create(:organisation) }
+
+  let!(:organisation_project) { create(:project_activity, organisation: other_organisation) }
+  let!(:other_project) { create(:project_activity) }
+
+  describe "#call" do
+    context "when the organisation is the service owner" do
+      it "returns all project activities" do
+        result = described_class.new(organisation: service_owner, current_user: user).call
+
+        expect(result).to match_array [organisation_project, other_project]
+      end
+    end
+
+    context "when the organisation is not the service owner" do
+      it "returns project activities for this organisation" do
+        result = described_class.new(organisation: other_organisation, current_user: user).call
+
+        expect(result).to match_array [organisation_project]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/XhZ45G6F/520-beis-users-only-see-an-organisations-activities-on-the-organisation-show-page

BEIS users have the right to view all activities, no matter which organisation they belong to.
The can also view any organisation's show page.

However, because of a bug, BEIS user's would see *all* activities on any organisation's
show page, because the list of activities is not filtered by organisation.

Now, when a BEIS user views an organisation's show page, they will only see activities
which belong to that organisation. That is, fund and projects which belong to the organisation,
and programmes which have the organisation as its extending organisation.

When a BEIS user views the BEIS organisation, they will see *all* activities belonging
to all organisations.

Non-BEIS users will see the same activities on their organisation show page as they
did before.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
