### PR TITLE
public_activity update events on Activities are more granular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,13 +99,14 @@
 - Add privacy policy to site
 - Empty optional dates for `actual start date` and `actual end date` are not included on the activity XML
 - Reporting org in the IATI XML is always BEIS for funds, programmes and projects created by governmental organisations, and the activity's organisation if it is a non-governmental organisation
-- User actions are tracked on Activities, Budgets, Transactions and Users.
 
 ## [unreleased]
 
+- User actions are tracked on Activities, Budgets, Transactions and Users.
 - Activities that have an identifier already can use it as the iati-identifier
   in the xml output
 - User actions are tracked on Organisations.  
+- Individual Activity update steps are tracked on create & update
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -43,6 +43,7 @@ class Staff::ActivityFormsController < Staff::BaseController
 
     update_activity_dates
     update_activity_attributes_except_dates
+    record_auditable_activity
 
     update_wizard_status
 
@@ -52,6 +53,11 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   private
+
+  def record_auditable_activity
+    action = @activity.wizard_complete? ? "update" : "create"
+    @activity.create_activity key: "activity.#{action}.#{step}", owner: current_user
+  end
 
   def date_field_params_regex
     # This regex will match the three date params from `date_field`;

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -171,11 +171,13 @@ RSpec.feature "Users can create a fund level activity" do
         visit organisation_path(user.organisation)
         click_on(I18n.t("page_content.organisation.button.create_fund"))
 
-        fill_in_activity_form(level: "fund")
+        fill_in_activity_form(level: "fund", identifier: "my-unique-identifier")
 
-        auditable_events = PublicActivity::Activity.all
-        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.update")
-        expect(auditable_events.first.owner_id).to eq user.id
+        fund = Activity.find_by(identifier: "my-unique-identifier")
+        auditable_events = PublicActivity::Activity.where(trackable_id: fund.id)
+        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+        expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
+        expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [fund.id]
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -62,8 +62,9 @@ RSpec.feature "Users can create a programme activity" do
 
         programme = Activity.find_by(identifier: "my-unique-identifier")
         auditable_events = PublicActivity::Activity.where(trackable_id: programme.id)
-        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.update")
+        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
         expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
+        expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [programme.id]
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -24,6 +24,26 @@ RSpec.feature "Users can create a project" do
 
         expect(project.organisation).to eq user.organisation
       end
+
+      scenario "project creation is tracked with public_activity" do
+        programme = create(:programme_activity, extending_organisation: user.organisation)
+
+        PublicActivity.with_tracking do
+          visit organisation_path(user.organisation)
+
+          click_on(programme.title)
+
+          click_on(I18n.t("page_content.organisation.button.create_project"))
+
+          fill_in_activity_form(level: "project", identifier: "my-unique-identifier")
+
+          project = Activity.find_by(identifier: "my-unique-identifier")
+          auditable_events = PublicActivity::Activity.where(trackable_id: project.id)
+          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+          expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
+          expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [project.id]
+        end
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -51,6 +51,27 @@ RSpec.feature "Users can edit an activity" do
 
         assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
       end
+
+      it "tracks activity updates with public_activity" do
+        activity = create(:fund_activity, organisation: user.organisation)
+        identifier = "AB-CDE-1234"
+        PublicActivity.with_tracking do
+          visit organisation_activity_path(activity.organisation, activity)
+
+          within(".identifier") do
+            click_on(I18n.t("generic.link.edit"))
+          end
+
+          fill_in "activity[identifier]", with: identifier
+          click_button I18n.t("form.activity.submit")
+
+          # grab the most recently created auditable_event
+          auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
+          expect(auditable_events.first.key).to eq "activity.update.identifier"
+          expect(auditable_events.first.owner_id).to eq user.id
+          expect(auditable_events.first.trackable_id).to eq activity.id
+        end
+      end
     end
 
     context "when the activity is incomplete" do


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/ZQlLq4nF/551-record-when-users-go-through-each-step-of-the-activity-form

Users update an Activity via a multi-step form, a step for each attribute. The
previous implementation of public_activity meant we had an `activity.update`
event for each step. This change changes the event keys to be more obvious
*what* is being created or updated.

We decide if an activity attribute is being created or updated by the `wizard_complete?`
method on Activities - if the wizard is complete, we can assume an attribute is being
updated; if not, we can assume the attribute is being created.

So the event keys will now be `activity.action.attribute`, e.g. activity.create
for the initial Activity creation; activity.create.identifier for the identifier
creaton, and activity.update.identifier for when the identifier is updated.

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
