### PR TITLE
(374) XML for projects contain related parent activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - Content added to start page
 - Links that open in a new window now have a message informing the user of this.
 - BEIS users only see an organisation's activities on that organisation's show page (bug)
+- XML file for projects now shows the identifiers for the parent activities.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -46,3 +46,6 @@
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }
+  - if activity.project?
+    - activity.parent_activities.each do |parent_activity|
+      %related-activity{"ref" => parent_activity.identifier, "type" => 1}

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -102,6 +102,21 @@ RSpec.feature "Users can view an activity as XML" do
         it_behaves_like "valid activity XML"
       end
 
+      context "when the activity is a project" do
+        let(:activity) { create(:project_activity) }
+        let(:fund) { create(:fund_activity) }
+        let(:programme) { create(:programme_activity) }
+        let(:activity_presenter) { ActivityXmlPresenter.new(activity) }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "includes its parent activity in the related-activity field" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/related-activity").count).to eq(2)
+          expect(xml.at("iati-activity/related-activity/@type").text).to eq("1")
+        end
+      end
+
       context "when the activity is a project activity" do
         let(:activity) { create(:project_activity_with_implementing_organisations, organisation: organisation) }
         let(:activity_presenter) { ActivityXmlPresenter.new(activity) }

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CreateProjectActivity do
       end
     end
 
-    it "sets the parent Activity to the fund" do
+    it "sets the parent Activity to the programme" do
       expect(result.parent_activity).to eq(programme)
     end
 

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe CreateProjectActivity do
       expect(result.parent_activity).to eq(programme)
     end
 
+    it "sets fund and programme to be parent activities of the project" do
+      fund = programme.parent_activity
+      programme = result.parent_activity
+
+      expect(result.parent_activities.first).to eq(fund)
+      expect(result.parent_activities.last).to eq(programme)
+    end
+
     it "sets the initial wizard_status" do
       expect(result.wizard_status).to eq("blank")
     end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/fMOwz0lj

IATI gives the possibility of publishing the level of hierarchy of an activity by including the parent activities. This PR modifies the XML template for activities to include a new field called `related-activity` which will contain the identifiers of the parent activities of a project (fund and
programme). For now, we are only including parent activities for projects as they are the only ones that are published to IATI at the moment.

On a separate commit, there is an error fixed in one of the test descriptions.

### XML Validation

https://stage.dataworkbench.io/validate/e4fc6e24-ced2-417d-8c05-95854cb624aa

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
