### PR TITLE
(521) Recipient region/country edit flow change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 
 - Transaction and budget values are validated down to 0.01
 - Add Skylight application performance monitoring
+- No longer show the geography response on the activity summary and when changing country or region the flow includes the geography question
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -89,15 +89,6 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_end_date.label"))
 
-  .govuk-summary-list__row.geography
-    %dt.govuk-summary-list__key
-      = t("page_content.activity.geography.label")
-    %dd.govuk-summary-list__value
-      = activity_presenter.geography
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :geography)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:geography)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.geography.label"))
-
   - if activity_presenter.recipient_region?
     .govuk-summary-list__row.recipient_region
       %dt.govuk-summary-list__key
@@ -106,7 +97,7 @@
         = activity_presenter.recipient_region
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :region)
-          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :region), t("page_content.activity.recipient_region.label"))
+          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_region.label"))
 
   - if activity_presenter.recipient_country?
     .govuk-summary-list__row.recipient_country
@@ -116,7 +107,7 @@
         = activity_presenter.recipient_country
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :country)
-          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_country)}"), activity_step_path(activity_presenter, :country), t("page_content.activity.recipient_country.label"))
+          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_country)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_country.label"))
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -84,7 +84,8 @@ RSpec.feature "Users can edit an activity" do
         within(".recipient_region") do
           click_on(I18n.t("generic.link.edit"))
         end
-
+        choose "Region"
+        click_button I18n.t("form.activity.submit")
         select recipient_region, from: "activity[recipient_region]"
         click_button I18n.t("form.activity.submit")
 
@@ -262,18 +263,10 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   end
   click_on(I18n.t("generic.link.back"))
 
-  within(".geography") do
-    click_on(I18n.t("generic.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :geography)
-    )
-  end
-  click_on(I18n.t("generic.link.back"))
-
   within(".recipient_region") do
     click_on(I18n.t("generic.link.edit"))
     expect(page).to have_current_path(
-      activity_step_path(activity, :region)
+      activity_step_path(activity, :geography)
     )
   end
   click_on(I18n.t("generic.link.back"))

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Users can provide the geography for an activity" do
         activity_path = organisation_activity_path(activity.organisation, activity)
 
         visit activity_path
-        within(".geography") do
+        within(".recipient_region") do
           click_on "Edit"
         end
 
@@ -62,6 +62,7 @@ RSpec.feature "Users can provide the geography for an activity" do
         click_button I18n.t("form.activity.submit")
 
         expect(page).to have_current_path(activity_path)
+        expect(page).not_to have_content I18n.t("page_content.activity.recipient_region.label")
         within(".recipient_country") do
           expect(page).to have_content "Uganda"
         end
@@ -72,7 +73,7 @@ RSpec.feature "Users can provide the geography for an activity" do
         activity_path = organisation_activity_path(activity.organisation, activity)
 
         visit activity_path
-        within(".geography") do
+        within(".recipient_country") do
           click_on "Edit"
         end
 
@@ -84,6 +85,7 @@ RSpec.feature "Users can provide the geography for an activity" do
         click_button I18n.t("form.activity.submit")
 
         expect(page).to have_current_path(activity_path)
+        expect(page).not_to have_content I18n.t("page_content.activity.recipient_country.label")
         within(".recipient_region") do
           expect(page).to have_content "Developing countries, unspecified"
         end


### PR DESCRIPTION
## Changes in this PR
After discussion with out interaction designer, remove the geography
response from the activity summary view.

When a user clicks on edit for country or region they are taken to the
geography question and then asked about the specific region or country.

## Screenshots of UI changes

### Before
![Screenshot_2020-05-07 Activity GCRF — Report your official development assistance](https://user-images.githubusercontent.com/480578/81292905-56772680-9064-11ea-93f1-fed6efefa815.png)

### After
![Screenshot_2020-05-07 Activity GCRF — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/81292912-59721700-9064-11ea-8bba-0c6ff173bf73.png)

![Screenshot_2020-05-07 Activity GCRF — Report your official development assistance(2)](https://user-images.githubusercontent.com/480578/81292925-5d9e3480-9064-11ea-94b7-90e367130e53.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
