### PR TITLE
(636) A BEIS transparency user can download all activities for each delivery partner in a single XML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - Transaction disbursement channel is no longer mandatory
 - IATI ingest tool now saves the original XML for each activity to enable future tasks to copy across additional fields
 - User can add, view and edit planned disbursements to projects and third-party projects
+- BEIS users can download all of an Organisation's project (or third-party project) activities as XML from the organisation show page
 
 ## [unreleased]
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -17,10 +17,22 @@ class Staff::OrganisationsController < Staff::BaseController
     project_activities = FindProjectActivities.new(organisation: organisation, current_user: current_user).call
     third_party_project_activities = FindThirdPartyProjectActivities.new(organisation: organisation, current_user: current_user).call
 
-    @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
-    @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
-    @project_activities = project_activities.map { |activity| ActivityPresenter.new(activity) }
-    @third_party_project_activities = third_party_project_activities.map { |activity| ActivityPresenter.new(activity) }
+    respond_to do |format|
+      format.html do
+        @fund_activities = fund_activities.map { |activity| ActivityPresenter.new(activity) }
+        @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
+        @project_activities = project_activities.map { |activity| ActivityPresenter.new(activity) }
+        @third_party_project_activities = third_party_project_activities.map { |activity| ActivityPresenter.new(activity) }
+      end
+      format.xml do
+        @project_activities = if third_party_project_activities.present?
+          third_party_project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+        else
+          project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+        end
+        response.headers["Content-Disposition"] = "attachment; filename=\"#{organisation.iati_reference}.xml\""
+      end
+    end
   end
 
   def new

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -25,10 +25,13 @@ class Staff::OrganisationsController < Staff::BaseController
         @third_party_project_activities = third_party_project_activities.map { |activity| ActivityPresenter.new(activity) }
       end
       format.xml do
-        @project_activities = if third_party_project_activities.present?
+        @activities = case level
+        when "project"
+          project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+        when "third_party_project"
           third_party_project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
         else
-          project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+          []
         end
         response.headers["Content-Disposition"] = "attachment; filename=\"#{organisation.iati_reference}.xml\""
       end
@@ -83,5 +86,9 @@ class Staff::OrganisationsController < Staff::BaseController
 
   def organisation_params
     params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference)
+  end
+
+  def level
+    params[:level]
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -42,6 +42,10 @@ class Activity < ApplicationRecord
   has_many :implementing_organisations
   belongs_to :reporting_organisation, foreign_key: "reporting_organisation_id", class_name: "Organisation"
 
+  has_many :budgets, foreign_key: "parent_activity_id"
+  has_many :transactions, foreign_key: "parent_activity_id"
+  has_many :planned_disbursements, foreign_key: "parent_activity_id"
+
   enum level: {
     fund: "fund",
     programme: "programme",

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -19,6 +19,10 @@ class OrganisationPolicy < ApplicationPolicy
     beis_user?
   end
 
+  def download?
+    beis_user?
+  end
+
   private def associated_user?
     user.organisation.eql?(record)
   end

--- a/app/views/pages/errors/not_authorised.xml.haml
+++ b/app/views/pages/errors/not_authorised.xml.haml
@@ -1,0 +1,6 @@
+!!!XML
+%error
+  %title
+    = t("page_title.errors.not_authorised")
+  %body
+    = t("page_content.errors.support_prompt")

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -73,3 +73,8 @@
 
       - if policy(:organisation).edit?
         = link_to t("page_content.organisation.button.edit_details"), edit_organisation_path(@organisation_presenter), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      - if policy(:organisation).download?
+        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml), class: "govuk-button"

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -36,6 +36,14 @@
 
         = render partial: "staff/shared/projects/table", locals: { projects: @project_activities }
 
+  - if policy(:organisation).download? && @project_activities.present?
+    .govuk-grid-row
+      .govuk-grid-column-full.download-projects
+        %div.govuk-body
+          = t("page_content.organisation.download.projects.explanation")
+        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :project), class: "govuk-button"
+
+
   - if policy(:third_party_project).index?
     .govuk-grid-row
       .govuk-grid-column-full
@@ -43,6 +51,14 @@
           = t("page_content.organisation.third_party_projects")
 
         = render partial: "staff/shared/third_party_projects/table", locals: { third_party_projects: @third_party_project_activities }
+
+  - if policy(:organisation).download? && @third_party_project_activities.present?
+    .govuk-grid-row
+      .govuk-grid-column-full.download-third-party-projects
+        %div.govuk-body
+          = t("page_content.organisation.download.third-party-projects.explanation")
+        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :third_party_project), class: "govuk-button"
+
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -74,7 +90,3 @@
       - if policy(:organisation).edit?
         = link_to t("page_content.organisation.button.edit_details"), edit_organisation_path(@organisation_presenter), class: "govuk-button"
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      - if policy(:organisation).download?
-        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml), class: "govuk-button"

--- a/app/views/staff/organisations/show.xml.haml
+++ b/app/views/staff/organisations/show.xml.haml
@@ -3,3 +3,4 @@
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
     = render partial: "staff/shared/xml/activity", locals: { activity: activity, transactions: activity.transactions, budgets: activity.budgets, planned_disbursements: activity.planned_disbursements }
+

--- a/app/views/staff/organisations/show.xml.haml
+++ b/app/views/staff/organisations/show.xml.haml
@@ -1,0 +1,5 @@
+!!! XML
+%iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
+"generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
+  - @activities.each do |activity|
+    = render partial: "staff/shared/xml/activity", locals: { activity: activity, transactions: activity.transactions, budgets: activity.budgets, planned_disbursements: activity.planned_disbursements }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,13 @@ en:
       default_currency:
         label: Default currency
       details: Organisation details
+      download:
+        explanation: Download all activities for this organisation
+        projects:
+          explanation: Download all project (level C) activities for this organisation as XML
+        third-party-projects:
+          explanation: Download all third-party project (level D) activities for this organisation as XML
+        title: Download as XML
       funds: Funds
       iati_reference:
         label: International Aid Transparency Initiative (IATI) reference

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -1,23 +1,28 @@
 RSpec.feature "Users can view an organisation as XML" do
   let(:user) { create(:beis_user) }
-  let(:organisation) { create(:delivery_partner_organisation) }
+  let!(:organisation) { create(:delivery_partner_organisation) }
 
   context "when the user belongs to BEIS" do
     before { authenticate!(user: user) }
 
     context "when the user is viewing any organisation show page" do
-      scenario "they can download the XML of the organisation" do
-        visit organisation_path(organisation)
-
-        expect(page).to have_content(organisation.name)
-        expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
-      end
-
       context "whe organisation has projects" do
+        scenario "they can download the organisation's projects as XML" do
+          _project = create(:project_activity, organisation: organisation)
+
+          visit organisation_path(organisation)
+
+          expect(page).to have_content(organisation.name)
+          expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
+        end
+
         scenario "the XML file contains an `iati-activity` element for the project activities in the organisation" do
           project = create(:project_activity, organisation: organisation)
 
-          visit organisation_path(organisation, format: :xml)
+          visit organisation_path(organisation)
+          within ".download-projects" do
+            click_link I18n.t("generic.button.download_as_xml")
+          end
           xml = Nokogiri::XML::Document.parse(page.body)
 
           expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
@@ -26,16 +31,46 @@ RSpec.feature "Users can view an organisation as XML" do
       end
 
       context "the organisation has third-party projects" do
+        scenario "they can download the organisation's third-party projects as XML" do
+          _third_party_project = create(:third_party_project_activity, organisation: organisation)
+
+          visit organisation_path(organisation)
+
+          expect(page).to have_content(organisation.name)
+          expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
+        end
+
         scenario "the XML file contains an `iati-activity` element for the third-party project activity in the organisation" do
           project = create(:project_activity, organisation: organisation)
           third_party_project = create(:third_party_project_activity, organisation: organisation)
 
-          visit organisation_path(organisation, format: :xml)
+          visit organisation_path(organisation)
+          within ".download-third-party-projects" do
+            click_link I18n.t("generic.button.download_as_xml")
+          end
           xml = Nokogiri::XML::Document.parse(page.body)
 
           expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
           expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to eq third_party_project.title
           expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to_not eq project.title
+        end
+      end
+
+      context "the organisation does not have projects" do
+        scenario "the download button does not appear for projects" do
+          visit organisation_path(organisation)
+
+          expect(page).to have_content(organisation.name)
+          expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+        end
+      end
+
+      context "the organisation does not have third-party projects" do
+        scenario "the download button does not appear for third-party projects" do
+          visit organisation_path(organisation)
+
+          expect(page).to have_content(organisation.name)
+          expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
         end
       end
 
@@ -54,7 +89,8 @@ RSpec.feature "Users can view an organisation as XML" do
         _budget = create(:budget, parent_activity: project, value: 2000)
         _transaction = create(:transaction, parent_activity: project, value: 100)
 
-        visit organisation_path(organisation, format: :xml)
+        visit organisation_path(organisation)
+        click_link I18n.t("generic.button.download_as_xml")
         xml = Nokogiri::XML::Document.parse(page.body)
 
         expect(xml.xpath("/iati-activities/iati-activity/budget/value").text).to eq "2000.0"
@@ -71,7 +107,9 @@ RSpec.feature "Users can view an organisation as XML" do
     context "when the user is viewing their own organisaton" do
       let(:organisation) { user.organisation }
 
-      scenario "they cannot download the XML of the organisation" do
+      scenario "they cannot download the organisation's activities as XML" do
+        _project = create(:project_activity, organisation: organisation)
+
         visit organisation_path(organisation)
 
         expect(page).to have_content(organisation.name)

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -1,0 +1,92 @@
+RSpec.feature "Users can view an organisation as XML" do
+  let(:user) { create(:beis_user) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  context "when the user belongs to BEIS" do
+    before { authenticate!(user: user) }
+
+    context "when the user is viewing any organisation show page" do
+      scenario "they can download the XML of the organisation" do
+        visit organisation_path(organisation)
+
+        expect(page).to have_content(organisation.name)
+        expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
+      end
+
+      context "whe organisation has projects" do
+        scenario "the XML file contains an `iati-activity` element for the project activities in the organisation" do
+          project = create(:project_activity, organisation: organisation)
+
+          visit organisation_path(organisation, format: :xml)
+          xml = Nokogiri::XML::Document.parse(page.body)
+
+          expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
+          expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to eq project.title
+        end
+      end
+
+      context "the organisation has third-party projects" do
+        scenario "the XML file contains an `iati-activity` element for the third-party project activity in the organisation" do
+          project = create(:project_activity, organisation: organisation)
+          third_party_project = create(:third_party_project_activity, organisation: organisation)
+
+          visit organisation_path(organisation, format: :xml)
+          xml = Nokogiri::XML::Document.parse(page.body)
+
+          expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
+          expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to eq third_party_project.title
+          expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to_not eq project.title
+        end
+      end
+
+      scenario "the XML file does not contain fund or programme activities in the organisation" do
+        _fund = create(:fund_activity, organisation: organisation)
+        _programme = create(:programme_activity, extending_organisation: organisation)
+
+        visit organisation_path(organisation, format: :xml)
+        xml = Nokogiri::XML::Document.parse(page.body)
+
+        expect(xml.xpath("/iati-activities/iati-activity").count).to eq 0
+      end
+
+      scenario "the XML file contains budgets and transactions for activities in the organisation" do
+        project = create(:project_activity, organisation: organisation)
+        _budget = create(:budget, parent_activity: project, value: 2000)
+        _transaction = create(:transaction, parent_activity: project, value: 100)
+
+        visit organisation_path(organisation, format: :xml)
+        xml = Nokogiri::XML::Document.parse(page.body)
+
+        expect(xml.xpath("/iati-activities/iati-activity/budget/value").text).to eq "2000.0"
+        expect(xml.xpath("/iati-activities/iati-activity/transaction/value").text).to eq "100.0"
+      end
+    end
+  end
+
+  context "when the user does not belong to BEIS" do
+    let(:user) { create(:delivery_partner_user) }
+
+    before { authenticate!(user: user) }
+
+    context "when the user is viewing their own organisaton" do
+      let(:organisation) { user.organisation }
+
+      scenario "they cannot download the XML of the organisation" do
+        visit organisation_path(organisation)
+
+        expect(page).to have_content(organisation.name)
+        expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+      end
+    end
+
+    context "when the user is viewing another organisaton" do
+      let(:organisation) { create(:delivery_partner_organisation) }
+
+      scenario "they cannot download the XML of the organisation" do
+        visit organisation_path(organisation, format: :xml)
+
+        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+      end
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -236,6 +236,9 @@ RSpec.describe Activity, type: :model do
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
     it { should have_many(:implementing_organisations) }
     it { should belong_to(:reporting_organisation).with_foreign_key("reporting_organisation_id") }
+    it { should have_many(:budgets) }
+    it { should have_many(:transactions) }
+    it { should have_many(:planned_disbursements) }
   end
 
   describe "#parent_activity" do

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OrganisationPolicy do
     it { is_expected.to permit_new_and_create_actions }
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to permit_action(:download) }
   end
 
   context "as user that does NOT belong to BEIS" do
@@ -24,6 +25,7 @@ RSpec.describe OrganisationPolicy do
       it { is_expected.to forbid_new_and_create_actions }
       it { is_expected.to permit_edit_and_update_actions }
       it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:download) }
     end
 
     context "when the user does NOT belong to that organisation" do
@@ -34,6 +36,7 @@ RSpec.describe OrganisationPolicy do
       it { is_expected.to forbid_new_and_create_actions }
       it { is_expected.to forbid_edit_and_update_actions }
       it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:download) }
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/XpXfmNXM/636-a-beis-transparency-user-can-download-the-xml-all-activities-for-each-delivery-partner-in-a-single-file

A BEIS user needs to be able to download all the (project C or third-party project D, whichever is lowest) activities for an organisation as a single file. Currently the BEIS transparency user has to go to each Activity show page to download each Activity individually. 

In this PR I have added `has_many` association to Activities linking to Budgets and Transactions. This is after a lot of thought about the simplest way to get all budgets/transactions for each Activity. 

In Organisation#show we are getting all the project & third-party activities for that organisation. Without these associations, we would have to iterate over each activity in the Organisation controller and get that activity's budgets/transactions. Adding this association seemed like the simplest way to address this.

In future these files can potentially become extremely large, as each Organisation has to retrieve more and more activities to display. We should think about ways we can ensure the application remains performant, possibly via caching of activities and/or their budgets/transactions?

## Screenshots of UI changes

### Before

### After

<img width="1239" alt="Screenshot 2020-05-19 at 14 15 07" src="https://user-images.githubusercontent.com/1089521/82332086-df834b80-99dc-11ea-9c4c-e1b1b2d8b802.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
