### PR TITLE
Debugging to check why userinfo isn't always set in the session

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -4,6 +4,13 @@ class Auth0Controller < ApplicationController
     # and the IdP
     session[:userinfo] = request.env["omniauth.auth"]
 
+    # DEBUG: Is the session set correctly on the auth0 callback? Is it ready to
+    # read straight away or is there a delay?
+    if Rails.env.production?
+      Rails.logger.info("* Auth0 callback contained the following id: #{request.env.dig("omniauth.auth", "uid")}")
+      Rails.logger.info("** Auth0 callback has been received. The session has an auth0 id of #{session.dig(:userinfo, :uid)}")
+    end
+
     # Redirect to the URL you want after successful auth
     if current_user.active && current_user.organisation
       redirect_to organisation_path(current_user.organisation)


### PR DESCRIPTION
## Changes in this PR

Only replicatable on staging so we have to push to develop.

On our initial debugging 048c0fd2ffde499a483ed78f7d08ac1b4f6afa43 we learnt that the user does have a session, keys are present but not the userinfo key. Let's verify if the callback endpoint recieves this data when auth0 sends a callback.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
