### PR TITLE
(fix) Budget and transaction value error message

### DIFF
--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -78,6 +78,8 @@ en:
             period_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_after_end_date: The period start date cannot be after the period end date
+            value:
+              inclusion: Value must be between 0.01 and 99,999,999,999.00
         organisation:
           attributes:
             iati_reference:
@@ -88,7 +90,7 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Date must not be in the future
             value:
-              inclusion: Value must be between 1 and 99,999,999,999.00
+              inclusion: Value must be between 0.01 and 99,999,999,999.00
         user:
           attributes:
             organisation_ids:

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Users can create a budget" do
         expect(page).to have_content("Status can't be blank")
         expect(page).to have_content("Period start date can't be blank")
         expect(page).to have_content("Period end date can't be blank")
-        expect(page).to have_content("Value is not included in the list")
+        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.inclusion")
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Users can create a transaction" do
       expect(page).to have_content("Description can't be blank")
       expect(page).to have_content("Transaction type can't be blank")
       expect(page).to have_content("Date can't be blank")
-      expect(page).to have_content("Value must be between 1 and 99,999,999,999.00")
+      expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.inclusion")
       expect(page).to have_content("Providing organisation name can't be blank")
       expect(page).to have_content("Providing organisation type can't be blank")
       expect(page).to have_content("Receiving organisation name can't be blank")
@@ -100,7 +100,7 @@ RSpec.feature "Users can create a transaction" do
         select "Pound Sterling", from: "transaction[currency]"
         click_on(I18n.t("generic.button.submit"))
 
-        expect(page).to have_content("Value must be between 1 and 99,999,999,999.00")
+        expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.inclusion")
       end
 
       scenario "When the value includes a pound sign" do


### PR DESCRIPTION
## Changes in this PR

The validation on the value attribute for transactions was changed to
include values from 0.01 but the locale was not updated to reflect the
change.

Budgets have the same attribute with the same validation but never had the
nice error message applied in the locales.

## Screenshots of UI changes

### Before
![Screenshot_2020-05-11 Create budget — Report your official development assistance](https://user-images.githubusercontent.com/480578/81605833-fcf75a80-93c9-11ea-97dc-69c80dc86b57.png)

![Screenshot_2020-05-11 Add a transaction — Report your official development assistance](https://user-images.githubusercontent.com/480578/81605853-fff24b00-93c9-11ea-8c55-839702a3007b.png)

### After
![Screenshot_2020-05-11 Create budget — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/81605906-13051b00-93ca-11ea-812b-ecca9bf58286.png)

![Screenshot_2020-05-11 Add a transaction — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/81605913-16000b80-93ca-11ea-9f8e-c985be2574e0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation]
