### PR TITLE
Expose test-container runtime errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ jobs:
       docker network create test
       docker run -d --name pg --network test -p 5432:5432 postgres:11.6
       docker run -d --name redis --network test -p 6379:6379 redis:4.0.14
-      docker run -d \
-        --name test-container \
+      docker run \
         --network test \
         -e RAILS_ENV=test \
         -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
@@ -29,9 +28,7 @@ jobs:
         -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" \
         -e CI=true \
         --env-file .env.test \
-        app/test /bin/bash -c "tail -f /dev/null"
-      docker exec test-container bundle exec rake
-      docker exec test-container bundle exec brakeman
+        app/test /bin/bash -c "set -eu; bundle exec rake; bundle exec brakeman"
       echo "==== testing terrafrom ===="
       cd terraform
       git clone https://github.com/tfutils/tfenv.git ~/.tfenv


### PR DESCRIPTION
Don't run the test container inside a daemon so any errors are written
to STDOUT, rather than causing the build to fail silently. The tests
will now within the `docker run` command, and the container will exit on
completion.

NB: Including `set -eu` before running the tests means that the exit
code gets reported correctly. Without this, the specs will fail *BUT*
the container will exit successfully, causing the build to pass whilst
broken.
