### PR TITLE
Remove Transaction reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - BEIS users only see an organisation's activities on that organisation's show page (bug)
 - XML file for projects now shows the identifiers for the parent activities.
 - Fix descriptive labels on action links
+- Remove `reference` from Transactions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,8 +2,7 @@ class Transaction < ApplicationRecord
   include PublicActivity::Common
 
   belongs_to :parent_activity, class_name: "Activity"
-  validates_presence_of :reference,
-    :description,
+  validates_presence_of :description,
     :transaction_type,
     :date,
     :currency,

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -3,8 +3,6 @@
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header
-          = t("activerecord.attributes.transaction.reference")
-        %th.govuk-table__header
           = t("activerecord.attributes.transaction.transaction_type")
         %th.govuk-table__header
           = t("activerecord.attributes.transaction.date")
@@ -23,7 +21,6 @@
     %tbody.govuk-table__body
       - transactions.each do |transaction|
         %tr.govuk-table__row{id: transaction.id}
-          %td.govuk-table__cell= transaction.reference
           %td.govuk-table__cell= transaction.transaction_type
           %td.govuk-table__cell= transaction.date
           %td.govuk-table__cell= transaction.currency
@@ -33,4 +30,4 @@
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(transaction).create?
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun", reference: transaction.reference))
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))

--- a/app/views/staff/shared/xml/_transaction.xml.haml
+++ b/app/views/staff/shared/xml/_transaction.xml.haml
@@ -1,4 +1,4 @@
-%transaction{"ref" => transaction.reference}
+%transaction
   %transaction-type{"code" => transaction.transaction_type}
   %transaction-date{"iso-date" => transaction.date}
   %value{"currency" => transaction.currency, "value-date" => transaction.date}=transaction.value

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -1,6 +1,4 @@
 = f.govuk_error_summary
-= f.govuk_text_field :reference,
-  label: { text: t("form.transaction.reference.label") }
 = f.govuk_text_area :description,
   label: { text: t("form.transaction.description.label") }
 = f.govuk_collection_select :transaction_type,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,9 +100,6 @@ en:
       receiving_organisation_reference:
         hint: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
         label: IATI Reference (optional)
-      reference:
-        hint: This reference should link this activity back to the finance system.
-        label: Add your own reference to track this transaction
       transaction_type:
         hint: The type of the transaction (e.g. commitment, disbursement, expenditure, etc.).
         label: Type
@@ -259,7 +256,7 @@ en:
     transactions:
       button:
         create: Add a transaction
-      edit_noun: transaction %{reference}
+      edit_noun: transaction
       table:
         headers:
           providing_organisation: Provider

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -47,7 +47,6 @@ en:
         providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name
         receiving_organisation_type: Receiving organisation type
-        reference: Reference
         transaction_type: Transaction type
         value: Value
       user:

--- a/db/migrate/20200427130408_remove_reference_from_transaction.rb
+++ b/db/migrate/20200427130408_remove_reference_from_transaction.rb
@@ -1,0 +1,5 @@
+class RemoveReferenceFromTransaction < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :transactions, :reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_101829) do
+ActiveRecord::Schema.define(version: 2020_04_27_130408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -106,7 +106,6 @@ ActiveRecord::Schema.define(version: 2020_04_14_101829) do
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "reference"
     t.text "description"
     t.string "transaction_type"
     t.date "date"

--- a/spec/factories/implementing_organisation.rb
+++ b/spec/factories/implementing_organisation.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
+  sequence(:reference) { |n| "organisation-#{n}" }
+
   factory :implementing_organisation do
     name { Faker::Company.name }
     reference

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -1,8 +1,5 @@
 FactoryBot.define do
-  sequence(:reference) { |n| "transaction-#{n}" }
-
   factory :transaction do
-    reference
     description { Faker::Lorem.paragraph }
     transaction_type { "1" }
     date { Date.today }

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -56,7 +56,6 @@ RSpec.feature "Users can create a transaction" do
       click_on(I18n.t("generic.button.submit"))
 
       expect(page).to_not have_content(I18n.t("form.transaction.create.success"))
-      expect(page).to have_content("Reference can't be blank")
       expect(page).to have_content("Description can't be blank")
       expect(page).to have_content("Transaction type can't be blank")
       expect(page).to have_content("Date can't be blank")
@@ -78,7 +77,6 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(I18n.t("page_content.transactions.button.create"))
 
-        fill_in "transaction[reference]", with: "123"
         fill_in "transaction[description]", with: "This money will be purchasing a new school roof"
         select "Outgoing Pledge", from: "transaction[transaction_type]"
         fill_in "transaction[date(3i)]", with: "1"

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -17,14 +17,13 @@ RSpec.feature "Users can edit a transaction" do
 
       click_on(activity.title)
 
-      expect(page).to have_content(transaction.reference)
+      expect(page).to have_content(transaction.value)
 
       within("##{transaction.id}") do
         click_on(I18n.t("generic.link.edit"))
       end
 
       fill_in_transaction_form(
-        reference: "new-transaction-reference",
         description: "This money will be buying some books for students",
         transaction_type: "Expenditure",
         date_day: "1",
@@ -44,14 +43,13 @@ RSpec.feature "Users can edit a transaction" do
 
         click_on(activity.title)
 
-        expect(page).to have_content(transaction.reference)
+        expect(page).to have_content(transaction.value)
 
         within("##{transaction.id}") do
           click_on(I18n.t("generic.link.edit"))
         end
 
         fill_in_transaction_form(
-          reference: "new-transaction-reference",
           description: "This money will be buying some books for students",
           transaction_type: "Expenditure",
           date_day: "1",
@@ -73,7 +71,7 @@ RSpec.feature "Users can edit a transaction" do
 
       click_on(activity.title)
 
-      expect(page).to have_content(transaction.reference)
+      expect(page).to have_content(transaction.value)
 
       within("##{transaction.id}") do
         click_on(I18n.t("generic.link.edit"))

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -11,15 +11,15 @@ RSpec.feature "Users can view transactions on an activity page" do
       let(:other_activity) { create(:fund_activity, organisation: user.organisation) }
 
       scenario "only transactions belonging to this fund activity are shown on the Activity#show page" do
-        transaction = create(:transaction, parent_activity: activity)
-        other_transaction = create(:transaction, parent_activity: other_activity)
+        transaction = create(:transaction, parent_activity: activity, value: "100")
+        other_transaction = create(:transaction, parent_activity: other_activity, value: "200")
 
         visit organisation_path(user.organisation)
 
         click_link activity.title
 
-        expect(page).to have_content(transaction.reference)
-        expect(page).to_not have_content(other_transaction.reference)
+        expect(page).to have_content(transaction.value)
+        expect(page).to_not have_content(other_transaction.value)
       end
 
       scenario "transaction information is shown on the page" do
@@ -30,7 +30,6 @@ RSpec.feature "Users can view transactions on an activity page" do
 
         click_link activity.title
 
-        expect(page).to have_content(transaction_presenter.reference)
         expect(page).to have_content(transaction_presenter.transaction_type)
         expect(page).to have_content(transaction_presenter.date)
         expect(page).to have_content(transaction_presenter.currency)
@@ -68,7 +67,6 @@ RSpec.feature "Users can view transactions on an activity page" do
         click_link programme_activity.title
         click_link project_activity.title
 
-        expect(page).to have_content(transaction_presenter.reference)
         expect(page).to have_content(transaction_presenter.transaction_type)
         expect(page).to have_content(transaction_presenter.date)
         expect(page).to have_content(transaction_presenter.currency)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Transaction, type: :model do
   let(:activity) { build(:activity) }
 
   describe "validations" do
-    it { should validate_presence_of(:reference) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:transaction_type) }
     it { should validate_presence_of(:date) }

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe CreateTransaction do
 
     context "when attributes are passed in" do
       it "sets the attributes passed in as transaction attributes" do
-        attributes = ActionController::Parameters.new(reference: "foo").permit!
+        attributes = ActionController::Parameters.new(description: "foo").permit!
 
         result = described_class.new(activity: activity).call(attributes: attributes)
 
-        expect(result.object.reference).to eq("foo")
+        expect(result.object.description).to eq("foo")
       end
 
       subject { described_class.new(activity: activity) }

--- a/spec/services/update_transaction_spec.rb
+++ b/spec/services/update_transaction_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe UpdateTransaction do
 
     context "when attributes are passed in" do
       it "sets the attributes passed in as transaction attributes" do
-        attributes = ActionController::Parameters.new(reference: "foo").permit!
+        attributes = ActionController::Parameters.new(description: "foo").permit!
 
         result = described_class.new(transaction: transaction).call(attributes: attributes)
 
-        expect(result.object.reference).to eq("foo")
+        expect(result.object.description).to eq("foo")
       end
 
       subject { described_class.new(transaction: transaction) }

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -121,7 +121,6 @@ module FormHelpers
   end
 
   def fill_in_transaction_form(expectations: true,
-    reference: "123",
     description: "This money will be purchasing a new school roof",
     transaction_type: "Outgoing Pledge",
     date_year: "2020",
@@ -132,7 +131,6 @@ module FormHelpers
     currency: "Pound Sterling",
     providing_organisation: OpenStruct.new(name: "Example provider", reference: "GB-GOV-1", type: "Government"),
     receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-123", type: "Private Sector"))
-    fill_in "transaction[reference]", with: reference
     fill_in "transaction[description]", with: description
     select transaction_type, from: "transaction[transaction_type]"
     fill_in "transaction[date(3i)]", with: date_day
@@ -154,7 +152,6 @@ module FormHelpers
 
     if expectations
       within ".transactions" do
-        expect(page).to have_content(reference)
         expect(page).to have_content(transaction_type)
         expect(page).to have_content localise_date_from_input_fields(
           year: date_year,

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -69,7 +69,7 @@ RSpec.shared_examples "valid activity XML" do
   it "contains the transaction XML" do
     transaction = create(:transaction, parent_activity: activity)
     visit organisation_activity_path(organisation, activity, format: :xml)
-    expect(xml.at("iati-activity/transaction/@ref").text).to eq(transaction.reference)
+    expect(xml.at("iati-activity/transaction/description/narrative").text).to eq(transaction.description)
   end
 
   it "contains the budget XML" do


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/Azapqja1/554-remove-reference-from-create-a-transaction

In user testing, the Transaction reference was found to be confusing for users.
It is also not required by IATI.

Remove the reference entirely.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
