### PR TITLE
Add a boolean flag to Transactions to indicate if they've been ingested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 - No longer show the geography response on the activity summary and when changing country or region the flow includes the geography question
 - Add concept of `ingested` to budgets, and skip validation on ingested budgets. This is in preparation for ingesting legacy data from IATI.
 - Sector questions asks for a category and uses radio buttons
+- Add concept of `ingested` to transactions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -139,7 +139,8 @@ class IngestIatiActivities
         providing_organisation_reference: providing_organisation_reference,
         receiving_organisation_name: receiving_organisation_name,
         receiving_organisation_type: "0",
-        receiving_organisation_reference: receiving_organisation_reference
+        receiving_organisation_reference: receiving_organisation_reference,
+        ingested: true
       )
 
       transaction.save!

--- a/db/migrate/20200512144535_add_ingested_boolean_to_transactions.rb
+++ b/db/migrate/20200512144535_add_ingested_boolean_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddIngestedBooleanToTransactions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transactions, :ingested, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_151949) do
+ActiveRecord::Schema.define(version: 2020_05_12_144535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_151949) do
     t.string "providing_organisation_reference"
     t.string "receiving_organisation_reference"
     t.uuid "parent_activity_id"
+    t.boolean "ingested", default: false
     t.index ["parent_activity_id"], name: "index_transactions_on_parent_activity_id"
   end
 

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     value { BigDecimal("110.01") }
     disbursement_channel { "1" }
     currency { "gbp" }
+    ingested { false }
 
     # Government organisation
     providing_organisation_name { "Department for Business, Energy & Industrial Strategy" }

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe IngestIatiActivities do
       expect(activity.aid_type).to eql("C01")
     end
 
-    it "creates transactions" do
+    it "creates transactions and marks them as ingested" do
       _beis = create(:beis_organisation)
       uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
       legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_transactions.xml")
@@ -129,6 +129,8 @@ RSpec.describe IngestIatiActivities do
       expect(
         transactions.find_by(description: "Initial proof of concept testing os remote live teaching")
       ).to_not be_nil
+
+      expect(transaction.ingested).to be true
     end
 
     it "creates budgets and marks them as ingested" do


### PR DESCRIPTION
## Changes in this PR

Related to https://trello.com/c/Nbh9Taqp/615-how-do-we-address-the-fact-that-dates-in-budgets-published-to-iati-are-not-valid

Similar to https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/382 this change adds the concept of `ingested` (true/false) to Transactions. This way we can mark them as records in the application that may not pass our validations, and may not be edited within the application. 

These use-cases are not implemented yet but this PR lays the groundwork for them.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
