### PR TITLE
(618) Validate values down to 1 pence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@
 
 ## [unreleased]
 
+- Transaction and budget values are validated down to 0.01
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -9,7 +9,7 @@ class Budget < ApplicationRecord
     :period_end_date,
     :value,
     :currency
-  validates :value, inclusion: 1..99_999_999_999.00
+  validates :value, inclusion: 0.01..99_999_999_999.00
   validates :period_start_date, :period_end_date, date_within_boundaries: true
 
   validates_with BudgetDatesValidator, if: -> { period_start_date.present? && period_end_date.present? }

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,6 +12,6 @@ class Transaction < ApplicationRecord
     :providing_organisation_type,
     :receiving_organisation_name,
     :receiving_organisation_type
-  validates :value, inclusion: 1..99_999_999_999.00
+  validates :value, inclusion: 0.01..99_999_999_999.00
   validates :date, date_not_in_future: true
 end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -14,14 +14,19 @@ RSpec.describe Budget do
     it { should validate_presence_of(:currency) }
   end
 
-  context "value must be between 1 and 99,999,999,999.00 (100 billion minus one)" do
+  context "value must be between 0.01 and 99,999,999,999.00 (100 billion minus one)" do
     it "allows the maximum possible value" do
       budget = build(:budget, value: 99_999_999_999.00)
       expect(budget).to be_valid
     end
 
-    it "does not allow a value of less than 1" do
-      budget = build(:budget, value: -1)
+    it "allows the minimum possible value" do
+      budget = build(:budget, value: 0.01)
+      expect(budget).to be_valid
+    end
+
+    it "does not allow a value of less than 0.01" do
+      budget = build(:budget, value: 0)
       expect(budget).to_not be_valid
     end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -23,8 +23,13 @@ RSpec.describe Transaction, type: :model do
         expect(transaction.valid?).to be true
       end
 
-      it "does not allow a value of less than 1" do
-        transaction = build(:transaction, parent_activity: activity, value: -1)
+      it "allows the minimum possible value" do
+        transaction = build(:transaction, parent_activity: activity, value: 0.01)
+        expect(transaction.valid?).to be true
+      end
+
+      it "does not allow a value of less than 0.01" do
+        transaction = build(:transaction, parent_activity: activity, value: 0)
         expect(transaction.valid?).to be false
       end
 


### PR DESCRIPTION
## Changes in this PR
The value attribute for both budgets and transactions accepted a
minimum value of 1 (one pound in sterling), looking at existing data
revealed transactions with a value of less that 1 (0.57).

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
