### PR TITLE
(568) Fix skip link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem "redis-store"
 gem "sassc", "~> 2.3.0" # Downgrade to fix https://github.com/sass/sassc-ruby/issues/133
 gem "sass-rails", "~> 6.0"
 gem "sidekiq", "~> 5.2"
-gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"
 gem "wicked"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,9 +400,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     tins (1.22.2)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -489,7 +486,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   standard
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
@@ -500,4 +496,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.3
+   2.1.4

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,5 @@
 //= require jquery3
 //= require accessible-autocomplete/dist/accessible-autocomplete.min.js
 //= require rails-ujs
-//= require turbolinks
 //= require govuk-frontend/govuk/all
 //= require_tree .


### PR DESCRIPTION
## Changes in this PR

The April 2020 accessibility audit showed that the skip link was not
working as expected.

After triaging the issue, it looks like Turbolinks was causing the
issue. As we do not rely on Turbolinks behaviour in the application it
has been turned off.

Further information on Turbolinks:

https://github.com/turbolinks/turbolinks

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
