### PR TITLE
Reference Transaction & Budget Activity association by id, not object

### DIFF
--- a/db/migrate/20200408173215_rename_budget_activity_id_to_parent_activity_id.rb
+++ b/db/migrate/20200408173215_rename_budget_activity_id_to_parent_activity_id.rb
@@ -6,7 +6,7 @@ class RenameBudgetActivityIdToParentActivityId < ActiveRecord::Migration[6.0]
 
     ActiveRecord::Base.transaction do
       Budget.all.each do |budget|
-        budget.parent_activity = budget.activity
+        budget.parent_activity_id = budget.activity_id
         budget.save!
       end
     end
@@ -21,7 +21,7 @@ class RenameBudgetActivityIdToParentActivityId < ActiveRecord::Migration[6.0]
 
     ActiveRecord::Base.transaction do
       Budget.all.each do |budget|
-        budget.activity = budget.parent_activity
+        budget.activity_id = budget.parent_activity_id
         budget.save!
       end
     end

--- a/db/migrate/20200409133152_rename_transaction_activity_id_to_parent_activity_id.rb
+++ b/db/migrate/20200409133152_rename_transaction_activity_id_to_parent_activity_id.rb
@@ -6,7 +6,7 @@ class RenameTransactionActivityIdToParentActivityId < ActiveRecord::Migration[6.
 
     ActiveRecord::Base.transaction do
       Transaction.all.each do |transaction|
-        transaction.parent_activity = transaction.activity
+        transaction.parent_activity_id = transaction.activity_id
         transaction.save!
       end
     end
@@ -21,7 +21,7 @@ class RenameTransactionActivityIdToParentActivityId < ActiveRecord::Migration[6.
 
     ActiveRecord::Base.transaction do
       Transaction.all.each do |transaction|
-        transaction.activity = transaction.parent_activity
+        transaction.activity_id = transaction.parent_activity_id
         transaction.save!
       end
     end


### PR DESCRIPTION
Rollbar: https://rollbar.com/dxw/beis-roda/items/139/

```
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `activity' for #<Budget:0x000055f690cb3270>
Did you mean? activity_id
```

Refer to the Activity association in Budgets & Transactions by the id, not the object.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
