### PR TITLE
Do not validate dates for "ingested" budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Transaction and budget values are validated down to 0.01
 - Add Skylight application performance monitoring
 - No longer show the geography response on the activity summary and when changing country or region the flow includes the geography question
+- Add concept of `ingested` to budgets, and skip validation on ingested budgets. This is in preparation for ingesting legacy data from IATI.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/validators/budget_dates_validator.rb
+++ b/app/validators/budget_dates_validator.rb
@@ -1,5 +1,6 @@
 class BudgetDatesValidator < ActiveModel::Validator
   def validate(record)
+    return if record.ingested?
     unless dates_not_more_than_365_days_apart?(record.period_start_date, record.period_end_date)
       record.errors.add :period_end_date,
         I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")

--- a/db/migrate/20200507151949_add_ingested_to_budgets.rb
+++ b/db/migrate/20200507151949_add_ingested_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddIngestedToBudgets < ActiveRecord::Migration[6.0]
+  def change
+    add_column :budgets, :ingested, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_093232) do
+ActiveRecord::Schema.define(version: 2020_05_07_151949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_093232) do
     t.decimal "value", precision: 13, scale: 2
     t.string "currency"
     t.uuid "parent_activity_id"
+    t.boolean "ingested", default: false
     t.index ["parent_activity_id"], name: "index_budgets_on_parent_activity_id"
   end
 

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     period_end_date { Date.tomorrow }
     value { BigDecimal("110.01") }
     currency { "gbp" }
+    ingested { false }
     association :parent_activity, factory: :activity
   end
 end

--- a/spec/validators/budget_date_validator_spec.rb
+++ b/spec/validators/budget_date_validator_spec.rb
@@ -72,4 +72,16 @@ RSpec.describe BudgetDatesValidator do
       expect(subject.errors.messages[:period_end_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
     end
   end
+
+  context "when the budget is ingested" do
+    context "when the dates are more than 365 days apart" do
+      it "is valid (skips validation)" do
+        subject.ingested = true
+        subject.period_start_date = Date.today
+        subject.period_end_date = subject.period_start_date + 366.days
+
+        expect(subject).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

We have found that legacy budgets from IATI do not follow the rule of spanning
no more than a year in their start & end dates. So in order to skip date
validation on these records, we are marking them as `ingested`.

In a future commit, we will use this `ingested` flag to skip validations on
budgets when ingesting them from IATI

Spun off from https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/362

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
