### PR TITLE
Use public_activity to record when an Organisation is created/edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 
 - Activities that have an identifier already can use it as the iati-identifier
   in the xml output
+- User actions are tracked on Organisations.  
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -33,6 +33,7 @@ class Staff::OrganisationsController < Staff::BaseController
 
     if @organisation.valid?
       @organisation.save
+      @organisation.create_activity key: "organisation.create", owner: current_user
       flash[:notice] = I18n.t("form.organisation.create.success")
       redirect_to organisation_path(@organisation)
     else
@@ -53,6 +54,7 @@ class Staff::OrganisationsController < Staff::BaseController
 
     if @organisation.valid?
       @organisation.save
+      @organisation.create_activity key: "organisation.update", owner: current_user
       flash[:notice] = I18n.t("form.organisation.update.success")
       redirect_to organisation_path(@organisation)
     else

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,6 @@
 class Organisation < ApplicationRecord
+  include PublicActivity::Common
+
   has_many :users
   has_many :funds
 


### PR DESCRIPTION


## Changes in this PR

Trello: https://trello.com/c/XVTv8mOR/577-record-when-an-organisation-is-created-updated-auditing

In https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/309
we added public_activity tracking to Users, Activities, Budgets and Transaction
but missed out Organisations. This PR adds tracking to Organisations.

In `beis_users_can_create_an_organisation_spec.rb` there were two identical copis
of the test `successfully creating an organisation` so we have repurposed one of
these to track the creation of the Organisation.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
