### PR TITLE
Hotfix/debugging bad sign ins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
   script: bash travis-docker-push.sh
   on:
     all_branches: true
-    condition: "$TRAVIS_BRANCH =~ ^(develop|master)$"
+    condition: "$TRAVIS_BRANCH =~ ^(develop|master|hotfix)"
 - provider: script
   script: bash deploy-terraform.sh
   on:

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -6,6 +6,17 @@ module Secured
   end
 
   def logged_in_using_omniauth?
+    # DEBUG: Session info can be missing
+    if Rails.env.production? && session[:userinfo].blank?
+      # Is there a session object?
+      Rails.logger.info(session)
+
+      # Are there any keys?
+      Rails.logger.info(session.keys)
+
+      # Is Redis available as a session_store?
+      Rails.logger.info(Redis.new(url: ENV["REDIS_URL"]).ping)
+    end
     redirect_to "/" if session[:userinfo].blank?
   end
 end


### PR DESCRIPTION
## Changes in this PR

The staging environment is showing signs of failed log in attempts. The user is bumped back to the root path, rather than their organisation's page. On clicking sign in again 1, 2 or 3 times the application will then allow them to see their organisation without providing credentials again. Due to the behaviour we think it is around the method: `logged_in_using_omniauth?` but cannot replicate locally or on the pentest environment, where this commit has already been tested.

This change includes a small change to allow branches prefixed with `hotfix` to build new docker images for use in manual deploys to environments.

My plan is to do a basic check to see if there is a session object, what keys it has, I should be able to see a csrf_token at the very least, and then if redis is available as the session store. If Redis is not available it might be slow to load or connect which might explain why we are observing intermittent behaviour.

![Screenshot 2020-05-12 at 15 31 48](https://user-images.githubusercontent.com/912473/81704554-db4bb100-9465-11ea-9d30-59caaed0a545.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
