### PR TITLE
Fix session store so that it uses RedisStore on live environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,11 @@ COPY . ${APP_HOME}
 RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
 RUN cp -R $DEPS_HOME/node_modules/govuk-frontend/govuk/assets $APP_HOME/app/assets
 
-RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
+RUN \
+  RAILS_ENV=$RAILS_ENV \
+  SECRET_KEY_BASE="super secret" \
+  REDIS_URL="redis://build.local:6379" \
+  bundle exec rake assets:precompile --quiet
 
 # create tmp/pids
 RUN mkdir -p tmp/pids

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Load environment variables that are created by Terraform
+require_relative "../../lib/vcap_parser.rb"
+VcapParser.load_service_environment_variables!
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,13 +1,4 @@
 redis_url = ENV.fetch("REDIS_URL", nil)
-if redis_url.nil?
-  # If REDIS_URL is unexpectedly unavailable Rails will use the default
-  # cookie_store. We declare this explicity so the fallback is clear.
-  Rails.application.config.session_store :cookie_store,
-    key: "_roda_session",
-    expire_after: 12.hours
-  return
-end
-
 redis_uri = URI(redis_url)
 redis_store_params = {
   servers: {
@@ -21,5 +12,4 @@ redis_store_params = {
   threadsafe: true,
 }
 redis_store_params[:secure] = true if Rails.env.production?
-
 Rails.application.config.session_store :redis_store, redis_store_params

--- a/config/initializers/vcap_services.rb
+++ b/config/initializers/vcap_services.rb
@@ -1,2 +1,0 @@
-require "vcap_parser"
-VcapParser.load_service_environment_variables!

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "vcap_parser"
 
 RSpec.describe VcapParser do
   describe ".load_service_environment_variables!" do


### PR DESCRIPTION
## Changes in this PR

This change comes about [investigating odd sign-in behaviour](https://trello.com/c/bS7zZIBq) on staging where sometimes users are sent back to the start page. On attempting to wipe the redis store for active sessions to rule out any bad state I found the CookieStore was being used instead. This is not expected and means I cannot flush the redis state in order to continue the ingestigation.

- require a REDIS_URL environment variable to be present during application start so we are alerted early when it's missing to avoid this type of problem again
- fix the core issue which was vcap being called very late in the Rails initialisation process on app boot. It is now called before the session_store.rb initialiser which means REDIS_URL is present
- take a different approach of allowing the `docker build` to succeed on the asset procompilation step without a real redis_url being needed by faking it

## Screenshots of UI changes

### Before
![Screenshot 2020-05-14 at 17 30 14](https://user-images.githubusercontent.com/912473/81963786-82b71800-960d-11ea-888c-b186f8a462e6.png)

### After
![Screenshot 2020-05-14 at 18 04 47](https://user-images.githubusercontent.com/912473/81963794-85197200-960d-11ea-9be0-c4ce4cbcf5fb.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
