### PR TITLE
(586) Add third party projects (level D activities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - XML file for projects now shows the identifiers for the parent activities.
 - Fix descriptive labels on action links
 - Remove `reference` from Transactions
+- Add level D activities (third-party projects)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -15,10 +15,12 @@ class Staff::OrganisationsController < Staff::BaseController
     fund_activities = FindFundActivities.new(organisation: organisation, current_user: current_user).call
     programme_activities = FindProgrammeActivities.new(organisation: organisation, current_user: current_user).call
     project_activities = FindProjectActivities.new(organisation: organisation, current_user: current_user).call
+    third_party_project_activities = FindThirdPartyProjectActivities.new(organisation: organisation, current_user: current_user).call
 
     @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
     @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
     @project_activities = project_activities.map { |activity| ActivityPresenter.new(activity) }
+    @third_party_project_activities = third_party_project_activities.map { |activity| ActivityPresenter.new(activity) }
   end
 
   def new

--- a/app/controllers/staff/third_party_projects_controller.rb
+++ b/app/controllers/staff/third_party_projects_controller.rb
@@ -1,0 +1,10 @@
+class Staff::ThirdPartyProjectsController < Staff::ActivitiesController
+  def create
+    @third_party_project = CreateThirdPartyProjectActivity.new(user: current_user, organisation_id: params["organisation_id"], project_id: params["project_id"]).call
+    authorize @third_party_project
+
+    @third_party_project.create_activity key: "activity.create", owner: current_user
+
+    redirect_to activity_step_path(@third_party_project.id, @third_party_project.wizard_status)
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -31,6 +31,7 @@ class Activity < ApplicationRecord
     fund: "fund",
     programme: "programme",
     project: "project",
+    third_party_project: "third_party_project",
   }
 
   enum geography: {
@@ -125,6 +126,7 @@ class Activity < ApplicationRecord
   def parent_activities
     return [parent_activity] if programme?
     return [parent_activity.parent_activity, parent_activity] if project?
+    return [parent_activity.parent_activity.parent_activity, parent_activity.parent_activity, parent_activity] if third_party_project?
     []
   end
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -9,7 +9,7 @@ class ActivityPolicy < ApplicationPolicy
   def create?
     record.fund? && beis_user? ||
       record.programme? && beis_user? ||
-        (record.project? || record.third_party_project?) && delivery_partner_user?
+      (record.project? || record.third_party_project?) && delivery_partner_user?
   end
 
   def update?

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -2,19 +2,20 @@ class ActivityPolicy < ApplicationPolicy
   def show?
     record.fund? && beis_user? ||
       record.programme? ||
-      record.project?
+      record.project? ||
+      record.third_party_project?
   end
 
   def create?
     record.fund? && beis_user? ||
       record.programme? && beis_user? ||
-      record.project? && delivery_partner_user?
+        (record.project? || record.third_party_project?) && delivery_partner_user?
   end
 
   def update?
     record.fund? && beis_user? ||
       record.programme? && beis_user? ||
-      record.project? && delivery_partner_user?
+      (record.project? || record.third_party_project?) && delivery_partner_user?
   end
 
   def destroy?

--- a/app/policies/third_party_project_policy.rb
+++ b/app/policies/third_party_project_policy.rb
@@ -1,0 +1,2 @@
+class ThirdPartyProjectPolicy < ProjectPolicy
+end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -64,4 +64,9 @@ class ActivityPresenter < SimpleDelegator
     return "Untitled (#{id})" if title.nil?
     title
   end
+
+  def level
+    return if super.blank?
+    I18n.t("page_content.activity.level.#{super}")
+  end
 end

--- a/app/services/create_third_party_project_activity.rb
+++ b/app/services/create_third_party_project_activity.rb
@@ -1,0 +1,47 @@
+class CreateThirdPartyProjectActivity
+  attr_accessor :user, :organisation_id, :project_id
+
+  def initialize(user:, organisation_id:, project_id:)
+    self.organisation_id = organisation_id
+    self.project_id = project_id
+    self.user = user
+  end
+
+  def call
+    activity = Activity.new
+    activity.organisation = creating_organisation
+    activity.reporting_organisation = reporting_organisation
+    activity.extending_organisation = creating_organisation
+
+    project = Activity.find(project_id)
+    project.child_activities << activity
+
+    activity.wizard_status = "blank"
+    activity.level = :third_party_project
+
+    activity.funding_organisation_name = service_owner.name
+    activity.funding_organisation_reference = service_owner.iati_reference
+    activity.funding_organisation_type = service_owner.organisation_type
+
+    activity.accountable_organisation_name = service_owner.name
+    activity.accountable_organisation_reference = service_owner.iati_reference
+    activity.accountable_organisation_type = service_owner.organisation_type
+
+    activity.save(validate: false)
+    activity
+  end
+
+  private
+
+  def service_owner
+    Organisation.find_by_service_owner(true)
+  end
+
+  def creating_organisation
+    Organisation.find(organisation_id)
+  end
+
+  def reporting_organisation
+    creating_organisation.is_government? ? service_owner : creating_organisation
+  end
+end

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -1,0 +1,22 @@
+class FindThirdPartyProjectActivities
+  include Pundit
+
+  attr_accessor :organisation, :current_user
+
+  def initialize(organisation:, current_user:)
+    @organisation = organisation
+    @current_user = current_user
+  end
+
+  def call
+    third_party_projects = policy_scope(Activity.third_party_project, policy_scope_class: ThirdPartyProjectPolicy::Scope)
+      .includes(:organisation)
+      .order("created_at ASC")
+    third_party_projects = if organisation.service_owner
+      third_party_projects.all
+    else
+      third_party_projects.where(organisation_id: organisation.id)
+    end
+    third_party_projects
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -25,6 +25,7 @@
     = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
 
   - if @activity.project?
+    = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -26,6 +26,8 @@
 
   - if @activity.project?
     = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
+
+  - if @activity.project? || @activity.third_party_project?
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -29,7 +29,7 @@
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 
-  - if @activity.project?
+  - if @activity.project? || @activity.third_party_project?
     = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
-    - if policy(:project).download?
+    - if policy(:project).download? || policy(:third_party_project).download?
       = link_to t("generic.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
-  %h1.govuk-heading-xl= t("page_title.activity_form.show.purpose_level", level: f.object.level)
+  %h1.govuk-heading-xl= t("page_title.activity_form.show.purpose_level", level: t("page_content.activity.level.#{f.object.level}"))
 
   = f.govuk_text_field :title
   = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -3,5 +3,5 @@
     yaml_to_objects(entity: "activity", type: "sector", with_empty_item: true),
     :code,
     :name,
-    label: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: f.object.level) },
+    label: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: t("page_content.activity.level.#{f.object.level}")) },
     hint_text: t("helpers.hint.activity.sector.html", level: f.object.level)

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :status, value: nil
-  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: "Status" }, hint_text: I18n.t("helpers.hint.activity.status", level: f.object.level)
+  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: "Status" }, hint_text: I18n.t("helpers.hint.activity.status", level: t("page_content.activity.level.#{f.object.level}"))

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -36,6 +36,14 @@
 
         = render partial: "staff/shared/projects/table", locals: { projects: @project_activities }
 
+  - if policy(:third_party_project).index?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("page_content.organisation.third_party_projects")
+
+        = render partial: "staff/shared/third_party_projects/table", locals: { third_party_projects: @third_party_project_activities }
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m

--- a/app/views/staff/shared/activities/_third_party_projects.html.haml
+++ b/app/views/staff/shared/activities/_third_party_projects.html.haml
@@ -4,3 +4,4 @@
       = t("page_content.activity.third_party_projects")
     - if policy(:third_party_project).create?
       = button_to t("page_content.organisation.button.create_third_party_project"), organisation_fund_programme_project_third_party_projects_path(current_user.organisation, activity.parent_activity.parent_activity, activity.parent_activity, activity), class: "govuk-button"
+    = render partial: '/staff/shared/third_party_projects/table', locals: { third_party_projects: activities }

--- a/app/views/staff/shared/activities/_third_party_projects.html.haml
+++ b/app/views/staff/shared/activities/_third_party_projects.html.haml
@@ -1,0 +1,6 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.third_party_projects")
+    - if policy(:third_party_project).create?
+      = button_to t("page_content.organisation.button.create_third_party_project"), organisation_fund_programme_project_third_party_projects_path(current_user.organisation, activity.parent_activity.parent_activity, activity.parent_activity, activity), class: "govuk-button"

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -1,0 +1,19 @@
+- unless third_party_projects.empty?
+  %table.govuk-table.third-party-projects
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.organisation.third_party_projects")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("activerecord.attributes.activity.title")
+        %th.govuk-table__header
+          = t("page_content.activity.identitfier.label")
+        %th.govuk-table__header
+          =t("activerecord.attributes.activity.project.programme")
+
+    %tbody.govuk-table__body
+      - third_party_projects.each do |project|
+        %tr.govuk-table__row{id: project.id}
+          %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
+          %td.govuk-table__cell= project.identifier
+          %td.govuk-table__cell= project.parent_activity.title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,7 @@ en:
         label: Name
       programmes: Programmes
       projects: Projects
+      third_party_projects: Third-party projects
       type:
         label: Type
     organisation_details: Organisation details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,11 @@ en:
         success: Project successfully created
       update:
         success: Project successfully updated
+    third_party_project:
+      create:
+        success: Third-party project successfully created
+      update:
+        success: Third-party project successfully updated
     transaction:
       create:
         success: Transaction successfully created
@@ -190,6 +195,7 @@ en:
         label: Focus area
       status:
         label: Status
+      third_party_projects: Third-party projects
       title:
         label: Title
       transactions: Transactions
@@ -226,6 +232,7 @@ en:
         create_fund: Create fund
         create_programme: Create programme
         create_project: Create project
+        create_third_party_project: Create third-party project
         edit: Edit organisation
         edit_details: Edit details
       default_currency:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,11 @@ en:
         button:
           new: Add implementing organisation
         heading: Implementing organisations
+      level:
+        fund: fund
+        programme: programme
+        project: project
+        third_party_project: third-party project
       organisation:
         label: Organisation
       planned_end_date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       resources :activities, except: [:destroy]
       resources :funds, only: [:create] do
         resources :programmes, only: [:create] do
-          resources :projects, only: [:create]
+          resources :projects, only: [:create] do
+            resources :third_party_projects, only: [:create]
+          end
         end
       end
     end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -71,6 +71,20 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :third_party_project_activity do
+      activity factory: :project_activity
+      level { :third_party_project }
+      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      funding_organisation_reference { "GB-GOV-13" }
+      funding_organisation_type { "10" }
+      accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
+      accountable_organisation_reference { "GB-GOV-13" }
+      accountable_organisation_type { "10" }
+
+      association :extending_organisation, factory: :delivery_partner_organisation
+      association :reporting_organisation, factory: :beis_organisation
+    end
   end
 
   trait :at_identifier_step do

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -10,6 +10,7 @@ feature "Organisation show page" do
       extending_organisation: delivery_partner_user.organisation)
   end
   let!(:project) { create(:project_activity, activity: programme, organisation: delivery_partner_user.organisation) }
+  let!(:third_party_project) { create(:third_party_project_activity, activity: project, organisation: delivery_partner_user.organisation) }
   let!(:another_programme) { create(:programme_activity) }
   let!(:another_project) { create(:project_activity) }
 
@@ -57,6 +58,14 @@ feature "Organisation show page" do
           expect(page).to have_link another_project.title, href: organisation_activity_path(another_project.organisation, another_project)
           expect(page).to have_content another_project.identifier
           expect(page).to have_content another_project.parent_activity.title
+        end
+      end
+
+      scenario "they see a list of all third-party projects" do
+        within("##{third_party_project.id}") do
+          expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
+          expect(page).to have_content third_party_project.identifier
+          expect(page).to have_content third_party_project.parent_activity.title
         end
       end
 
@@ -122,8 +131,23 @@ feature "Organisation show page" do
       expect(page.find("table.projects  tbody tr:first-child")[:id]).to have_content(yet_another_project.id)
       expect(page.find("table.projects  tbody tr:last-child")[:id]).to have_content(project.id)
     end
+
     scenario "they do not see projects that they are not the reporting organisation of" do
       expect(page).not_to have_content another_project.identifier
+    end
+
+    scenario "they see a list of all their third-party projects" do
+      within("##{third_party_project.id}") do
+        expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
+        expect(page).to have_content third_party_project.identifier
+        expect(page).to have_content third_party_project.parent_activity.title
+      end
+    end
+
+    scenario "they do not see third-party projects that belong to another organisation" do
+      other_third_party_project = create(:third_party_project_activity, organisation: create(:delivery_partner_organisation))
+
+      expect(page).to_not have_content(other_third_party_project.title)
     end
 
     scenario "they do not see the edit detials button" do

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -1,0 +1,47 @@
+RSpec.feature "Users can create a project" do
+  context "when the user does NOT belong to BEIS" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    context "when viewing a project" do
+      scenario "a new third party project can be added to the project" do
+        project = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_path(user.organisation)
+
+        click_on(project.title)
+
+        click_on(I18n.t("page_content.organisation.button.create_third_party_project"))
+
+        fill_in_activity_form(level: "third_party_project")
+
+        expect(page).to have_content I18n.t("form.third_party_project.create.success")
+        expect(project.child_activities.count).to eq 1
+
+        third_party_project = project.child_activities.last
+
+        expect(third_party_project.organisation).to eq user.organisation
+      end
+
+      scenario "third party project creation is tracked with public_activity" do
+        project = create(:project_activity, organisation: user.organisation)
+
+        PublicActivity.with_tracking do
+          visit organisation_path(user.organisation)
+
+          click_on(project.title)
+
+          click_on(I18n.t("page_content.organisation.button.create_third_party_project"))
+
+          fill_in_activity_form(level: "third_party_project", identifier: "my-unique-identifier")
+
+          third_party_project = Activity.find_by(identifier: "my-unique-identifier")
+          auditable_events = PublicActivity::Activity.where(trackable_id: third_party_project.id)
+          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+          expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
+          expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [third_party_project.id]
+        end
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -168,6 +168,25 @@ RSpec.feature "Users can edit an activity" do
       end
     end
   end
+
+  context "when the activity is a third-party project" do
+    context "when the user is a delivery_partner_user" do
+      let(:user) { create(:delivery_partner_user) }
+
+      it "shows an update success message" do
+        activity = create(:third_party_project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        within(".title") do
+          click_on(I18n.t("generic.link.edit"))
+        end
+
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content(I18n.t("form.third_party_project.update.success"))
+      end
+    end
+  end
 end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -15,6 +15,15 @@ RSpec.feature "Users can view a project" do
       expect(page).to have_content project.title
     end
 
+    scenario "can see a list of third-party projects on the project view" do
+      project = create(:project_activity, organisation: user.organisation)
+      third_party_project = create(:third_party_project_activity, activity: project)
+
+      visit organisation_activity_path(project.organisation, project)
+
+      expect(page).to have_content third_party_project.title
+    end
+
     scenario "when viewing the status the hint text has the correct level" do
       project = create(:project_activity)
       visit activity_step_path(project, :status)

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -1,0 +1,36 @@
+RSpec.feature "Users can view a third-party project" do
+  context "when the user does NOT belong to BEIS" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "can view a third-party project" do
+      project = create(:project_activity, organisation: user.organisation)
+      third_party_project = create(:third_party_project_activity, activity: project)
+
+      visit organisation_activity_path(third_party_project.organisation, third_party_project)
+
+      expect(page).to have_content third_party_project.title
+    end
+
+    scenario "when viewing the status the hint text has the correct level" do
+      third_party_project = create(:third_party_project_activity)
+      visit activity_step_path(third_party_project, :status)
+
+      expect(page).to have_content I18n.t("helpers.hint.activity.status", level: third_party_project.level)
+    end
+  end
+
+  context "when the user belongs to BEIS" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    scenario "can view a third-party project but not create one" do
+      third_party_project = create(:third_party_project_activity)
+
+      visit organisation_activity_path(third_party_project.organisation, third_party_project)
+
+      expect(page).to have_content third_party_project.title
+      expect(page).to_not have_content I18n.t("page_content.organisation.button.create_third_party_project")
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Users can view a third-party project" do
       third_party_project = create(:third_party_project_activity)
       visit activity_step_path(third_party_project, :status)
 
-      expect(page).to have_content I18n.t("helpers.hint.activity.status", level: third_party_project.level)
+      expect(page).to have_content I18n.t("helpers.hint.activity.status", level: I18n.t("page_content.activity.level.#{third_party_project.level}"))
     end
 
     scenario "cannot download a project as XML" do

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -18,6 +18,14 @@ RSpec.feature "Users can view a third-party project" do
 
       expect(page).to have_content I18n.t("helpers.hint.activity.status", level: third_party_project.level)
     end
+
+    scenario "cannot download a project as XML" do
+      third_party_project = create(:third_party_project_activity)
+
+      visit organisation_activity_path(third_party_project.organisation, third_party_project)
+
+      expect(page).to_not have_content I18n.t("generic.button.download_as_xml")
+    end
   end
 
   context "when the user belongs to BEIS" do
@@ -31,6 +39,23 @@ RSpec.feature "Users can view a third-party project" do
 
       expect(page).to have_content third_party_project.title
       expect(page).to_not have_content I18n.t("page_content.organisation.button.create_third_party_project")
+    end
+
+    scenario "can download a third-party project as XML" do
+      third_party_project = create(:third_party_project_activity)
+      project_presenter = ActivityXmlPresenter.new(third_party_project)
+
+      visit organisation_activity_path(third_party_project.organisation, third_party_project)
+
+      expect(page).to have_content I18n.t("generic.button.download_as_xml")
+
+      click_on I18n.t("generic.button.download_as_xml")
+
+      expect(page.response_headers["Content-Type"]).to include("application/xml")
+
+      header = page.response_headers["Content-Disposition"]
+      expect(header).to match(/^attachment/)
+      expect(header).to match(/filename=\"#{project_presenter.iati_identifier}.xml\"$/)
     end
   end
 end

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -26,6 +26,19 @@ RSpec.feature "Users can view a third-party project" do
 
       expect(page).to_not have_content I18n.t("generic.button.download_as_xml")
     end
+
+    scenario "can view and add budgets and transactions on a third-party project" do
+      third_party_project = create(:third_party_project_activity, organisation: user.organisation)
+      budget = create(:budget, parent_activity: third_party_project)
+      transaction = create(:transaction, parent_activity: third_party_project)
+
+      visit organisation_activity_path(third_party_project.organisation, third_party_project)
+
+      expect(page).to have_content(budget.value)
+      expect(page).to have_content(transaction.value)
+      expect(page).to have_content(I18n.t("page_content.budgets.button.create"))
+      expect(page).to have_content(I18n.t("page_content.transactions.button.create"))
+    end
   end
 
   context "when the user belongs to BEIS" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -251,6 +251,21 @@ RSpec.describe Activity, type: :model do
         expect(result.second.id).to eq(programme.id)
       end
     end
+
+    context "when the activity is a third party project" do
+      it "returns the fund and then the programme and then the project" do
+        third_party_project = create(:third_party_project_activity)
+        project = third_party_project.parent_activity
+        programme = project.parent_activity
+        fund = programme.parent_activity
+
+        result = third_party_project.parent_activities
+
+        expect(result.first.id).to eq(fund.id)
+        expect(result.second.id).to eq(programme.id)
+        expect(result.third.id).to eq(project.id)
+      end
+    end
   end
 
   describe "#wizard_complete?" do

--- a/spec/policies/third_party_project_policy_spec.rb
+++ b/spec/policies/third_party_project_policy_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe ThirdPartyProjectPolicy do
+  let(:organisation) { create(:delivery_partner_organisation) }
+  let(:third_party_project) { create(:third_party_project_activity, organisation: organisation) }
+  let(:another_third_party_project) { create(:third_party_project_activity) }
+
+  subject { described_class.new(user, Activity.third_party_project) }
+
+  context "as a user that belongs to BEIS" do
+    let(:user) { build_stubbed(:beis_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to permit_action(:download) }
+
+    it "includes all third party projects in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Activity.third_party_project).resolve
+      expect(resolved_scope).to contain_exactly(third_party_project, another_third_party_project)
+    end
+  end
+
+  context "as a user that does NOT belong to BEIS" do
+    let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to forbid_action(:download) }
+
+    it "includes only projects that the users organisation is reporting the project in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Activity.third_party_project).resolve
+      expect(resolved_scope).to include third_party_project
+      expect(resolved_scope).not_to include another_third_party_project
+    end
+  end
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -216,4 +216,12 @@ RSpec.describe ActivityPresenter do
       end
     end
   end
+
+  describe "#level" do
+    it "returns the Activity level without any underscores" do
+      activity = build(:third_party_project_activity)
+
+      expect(described_class.new(activity).level).to eql("third-party project")
+    end
+  end
 end

--- a/spec/presenters/activity_xml_presenter_spec.rb
+++ b/spec/presenters/activity_xml_presenter_spec.rb
@@ -37,5 +37,20 @@ RSpec.describe ActivityXmlPresenter do
         end
       end
     end
+
+    context "when the activity is a third-party project" do
+      context "when the reporting organisation is a government organisation" do
+        it "returns an identifier with the reporting organisation, fund, programme, project and third-party project" do
+          government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
+          third_party_project = create(:third_party_project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
+          project = third_party_project.parent_activity
+          programme = project.parent_activity
+          fund = programme.parent_activity
+
+          expect(described_class.new(third_party_project).iati_identifier)
+            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}-#{third_party_project.identifier}")
+        end
+      end
+    end
   end
 end

--- a/spec/services/create_third_party_project_activity_spec.rb
+++ b/spec/services/create_third_party_project_activity_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe CreateThirdPartyProjectActivity do
+  let(:beis) { create(:beis_organisation) }
+  let(:delivery_partner_organisation) { create(:delivery_partner_organisation, organisation_type: 10) }
+  let(:user) { create(:administrator, organisation: delivery_partner_organisation) }
+  let(:project) { create(:project_activity, organisation: delivery_partner_organisation) }
+
+  describe "#call" do
+    let(:result) {
+      described_class.new(user: user, organisation_id: user.organisation.id, project_id: project.id).call
+    }
+
+    it "sets the Organisation to that of users organisation" do
+      expect(result.organisation).to eq delivery_partner_organisation
+    end
+
+    context "when the user's organisation is a Government organisation" do
+      it "uses the service owner as the reporting organisation" do
+        expect(result.reporting_organisation.iati_reference).to eq(beis.iati_reference)
+      end
+    end
+
+    context "when the user's organisation is a non-governmental organisation" do
+      let(:delivery_partner_organisation) { create(:delivery_partner_organisation, organisation_type: 21) }
+
+      it "sets the reporting organisation to be the delivery partner" do
+        expect(result.reporting_organisation.iati_reference).to eq(delivery_partner_organisation.iati_reference)
+      end
+    end
+
+    it "sets the parent Activity to the project" do
+      expect(result.parent_activity).to eq(project)
+    end
+
+    it "sets fund, programme & project to be parent activities of the third party project" do
+      programme = project.parent_activity
+      fund = programme.parent_activity
+      project = result.parent_activity
+
+      expect(result.parent_activities.first).to eq(fund)
+      expect(result.parent_activities.second).to eq(programme)
+      expect(result.parent_activities.third).to eq(project)
+    end
+
+    it "sets the initial wizard_status" do
+      expect(result.wizard_status).to eq("blank")
+    end
+
+    it "sets the Activity level to 'third_party_project'" do
+      expect(result.level).to eq("third_party_project")
+    end
+
+    it "sets the funding organisation details" do
+      expect(result.funding_organisation_name).to eq beis.name
+      expect(result.funding_organisation_reference).to eq beis.iati_reference
+      expect(result.funding_organisation_type).to eq beis.organisation_type
+    end
+
+    it "sets the accountable organisation details" do
+      expect(result.accountable_organisation_name).to eq beis.name
+      expect(result.accountable_organisation_reference).to eq beis.iati_reference
+      expect(result.accountable_organisation_type).to eq beis.organisation_type
+    end
+
+    it "sets the extending organisation to that of signed in delivery partner" do
+      expect(result.extending_organisation).to eq delivery_partner_organisation
+    end
+  end
+end

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe FindThirdPartyProjectActivities do
+  let(:user) { create(:beis_user) }
+  let(:service_owner) { create(:beis_organisation) }
+  let(:other_organisation) { create(:organisation) }
+
+  let!(:organisation_project) { create(:third_party_project_activity, organisation: other_organisation) }
+  let!(:other_project) { create(:third_party_project_activity) }
+
+  describe "#call" do
+    context "when the organisation is the service owner" do
+      it "returns all third party project activities" do
+        result = described_class.new(organisation: service_owner, current_user: user).call
+
+        expect(result).to match_array [organisation_project, other_project]
+      end
+    end
+
+    context "when the organisation is not the service owner" do
+      it "returns third party project activities for this organisation" do
+        result = described_class.new(organisation: other_organisation, current_user: user).call
+
+        expect(result).to match_array [organisation_project]
+      end
+    end
+  end
+end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -29,14 +29,14 @@ module FormHelpers
     fill_in "activity[identifier]", with: identifier
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose_level", level: level)
+    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose_level", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content I18n.t("activerecord.attributes.activity.title")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: level)
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
         I18n.t("helpers.hint.activity.sector.html", level: level)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/ZVwI3ta9/586-add-third-party-projects

Add third-party projects (sub-projects), or level D activities.

These are identical to level C activities (projects) except they sit under level C activities, with the level C activity as their parent activity. They are creatable and editable only by delivery partners. They can be downloaded as XML by BEIS users. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
