### PR TITLE
(598) Refactor activity validations

### DIFF
--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -47,7 +47,7 @@ class Staff::ActivityFormsController < Staff::BaseController
 
     update_wizard_status
 
-    render_wizard @activity
+    render_wizard @activity, context: :"#{step}_step"
   end
 
   private

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -45,6 +45,10 @@ class Staff::ActivityFormsController < Staff::BaseController
     update_activity_attributes_except_dates
     record_auditable_activity
 
+    if @activity.wizard_complete?
+      reset_geography_dependent_answers if step == :geography
+    end
+
     update_wizard_status
 
     render_wizard @activity, context: :"#{step}_step"
@@ -103,5 +107,9 @@ class Staff::ActivityFormsController < Staff::BaseController
     else
       @activity.wizard_status = step
     end
+  end
+
+  def reset_geography_dependent_answers
+    @activity.update(recipient_region: nil, recipient_country: nil)
   end
 end

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -45,7 +45,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     update_activity_attributes_except_dates
     record_auditable_activity
 
-    if @activity.wizard_complete?
+    if @activity.form_steps_completed?
       reset_geography_dependent_answers if step == :geography
     end
 
@@ -57,7 +57,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   private
 
   def record_auditable_activity
-    action = @activity.wizard_complete? ? "update" : "create"
+    action = @activity.form_steps_completed? ? "update" : "create"
     @activity.create_activity key: "activity.#{action}.#{step}", owner: current_user
   end
 
@@ -101,7 +101,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   def update_form_state
     return if @activity.invalid?
 
-    if @activity.wizard_complete?
+    if @activity.form_steps_completed?
       flash[:notice] ||= I18n.t("form.#{@activity.level}.update.success")
       jump_to Wicked::FINISH_STEP
     else

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -49,7 +49,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       reset_geography_dependent_answers if step == :geography
     end
 
-    update_wizard_status
+    update_form_state
 
     render_wizard @activity, context: :"#{step}_step"
   end
@@ -94,18 +94,18 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def finish_wizard_path
     flash[:notice] ||= I18n.t("form.#{@activity.level}.create.success")
-    @activity.update(wizard_status: "complete")
+    @activity.update(form_state: "complete")
     organisation_activity_path(@activity.organisation, @activity)
   end
 
-  def update_wizard_status
+  def update_form_state
     return if @activity.invalid?
 
     if @activity.wizard_complete?
       flash[:notice] ||= I18n.t("form.#{@activity.level}.update.success")
       jump_to Wicked::FINISH_STEP
     else
-      @activity.wizard_status = step
+      @activity.form_state = step
     end
   end
 

--- a/app/controllers/staff/funds_controller.rb
+++ b/app/controllers/staff/funds_controller.rb
@@ -7,6 +7,6 @@ class Staff::FundsController < Staff::ActivitiesController
 
     @fund.create_activity key: "activity.create", owner: current_user
 
-    redirect_to activity_step_path(@fund.id, @fund.wizard_status)
+    redirect_to activity_step_path(@fund.id, @fund.form_state)
   end
 end

--- a/app/controllers/staff/programmes_controller.rb
+++ b/app/controllers/staff/programmes_controller.rb
@@ -7,6 +7,6 @@ class Staff::ProgrammesController < Staff::ActivitiesController
 
     @programme.create_activity key: "activity.create", owner: current_user
 
-    redirect_to activity_step_path(@programme.id, @programme.wizard_status)
+    redirect_to activity_step_path(@programme.id, @programme.form_state)
   end
 end

--- a/app/controllers/staff/projects_controller.rb
+++ b/app/controllers/staff/projects_controller.rb
@@ -5,6 +5,6 @@ class Staff::ProjectsController < Staff::ActivitiesController
 
     @project.create_activity key: "activity.create", owner: current_user
 
-    redirect_to activity_step_path(@project.id, @project.wizard_status)
+    redirect_to activity_step_path(@project.id, @project.form_state)
   end
 end

--- a/app/controllers/staff/third_party_projects_controller.rb
+++ b/app/controllers/staff/third_party_projects_controller.rb
@@ -5,6 +5,6 @@ class Staff::ThirdPartyProjectsController < Staff::ActivitiesController
 
     @third_party_project.create_activity key: "activity.create", owner: current_user
 
-    redirect_to activity_step_path(@third_party_project.id, @third_party_project.wizard_status)
+    redirect_to activity_step_path(@third_party_project.id, @third_party_project.form_state)
   end
 end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -2,11 +2,11 @@ module ActivityHelper
   def step_is_complete_or_next?(activity:, step:)
     steps = Staff::ActivityFormsController::FORM_STEPS
 
-    return false if activity.wizard_status.nil?
+    return false if activity.form_state.nil?
     return true if activity.wizard_complete?
 
     presenter_position = steps.index(step.to_sym)
-    activity_position = steps.index(activity.wizard_status.to_sym)
+    activity_position = steps.index(activity.form_state.to_sym)
 
     presenter_position <= activity_position + 1
   end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -3,7 +3,7 @@ module ActivityHelper
     steps = Staff::ActivityFormsController::FORM_STEPS
 
     return false if activity.form_state.nil?
-    return true if activity.wizard_complete?
+    return true if activity.form_steps_completed?
 
     presenter_position = steps.index(step.to_sym)
     activity_position = steps.index(activity.form_state.to_sym)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -26,7 +26,7 @@ class Activity < ApplicationRecord
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
 
-  validates_uniqueness_of :identifier
+  validates_uniqueness_of :identifier, allow_nil: true
   validates :planned_start_date, :planned_end_date, presence: true, on: :dates_step
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -72,7 +72,7 @@ class Activity < ApplicationRecord
   end
 
   def wizard_complete?
-    wizard_status == "complete"
+    form_state == "complete"
   end
 
   def default_currency

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -55,12 +55,12 @@ class Activity < ApplicationRecord
   scope :programmes, -> { where(level: :programme) }
 
   def valid?(context = nil)
-    context = VALIDATION_STEPS if context.nil? && final?
+    context = VALIDATION_STEPS if context.nil? && form_steps_completed?
     super(context)
   end
 
-  def final?
-    wizard_complete?
+  def form_steps_completed?
+    form_state == "complete"
   end
 
   def finance
@@ -69,10 +69,6 @@ class Activity < ApplicationRecord
 
   def tied_status
     UNTIED_TIED_STATUS_CODE
-  end
-
-  def wizard_complete?
-    form_state == "complete"
   end
 
   def default_currency

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -22,7 +22,7 @@ class CreateFundActivity
     activity.accountable_organisation_reference = "GB-GOV-13"
     activity.accountable_organisation_type = "10"
 
-    activity.save(validate: false)
+    activity.save!
     activity
   end
 

--- a/app/services/create_fund_activity.rb
+++ b/app/services/create_fund_activity.rb
@@ -11,7 +11,7 @@ class CreateFundActivity
     activity.reporting_organisation = activity.organisation
     activity.extending_organisation = service_owner
 
-    activity.wizard_status = "blank"
+    activity.form_state = "blank"
     activity.level = :fund
 
     activity.funding_organisation_name = "HM Treasury"

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -25,7 +25,7 @@ class CreateProgrammeActivity
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type
 
-    activity.save(validate: false)
+    activity.save!
     activity
   end
 

--- a/app/services/create_programme_activity.rb
+++ b/app/services/create_programme_activity.rb
@@ -14,7 +14,7 @@ class CreateProgrammeActivity
     fund = Activity.find(fund_id)
     fund.child_activities << activity
 
-    activity.wizard_status = "blank"
+    activity.form_state = "blank"
     activity.level = :programme
 
     activity.funding_organisation_name = service_owner.name

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -27,7 +27,7 @@ class CreateProjectActivity
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type
 
-    activity.save(validate: false)
+    activity.save!
     activity
   end
 

--- a/app/services/create_project_activity.rb
+++ b/app/services/create_project_activity.rb
@@ -16,7 +16,7 @@ class CreateProjectActivity
     programme = Activity.find(programme_id)
     programme.child_activities << activity
 
-    activity.wizard_status = "blank"
+    activity.form_state = "blank"
     activity.level = :project
 
     activity.funding_organisation_name = service_owner.name

--- a/app/services/create_third_party_project_activity.rb
+++ b/app/services/create_third_party_project_activity.rb
@@ -16,7 +16,7 @@ class CreateThirdPartyProjectActivity
     project = Activity.find(project_id)
     project.child_activities << activity
 
-    activity.wizard_status = "blank"
+    activity.form_state = "blank"
     activity.level = :third_party_project
 
     activity.funding_organisation_name = service_owner.name

--- a/db/migrate/20200505093232_change_wizard_status_to_form_state.rb
+++ b/db/migrate/20200505093232_change_wizard_status_to_form_state.rb
@@ -1,0 +1,13 @@
+class ChangeWizardStatusToFormState < ActiveRecord::Migration[6.0]
+  def up
+    change_table :activities do |t|
+      t.rename :wizard_status, :form_state
+    end
+  end
+
+  def down
+    change_table :activities do |t|
+      t.rename :form_state, :wizard_status
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_27_130408) do
+ActiveRecord::Schema.define(version: 2020_05_05_093232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_04_27_130408) do
     t.string "recipient_region"
     t.string "flow"
     t.string "aid_type"
-    t.string "wizard_status"
+    t.string "form_state"
     t.string "level"
     t.uuid "activity_id"
     t.string "funding_organisation_name"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     aid_type { "A01" }
     level { :fund }
 
-    wizard_status { "complete" } # wizard is complete
+    form_state { "complete" }
 
     association :organisation, factory: :organisation
     association :reporting_organisation, factory: :beis_organisation
@@ -89,7 +89,7 @@ FactoryBot.define do
 
   trait :at_identifier_step do
     identifier { nil }
-    wizard_status { "identifier" }
+    form_state { "identifier" }
     title { nil }
     description { nil }
     sector { nil }
@@ -106,7 +106,7 @@ FactoryBot.define do
   end
 
   trait :at_purpose_step do
-    wizard_status { "identifier" }
+    form_state { "identifier" }
     title { nil }
     description { nil }
     sector { nil }
@@ -123,21 +123,21 @@ FactoryBot.define do
   end
 
   trait :at_region_step do
-    wizard_status { "region" }
+    form_state { "region" }
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
   end
 
   trait :at_geography_step do
-    wizard_status { "geography" }
+    form_state { "geography" }
     recipient_region { nil }
     recipient_country { nil }
     flow { nil }
     aid_type { nil }
   end
 
-  trait :nil_wizard_status do
-    wizard_status { nil }
+  trait :nil_form_state do
+    form_state { nil }
   end
 end

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -73,6 +73,34 @@ RSpec.feature "Users can create a fund level activity" do
       expect(activity.extending_organisation).to eql(user.organisation)
     end
 
+    context "when there is an existing activity with a nil identifier" do
+      scenario "successfully create a activity" do
+        visit organisation_path(user.organisation)
+        click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+        visit organisation_path(user.organisation)
+        click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+        fill_in_activity_form(level: "fund")
+
+        expect(page).to have_content I18n.t("form.fund.create.success")
+      end
+    end
+
+    context "when there is an existing activity with the same identifier" do
+      scenario "cannot use the duplicate identifier" do
+        identifier = "A-non-unique-identifier"
+        create(:activity, identifier: identifier)
+        visit organisation_path(user.organisation)
+        click_on(I18n.t("page_content.organisation.button.create_fund"))
+
+        fill_in "activity[identifier]", with: identifier
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content "Your unique identifier has already been taken"
+      end
+    end
+
     context "validations" do
       scenario "validation errors work as expected" do
         visit organisation_path(user.organisation)

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Users can edit an activity" do
 
     context "when a title attribute is present" do
       it "the call to action is 'Edit'" do
-        activity = create(:fund_activity, organisation: user.organisation, wizard_status: :sector)
+        activity = create(:fund_activity, organisation: user.organisation, form_state: :sector)
 
         visit organisation_activity_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -58,14 +58,17 @@ RSpec.feature "Users can provide the geography for an activity" do
         choose "Country"
         click_button I18n.t("form.activity.submit")
 
+        select "Uganda", from: "activity[recipient_country]"
+        click_button I18n.t("form.activity.submit")
+
         expect(page).to have_current_path(activity_path)
         within(".recipient_country") do
-          expect(page).to have_content "Add"
+          expect(page).to have_content "Uganda"
         end
       end
 
       scenario "they can change the geography from country to region" do
-        activity = create(:activity, geography: :recipient_country, recipient_region: nil)
+        activity = create(:activity, geography: :recipient_country, recipient_region: nil, recipient_country: "AG")
         activity_path = organisation_activity_path(activity.organisation, activity)
 
         visit activity_path
@@ -77,10 +80,12 @@ RSpec.feature "Users can provide the geography for an activity" do
 
         choose "Region"
         click_button I18n.t("form.activity.submit")
+        select "Developing countries, unspecified", from: "activity[recipient_region]"
+        click_button I18n.t("form.activity.submit")
 
         expect(page).to have_current_path(activity_path)
         within(".recipient_region") do
-          expect(page).to have_content "Add"
+          expect(page).to have_content "Developing countries, unspecified"
         end
       end
     end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
 
-    context "when the activity wizard hasn't been started" do
+    context "when the activity form hasn't been started" do
       it "shows no steps" do
-        activity = build(:activity, :nil_wizard_status)
+        activity = build(:activity, :nil_form_state)
         all_steps = Staff::ActivityFormsController::FORM_STEPS
 
         all_steps.each do |step|
@@ -87,9 +87,9 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
 
-    context "when the activity wizard has been completed" do
+    context "when the activity form has been completed" do
       it "shows all steps" do
-        activity = build(:activity, wizard_status: "complete")
+        activity = build(:activity, form_state: "complete")
         all_steps = Staff::ActivityFormsController::FORM_STEPS
 
         all_steps.each do |step|

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -36,61 +36,92 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "validations" do
+    context "overall activity state" do
+      context "when the activity form is a draft" do
+        subject { build(:activity, :at_identifier_step, wizard_status: "blank") }
+        it { should be_valid }
+      end
+
+      context "when the activity form is final" do
+        subject { build(:activity, :at_identifier_step, wizard_status: "complete") }
+        it { should be_invalid }
+      end
+    end
+
     context "when identifier is blank" do
-      subject { build(:activity, identifier: nil, wizard_status: :identifier) }
-      it { should validate_presence_of(:identifier) }
+      subject(:activity) { build(:activity, identifier: nil) }
+      it "it should not be valid" do
+        expect(activity.valid?(:identifier_step)).to be_falsey
+      end
     end
 
     context "when identifier is not unique" do
-      before(:each) { create(:activity, identifier: "GB-GOV-13", wizard_status: :identifier) }
-      subject { build(:activity, identifier: "GB-GOV-13", wizard_status: :identifier) }
+      before(:each) { create(:activity, identifier: "GB-GOV-13") }
+      subject { build(:activity, identifier: "GB-GOV-13") }
       it { should validate_uniqueness_of(:identifier) }
     end
 
     context "when title is blank" do
-      subject { build(:activity, title: nil, wizard_status: :purpose) }
-      it { should validate_presence_of(:title) }
+      subject(:activity) { build(:activity, title: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:purpose_step)).to be_falsey
+      end
     end
 
     context "when description is blank" do
-      subject { build(:activity, description: nil, wizard_status: :purpose) }
-      it { should validate_presence_of(:description) }
+      subject(:activity) { build(:activity, description: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:purpose_step)).to be_falsey
+      end
     end
 
     context "when sector is blank" do
-      subject { build(:activity, sector: nil, wizard_status: :sector) }
-      it { should validate_presence_of(:sector) }
+      subject(:activity) { build(:activity, sector: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:sector_step)).to be_falsey
+      end
     end
 
     context "when planned dates are blank" do
-      subject { build(:activity, planned_start_date: nil, planned_end_date: nil, wizard_status: :dates) }
-      it { should validate_presence_of(:planned_start_date) }
-      it { should validate_presence_of(:planned_end_date) }
+      subject(:activity) { build(:activity, planned_start_date: nil, planned_end_date: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:dates_step)).to be_falsey
+      end
     end
 
     context "when status is blank" do
-      subject { build(:activity, status: nil, wizard_status: :status) }
-      it { should validate_presence_of(:status) }
+      subject(:activity) { build(:activity, status: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:status_step)).to be_falsey
+      end
     end
 
     context "when planned_start_date is blank" do
-      subject { build(:activity, planned_start_date: nil, wizard_status: :dates) }
-      it { should validate_presence_of(:planned_start_date) }
+      subject(:activity) { build(:activity, planned_start_date: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:dates_step)).to be_falsey
+      end
     end
 
     context "when planned_end_date is blank" do
-      subject { build(:activity, planned_end_date: nil, wizard_status: :dates) }
-      it { should validate_presence_of(:planned_end_date) }
+      subject(:activity) { build(:activity, planned_end_date: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:dates_step)).to be_falsey
+      end
     end
 
     context "when actual_start_date is blank" do
-      subject { build(:activity, actual_start_date: nil, wizard_status: :dates) }
-      it { should_not validate_presence_of(:actual_start_date) }
+      subject(:activity) { build(:activity, actual_start_date: nil) }
+      it "should be valid" do
+        expect(activity.valid?(:dates_step)).to be_truthy
+      end
     end
 
     context "when actual_end_date is blank" do
-      subject { build(:activity, actual_end_date: nil, wizard_status: :dates) }
-      it { should_not validate_presence_of(:actual_end_date) }
+      subject(:activity) { build(:activity, actual_end_date: nil) }
+      it "should be valid" do
+        expect(activity.valid?(:dates_step)).to be_truthy
+      end
     end
 
     context "when planned_start_date is not blank" do
@@ -148,43 +179,33 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when geography is blank" do
-      subject { build(:activity, wizard_status: :geography) }
-      it { should validate_presence_of(:geography) }
+      subject(:activity) { build(:activity, geography: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:geography_step)).to be_falsey
+      end
     end
 
     context "when geography is recipient_region" do
       context "and recipient_region and recipient_contry are blank" do
-        subject { build(:activity, wizard_status: :region) }
-        it { should validate_presence_of(:recipient_region) }
-        it { should_not validate_presence_of(:recipient_country) }
+        subject { build(:activity) }
+        it { should validate_presence_of(:recipient_region).on(:region_step) }
+        it { should_not validate_presence_of(:recipient_country).on(:country_step) }
       end
     end
 
     context "when geography is recipient_country" do
       context "and recipient_region and recipient_country are blank" do
-        subject { build(:activity, geography: :recipient_country, wizard_status: :country) }
-        it { should validate_presence_of(:recipient_country) }
-        it { should_not validate_presence_of(:recipient_region) }
+        subject { build(:activity, geography: :recipient_country) }
+        it { should validate_presence_of(:recipient_country).on(:country_step) }
+        it { should_not validate_presence_of(:recipient_region).on(:region_step) }
       end
     end
 
     context "when flow is blank" do
-      subject { build(:activity, flow: nil, wizard_status: :flow) }
-      it { should validate_presence_of(:flow) }
-    end
-
-    context "when the wizard_status is complete" do
-      subject { build(:activity, wizard_status: "complete") }
-      it { should validate_presence_of(:title) }
-      it { should validate_presence_of(:description) }
-      it { should validate_presence_of(:sector) }
-      it { should validate_presence_of(:status) }
-      it { should validate_presence_of(:planned_start_date) }
-      it { should validate_presence_of(:planned_end_date) }
-      it { should_not validate_presence_of(:actual_start_date) }
-      it { should_not validate_presence_of(:actual_end_date) }
-      it { should validate_presence_of(:geography) }
-      it { should validate_presence_of(:flow) }
+      subject(:activity) { build(:activity, flow: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:flow_step)).to be_falsey
+      end
     end
 
     context "when saving in the update_extending_organisation context" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -289,23 +289,23 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#wizard_complete?" do
-    it "is true if the wizard has been completed" do
+  describe "#form_stpes_completed?" do
+    it "is true when a user has completed all of the form steps" do
       activity = build(:activity, form_state: :complete)
 
-      expect(activity.wizard_complete?).to be_truthy
+      expect(activity.form_steps_completed?).to be_truthy
     end
 
-    it "is false if the wizard is in progress" do
+    it "is false when a user is still completing one of the form steps" do
       activity = build(:activity, form_state: :purpose)
 
-      expect(activity.wizard_complete?).to be_falsey
+      expect(activity.form_steps_completed?).to be_falsey
     end
 
-    it "is false if the wizard is not started" do
+    it "is false when the form_stat is nil " do
       activity = build(:activity, form_state: nil)
 
-      expect(activity.wizard_complete?).to be_falsey
+      expect(activity.form_steps_completed?).to be_falsey
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Activity, type: :model do
   describe "validations" do
     context "overall activity state" do
       context "when the activity form is a draft" do
-        subject { build(:activity, :at_identifier_step, wizard_status: "blank") }
+        subject { build(:activity, :at_identifier_step, form_state: "blank") }
         it { should be_valid }
       end
 
       context "when the activity form is final" do
-        subject { build(:activity, :at_identifier_step, wizard_status: "complete") }
+        subject { build(:activity, :at_identifier_step, form_state: "complete") }
         it { should be_invalid }
       end
     end
@@ -213,9 +213,9 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:extending_organisation_id).on(:update_extending_organisation) }
     end
 
-    context "when the wizard status is blank" do
+    context "when the form state is blank" do
       it "allows updates to be made to other fields set on creation" do
-        blank_activity = create(:activity, funding_organisation_name: "old", wizard_status: :blank)
+        blank_activity = create(:activity, funding_organisation_name: "old", form_state: :blank)
         blank_activity.funding_organisation_name = "new"
         expect(blank_activity.valid?).to eq(true)
       end
@@ -291,19 +291,19 @@ RSpec.describe Activity, type: :model do
 
   describe "#wizard_complete?" do
     it "is true if the wizard has been completed" do
-      activity = build(:activity, wizard_status: :complete)
+      activity = build(:activity, form_state: :complete)
 
       expect(activity.wizard_complete?).to be_truthy
     end
 
     it "is false if the wizard is in progress" do
-      activity = build(:activity, wizard_status: :purpose)
+      activity = build(:activity, form_state: :purpose)
 
       expect(activity.wizard_complete?).to be_falsey
     end
 
     it "is false if the wizard is not started" do
-      activity = build(:activity, wizard_status: nil)
+      activity = build(:activity, form_state: nil)
 
       expect(activity.wizard_complete?).to be_falsey
     end

--- a/spec/services/create_fund_activity_spec.rb
+++ b/spec/services/create_fund_activity_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe CreateFundActivity do
       expect(result.reporting_organisation.iati_reference).to eq(organisation.iati_reference)
     end
 
-    it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("blank")
+    it "sets the initial form_state" do
+      expect(result.form_state).to eq("blank")
     end
 
     it "sets the activity level to 'fund'" do

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe CreateProgrammeActivity do
       expect(result.parent_activity).to eq(fund)
     end
 
-    it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("blank")
+    it "sets the initial form_state" do
+      expect(result.form_state).to eq("blank")
     end
 
     it "sets the Activity level to 'programme'" do

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe CreateProjectActivity do
       expect(result.parent_activities.last).to eq(programme)
     end
 
-    it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("blank")
+    it "sets the initial form_state" do
+      expect(result.form_state).to eq("blank")
     end
 
     it "sets the Activity level to 'project'" do

--- a/spec/services/create_third_party_project_activity_spec.rb
+++ b/spec/services/create_third_party_project_activity_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe CreateThirdPartyProjectActivity do
       expect(result.parent_activities.third).to eq(project)
     end
 
-    it "sets the initial wizard_status" do
-      expect(result.wizard_status).to eq("blank")
+    it "sets the initial form_state" do
+      expect(result.form_state).to eq("blank")
     end
 
     it "sets the Activity level to 'third_party_project'" do


### PR DESCRIPTION
## Changes in this PR
The goal of this work is to to simplify the stepped form and related Activity creation:

- stop skipping validation when creating a new activity
- use validations contexts to run validation during the form steps
- when all form steps are completed by the user, run all the validations

With the refactor in-place the form steps work as expect when one question depends on the answer to another, by resetting the value to nil the activity is no longer valid so the reset step is shown as the user expects - you can see this in 3ec5514 where the `recipient_country` or `recipient_region` is rest and the spec needed to be updated to reflect the working behaviour. This relates to https://trello.com/c/GwGnh3N1

The use of the word 'wizard' has been minimised to only methods from the gem to try and make the intention of things clearer to developers.
