### PR TITLE
Show programmes in a table on fund show view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,8 +114,10 @@
 - Fix descriptive labels on action links
 - Remove `reference` from Transactions
 - Add level D activities (third-party projects)
+<<<<<<< HEAD
 - Store Budget status and type as numbers, not words
 - Delivery partner users can view budgets on Level B activities (but not edit or create them)
+- Show a funds programmes in a table 
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...HEAD
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/views/staff/shared/activities/_programmes.html.haml
+++ b/app/views/staff/shared/activities/_programmes.html.haml
@@ -1,10 +1,8 @@
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-full-width-column
     %h2.govuk-heading-m
       = t("page_content.organisation.programmes")
     = form_tag(organisation_fund_programmes_path(current_user.organisation, activity), method: "post") do
       = submit_tag t("page_content.organisation.button.create_programme"), class: "govuk-button"
-    %ul.govuk-list.govuk-list--bullet
-      - activities.each do |activity|
-        %li
-          = link_to activity.display_title, organisation_activity_path(activity.organisation, activity)
+
+    = render partial: "staff/shared/programmes/table", locals: { programmes: activities }


### PR DESCRIPTION
## Changes in this PR
As with the rest of the application a funds programmes are best shown as a table.
## Screenshots of UI changes

### Before
![Screenshot_2020-05-05 Activity Global Challenges Research Fund (GCRF) — Report your official development assistance](https://user-images.githubusercontent.com/480578/81086609-a6cd7780-8ef0-11ea-8aa0-9bad874783ba.png)

### After
![Screenshot_2020-05-05 Activity Global Challenges Research Fund (GCRF) — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/81086634-ad5bef00-8ef0-11ea-99b1-c0a4cd0a66c8.png)
