### PR TITLE
(fix) Activity show programme container class

### DIFF
--- a/app/views/staff/shared/activities/_programmes.html.haml
+++ b/app/views/staff/shared/activities/_programmes.html.haml
@@ -1,5 +1,5 @@
 .govuk-grid-row
-  .govuk-grid-full-width-column
+  .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.organisation.programmes")
     = form_tag(organisation_fund_programmes_path(current_user.organisation, activity), method: "post") do


### PR DESCRIPTION
## Changes in this PR
The new Programme table on the activity show view had the wrong css
class name so was outside the boundaries of the page layout.


