### PR TITLE
(567) Heading error fixed on Geography step

### DIFF
--- a/app/views/staff/activity_forms/geography.html.haml
+++ b/app/views/staff/activity_forms/geography.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset(:geography, legend: { text: t("page_title.activity_form.show.geography"), size: "xl", tag: "hq" }) do
+  = f.govuk_radio_buttons_fieldset(:geography, legend: { text: t("page_title.activity_form.show.geography"), size: "xl", tag: "h1" }) do
     = f.hidden_field :geography, value: nil
     = f.govuk_radio_button :geography, :recipient_region, label: { text: t("activity.geography.recipient_region") }
     = f.govuk_radio_button :geography, :recipient_country, label: { text: t("activity.geography.recipient_country") }


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/6PnGREFR

We found a typo on the heading of the geography step of activities. It should be a `h1` but it was `hq` instead. As a result, screen readers were struggling to determine the layout of the page and the accessibility of the app was compromised.

This PR fixes that typo on the heading making the geography page accessible for people with vision impairment.

## Screenshots of UI changes

### After

<img width="1792" alt="Screenshot 2020-04-20 at 15 26 58" src="https://user-images.githubusercontent.com/48016017/79765124-20c10680-831e-11ea-80dc-7d77e300bee2.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
