### PR TITLE
Transaction disbursement channel is no longer mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 - Add concept of `ingested` to budgets, and skip validation on ingested budgets. This is in preparation for ingesting legacy data from IATI.
 - Sector questions asks for a category and uses radio buttons
 - Add concept of `ingested` to transactions
+- Transaction disbursement channel is no longer mandatory
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -7,7 +7,6 @@ class Transaction < ApplicationRecord
     :date,
     :currency,
     :value,
-    :disbursement_channel,
     :providing_organisation_name,
     :providing_organisation_type,
     :receiving_organisation_name,

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -114,6 +114,9 @@ class IngestIatiActivities
       date = transaction_element.children.detect { |child| child.name.eql?("value") }.attributes["value-date"].value
       value = transaction_element.children.detect { |child| child.name.eql?("value") }.children.text
       transaction_type = transaction_element.children.detect { |child| child.name.eql?("transaction-type") }.attributes["code"].value
+      disbursement_channel = if transaction_element.children.detect { |child| child.name.eql?("disbursement-channel") }.present?
+        transaction_element.children.detect { |child| child.name.eql?("disbursement-channel") }.attributes["code"].value
+      end
 
       description = if transaction_element.children.detect { |child| child.name.eql?("description") }.present?
         transaction_element.children.detect { |child| child.name.eql?("description") }.children.detect { |child| child.name.eql?("narrative") }.text
@@ -133,7 +136,7 @@ class IngestIatiActivities
         date: date,
         value: value,
         parent_activity: new_activity,
-        disbursement_channel: "1", # guess as it's not returned,
+        disbursement_channel: disbursement_channel,
         providing_organisation_name: providing_organisation_name,
         providing_organisation_type: "10",
         providing_organisation_reference: providing_organisation_reference,

--- a/app/views/staff/shared/xml/_transaction.xml.haml
+++ b/app/views/staff/shared/xml/_transaction.xml.haml
@@ -8,4 +8,5 @@
     %narrative=transaction.providing_organisation_name
   %receiver-org{"receiver-activity-id" => "", "type" => transaction.receiving_organisation_type, "ref" => transaction.receiving_organisation_reference}
     %narrative=transaction.receiving_organisation_name
-  %disbursement-channel{"code" => transaction.disbursement_channel}
+  - if transaction.disbursement_channel.present?
+    %disbursement-channel{"code" => transaction.disbursement_channel}

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -43,7 +43,7 @@ en:
         currency: Currency
         date: Date
         description: Description
-        disbursement_channel: Disbursement channel
+        disbursement_channel: Disbursement channel (optional)
         providing_organisation_name: Providing organisation name
         providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -60,11 +60,24 @@ RSpec.feature "Users can create a transaction" do
       expect(page).to have_content("Transaction type can't be blank")
       expect(page).to have_content("Date can't be blank")
       expect(page).to have_content("Value must be between 1 and 99,999,999,999.00")
-      expect(page).to have_content("Disbursement channel can't be blank")
       expect(page).to have_content("Providing organisation name can't be blank")
       expect(page).to have_content("Providing organisation type can't be blank")
       expect(page).to have_content("Receiving organisation name can't be blank")
       expect(page).to have_content("Receiving organisation type can't be blank")
+    end
+
+    scenario "disbursement channel is optional" do
+      activity = create(:fund_activity, organisation: user.organisation)
+
+      visit organisation_path(user.organisation)
+
+      click_on(activity.title)
+
+      click_on(I18n.t("page_content.transactions.button.create"))
+      expect(page).to have_content("Disbursement channel (optional)")
+      click_on(I18n.t("generic.button.submit"))
+
+      expect(page).to_not have_content("Disbursement channel can't be blank")
     end
 
     context "Value number validation" do

--- a/spec/fixtures/activities/uksa/with_transactions.xml
+++ b/spec/fixtures/activities/uksa/with_transactions.xml
@@ -96,6 +96,7 @@
       <receiver-org>
         <narrative>Avanti Communications</narrative>
       </receiver-org>
+      <disbursement-channel code="1"/>
     </transaction>
     <transaction>
       <transaction-type code="3"/>

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Transaction, type: :model do
     it { should validate_presence_of(:date) }
     it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:value) }
-    it { should validate_presence_of(:disbursement_channel) }
+    it { should_not validate_presence_of(:disbursement_channel) }
     it { should validate_presence_of(:providing_organisation_name) }
     it { should validate_presence_of(:providing_organisation_type) }
     it { should validate_presence_of(:receiving_organisation_name) }

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe IngestIatiActivities do
       transaction = transactions.find_by(description: "50 schools identified for satellite instalation")
       expect(transaction.description).to eql("50 schools identified for satellite instalation")
       expect(transaction.date).to eql(Date.new(2016, 12, 16))
-      expect(transaction.disbursement_channel).to eql("1")
+      expect(transaction.disbursement_channel).to eq("1")
       expect(transaction.currency).to eql("GBP")
       expect(transaction.transaction_type).to eql("3")
       expect(transaction.value.to_s).to eql("647264.0")
@@ -113,6 +113,7 @@ RSpec.describe IngestIatiActivities do
       expect(transaction.receiving_organisation_name).to eql("Avanti Communications")
       expect(transaction.receiving_organisation_reference).to eql(nil)
       expect(transaction.receiving_organisation_type).to eql("0")
+      expect(transaction.ingested).to be true
 
       expect(
         transactions.find_by(description: "50 schools connected with satellite internet")
@@ -130,7 +131,9 @@ RSpec.describe IngestIatiActivities do
         transactions.find_by(description: "Initial proof of concept testing os remote live teaching")
       ).to_not be_nil
 
-      expect(transaction.ingested).to be true
+      expect(
+        transactions.find_by(description: "Initial proof of concept testing os remote live teaching").disbursement_channel
+      ).to be_nil
     end
 
     it "creates budgets and marks them as ingested" do


### PR DESCRIPTION

## Changes in this PR

https://trello.com/c/iDDYOe9j/632-transaction-disbursement-channel-field-to-become-an-optional-field

While working on UKSA data exported from IATI we discovered that many
Transactions do not have a disbursement channel set. This field is not mandatory
in IATI, so it should not be mandatory in our application.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
