### PR TITLE
(474) Delivery partners can see Level B budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Remove `reference` from Transactions
 - Add level D activities (third-party projects)
 - Store Budget status and type as numbers, not words
+- Delivery partner users can view budgets on Level B activities (but not edit or create them)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -19,9 +19,9 @@
   - if @activity.programme? && policy(:programme).create?
     = render partial: "staff/shared/activities/extending_organisation", locals: { activity: @activity }
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
-    = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 
   - if @activity.programme?
+    = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
     = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
 
   - if @activity.project?

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Users can create a budget" do
     let(:user) { create(:delivery_partner_user) }
 
     context "on a programme level activity" do
-      scenario "they cannot create budgets" do
+      scenario "they can view but not create budgets" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         programme_activity = create(:programme_activity,
           activity: fund_activity,
@@ -91,7 +91,7 @@ RSpec.describe "Users can create a budget" do
         visit organisation_path(user.organisation)
         click_on(programme_activity.title)
 
-        expect(page).not_to have_content(I18n.t("page_content.activity.budgets"))
+        expect(page).to have_content(I18n.t("page_content.activity.budgets"))
         expect(page).not_to have_content(I18n.t("page_content.budgets.button.create"))
       end
     end


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/GU3pfrad/474-delivery-partners-can-see-level-b-budgets

Previously, Delivery partner users could view Level B (programme) activities
but not see their budgets. This meant the DP didn't have visibility of what
the total of their Level C (project) budgets should be.

Now, DPs can view budgets on a programme, but not edit or create them.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
