### PR TITLE
(fix) Only run data migrations in production

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,13 +8,17 @@ setup_database()
   echo "Preparing database…"
   bundle exec rake db:prepare
   echo "Finished database setup."
+}
 
+run_data_migrations()
+{
   echo "Running data migrations…"
   bundle exec rake data:migrate
   echo "Finished running data migrations."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi
+if [ "$RAILS_ENV" == "production" ]; then run_data_migrations; else echo "Not running data migrations, not in production"; fi
 
 echo "Finished docker entrypoint."
 exec "$@"


### PR DESCRIPTION
## Changes in this PR
We use the data migrate gem to manage data migrations.

https://github.com/ilyakatz/data-migrate

Previously we ran the data migrations in all environments which caused
an issue when the name of a column in the database was later changed.

Because the test environment destroys and re-creates the database from
the schema, not the migrations, when the data migrations run the
database has a different column name and so fails.

We shouldn't run data migrations in the test environment anyway as there
is no data to migrate.

I would have solved this issue much quicker if we could see the container output in the Travis log - is there someway to do that?
