### PR TITLE
Remove default `activity.update` key that was accidentally left in tracking

### DIFF
--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -47,8 +47,6 @@ class Staff::ActivityFormsController < Staff::BaseController
 
     update_wizard_status
 
-    @activity.create_activity key: "activity.update", owner: current_user
-
     render_wizard @activity
   end
 


### PR DESCRIPTION
## Changes in this PR

In a previous commit https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/336 we added more granular event auditing to Activities, but
a line tracking the default "update" auditable event was accidentally left in place.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
