### PR TITLE
(462) Sector step uses categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
 - Add Skylight application performance monitoring
 - No longer show the geography response on the activity summary and when changing country or region the flow includes the geography question
 - Add concept of `ingested` to budgets, and skip validation on ingested budgets. This is in preparation for ingesting legacy data from IATI.
+- Sector questions asks for a category and uses radio buttons
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -21,8 +21,8 @@ class Staff::ActivityFormsController < Staff::BaseController
   steps(*FORM_STEPS)
 
   def show
-    @page_title = t("page_title.activity_form.show.#{step}")
     @activity = Activity.find(params[:activity_id])
+    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
     authorize @activity
 
     case step

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -7,6 +7,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :blank,
     :identifier,
     :purpose,
+    :sector_category,
     :sector,
     :status,
     :dates,
@@ -47,6 +48,7 @@ class Staff::ActivityFormsController < Staff::BaseController
 
     if @activity.form_steps_completed?
       reset_geography_dependent_answers if step == :geography
+      @activity.update(sector: nil) if step == :sector_category
     end
 
     update_form_state
@@ -86,7 +88,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def activity_params
-    params.require(:activity).permit(:identifier, :sector, :title, :description, :status,
+    params.require(:activity).permit(:identifier, :sector_category, :sector, :title, :description, :status,
       :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date,
       :geography, :recipient_region, :recipient_country, :flow,
       :aid_type)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -54,6 +54,10 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
   end
 
+  def sector_category_radio_options
+    yaml_to_objects(entity: "activity", type: "sector_category", with_empty_item: false)
+  end
+
   def sector_radio_options(category: nil)
     options = yaml_to_objects_with_categories(entity: "activity", type: "sector")
     if category.present?

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -24,6 +24,16 @@ module CodelistHelper
     data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"], description: item["description"]) }.sort_by(&:code)
   end
 
+  def yaml_to_objects_with_categories(entity:, type:)
+    data = load_yaml(entity: entity, type: type)
+    return [] if data.empty?
+
+    data.collect { |item|
+      next if item["status"] == "withdrawn"
+      OpenStruct.new(name: item["name"], code: item["code"], category: item["category"])
+    }.compact.sort_by(&:name)
+  end
+
   def currency_select_options
     objects = yaml_to_objects(entity: "generic", type: "default_currency", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "Pound Sterling", code: "GBP")).uniq
@@ -42,6 +52,15 @@ module CodelistHelper
   def flow_select_options
     objects = yaml_to_objects(entity: "activity", type: "flow", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
+  end
+
+  def sector_radio_options(category: nil)
+    options = yaml_to_objects_with_categories(entity: "activity", type: "sector")
+    if category.present?
+      options.filter { |sector| sector.category == category.to_s }
+    else
+      options
+    end
   end
 
   def load_yaml(entity:, type:)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -24,12 +24,12 @@ module CodelistHelper
     data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"], description: item["description"]) }.sort_by(&:code)
   end
 
-  def yaml_to_objects_with_categories(entity:, type:)
+  def yaml_to_objects_with_categories(entity:, type:, include_withdrawn: false)
     data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
 
     data.collect { |item|
-      next if item["status"] == "withdrawn"
+      next if item["status"] == "withdrawn" && include_withdrawn == false
       OpenStruct.new(name: item["name"], code: item["code"], category: item["category"])
     }.compact.sort_by(&:name)
   end
@@ -65,6 +65,10 @@ module CodelistHelper
     else
       options
     end
+  end
+
+  def all_sectors
+    yaml_to_objects_with_categories(entity: "activity", type: "sector", include_withdrawn: true)
   end
 
   def load_yaml(entity:, type:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,6 @@
 class Activity < ApplicationRecord
   include PublicActivity::Common
+  include CodelistHelper
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
@@ -7,6 +8,7 @@ class Activity < ApplicationRecord
   VALIDATION_STEPS = [
     :identifier_step,
     :purpose_step,
+    :sector_category_step,
     :sector_step,
     :status_step,
     :geography_step,
@@ -18,6 +20,7 @@ class Activity < ApplicationRecord
 
   validates :identifier, presence: true, on: :identifier_step
   validates :title, :description, presence: true, on: :purpose_step
+  validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
   validates :status, presence: true, on: :status_step
   validates :geography, presence: true, on: :geography_step

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ActivityPresenter < SimpleDelegator
+  include CodelistHelper
+
   def aid_type
     return if super.blank?
     I18n.t("activity.aid_type.#{super.downcase}")

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -1,7 +1,9 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :sector,
-    yaml_to_objects(entity: "activity", type: "sector", with_empty_item: true),
+  = f.govuk_error_summary
+  = f.hidden_field :sector, value: nil
+  = f.govuk_collection_radio_buttons :sector,
+    sector_radio_options,
     :code,
     :name,
-    label: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: t("page_content.activity.level.#{f.object.level}")) },
-    hint_text: t("helpers.hint.activity.sector.html", level: f.object.level)
+    legend: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: t("page_content.activity.level.#{f.object.level}")) },
+    hint_text: t("helpers.fieldset.activity.sector.html", level: f.object.level)

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -2,8 +2,7 @@
   = f.govuk_error_summary
   = f.hidden_field :sector, value: nil
   = f.govuk_collection_radio_buttons :sector,
-    sector_radio_options,
+    sector_radio_options(category: f.object.sector_category),
     :code,
     :name,
-    legend: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", level: t("page_content.activity.level.#{f.object.level}")) },
-    hint_text: t("helpers.fieldset.activity.sector.html", level: f.object.level)
+    legend: { tag: 'h1', size: 'xl', text:  I18n.t("page_title.activity_form.show.sector", sector_category: t("activity.sector_category.#{f.object.sector_category}"), level: t("page_content.activity.level.#{f.object.level}")) }

--- a/app/views/staff/activity_forms/sector_category.html.haml
+++ b/app/views/staff/activity_forms/sector_category.html.haml
@@ -1,0 +1,9 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_error_summary
+  = f.hidden_field :sector_category, value: nil
+  = f.govuk_collection_radio_buttons :sector_category,
+    sector_category_radio_options,
+    :code,
+    :name,
+    legend: { tag: "h1", size: "xl", text: t("page_title.activity_form.show.sector_category", level: t("page_content.activity.level.#{f.object.level}")) },
+    hint_text: t("helpers.fieldset.activity.sector_category.html", level: t("page_content.activity.level.#{f.object.level}"))

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -41,7 +41,7 @@
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector), t("page_content.activity.sector.label"))
+        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector.label"))
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -613,6 +613,51 @@ en:
       '93018': Refugees/asylum seekers in donor countries - administrative costs
       '99810': Sectors not specified
       '99820': Promotion of development awareness (non-sector allocable)
+    sector_category:
+      '111': Education, Level Unspecified
+      '112': Basic Education
+      '113': Secondary Education
+      '114': Post-Secondary Education
+      '121': Health, General
+      '122': Basic Health
+      '123': Non-communicable diseases (NCDs)
+      '130': Population Policies/Programmes & Reproductive Health
+      '140': Water Supply & Sanitation
+      '151': Government & Civil Society-general
+      '152': Conflict, Peace & Security
+      '160': Other Social Infrastructure & Services
+      '210': Transport & Storage
+      '220': Communications
+      '230': ENERGY GENERATION AND SUPPLY
+      '231': Energy Policy
+      '232': Energy generation, renewable sources
+      '233': Energy generation, non-renewable sources
+      '234': Hybrid energy plants
+      '235': Nuclear energy plants
+      '236': Energy distribution
+      '240': Banking & Financial Services
+      '250': Business & Other Services
+      '311': Agriculture
+      '312': Forestry
+      '313': Fishing
+      '321': Industry
+      '322': Mineral Resources & Mining
+      '323': Construction
+      '331': Trade Policies & Regulations
+      '332': Tourism
+      '410': General Environment Protection
+      '430': Other Multisector
+      '510': General Budget Support
+      '520': Developmental Food Aid/Food Security Assistance
+      '530': Other Commodity Assistance
+      '600': Action Relating to Debt
+      '720': Emergency Response
+      '730': Reconstruction Relief & Rehabilitation
+      '740': Disaster Prevention & Preparedness
+      '910': Administrative Costs of Donors
+      '920': SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
+      '930': Refugees in Donor Countries
+      '998': Unallocated / Unspecified
     status:
       '1': Pipeline/identification
       '2': Implementation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,8 @@ en:
         label: Recipient region
       sector:
         label: Focus area
+      sector_category:
+        label: Focus area category
       status:
         label: Status
       third_party_projects: Third-party projects
@@ -298,7 +300,8 @@ en:
         purpose: Purpose
         purpose_level: Purpose of %{level}
         region: Recipient region
-        sector: What area of the economy or society is your %{level} helping?
+        sector: Which %{sector_category} sector is the focus area for this %{level}
+        sector_category: What is the focus area category for this %{level}
         status: Status
     budget:
       edit: Edit budget

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -99,6 +99,8 @@ en:
         actual_start_date: Actual start date (optional)
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        sector:
+          html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
       user:
         organisation_ids: Organisations
         role: Role
@@ -116,8 +118,6 @@ en:
         recipient_country: A country that will benefit from this activity
         recipient_region:
           html: A supranational geopolitical region that will benefit from this activity.
-        sector:
-          html: For example, research, education or small and medium enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>Common reporting standard (CRS) purpose codes (Opens in new window).</a>
         status: This is the stage your %{level} is currently at
         title: A short, human-readable title that contains a meaningful summary of the activity.
       budget:

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -14,6 +14,7 @@ en:
         recipient_country: Country
         recipient_region: Recipient region
         sector: Focus area
+        sector_category: Focus area category
         status: Status
         title: Title
       budget:
@@ -99,7 +100,7 @@ en:
         actual_start_date: Actual start date (optional)
         planned_end_date: Planned end date
         planned_start_date: Planned start date
-        sector:
+        sector_category:
           html: What area of the economy or society is your %{level} helping? For example, research, education or SME development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes.</a>
       user:
         organisation_ids: Organisations

--- a/db/data/20200507142459_add_sector_category_to_activities.rb
+++ b/db/data/20200507142459_add_sector_category_to_activities.rb
@@ -1,0 +1,17 @@
+class AddSectorCategoryToActivities < ActiveRecord::Migration[6.0]
+  include CodelistHelper
+
+  def up
+    sectors = sector_radio_options
+    activities_with_sectors = Activity.where.not(sector: [nil, ""])
+
+    activities_with_sectors.each do |activity|
+      sector = sectors.find { |sector| sector.code == activity.sector }
+      activity.update(sector_category: sector.category) unless sector.nil?
+    end
+  end
+
+  def down
+    Activity.update_all(sector_category: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20200504145224)
+DataMigrate::Data.define(version: 20200507142459)

--- a/db/migrate/20200415134754_add_sector_category_to_activities.rb
+++ b/db/migrate/20200415134754_add_sector_category_to_activities.rb
@@ -1,0 +1,5 @@
+class AddSectorCategoryToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :sector_category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_151949) do
     t.string "geography"
     t.uuid "reporting_organisation_id"
     t.string "previous_identifier"
+    t.string "sector_category"
     t.boolean "ingested", default: false
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     description { Faker::Lorem.paragraph }
+    sector_category { "111" }
     sector { "11110" }
     status { "2" }
     planned_start_date { Date.today }
@@ -92,6 +93,7 @@ FactoryBot.define do
     form_state { "identifier" }
     title { nil }
     description { nil }
+    sector_category { nil }
     sector { nil }
     status { nil }
     planned_start_date { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature "Users can create a fund level activity" do
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
 
-        select "Education policy and administrative management", from: "activity[sector]"
+        choose "Education policy and administrative management"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.status")
 

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -124,13 +124,22 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[description]", with: Faker::Lorem.paragraph
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector_category", level: "fund")
+
+        # Don't provide a sector category
+        click_button I18n.t("form.activity.submit")
+        expect(page).to have_content "can't be blank"
+
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: "Basic Education", level: "fund")
 
         # Don't provide a sector
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: "fund")
+        expect(page).to have_content "can't be blank"
 
-        choose "Education policy and administrative management"
+        choose "Primary education"
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content I18n.t("page_title.activity_form.show.status")
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -202,7 +202,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   within(".sector") do
     click_on(I18n.t("generic.link.edit"))
     expect(page).to have_current_path(
-      activity_step_path(activity, :sector)
+      activity_step_path(activity, :sector_category)
     )
   end
   click_on(I18n.t("generic.link.back"))

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -1,0 +1,41 @@
+RSpec.feature "Users can manage Sectors" do
+  context "when they belong to BEIS" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    context "with a new activity" do
+      scenario "they can provide the sector category" do
+        activity = create(:activity, :at_identifier_step, identifier: "GCRF")
+        visit activity_step_path(activity, :sector_category)
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_current_path(activity_step_path(activity, :sector))
+        expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: I18n.t("activity.sector_category.#{activity.reload.sector_category}"), level: activity.level)
+      end
+    end
+
+    context "with an existing activity" do
+      let(:activity) { create(:activity, organisation: user.organisation) }
+
+      scenario "they can edit the sector by changing the sector category and sector and retruning to the summary" do
+        visit organisation_activity_path(user.organisation, activity)
+        within ".sector" do
+          click_on "Edit"
+        end
+
+        expect(page).to have_current_path(activity_step_path(activity, :sector_category))
+
+        choose "Basic Education"
+        click_button I18n.t("form.activity.submit")
+        choose "Early childhood education"
+        click_button I18n.t("form.activity.submit")
+
+        expect(page).to have_current_path(organisation_activity_path(user.organisation, activity))
+        within ".sector" do
+          expect(page).to have_content "Early childhood education"
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -135,5 +135,23 @@ RSpec.describe CodelistHelper, type: :helper do
           .to eq(OpenStruct.new(name: "ODA", code: "10"))
       end
     end
+
+    describe "#sector_radio_options" do
+      it "returns all sectors when no category is passed" do
+        options = helper.sector_radio_options
+
+        expect(options.length).to eq 283
+        expect(options).to include OpenStruct.new(name: "Women's equality organisations and institutions", code: "15170", category: "151")
+        expect(options).to include OpenStruct.new(name: "Action relating to debt", code: "60010", category: "600")
+      end
+
+      it "returns only the sectors from the category when one is passed" do
+        options = helper.sector_radio_options(category: 112)
+
+        expect(options.length).to eq 6
+        expect(options).to include OpenStruct.new(name: "Basic life skills for youth", code: "11231", category: "112")
+        expect(options).to include OpenStruct.new(name: "School feeding", code: "11250", category: "112")
+      end
+    end
   end
 end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.length).to eq 6
         expect(options).to include OpenStruct.new(name: "Basic life skills for youth", code: "11231", category: "112")
         expect(options).to include OpenStruct.new(name: "School feeding", code: "11250", category: "112")
+        expect(options).not_to include OpenStruct.new(name: "Immediate post-emergency reconstruction and rehabilitation", code: "73010", category: "730")
+      end
+    end
+
+    describe "#all_sectors" do
+      it "returns all the sectors including those that are withdrawn" do
+        sectors = helper.all_sectors
+        active_sector = OpenStruct.new(name: "Basic life skills for youth", code: "11231", category: "112")
+        withdrawn_sector = OpenStruct.new(name: "Disaster prevention and preparedness", code: "74010", category: "740")
+
+        expect(sectors).to include active_sector
+        expect(sectors).to include withdrawn_sector
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when sector category is blank" do
+      subject(:activity) { build(:activity, sector_category: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:sector_category_step)).to be_falsey
+      end
+    end
+
     context "when sector is blank" do
       subject(:activity) { build(:activity, sector: nil) }
       it "should not be valid" do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -39,10 +39,10 @@ module FormHelpers
     expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
-        I18n.t("helpers.hint.activity.sector.html", level: level)
+        I18n.t("helpers.fieldset.activity.sector.html", level: level)
       )
     )
-    select sector, from: "activity[sector]"
+    choose sector
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("activerecord.attributes.activity.status")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -3,7 +3,8 @@ module FormHelpers
     identifier: "A-Unique-Identifier",
     title: "My Aid Activity",
     description: Faker::Lorem.paragraph,
-    sector: "Education policy and administrative management",
+    sector_category: "Basic Education",
+    sector: "Primary education",
     status: "2",
     planned_start_date_day: "1",
     planned_start_date_month: "1",
@@ -36,12 +37,17 @@ module FormHelpers
     fill_in "activity[description]", with: description
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector_category", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
-        I18n.t("helpers.fieldset.activity.sector.html", level: level)
+        I18n.t("helpers.fieldset.activity.sector_category.html", level: I18n.t("page_content.activity.level.#{level}"))
       )
     )
+    choose sector_category
+    click_button I18n.t("form.activity.submit")
+
+    expect(page).to have_content I18n.t("page_title.activity_form.show.sector", sector_category: sector_category, level: I18n.t("page_content.activity.level.#{level}"))
+
     choose sector
     click_button I18n.t("form.activity.submit")
 

--- a/vendor/data/codelists/IATI/2_03/activity/sector_category.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/sector_category.yml
@@ -1,0 +1,201 @@
+---
+attributes:
+  name: SectorCategory
+  complete: '1'
+  embedded: '0'
+  category-codelist:
+metadata:
+  name: DAC 3 Digit Sector
+  description: ''
+  category: Replicated
+  url: http://www.oecd.org/dac/stats/dacandcrscodelists.htm
+data:
+- code: '111'
+  name: Education, Level Unspecified
+  description: The codes in this category are to be used only when level of education
+    is unspecified or unknown (e.g. training of primary school teachers should be
+    coded under 11220).
+  status: active
+- code: '112'
+  name: Basic Education
+  description:
+  status: active
+- code: '113'
+  name: Secondary Education
+  description:
+  status: active
+- code: '114'
+  name: Post-Secondary Education
+  description:
+  status: active
+- code: '121'
+  name: Health, General
+  description:
+  status: active
+- code: '122'
+  name: Basic Health
+  description:
+  status: active
+- code: '123'
+  name: Non-communicable diseases (NCDs)
+  description:
+  status: active
+- code: '130'
+  name: Population Policies/Programmes & Reproductive Health
+  description:
+  status: active
+- code: '140'
+  name: Water Supply & Sanitation
+  description:
+  status: active
+- code: '151'
+  name: Government & Civil Society-general
+  description: N.B. Use code 51010 for general budget support.
+  status: active
+- code: '152'
+  name: Conflict, Peace & Security
+  description: N.B. Further notes on ODA eligibility (and exclusions) of conflict,
+    peace and security related activities are given in paragraphs 76-81 of the Directives.
+  status: active
+- code: '160'
+  name: Other Social Infrastructure & Services
+  description:
+  status: active
+- code: '210'
+  name: Transport & Storage
+  description: 'Note: Manufacturing of transport equipment should be included under
+    code 32172.'
+  status: active
+- code: '220'
+  name: Communications
+  description:
+  status: active
+- code: '230'
+  name: ENERGY GENERATION AND SUPPLY
+  description: Energy sector policy, planning and programmes; aid to energy ministries;
+    institution capacity building and advice; unspecified energy activities including
+    energy conservation.
+  status: withdrawn
+- code: '231'
+  name: Energy Policy
+  description:
+  status: active
+- code: '232'
+  name: Energy generation, renewable sources
+  description:
+  status: active
+- code: '233'
+  name: Energy generation, non-renewable sources
+  description:
+  status: active
+- code: '234'
+  name: Hybrid energy plants
+  description:
+  status: active
+- code: '235'
+  name: Nuclear energy plants
+  description:
+  status: active
+- code: '236'
+  name: Energy distribution
+  description:
+  status: active
+- code: '240'
+  name: Banking & Financial Services
+  description:
+  status: active
+- code: '250'
+  name: Business & Other Services
+  description:
+  status: active
+- code: '311'
+  name: Agriculture
+  description:
+  status: active
+- code: '312'
+  name: Forestry
+  description:
+  status: active
+- code: '313'
+  name: Fishing
+  description:
+  status: active
+- code: '321'
+  name: Industry
+  description:
+  status: active
+- code: '322'
+  name: Mineral Resources & Mining
+  description:
+  status: active
+- code: '323'
+  name: Construction
+  description:
+  status: active
+- code: '331'
+  name: Trade Policies & Regulations
+  description:
+  status: active
+- code: '332'
+  name: Tourism
+  description:
+  status: active
+- code: '410'
+  name: General Environment Protection
+  description: Covers activities concerned with conservation, protection or amelioration
+    of the physical environment without sector allocation.
+  status: active
+- code: '430'
+  name: Other Multisector
+  description:
+  status: active
+- code: '510'
+  name: General Budget Support
+  description: Budget support in the form of sector-wide approaches (SWAps) should
+    be included in the respective sectors.
+  status: active
+- code: '520'
+  name: Developmental Food Aid/Food Security Assistance
+  description:
+  status: active
+- code: '530'
+  name: Other Commodity Assistance
+  description: Non-food commodity assistance (when benefiting sector not specified).
+  status: active
+- code: '600'
+  name: Action Relating to Debt
+  description:
+  status: active
+- code: '720'
+  name: Emergency Response
+  description: An emergency is a situation which results from man made crises and/or
+    natural disasters.
+  status: active
+- code: '730'
+  name: Reconstruction Relief & Rehabilitation
+  description: This relates to activities during and in the aftermath of an emergency
+    situation. Longer-term activities to improve the level of infrastructure or social
+    services should be reported under the relevant economic and social sector codes.
+    See also guideline on distinguishing humanitarian from sector-allocable aid.
+  status: active
+- code: '740'
+  name: Disaster Prevention & Preparedness
+  description: See codes 41050 and 15220 for prevention of floods and conflicts.
+  status: active
+- code: '910'
+  name: Administrative Costs of Donors
+  description:
+  status: active
+- code: '920'
+  name: SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
+  description: In the donor country.
+  status: withdrawn
+- code: '930'
+  name: Refugees in Donor Countries
+  description:
+  status: active
+- code: '998'
+  name: Unallocated / Unspecified
+  description: Contributions to general development of the recipient should be included
+    under programme assistance (51010).
+  status: active


### PR DESCRIPTION
## Changes in this PR
The goal of this work is to split the sector quesiton in two. It turns out we had all the sectors lumped together in one, very long, list when in-fact they each fall into a categories.

Research showed that users liked choosing a 'sector category' first and then seeing a more refined list of sectors to choose from.

The category list is still quite long - but this is defined by IATI.

- make the sector question use radio buttons
- make the list of sector able to accept a catgory and show only sectors in that cateogry
- make the flow dynamic based on the answer to the sector category question
- backfill exisiting activities with the correct sector category

## Screenshots of UI changes

Activity show view, we do not show the sector category as it is not a real questions, just the means to aid the user to answer the sector question:
![Screenshot_2020-04-29 Activity Global Challenges Research Fund (GCRF) — Report your official development assistance](https://user-images.githubusercontent.com/480578/80576963-fb0ebe00-89fd-11ea-9f81-10a83eeda487.png)

Sector category question, list is still quite long:
![Screenshot_2020-04-29 What is the focus area category for this fund — Report your official development assistance](https://user-images.githubusercontent.com/480578/80576977-006c0880-89fe-11ea-9b9b-25579f08b5d4.png)

Sector question with reduce responses:
![Screenshot_2020-04-29 Which Unallocated Unspecified sector is the focus area for this fund — Report your official developme](https://user-images.githubusercontent.com/480578/80576984-03ff8f80-89fe-11ea-8254-87a0d5c6254f.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
