### PR TITLE
Make Terraform version explicit in manual deployment docs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,14 +13,15 @@ Deploys will happen automatically from travis
 We should avoid manual deployments but the following instructions will allow you to do one.
 
 ### Setup
-- go to the application /terraform directory
-- install terraform (use `tfenv`)
+- go to the application `/terraform` directory
+- install [tfenv](https://github.com/tfutils/tfenv)
+- install Terraform version `0.12.x` using `tfenv`, use `tfenv list-remote` to see available versions. Our Terrafiles are not backwards-compatible with Terraform `0.11.x`
 - install the latest [cloundfoundry provider](https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#installations)
 
 ### Deployment
 - checkout the correct branch
-  - develop for staging or other testing environments
-  - master for production
+  - `develop` for staging or other testing environments
+  - `master` for production
 - export environment variables for AWS credentials
   These can be found in the RODA 1password vault
   Your local `~/.aws/credentials` should include the values for `aws_access_key` and `aws_secret_access_key`


### PR DESCRIPTION


## Changes in this PR

When deploying manually to `pentest` we discovered that our terrafiles are not
backwards-compatible with Terraform `0.11.x`. Make it explicit in the docs that
you will need Terraform `0.12.x` to use our terrafiles, along with how to install
& use `tfenv`

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
