### PR TITLE
(569) Fix descriptive label issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 - Links that open in a new window now have a message informing the user of this.
 - BEIS users only see an organisation's activities on that organisation's show page (bug)
 - XML file for projects now shows the identifiers for the parent activities.
+- Fix descriptive labels on action links
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -27,4 +27,4 @@
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).create?
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget))
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("page_content.budgets.edit_noun"))

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -33,4 +33,4 @@
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(transaction).create?
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction))
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun", reference: transaction.reference))

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -22,5 +22,5 @@
         %td.govuk-table__cell.organisation= user.organisation.name
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
-          = link_to(I18n.t("generic.link.show"), user_path(user), class: "govuk-link")
+          = a11y_action_link(t("generic.link.show"), user_path(user), user.name)
           = a11y_action_link(I18n.t("generic.link.edit"), edit_user_path(user), user.name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
     budgets:
       button:
         create: Create budget
+      edit_noun: budget
     errors:
       auth0:
         error_messages:
@@ -258,6 +259,7 @@ en:
     transactions:
       button:
         create: Add a transaction
+      edit_noun: transaction %{reference}
       table:
         headers:
           providing_organisation: Provider


### PR DESCRIPTION
The April 2020 accessibility audit identified these 'edit' links as
problematic as they have no context for assistive technology users.

We already have our `a11y_action_link` helper, so use it to give the
links more context.

- for users, the name of the user to show
- for transactions 'Edit transaction {transaction reference}'
- for budgets 'Edit budget'

I could not see a better way of identifying budgets.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
