### PR TITLE
(fix) Only deploy docker images from develop and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ deploy:
   script: bash travis-docker-push.sh
   on:
     all_branches: true
+    condition: "$TRAVIS_BRANCH =~ ^(develop|master)$"
 - provider: script
   script: bash deploy-terraform.sh
   on:


### PR DESCRIPTION
## Changes in this PR

There is no need to push an image of a branch that will never be
deployed, not doing so will save time getting PR work to green and into
review.
