### PR TITLE
Store Budget.status and Budget.type as numbers, not word strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - Fix descriptive labels on action links
 - Remove `reference` from Transactions
 - Add level D activities (third-party projects)
+- Store Budget status and type as numbers, not words
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -14,6 +14,6 @@ class Budget < ApplicationRecord
 
   validates_with BudgetDatesValidator, if: -> { period_start_date.present? && period_end_date.present? }
 
-  BUDGET_TYPES = {original: "original", updated: "updated"}
-  STATUSES = {indicative: "indicative", committed: "committed"}
+  BUDGET_TYPES = {"1": "original", "2": "updated"}
+  STATUSES = {"1": "indicative", "2": "committed"}
 end

--- a/app/presenters/budget_xml_presenter.rb
+++ b/app/presenters/budget_xml_presenter.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class BudgetXmlPresenter < SimpleDelegator
-  XML_BUDGET_TYPES = {"original" => 1, "updated" => 2}
-  XML_STATUSES = {"indicative" => 1, "committed" => 2}
-
   def period_start_date
     return if super.blank?
     I18n.l(super, format: :iati)
@@ -16,15 +13,5 @@ class BudgetXmlPresenter < SimpleDelegator
 
   def value
     super.to_s
-  end
-
-  def budget_type
-    return if super.blank?
-    XML_BUDGET_TYPES[super]
-  end
-
-  def status
-    return if super.blank?
-    XML_STATUSES[super]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,11 +206,11 @@ en:
       transactions: Transactions
     budget:
       budget_type:
-        original: Original
-        updated: Updated
+        '1': Original
+        '2': Updated
       status:
-        committed: Committed
-        indicative: Indicative
+        '1': Indicative
+        '2': Committed
     budgets:
       button:
         create: Create budget

--- a/db/data/20200504145224_update_budget_status_and_type.rb
+++ b/db/data/20200504145224_update_budget_status_and_type.rb
@@ -1,0 +1,21 @@
+class UpdateBudgetStatusAndType < ActiveRecord::Migration[6.0]
+  def up
+    budgets = Budget.all
+    budgets.each do |budget|
+      status = budget.status == "indicative" ? "1" : "2"
+      type = budget.budget_type == "original" ? "1" : "2"
+      budget.update(status: status, budget_type: type)
+      budget.save!
+    end
+  end
+
+  def down
+    budgets = Budget.all
+    budgets.each do |budget|
+      status = budget.status == "1" ? "indicative" : "committed"
+      type = budget.budget_type == "1" ? "original" : "updated"
+      budget.update(status: status, budget_type: type)
+      budget.save!
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20200402180246)
+DataMigrate::Data.define(version: 20200504145224)

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :budget do
-    budget_type { "original" }
-    status { "indicative" }
+    budget_type { "1" }
+    status { "1" }
     period_start_date { Date.today }
     period_end_date { Date.tomorrow }
     value { BigDecimal("110.01") }

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe "Users can create a budget" do
   end
 
   def fill_in_and_submit_budget_form
-    choose("budget[budget_type]", option: "original")
-    choose("budget[status]", option: "indicative")
+    choose("budget[budget_type]", option: "1")
+    choose("budget[status]", option: "1")
     fill_in "budget[period_start_date(3i)]", with: "01"
     fill_in "budget[period_start_date(2i)]", with: "01"
     fill_in "budget[period_start_date(1i)]", with: "2020"

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Users can edit a budget" do
       end
 
       fill_in "budget[value]", with: "20"
-      choose("budget[budget_type]", option: "updated")
+      choose("budget[budget_type]", option: "2")
       click_on I18n.t("generic.button.submit")
 
       expect(page).to have_content(I18n.t("form.budget.update.success"))
@@ -36,7 +36,7 @@ RSpec.describe "Users can edit a budget" do
       end
 
       fill_in "budget[value]", with: "20"
-      choose("budget[budget_type]", option: "updated")
+      choose("budget[budget_type]", option: "2")
       click_on I18n.t("generic.button.submit")
 
       expect(page).to have_content(I18n.t("form.budget.update.success"))
@@ -55,7 +55,7 @@ RSpec.describe "Users can edit a budget" do
         end
 
         fill_in "budget[value]", with: "20"
-        choose("budget[budget_type]", option: "updated")
+        choose("budget[budget_type]", option: "2")
         click_on I18n.t("generic.button.submit")
 
         budget = Budget.last
@@ -67,7 +67,7 @@ RSpec.describe "Users can edit a budget" do
 
     scenario "validation errors work as expected" do
       activity = create(:project_activity, organisation: user.organisation)
-      budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10")
+      budget = create(:budget, parent_activity: activity, budget_type: "1", value: "10")
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -138,6 +138,16 @@ RSpec.feature "Users can view an activity as XML" do
 
           expect(xml.xpath("//iati-activity/budget").count).to eq(1)
         end
+
+        it "has the correct budget XML" do
+          _budget = create(:budget, parent_activity: activity)
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/budget/@type").text).to eq("1")
+          expect(xml.xpath("//iati-activity/budget/@status").text).to eq("1")
+          expect(xml.xpath("//iati-activity/budget/value").text).to eq("110.01")
+        end
       end
 
       context "when the activity has transactions" do
@@ -152,6 +162,15 @@ RSpec.feature "Users can view an activity as XML" do
           visit organisation_activity_path(organisation, activity, format: :xml)
 
           expect(xml.xpath("//iati-activity/transaction").count).to eq(1)
+        end
+
+        it "has the correct transaction XML" do
+          _transaction = create(:transaction, parent_activity: activity)
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/transaction/transaction-type/@code").text).to eq("1")
+          expect(xml.xpath("//iati-activity/transaction/value").text).to eq("110.01")
         end
       end
     end

--- a/spec/presenters/budget_xml_presenter_spec.rb
+++ b/spec/presenters/budget_xml_presenter_spec.rb
@@ -35,38 +35,6 @@ RSpec.describe BudgetXmlPresenter do
     end
   end
 
-  describe "#budget_type" do
-    context "when the budget_type is blank" do
-      it "returns nil" do
-        budget = build(:budget, budget_type: "")
-        expect(described_class.new(budget).budget_type).to be_nil
-      end
-    end
-
-    context "when the budget_type exists" do
-      it "returns the type in IATI format" do
-        budget = build(:budget, budget_type: "original")
-        expect(described_class.new(budget).budget_type).to eq(1)
-      end
-    end
-  end
-
-  describe "#status" do
-    context "when the status is blank" do
-      it "returns nil" do
-        budget = build(:budget, status: "")
-        expect(described_class.new(budget).status).to be_nil
-      end
-    end
-
-    context "when the status exists" do
-      it "returns the status in IATI format" do
-        budget = build(:budget, status: "indicative")
-        expect(described_class.new(budget).budget_type).to eq(1)
-      end
-    end
-  end
-
   describe "#value" do
     it "returns the value as a string" do
       budget = build(:budget, value: 21.01)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/jaDO9y6C/599-budgets-should-store-code-values-for-type-and-status-rather-than-the-human-readable-version-which-is-subject-to-change

We were previously storing the Budget type and status as word strings. This is potentially fragile in case IATI decide to change the wording; plus we were having to translate the word strings into numbers for the Activity XML using a presenter. It makes more sense to store them as numbers in the first place. 

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
