### PR TITLE
(462) sector step by category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - BEIS users only see an organisation's activities on that organisation's show page (bug)
 - XML file for projects now shows the identifiers for the parent activities.
 - Fix descriptive labels on action links
+- Sector step is made up of two questions sector category and sector
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -21,8 +21,8 @@ class Staff::ActivityFormsController < Staff::BaseController
   steps(*FORM_STEPS)
 
   def show
-    @page_title = t("page_title.activity_form.show.#{step}")
     @activity = Activity.find(params[:activity_id])
+    @page_title = t("page_title.activity_form.show.#{step}", sector_category: @activity.sector_category_name, level: @activity.level)
     authorize @activity
 
     case step

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -7,6 +7,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :blank,
     :identifier,
     :purpose,
+    :sector_category,
     :sector,
     :status,
     :dates,
@@ -82,7 +83,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def activity_params
-    params.require(:activity).permit(:identifier, :sector, :title, :description, :status,
+    params.require(:activity).permit(:identifier, :sector_category, :sector, :title, :description, :status,
       :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date,
       :geography, :recipient_region, :recipient_country, :flow,
       :aid_type)

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -34,6 +34,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step if @activity.recipient_region?
     end
 
+    @activity.update(wizard_status: "complete") if params["editing_until"] == step.to_s
     render_wizard
   end
 
@@ -45,6 +46,10 @@ class Staff::ActivityFormsController < Staff::BaseController
     update_activity_dates
     update_activity_attributes_except_dates
     record_auditable_activity
+
+    if @activity.wizard_complete?
+      reset_sector_answer if step == :sector_category
+    end
 
     update_wizard_status
 
@@ -104,5 +109,10 @@ class Staff::ActivityFormsController < Staff::BaseController
     else
       @activity.wizard_status = step
     end
+  end
+
+  def reset_sector_answer
+    @activity.update(sector: nil, wizard_status: "editing")
+    jump_to(:sector, editing_until: :sector)
   end
 end

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -54,6 +54,10 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
   end
 
+  def sector_category_radio_options
+    yaml_to_objects(entity: "activity", type: "sector_category", with_empty_item: false)
+  end
+
   def sector_radio_options(category: nil)
     options = yaml_to_objects_with_categories(entity: "activity", type: "sector")
     if category.present?

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -24,6 +24,16 @@ module CodelistHelper
     data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"], description: item["description"]) }.sort_by(&:code)
   end
 
+  def yaml_to_objects_with_categories(entity:, type:)
+    data = load_yaml(entity: entity, type: type)
+    return [] if data.empty?
+
+    data.collect { |item|
+      next if item["status"] == "withdrawn"
+      OpenStruct.new(name: item["name"], code: item["code"], category: item["category"])
+    }.compact.sort_by(&:name)
+  end
+
   def currency_select_options
     objects = yaml_to_objects(entity: "generic", type: "default_currency", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "Pound Sterling", code: "GBP")).uniq
@@ -42,6 +52,15 @@ module CodelistHelper
   def flow_select_options
     objects = yaml_to_objects(entity: "activity", type: "flow", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
+  end
+
+  def sector_radio_options(category: nil)
+    options = yaml_to_objects_with_categories(entity: "activity", type: "sector")
+    if category.present?
+      options.filter { |sector| sector.category == category.to_s }
+    else
+      options
+    end
   end
 
   def load_yaml(entity:, type:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,6 @@
 class Activity < ApplicationRecord
   include PublicActivity::Common
+  include CodelistHelper
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
@@ -7,6 +8,7 @@ class Activity < ApplicationRecord
   validates :identifier, presence: true, if: :identifier_step?
   validates_uniqueness_of :identifier, if: :identifier_step?
   validates :title, :description, presence: true, if: :purpose_step?
+  validates :sector_category, presence: true, if: :sector_category_step?
   validates :sector, presence: true, if: :sector_step?
   validates :status, presence: true, if: :status_step?
   validates :geography, presence: true, if: :geography_step?
@@ -49,12 +51,24 @@ class Activity < ApplicationRecord
     UNTIED_TIED_STATUS_CODE
   end
 
+  def sector_category_name
+    return if sector_category.blank?
+
+    sector_categories = yaml_to_objects(entity: "activity", type: "sector_category", with_empty_item: false)
+    sector_category_name = sector_categories.find { |category| category.code == sector_category }
+    sector_category_name.name
+  end
+
   private def identifier_step?
     wizard_status == "identifier" || wizard_complete?
   end
 
   private def purpose_step?
     wizard_status == "purpose" || wizard_complete?
+  end
+
+  private def sector_category_step?
+    wizard_status == "sector_category"
   end
 
   private def sector_step?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -72,7 +72,7 @@ class Activity < ApplicationRecord
   end
 
   private def sector_step?
-    wizard_status == "sector" || wizard_complete?
+    wizard_status == "sector"
   end
 
   private def status_step?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ActivityPresenter < SimpleDelegator
+  include CodelistHelper
+
   def aid_type
     return if super.blank?
     I18n.t("activity.aid_type.#{super.downcase}")

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,7 +1,9 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector,
-    yaml_to_objects(entity: "activity", type: "sector", with_empty_item: true),
+  = f.govuk_error_summary
+  = f.hidden_field :sector, value: nil
+  = f.govuk_collection_radio_buttons :sector,
+    sector_radio_options,
     :code,
     :name,
-    label: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: f.object.level) },
-    hint_text: t("helpers.hint.activity.sector.html", level: f.object.level)
+    legend: { tag: "h1", size: "xl", text: t("page_title.activity_form.show.sector", level: f.object.level) },
+    hint_text: t("helpers.fieldset.activity.sector.html", level: f.object.level)

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -2,8 +2,7 @@
   = f.govuk_error_summary
   = f.hidden_field :sector, value: nil
   = f.govuk_collection_radio_buttons :sector,
-    sector_radio_options,
+    sector_radio_options(category: @activity.sector_category),
     :code,
     :name,
-    legend: { tag: "h1", size: "xl", text: t("page_title.activity_form.show.sector", level: f.object.level) },
-    hint_text: t("helpers.fieldset.activity.sector.html", level: f.object.level)
+    legend: { tag: "h1", size: "xl", text: t("page_title.activity_form.show.sector", sector_category: @activity.sector_category_name, level: f.object.level) }

--- a/app/views/staff/activity_forms/sector_category.html.haml
+++ b/app/views/staff/activity_forms/sector_category.html.haml
@@ -1,0 +1,9 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_error_summary
+  = f.hidden_field :sector_category, value: nil
+  = f.govuk_collection_radio_buttons :sector_category,
+    sector_category_radio_options,
+    :code,
+    :name,
+    legend: { tag: "h1", size: "xl", text: t("page_title.activity_form.show.sector_category", level: f.object.level) },
+    hint_text: t("helpers.fieldset.activity.sector_category.html", level: f.object.level)

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -34,15 +34,6 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
         = a11y_action_link(I18n.t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
 
-  .govuk-summary-list__row.sector_category
-    %dt.govuk-summary-list__key
-      = t("page_content.activity.sector_category.label", level: activity_presenter.level)
-    %dd.govuk-summary-list__value
-      = activity_presenter.sector_category_name
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector_category)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector_category)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector_category.label"))
-
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
       = t("page_content.activity.sector.label", level: activity_presenter.level)

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -50,7 +50,7 @@
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector), t("page_content.activity.sector.label"))
+        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector.label"))
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -34,6 +34,15 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
         = a11y_action_link(I18n.t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
 
+  .govuk-summary-list__row.sector_category
+    %dt.govuk-summary-list__key
+      = t("page_content.activity.sector_category.label", level: activity_presenter.level)
+    %dd.govuk-summary-list__value
+      = activity_presenter.sector_category_name
+    %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector_category)
+        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector_category)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector_category.label"))
+
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
       = t("page_content.activity.sector.label", level: activity_presenter.level)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,6 +191,8 @@ en:
         label: Recipient region
       sector:
         label: Focus area
+      sector_category:
+        label: Focus area category
       status:
         label: Status
       title:
@@ -288,7 +290,8 @@ en:
         purpose: Purpose
         purpose_level: Purpose of %{level}
         region: Recipient region
-        sector: What area of the economy or society is your %{level} helping?
+        sector: Which %{sector_category} sector is the focus area for this %{level}
+        sector_category: What is the focus area category for this %{level}
         status: Status
     budget:
       edit: Edit budget

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -100,6 +100,8 @@ en:
         actual_start_date: Actual start date (optional)
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        sector:
+          html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
       user:
         organisation_ids: Organisations
         role: Role
@@ -117,8 +119,6 @@ en:
         recipient_country: A country that will benefit from this activity
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity.
-        sector:
-          html: For example, research, education or small and medium enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>Common reporting standard (CRS) purpose codes (Opens in new window).</a>
         status: This is the stage your %{level} is currently at
         title: A short, human-readable title that contains a meaningful summary of the activity.
       budget:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -14,6 +14,7 @@ en:
         recipient_country: Country
         recipient_region: Recipient region
         sector: Focus area
+        sector_category: Focus area category
         status: Status
         title: Title
       budget:
@@ -100,7 +101,7 @@ en:
         actual_start_date: Actual start date (optional)
         planned_end_date: Planned end date
         planned_start_date: Planned start date
-        sector:
+        sector_category:
           html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
       user:
         organisation_ids: Organisations

--- a/db/data/20200428152559_add_sector_category_to_activities.rb
+++ b/db/data/20200428152559_add_sector_category_to_activities.rb
@@ -1,0 +1,17 @@
+class AddSectorCategoryToActivities < ActiveRecord::Migration[6.0]
+  include CodelistHelper
+
+  def up
+    sectors = sector_radio_options
+    activities_with_sectors = Activity.where.not(sector: [nil, ""])
+
+    activities_with_sectors.each do |activity|
+      sector = sectors.find { |sector| sector.code == activity.sector }
+      activity.update(sector_category: sector.category)
+    end
+  end
+
+  def down
+    Activity.update_all(sector_category: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20200402180246)
+DataMigrate::Data.define(version: 20200428152559)

--- a/db/migrate/20200415134754_add_sector_category_to_activities.rb
+++ b/db/migrate/20200415134754_add_sector_category_to_activities.rb
@@ -1,0 +1,5 @@
+class AddSectorCategoryToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :sector_category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_101829) do
+ActiveRecord::Schema.define(version: 2020_04_15_134754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_101829) do
     t.string "geography"
     t.uuid "reporting_organisation_id"
     t.string "previous_identifier"
+    t.string "sector_category"
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     description { Faker::Lorem.paragraph }
+    sector_category { "111" }
     sector { "11110" }
     status { "2" }
     planned_start_date { Date.today }
@@ -78,6 +79,7 @@ FactoryBot.define do
     wizard_status { "identifier" }
     title { nil }
     description { nil }
+    sector_category { nil }
     sector { nil }
     status { nil }
     planned_start_date { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Users can create a fund level activity" do
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
 
-        select "Education policy and administrative management", from: "activity[sector]"
+        choose "Education policy and administrative management"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.status")
 

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -96,13 +96,22 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[description]", with: Faker::Lorem.paragraph
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector_category", level: "fund")
+
+        # Don't provide a sector category
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "can't be blank"
+
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: "Basic Education", level: "fund")
 
         # Don't provide a sector
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
+        expect(page).to have_content "can't be blank"
 
-        choose "Education policy and administrative management"
+        choose "Primary education"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.status")
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can edit an activity" do
           expect(page).to have_content(I18n.t("generic.link.add"))
         end
 
-        within(".sector") do
+        within(".sector_category") do
           expect(page).to_not have_content(I18n.t("generic.link.add"))
         end
       end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -182,7 +182,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   within(".sector") do
     click_on(I18n.t("generic.link.edit"))
     expect(page).to have_current_path(
-      activity_step_path(activity, :sector)
+      activity_step_path(activity, :sector_category)
     )
   end
   click_on(I18n.t("generic.link.back"))

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can edit an activity" do
           expect(page).to have_content(I18n.t("generic.link.add"))
         end
 
-        within(".sector_category") do
+        within(".sector") do
           expect(page).to_not have_content(I18n.t("generic.link.add"))
         end
       end

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -1,0 +1,56 @@
+RSpec.feature "Users can manage Sectors" do
+  context "when they belong to BEIS" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    context "with a new activity" do
+      scenario "they can provide the sector category" do
+        activity = create(:activity, :at_identifier_step, identifier: "GCRF")
+        visit activity_step_path(activity, :sector_category)
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_current_path(activity_step_path(activity, :sector))
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: activity.reload.sector_category_name, level: activity.level)
+      end
+    end
+
+    context "with an existing activity" do
+      let(:activity) { create(:activity, organisation: user.organisation) }
+
+      scenario "they can edit the sector category" do
+        visit organisation_activity_path(user.organisation, activity)
+        within ".sector_category" do
+          click_on "Edit"
+        end
+
+        expect(page).to have_current_path(activity_step_path(activity, :sector_category))
+
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_current_path(organisation_activity_path(user.organisation, activity))
+        within ".sector_category" do
+          expect(page).to have_content "Basic Education"
+        end
+      end
+
+      scenario "they can edit the sector" do
+        visit organisation_activity_path(user.organisation, activity)
+        within ".sector" do
+          click_on "Edit"
+        end
+
+        expect(page).to have_current_path(activity_step_path(activity, :sector))
+
+        choose "Teacher training"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_current_path(organisation_activity_path(user.organisation, activity))
+        within ".sector" do
+          expect(page).to have_content "Teacher training"
+        end
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can manage Sectors" do
 
       scenario "when editing the sector category it resets the sector value, redirects to the sector step and then the summary" do
         visit organisation_activity_path(user.organisation, activity)
-        within ".sector_category" do
+        within ".sector" do
           click_on "Edit"
         end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -135,5 +135,23 @@ RSpec.describe CodelistHelper, type: :helper do
           .to eq(OpenStruct.new(name: "ODA", code: "10"))
       end
     end
+
+    describe "#sector_radio_options" do
+      it "returns all sectors when no category is passed" do
+        options = helper.sector_radio_options
+
+        expect(options.length).to eq 283
+        expect(options).to include OpenStruct.new(name: "Women's equality organisations and institutions", code: "15170", category: "151")
+        expect(options).to include OpenStruct.new(name: "Action relating to debt", code: "60010", category: "600")
+      end
+
+      it "returns only the sectors from the category when one is passed" do
+        options = helper.sector_radio_options(category: 112)
+
+        expect(options.length).to eq 6
+        expect(options).to include OpenStruct.new(name: "Basic life skills for youth", code: "11231", category: "112")
+        expect(options).to include OpenStruct.new(name: "School feeding", code: "11250", category: "112")
+      end
+    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -182,7 +182,6 @@ RSpec.describe Activity, type: :model do
       subject { build(:activity, wizard_status: "complete") }
       it { should validate_presence_of(:title) }
       it { should validate_presence_of(:description) }
-      it { should validate_presence_of(:sector) }
       it { should validate_presence_of(:status) }
       it { should validate_presence_of(:planned_start_date) }
       it { should validate_presence_of(:planned_end_date) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:description) }
     end
 
+    context "when sector category is blank" do
+      subject { build(:activity, sector_category: nil, wizard_status: :sector_category) }
+      it { should validate_presence_of(:sector_category) }
+    end
+
     context "when sector is blank" do
       subject { build(:activity, sector: nil, wizard_status: :sector) }
       it { should validate_presence_of(:sector) }
@@ -320,6 +325,22 @@ RSpec.describe Activity, type: :model do
       activity = create(:project_activity_with_implementing_organisations)
 
       expect(activity.has_implementing_organisations?).to be true
+    end
+  end
+
+  describe "#sector_category_name" do
+    context "when the sector category exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, sector_category: "112")
+        expect(activity.sector_category_name).to eql("Basic Education")
+      end
+    end
+
+    context "when the activity does not have a sector category set" do
+      it "returns nil" do
+        activity = build(:activity, sector_category: nil)
+        expect(activity.sector_category_name).to be_nil
+      end
     end
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -3,7 +3,8 @@ module FormHelpers
     identifier: "A-Unique-Identifier",
     title: "My Aid Activity",
     description: Faker::Lorem.paragraph,
-    sector: "Education policy and administrative management",
+    sector_category: "Basic Education",
+    sector: "Primary education",
     status: "2",
     planned_start_date_day: "1",
     planned_start_date_month: "1",
@@ -36,12 +37,17 @@ module FormHelpers
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: level)
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector_category", level: level)
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
-        I18n.t("helpers.fieldset.activity.sector.html", level: level)
+        I18n.t("helpers.fieldset.activity.sector_category.html", level: level)
       )
     )
+    choose sector_category
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: sector_category, level: level)
+
     choose sector
     click_button I18n.t("form.activity.submit")
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -39,10 +39,10 @@ module FormHelpers
     expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: level)
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
-        I18n.t("helpers.hint.activity.sector.html", level: level)
+        I18n.t("helpers.fieldset.activity.sector.html", level: level)
       )
     )
-    select sector, from: "activity[sector]"
+    choose sector
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.status")

--- a/vendor/data/codelists/IATI/2_03/activity/sector_category.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/sector_category.yml
@@ -1,0 +1,201 @@
+---
+attributes:
+  name: SectorCategory
+  complete: '1'
+  embedded: '0'
+  category-codelist:
+metadata:
+  name: DAC 3 Digit Sector
+  description: ''
+  category: Replicated
+  url: http://www.oecd.org/dac/stats/dacandcrscodelists.htm
+data:
+- code: '111'
+  name: Education, Level Unspecified
+  description: The codes in this category are to be used only when level of education
+    is unspecified or unknown (e.g. training of primary school teachers should be
+    coded under 11220).
+  status: active
+- code: '112'
+  name: Basic Education
+  description:
+  status: active
+- code: '113'
+  name: Secondary Education
+  description:
+  status: active
+- code: '114'
+  name: Post-Secondary Education
+  description:
+  status: active
+- code: '121'
+  name: Health, General
+  description:
+  status: active
+- code: '122'
+  name: Basic Health
+  description:
+  status: active
+- code: '123'
+  name: Non-communicable diseases (NCDs)
+  description:
+  status: active
+- code: '130'
+  name: Population Policies/Programmes & Reproductive Health
+  description:
+  status: active
+- code: '140'
+  name: Water Supply & Sanitation
+  description:
+  status: active
+- code: '151'
+  name: Government & Civil Society-general
+  description: N.B. Use code 51010 for general budget support.
+  status: active
+- code: '152'
+  name: Conflict, Peace & Security
+  description: N.B. Further notes on ODA eligibility (and exclusions) of conflict,
+    peace and security related activities are given in paragraphs 76-81 of the Directives.
+  status: active
+- code: '160'
+  name: Other Social Infrastructure & Services
+  description:
+  status: active
+- code: '210'
+  name: Transport & Storage
+  description: 'Note: Manufacturing of transport equipment should be included under
+    code 32172.'
+  status: active
+- code: '220'
+  name: Communications
+  description:
+  status: active
+- code: '230'
+  name: ENERGY GENERATION AND SUPPLY
+  description: Energy sector policy, planning and programmes; aid to energy ministries;
+    institution capacity building and advice; unspecified energy activities including
+    energy conservation.
+  status: withdrawn
+- code: '231'
+  name: Energy Policy
+  description:
+  status: active
+- code: '232'
+  name: Energy generation, renewable sources
+  description:
+  status: active
+- code: '233'
+  name: Energy generation, non-renewable sources
+  description:
+  status: active
+- code: '234'
+  name: Hybrid energy plants
+  description:
+  status: active
+- code: '235'
+  name: Nuclear energy plants
+  description:
+  status: active
+- code: '236'
+  name: Energy distribution
+  description:
+  status: active
+- code: '240'
+  name: Banking & Financial Services
+  description:
+  status: active
+- code: '250'
+  name: Business & Other Services
+  description:
+  status: active
+- code: '311'
+  name: Agriculture
+  description:
+  status: active
+- code: '312'
+  name: Forestry
+  description:
+  status: active
+- code: '313'
+  name: Fishing
+  description:
+  status: active
+- code: '321'
+  name: Industry
+  description:
+  status: active
+- code: '322'
+  name: Mineral Resources & Mining
+  description:
+  status: active
+- code: '323'
+  name: Construction
+  description:
+  status: active
+- code: '331'
+  name: Trade Policies & Regulations
+  description:
+  status: active
+- code: '332'
+  name: Tourism
+  description:
+  status: active
+- code: '410'
+  name: General Environment Protection
+  description: Covers activities concerned with conservation, protection or amelioration
+    of the physical environment without sector allocation.
+  status: active
+- code: '430'
+  name: Other Multisector
+  description:
+  status: active
+- code: '510'
+  name: General Budget Support
+  description: Budget support in the form of sector-wide approaches (SWAps) should
+    be included in the respective sectors.
+  status: active
+- code: '520'
+  name: Developmental Food Aid/Food Security Assistance
+  description:
+  status: active
+- code: '530'
+  name: Other Commodity Assistance
+  description: Non-food commodity assistance (when benefiting sector not specified).
+  status: active
+- code: '600'
+  name: Action Relating to Debt
+  description:
+  status: active
+- code: '720'
+  name: Emergency Response
+  description: An emergency is a situation which results from man made crises and/or
+    natural disasters.
+  status: active
+- code: '730'
+  name: Reconstruction Relief & Rehabilitation
+  description: This relates to activities during and in the aftermath of an emergency
+    situation. Longer-term activities to improve the level of infrastructure or social
+    services should be reported under the relevant economic and social sector codes.
+    See also guideline on distinguishing humanitarian from sector-allocable aid.
+  status: active
+- code: '740'
+  name: Disaster Prevention & Preparedness
+  description: See codes 41050 and 15220 for prevention of floods and conflicts.
+  status: active
+- code: '910'
+  name: Administrative Costs of Donors
+  description:
+  status: active
+- code: '920'
+  name: SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
+  description: In the donor country.
+  status: withdrawn
+- code: '930'
+  name: Refugees in Donor Countries
+  description:
+  status: active
+- code: '998'
+  name: Unallocated / Unspecified
+  description: Contributions to general development of the recipient should be included
+    under programme assistance (51010).
+  status: active


### PR DESCRIPTION
## Changes in this PR
The goal of this work is to split the sector quesiton in two. It turns out we had all the sectors lumped together in one, very long, list when in-fact they each fall into a categories.

Research showed that users liked choosing a 'sector category' first and then seeing a more refined list of sectors to choose from.

The category list is still quite long - but this is defined by IATI.

I chose to approach this as simply as possible so I did things in this order:

- make the sector question use radio buttons
- make the list of sector able to accept a catgory and show only sectors in that cateogry
- add the sector category as a seperate question included in the flow
- make the flow dynamic based on the answer to the sector category question
- remove the sector category question as it is not really a data poing the users cares about, it's just a means to an end
- backfill exisiting activities with the correct sector category

Editing the dependent answer woks as expected:

A user decides to change their response to sector is first asked which category, the category they have previously selected is shown. They can keep the cateogry of change it before moving on to choose the sector from a refined list. Once they choose the sector they return to the summary view.

## Decisions along the way

I chose not to follow the existing pattern of having both vendor IATI data and locale data for the category - I find this duplication un-necessary until a point we need to retain the vendor data and map different language over it, which I don't belive we are at yet.

I chose to put a `sector_category_name` helper into the Activity model rather than the activity presenter. Although it felt like a good place for this to map the category code back to a name, we do not consisitently use the presenter in controllers which meant I would have to refactor there which would have made this PR too large for my taste!

I found getting the dependent answers to work really complicated! I came to the decision that the shoulda spec that tests validation when the wizard status is complete, was not a representativie test of the reality inside the applicaiton.

At no point do we do anything with an activity that has wizard status complete that would require validaiton. I can see a point not far off that we will have some concept of submitting the activitiy and it will need to be validated at that point, but that time is not now. By removing this requirement I was able to deliver the expected behaviour inside the forms controller.

The solution I have lets us pass the step that we want to end the 'editing' on and return the user to the summary view.

## Screenshots of UI changes

Activity show view, we do not show the sector category as it is not a real questions, just the means to aid the user to answer the sector question:
![Screenshot_2020-04-29 Activity Global Challenges Research Fund (GCRF) — Report your official development assistance](https://user-images.githubusercontent.com/480578/80576963-fb0ebe00-89fd-11ea-9f81-10a83eeda487.png)

Sector category question, list is still quite long:
![Screenshot_2020-04-29 What is the focus area category for this fund — Report your official development assistance](https://user-images.githubusercontent.com/480578/80576977-006c0880-89fe-11ea-9b9b-25579f08b5d4.png)

Sector question with reduce responses:
![Screenshot_2020-04-29 Which Unallocated Unspecified sector is the focus area for this fund — Report your official developme](https://user-images.githubusercontent.com/480578/80576984-03ff8f80-89fe-11ea-8254-87a0d5c6254f.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
