### PR TITLE
(594) Users can add and edit planned disbursements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
 - Add concept of `ingested` to transactions
 - Transaction disbursement channel is no longer mandatory
 - IATI ingest tool now saves the original XML for each activity to enable future tasks to copy across additional fields
+- User can add a planned disbursement to projects and third-party projects
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@
 - Add concept of `ingested` to transactions
 - Transaction disbursement channel is no longer mandatory
 - IATI ingest tool now saves the original XML for each activity to enable future tasks to copy across additional fields
-- User can add a planned disbursement to projects and third-party projects
+- User can add and view planned disbursements to projects and third-party projects
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@
 - Add concept of `ingested` to transactions
 - Transaction disbursement channel is no longer mandatory
 - IATI ingest tool now saves the original XML for each activity to enable future tasks to copy across additional fields
-- User can add and view planned disbursements to projects and third-party projects
+- User can add, view and edit planned disbursements to projects and third-party projects
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...HEAD
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -15,11 +15,13 @@ class Staff::ActivitiesController < Staff::BaseController
 
     @transactions = policy_scope(Transaction).where(parent_activity: @activity).order("date DESC")
     @budgets = policy_scope(Budget).where(parent_activity: @activity).order("period_start_date DESC")
+    @planned_disbursements = policy_scope(PlannedDisbursement).where(parent_activity: @activity).order("period_start_date DESC")
 
     respond_to do |format|
       format.html do
         @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
         @budget_presenters = @budgets.includes(:parent_activity).map { |budget| BudgetPresenter.new(budget) }
+        @planned_disbursement_presenters = @planned_disbursements.map { |planned_disbursement| PlannedDisbursementPresenter.new(planned_disbursement) }
         @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
       end
       format.xml do |_format|

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Staff::PlannedDisbursementsController < Staff::BaseController
+  def new
+    @activity = Activity.find(params["activity_id"])
+    @planned_disbursement = PlannedDisbursement.new
+    @planned_disbursement.parent_activity = @activity
+
+    authorize @planned_disbursement
+  end
+
+  def create
+    @activity = Activity.find(params["activity_id"])
+    authorize @activity
+
+    result = CreatePlannedDisbursement.new(activity: @activity).call(attributes: planned_disbursement_params)
+    @planned_disbursement = result.object
+
+    if result.success?
+      flash[:notice] = I18n.t("form.planned_disbursement.create.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def planned_disbursement_params
+    params.require(:planned_disbursement).permit(
+      :planned_disbursement_type,
+      :period_start_date,
+      :period_end_date,
+      :currency,
+      :value,
+      :providing_organisation_name,
+      :providing_organisation_type,
+      :providing_organisation_reference,
+      :receiving_organisation_name,
+      :receiving_organisation_type,
+      :receiving_organisation_reference
+    )
+  end
+end

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -24,6 +24,29 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     end
   end
 
+  def edit
+    @planned_disbursement = PlannedDisbursement.find(params["id"])
+    authorize @planned_disbursement
+
+    @activity = @planned_disbursement.parent_activity
+  end
+
+  def update
+    @planned_disbursement = PlannedDisbursement.find(params["id"])
+    authorize @planned_disbursement
+
+    @activity = Activity.find(params["activity_id"])
+    result = UpdatePlannedDisbursement.new(planned_disbursement: @planned_disbursement)
+      .call(attributes: planned_disbursement_params)
+
+    if result.success?
+      flash[:notice] = I18n.t("form.planned_disbursement.update.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def planned_disbursement_params

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -20,6 +20,18 @@ module FormHelper
     end
   end
 
+  def list_of_planned_disbursement_budget_types
+    @list_of_planned_disbursement_budget_types ||= begin
+      PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.map do |id, name|
+        OpenStruct.new(
+          id: id,
+          name: I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.#{name}.name"),
+          description: I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.#{name}.description")
+        )
+      end
+    end
+  end
+
   def list_of_budget_statuses
     @list_of_budget_statuses ||= begin
       Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.budget.status.#{name}")) }

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -1,0 +1,13 @@
+class PlannedDisbursement < ApplicationRecord
+  belongs_to :parent_activity, class_name: "Activity"
+
+  validates_presence_of :planned_disbursement_type,
+    :period_start_date,
+    :currency,
+    :value,
+    :providing_organisation_name,
+    :providing_organisation_type,
+    :receiving_organisation_name,
+    :receiving_organisation_type
+  validates :value, inclusion: {in: 0.01..99_999_999_999.00}
+end

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -1,4 +1,6 @@
 class PlannedDisbursement < ApplicationRecord
+  PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
+
   belongs_to :parent_activity, class_name: "Activity"
 
   validates_presence_of :planned_disbursement_type,
@@ -10,4 +12,5 @@ class PlannedDisbursement < ApplicationRecord
     :receiving_organisation_name,
     :receiving_organisation_type
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
+  validates_with EndDateNotBeforeStartDateValidator, if: -> { period_start_date.present? && period_end_date.present? }
 end

--- a/app/policies/planned_disbursement_policy.rb
+++ b/app/policies/planned_disbursement_policy.rb
@@ -1,0 +1,26 @@
+class PlannedDisbursementPolicy < ApplicationPolicy
+  def create?
+    return false if record.parent_activity.fund? || record.parent_activity.programme?
+    Pundit.policy!(user, record.parent_activity).create?
+  end
+
+  def update?
+    return false if record.parent_activity.fund? || record.parent_activity.programme?
+    Pundit.policy!(user, record.parent_activity).update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope < Scope
+    def resolve
+      if user.organisation.service_owner?
+        scope.all
+      else
+        activities = Activity.where(organisation_id: user.organisation)
+        scope.where(parent_activity_id: activities)
+      end
+    end
+  end
+end

--- a/app/presenters/planned_disbursement_presenter.rb
+++ b/app/presenters/planned_disbursement_presenter.rb
@@ -1,0 +1,26 @@
+class PlannedDisbursementPresenter < SimpleDelegator
+  def planned_disbursement_type
+    return if super.blank?
+    I18n.t("page_content.planned_disbursements.planned_disbursement_type.#{super}")
+  end
+
+  def period_start_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def period_end_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def currency
+    return if super.blank?
+    I18n.t("generic.default_currency.#{super.downcase}")
+  end
+
+  def value
+    return if super.blank?
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+end

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -1,0 +1,29 @@
+class CreatePlannedDisbursement
+  attr_accessor :activity
+
+  def initialize(activity:)
+    self.activity = activity
+  end
+
+  def call(attributes: {})
+    planned_disbursement = PlannedDisbursement.new
+
+    planned_disbursement.parent_activity = activity
+    planned_disbursement.assign_attributes(attributes)
+    planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
+
+    result = if planned_disbursement.valid?
+      Result.new(planned_disbursement.save, planned_disbursement)
+    else
+      Result.new(false, planned_disbursement)
+    end
+
+    result
+  end
+
+  private
+
+  def sanitize_monetary_string(value:)
+    Monetize.parse(value)
+  end
+end

--- a/app/services/update_planned_disbursement.rb
+++ b/app/services/update_planned_disbursement.rb
@@ -1,0 +1,26 @@
+class UpdatePlannedDisbursement
+  attr_accessor :planned_disbursement
+
+  def initialize(planned_disbursement:)
+    self.planned_disbursement = planned_disbursement
+  end
+
+  def call(attributes: {})
+    planned_disbursement.assign_attributes(attributes)
+    planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
+
+    result = if planned_disbursement.valid?
+      Result.new(planned_disbursement.save!, planned_disbursement)
+    else
+      Result.new(false, planned_disbursement)
+    end
+
+    result
+  end
+
+  private
+
+  def sanitize_monetary_string(value:)
+    Monetize.parse(value)
+  end
+end

--- a/app/validators/end_date_not_before_start_date_validator.rb
+++ b/app/validators/end_date_not_before_start_date_validator.rb
@@ -1,0 +1,13 @@
+class EndDateNotBeforeStartDateValidator < ActiveModel::Validator
+  def validate(record)
+    unless start_date_not_after_end_date?(record.period_start_date, record.period_end_date)
+      record.errors.add :period_end_date, I18n.t("activerecord.errors.validators.end_date_not_before_start_date")
+    end
+  end
+
+  private
+
+  def start_date_not_after_end_date?(start_date, end_date)
+    start_date <= end_date
+  end
+end

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -33,5 +33,6 @@
 
   - if @activity.project? || @activity.third_party_project?
     = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
+    = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity }
     - if policy(:project).download? || policy(:third_party_project).download?
       = link_to t("generic.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -28,11 +28,10 @@
     = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
 
   - if @activity.project? || @activity.third_party_project?
-    = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
     = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-
-  - if @activity.project? || @activity.third_party_project?
     = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
-    = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity }
+    = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
+    = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+
     - if policy(:project).download? || policy(:third_party_project).download?
       = link_to t("generic.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -1,0 +1,51 @@
+= f.govuk_error_summary
+
+= f.govuk_collection_radio_buttons :planned_disbursement_type,
+  list_of_planned_disbursement_budget_types,
+  :id,
+  :name,
+  :description,
+  legend: { tag: :h2, size: "s", text: t("form.planned_disbursement.planned_disbursement_type.label") },
+  hint_text: t("form.planned_disbursement.planned_disbursement_type.hint")
+
+= f.govuk_date_field :period_start_date,
+  legend: { text: t("form.planned_disbursement.period_start_date.label"), size: "s", tag: :h2 },
+    hint_text: t("form.planned_disbursement.period_start_date.hint")
+
+
+= f.govuk_date_field :period_end_date,
+  legend: { text: t("form.planned_disbursement.period_end_date.label"), size: "s", tag: :h2 },
+    hint_text: t("form.planned_disbursement.period_end_date.hint")
+
+= f.govuk_collection_select :currency,
+                               currency_select_options,
+                               :code,
+                               :name,
+          label: { text: t("form.planned_disbursement.currency.label"), size: "s", tag: :h2 }
+
+= f.govuk_text_field :value,
+          label: { text: t("form.planned_disbursement.value.label"), size: "s", tag: :h2 }
+
+%h2.govuk-heading-m= t("form.planned_disbursement.providing_organisation.title")
+%span.govuk-hint= t("form.planned_disbursement.providing_organisation.hint")
+= f.govuk_text_field :providing_organisation_name
+= f.govuk_collection_select :providing_organisation_type,
+                     yaml_to_objects(entity: "organisation", type: "organisation_type"),
+                     :code,
+                     :name
+= f.govuk_text_field :providing_organisation_reference,
+                      label: { text: t("form.planned_disbursement.providing_organisation_reference.label") },
+                      hint_text: t("form.planned_disbursement.providing_organisation_reference.hint").html_safe
+
+%h2.govuk-heading-m= t("form.planned_disbursement.receiving_organisation.title")
+%span.govuk-hint= t("form.planned_disbursement.receiving_organisation.hint")
+= f.govuk_text_field :receiving_organisation_name
+= f.govuk_collection_select :receiving_organisation_type,
+                     yaml_to_objects(entity: "organisation", type: "organisation_type"),
+                     :code,
+                     :name
+= f.govuk_text_field :receiving_organisation_reference,
+                     label: { text: t("form.planned_disbursement.receiving_organisation_reference.label") },
+                     hint_text: t("form.planned_disbursement.receiving_organisation_reference.hint").html_safe
+
+= f.govuk_submit t("generic.button.submit")

--- a/app/views/staff/planned_disbursements/edit.html.haml
+++ b/app/views/staff/planned_disbursements/edit.html.haml
@@ -1,0 +1,11 @@
+=content_for :page_title_prefix, t("page_title.planned_disbursement.edit")
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.planned_disbursement.edit")
+
+      = form_with model: @planned_disbursement, url: activity_planned_disbursement_path(@activity) do |f|
+        = render partial: "form", locals: { f: f }

--- a/app/views/staff/planned_disbursements/new.html.haml
+++ b/app/views/staff/planned_disbursements/new.html.haml
@@ -1,0 +1,11 @@
+=content_for :page_title_prefix, t("page_title.planned_disbursement.new")
+
+= link_to t("generic.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.planned_disbursement.new")
+
+        = form_with model: @planned_disbursement, url: activity_planned_disbursements_path(@activity) do |f|
+          = render partial: "form", locals: { f: f }

--- a/app/views/staff/shared/activities/_implementing_organisations.html.haml
+++ b/app/views/staff/shared/activities/_implementing_organisations.html.haml
@@ -3,8 +3,9 @@
     %h2.govuk-heading-m
       = t("page_content.activity.implementing_organisation.heading")
 
+    - if policy(:project).create?
+      = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(@activity), class: "govuk-button")
+
     - if @activity.implementing_organisations.present?
       = render partial: "staff/shared/implementing_organisations/table", locals: { implementing_organisations: @implementing_organisation_presenters }
 
-    - if policy(:project).create?
-      = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(@activity), class: "govuk-button")

--- a/app/views/staff/shared/activities/_planned_disbursements.html.haml
+++ b/app/views/staff/shared/activities/_planned_disbursements.html.haml
@@ -1,0 +1,6 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.planned_disbursements")
+    - if policy(activity).create?
+      = link_to(I18n.t("page_content.planned_disbursements.button.create"), new_activity_planned_disbursement_path(activity), class: "govuk-button")

--- a/app/views/staff/shared/activities/_planned_disbursements.html.haml
+++ b/app/views/staff/shared/activities/_planned_disbursements.html.haml
@@ -4,3 +4,4 @@
       = t("page_content.activity.planned_disbursements")
     - if policy(activity).create?
       = link_to(I18n.t("page_content.planned_disbursements.button.create"), new_activity_planned_disbursement_path(activity), class: "govuk-button")
+    = render partial: '/staff/shared/planned_disbursements/table', locals: { planned_disbursements: planned_disbursements }

--- a/app/views/staff/shared/planned_disbursements/_table.html.haml
+++ b/app/views/staff/shared/planned_disbursements/_table.html.haml
@@ -1,0 +1,29 @@
+- unless planned_disbursements.empty?
+  %table.govuk-table.planned-disbursements
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("form.planned_disbursement.planned_disbursement_type.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.period_start_date.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.period_end_date.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.currency.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.value.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.providing_organisation.label")
+        %th.govuk-table__header
+          =t("form.planned_disbursement.receiving_organisation.label")
+
+    %tbody.govuk-table__body
+      - planned_disbursements.each do |planned_disbursement|
+        %tr.govuk-table__row{id: planned_disbursement.id}
+          %td.govuk-table__cell= planned_disbursement.planned_disbursement_type
+          %td.govuk-table__cell= planned_disbursement.period_start_date
+          %td.govuk-table__cell= planned_disbursement.period_end_date
+          %td.govuk-table__cell= planned_disbursement.currency
+          %td.govuk-table__cell= planned_disbursement.value
+          %td.govuk-table__cell= planned_disbursement.providing_organisation_name
+          %td.govuk-table__cell= planned_disbursement.receiving_organisation_name

--- a/app/views/staff/shared/planned_disbursements/_table.html.haml
+++ b/app/views/staff/shared/planned_disbursements/_table.html.haml
@@ -16,6 +16,8 @@
           =t("form.planned_disbursement.providing_organisation.label")
         %th.govuk-table__header
           =t("form.planned_disbursement.receiving_organisation.label")
+        - if policy(@activity).edit?
+          %th.govuk-table__header
 
     %tbody.govuk-table__body
       - planned_disbursements.each do |planned_disbursement|
@@ -27,3 +29,6 @@
           %td.govuk-table__cell= planned_disbursement.value
           %td.govuk-table__cell= planned_disbursement.providing_organisation_name
           %td.govuk-table__cell= planned_disbursement.receiving_organisation_name
+          - if policy(planned_disbursement.parent_activity).edit?
+            %td.govuk-table__cell
+              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_planned_disbursement_path(planned_disbursement.parent_activity, planned_disbursement), t("form.planned_disbursement.edit_noun"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,12 +81,14 @@ en:
         label: Budget type
       providing_organisation:
         hint: The organisation where this planned disbursement is coming from.
+        label: Provider
         title: Providing organisation
       providing_organisation_reference:
         hint: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
         label: International Aid Transparency Initiative (IATI) Reference (optional)
       receiving_organisation:
         hint: The organisation receiving the money from this transaction.
+        label: Receiver
         title: Receiving organisation
       receiving_organisation_reference:
         hint: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
@@ -244,7 +246,7 @@ en:
         '2': Committed
     budgets:
       button:
-        create: Create budget
+        create: Add budget
       edit_noun: budget
     errors:
       auth0:
@@ -293,6 +295,9 @@ en:
     planned_disbursements:
       button:
         create: Add planned disbursement
+      planned_disbursement_type:
+        '1': Original
+        '2': Revised
     start_page:
       introduction: This service is for reporting BEIS research and innovation ODA.
       use_this_page_to: 'Use this service to:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         success: Planned disbursement successfully created
       currency:
         label: Currency
+      edit_noun: planned disbursement
       period_end_date:
         hint: The timeframe between the start date and the end date should not normally exceed 3 calendar months
         label: End date
@@ -80,19 +81,21 @@ en:
         hint: Whether this is an original plan (prepared when the original commitment was made) or has subsequently been revised
         label: Budget type
       providing_organisation:
-        hint: The organisation where this planned disbursement is coming from.
+        hint: The organisation where this planned disbursement is coming from
         label: Provider
         title: Providing organisation
       providing_organisation_reference:
-        hint: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        hint: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
         label: International Aid Transparency Initiative (IATI) Reference (optional)
       receiving_organisation:
         hint: The organisation receiving the money from this transaction.
         label: Receiver
         title: Receiving organisation
       receiving_organisation_reference:
-        hint: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        hint: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
         label: IATI Reference (optional)
+      update:
+        success: Planned disbursement successfully updated
       value:
         label: Value
     programme:
@@ -354,6 +357,7 @@ en:
       new: Create a new organisation
       show: Organisation %{name}
     planned_disbursement:
+      edit: Edit planned disbursement
       new: Add a planned disbursement
     privacy_policy: Privacy policy
     transaction:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,34 @@ en:
         label: Organisation type
       update:
         success: Organisation successfully updated
+    planned_disbursement:
+      create:
+        success: Planned disbursement successfully created
+      currency:
+        label: Currency
+      period_end_date:
+        hint: The timeframe between the start date and the end date should not normally exceed 3 calendar months
+        label: End date
+      period_start_date:
+        hint: The start date should define when the actual transfer of funds will take place, if a specific date is known. If the specific payment date is not known, the period in which the transfer is due to take place should be described by using both start date and end date
+        label: Start date
+      planned_disbursement_type:
+        hint: Whether this is an original plan (prepared when the original commitment was made) or has subsequently been revised
+        label: Budget type
+      providing_organisation:
+        hint: The organisation where this planned disbursement is coming from.
+        title: Providing organisation
+      providing_organisation_reference:
+        hint: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        label: International Aid Transparency Initiative (IATI) Reference (optional)
+      receiving_organisation:
+        hint: The organisation receiving the money from this transaction.
+        title: Receiving organisation
+      receiving_organisation_reference:
+        hint: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        label: IATI Reference (optional)
+      value:
+        label: Value
     programme:
       create:
         success: Programme successfully created
@@ -186,6 +214,7 @@ en:
         third_party_project: third-party project
       organisation:
         label: Organisation
+      planned_disbursements: Planned disbursements
       planned_end_date:
         label: Planned end date
       planned_start_date:
@@ -261,6 +290,9 @@ en:
     organisations:
       button:
         create: Create organisation
+    planned_disbursements:
+      button:
+        create: Add planned disbursement
     start_page:
       introduction: This service is for reporting BEIS research and innovation ODA.
       use_this_page_to: 'Use this service to:'
@@ -316,6 +348,8 @@ en:
       index: Organisations
       new: Create a new organisation
       show: Organisation %{name}
+    planned_disbursement:
+      new: Add a planned disbursement
     privacy_policy: Privacy policy
     transaction:
       edit: Edit transaction

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -39,6 +39,18 @@ en:
         language_code: Language code
         name: Name
         organisation_type: Organisation type
+      planned_disbursement:
+        planned_disbursement_type:
+          original:
+            description: The original budget allocated to the activity
+            name: Original
+          revised:
+            description: The updated budget for an activity
+            name: Revised
+        providing_organisation_name: Providing organisation name
+        providing_organisation_type: Providing organisation type
+        receiving_organisation_name: Receiving organisation name
+        receiving_organisation_type: Receiving organisation type
       transaction:
         currency: Currency
         date: Date
@@ -84,6 +96,10 @@ en:
           attributes:
             iati_reference:
               format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
+        planned_disbursement:
+          attributes:
+            value:
+              inclusion: Value must be between 0.01 and 99,999,999,999.00
         transaction:
           attributes:
             date:
@@ -95,6 +111,8 @@ en:
           attributes:
             organisation_ids:
               blank: Select the organisation(s) this user belongs to
+      validators:
+        end_date_not_before_start_date: The end date cannot be before the start date
   helpers:
     fieldset:
       activity:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,11 @@ Rails.application.routes.draw do
       resources :budgets, only: [:new, :create, :show, :edit, :update]
     end
 
-    resources :activities, only: [], concerns: [:transactionable, :budgetable] do
+    concern :disbursement_plannable do
+      resources :planned_disbursements, only: [:new, :create]
+    end
+
+    resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable] do
       resources :steps, controller: "activity_forms"
       resources :extending_organisations, only: [:edit, :update]
       resources :implementing_organisations, only: [:new, :create, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     end
 
     concern :disbursement_plannable do
-      resources :planned_disbursements, only: [:new, :create]
+      resources :planned_disbursements, only: [:new, :create, :edit, :update]
     end
 
     resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable] do

--- a/db/migrate/20200511113011_add_planned_disbursements.rb
+++ b/db/migrate/20200511113011_add_planned_disbursements.rb
@@ -1,0 +1,20 @@
+class AddPlannedDisbursements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :planned_disbursements, id: :uuid do |t|
+      t.string :planned_disbursement_type
+      t.date :period_start_date
+      t.date :period_end_date
+      t.decimal :value, precision: 13, scale: 2
+      t.string :currency
+      t.string :providing_organisation_name
+      t.string :providing_organisation_type
+      t.string :providing_organisation_reference
+      t.string :receiving_organisation_name
+      t.string :receiving_organisation_type
+      t.string :receiving_organisation_reference
+      t.boolean :ingested, default: false
+      t.references :parent_activity, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200518105959_add_foreign_key_constraint_to_planned_disbursements.rb
+++ b/db/migrate/20200518105959_add_foreign_key_constraint_to_planned_disbursements.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyConstraintToPlannedDisbursements < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key "planned_disbursements", "activities", column: "parent_activity_id", on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_152258) do
+ActiveRecord::Schema.define(version: 2020_05_18_105959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 2020_05_12_152258) do
   add_foreign_key "activities", "organisations", column: "reporting_organisation_id"
   add_foreign_key "activities", "organisations", on_delete: :restrict
   add_foreign_key "budgets", "activities", column: "parent_activity_id", on_delete: :cascade
+  add_foreign_key "planned_disbursements", "activities", column: "parent_activity_id", on_delete: :cascade
   add_foreign_key "transactions", "activities", column: "parent_activity_id", on_delete: :cascade
   add_foreign_key "users", "organisations", on_delete: :restrict
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,25 @@ ActiveRecord::Schema.define(version: 2020_05_12_152258) do
     t.index ["iati_reference"], name: "index_organisations_on_iati_reference", unique: true
   end
 
+  create_table "planned_disbursements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "planned_disbursement_type"
+    t.date "period_start_date"
+    t.date "period_end_date"
+    t.decimal "value", precision: 13, scale: 2
+    t.string "currency"
+    t.string "providing_organisation_name"
+    t.string "providing_organisation_type"
+    t.string "providing_organisation_reference"
+    t.string "receiving_organisation_name"
+    t.string "receiving_organisation_type"
+    t.string "receiving_organisation_reference"
+    t.boolean "ingested", default: false
+    t.uuid "parent_activity_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["parent_activity_id"], name: "index_planned_disbursements_on_parent_activity_id"
+  end
+
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "description"
     t.string "transaction_type"

--- a/spec/factories/planned_disbursement.rb
+++ b/spec/factories/planned_disbursement.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :planned_disbursement do
+    planned_disbursement_type { "1" }
+    period_start_date { Date.today + 1.year }
+    currency { "gbp" }
+    value { BigDecimal("100000.00") }
+    association :parent_activity, factory: :project_activity
+    providing_organisation_name { "Delivery partner" }
+    providing_organisation_type { "10" }
+    providing_organisation_reference { "GB-COH-1233442" }
+    receiving_organisation_name { Faker::Company.name }
+    receiving_organisation_reference { "GB-COH-{#{Faker::Number.number(digits: 6)}}" }
+    receiving_organisation_type { "70" }
+  end
+end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "Users can create a planned disbursement" do
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+
+    before { authenticate!(user: user) }
+
+    scenario "they can add a planned disbursement" do
+      project = create(:project_activity, organisation: user.organisation)
+      visit organisation_path(user.organisation)
+      click_on project.title
+
+      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+
+      click_on I18n.t("page_content.planned_disbursements.button.create")
+
+      expect(page).to have_content I18n.t("page_title.planned_disbursement.new")
+
+      choose I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.name")
+      fill_in "planned_disbursement[period_start_date(3i)]", with: "01"
+      fill_in "planned_disbursement[period_start_date(2i)]", with: "01"
+      fill_in "planned_disbursement[period_start_date(1i)]", with: "2020"
+      fill_in "planned_disbursement[period_end_date(3i)]", with: "31"
+      fill_in "planned_disbursement[period_end_date(2i)]", with: "12"
+      fill_in "planned_disbursement[period_end_date(1i)]", with: "2020"
+      select "Pound Sterling", from: "planned_disbursement[currency]"
+      fill_in "planned_disbursement[value]", with: "1000.00"
+      fill_in "planned_disbursement[providing_organisation_name]", with: "org"
+      select "Government", from: "planned_disbursement[providing_organisation_type]"
+      fill_in "planned_disbursement[receiving_organisation_name]", with: "another org"
+      select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
+      click_button I18n.t("generic.button.submit")
+
+      expect(page).to have_current_path organisation_activity_path(user.organisation, project)
+      expect(page).to have_content I18n.t("form.planned_disbursement.create.success")
+    end
+  end
+
+  context "when signed in as a beis user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before { authenticate!(user: beis_user) }
+
+    scenario "they cannot add a planned disbursement" do
+      project = create(:project_activity, organisation: beis_user.organisation)
+      visit organisation_path(beis_user.organisation)
+      click_on project.title
+
+      expect(page).not_to have_link I18n.t("page_content.planned_disbursements.button.create"), href: new_activity_planned_disbursement_path(project)
+
+      visit new_activity_planned_disbursement_path(project)
+
+      expect(page).to have_content I18n.t("page_title.errors.not_authorised")
+    end
+  end
+end

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "Users can edit a planned disbursement" do
+  context "when signed in as a deivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+
+    before { authenticate!(user: user) }
+
+    scenario "they can edit a planned disbursement" do
+      organisation = user.organisation
+      project = create(:project_activity, organisation: user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: project)
+      visit organisation_activity_path(organisation, project)
+
+      within "##{planned_disbursement.id}" do
+        click_on "Edit"
+      end
+
+      expect(page).to have_http_status(:success)
+
+      fill_in "Receiving organisation", with: "An Organisation"
+      click_button "Submit"
+
+      expect(page).to have_content I18n.t("form.planned_disbursement.update.success")
+      expect(page).to have_content "An Organisation"
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_view_planned_disbursements_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Users can view planned disbursements" do
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "they can view planned disburesment on projects" do
+      project = create(:project_activity, organisation: user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: project)
+
+      visit organisation_activity_path(user.organisation, project)
+
+      expect(page).to have_content "Planned disbursements"
+      expect(page).to have_selector "##{planned_disbursement.id}"
+    end
+
+    scenario "they can view planned disbursements on third-party projects" do
+      third_party_project = create(:third_party_project_activity, organisation: user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: third_party_project)
+
+      visit organisation_activity_path(user.organisation, third_party_project)
+
+      expect(page).to have_content "Planned disbursements"
+      expect(page).to have_selector "##{planned_disbursement.id}"
+    end
+  end
+
+  context "when signed in as a beis user" do
+    let(:beis_user) { create(:beis_user) }
+    before { authenticate!(user: beis_user) }
+
+    scenario "they can view planned disburesment on projects" do
+      project = create(:project_activity, organisation: beis_user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: project)
+
+      visit organisation_activity_path(beis_user.organisation, project)
+
+      expect(page).to have_content "Planned disbursements"
+      expect(page).to have_selector "##{planned_disbursement.id}"
+    end
+
+    scenario "they can view planned disbursements on third-party projects" do
+      third_party_project = create(:third_party_project_activity, organisation: beis_user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: third_party_project)
+
+      visit organisation_activity_path(beis_user.organisation, third_party_project)
+
+      expect(page).to have_content "Planned disbursements"
+      expect(page).to have_selector "##{planned_disbursement.id}"
+    end
+  end
+end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe FormHelper, type: :helper do
       helper.list_of_delivery_partners
     end
   end
+
+  describe "#list_of_planned_disbursement_budget_types" do
+    it "builds a list of budget types for a planned disbursement" do
+      budget_types = helper.list_of_planned_disbursement_budget_types
+
+      expect(budget_types[0].name).to eq I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.name")
+      expect(budget_types[0].description).to eq I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.description")
+    end
+  end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe PlannedDisbursement, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:planned_disbursement_type) }
+    it { should validate_presence_of(:period_start_date) }
+    it { should validate_presence_of(:currency) }
+    it { should validate_presence_of(:value) }
+  end
+end

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe PlannedDisbursementPolicy do
+  context "when the user is a beis user" do
+    let(:beis_user) { create(:beis_user) }
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: beis_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(beis_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: beis_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(beis_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: delivery_partner_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(beis_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a third-party project" do
+      let(:activity) { create(:third_party_project_activity, organisation: delivery_partner_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(beis_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes all planned_disbursementis in the resolved scope" do
+      activity = create(:activity, organisation: beis_user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: activity)
+      other_planned_disbursement = create(:planned_disbursement, parent_activity: create(:activity))
+      resolved_scope = described_class::Scope.new(beis_user, PlannedDisbursement.all).resolve
+
+      expect(resolved_scope).to include(planned_disbursement)
+      expect(resolved_scope).to include(other_planned_disbursement)
+    end
+  end
+
+  context "when the user is a delivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+    let(:beis_user) { create(:beis_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: beis_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(delivery_partner_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: beis_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(delivery_partner_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_new_and_create_actions }
+      it { is_expected.to forbid_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: delivery_partner_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(delivery_partner_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a third party project" do
+      let(:activity) { create(:third_party_project_activity, organisation: delivery_partner_user.organisation) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+      subject { described_class.new(delivery_partner_user, planned_disbursement) }
+
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_new_and_create_actions }
+      it { is_expected.to permit_edit_and_update_actions }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    it "includes only planned_disbursements that belong to the user's organisation in resolved scope" do
+      activity = create(:activity, organisation: delivery_partner_user.organisation)
+      planned_disbursement = create(:planned_disbursement, parent_activity: activity)
+      other_planned_disbursement = create(:planned_disbursement, parent_activity: create(:activity))
+      resolved_scope = described_class::Scope.new(delivery_partner_user, PlannedDisbursement.all).resolve
+
+      expect(resolved_scope).to include(planned_disbursement)
+      expect(resolved_scope).to_not include(other_planned_disbursement)
+    end
+  end
+end

--- a/spec/presenters/planned_disbursement_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_presenter_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe PlannedDisbursementPresenter do
+  let(:planned_disbursement) { build_stubbed(:planned_disbursement) }
+
+  describe "#planned_disbursement_type" do
+    it "returns the I18n string for the b#planned_disbursement_type" do
+      expect(described_class.new(planned_disbursement).planned_disbursement_type).to eq("Original")
+    end
+  end
+
+  describe "#period_start_date" do
+    it "returns a human readable date" do
+      planned_disbursement.period_start_date = "2020-06-25"
+      expect(described_class.new(planned_disbursement).period_start_date).to eq("25 Jun 2020")
+    end
+  end
+
+  describe "#period_end_date" do
+    it "returns a human readable date" do
+      planned_disbursement.period_end_date = "2020-10-20"
+      expect(described_class.new(planned_disbursement).period_end_date).to eq("20 Oct 2020")
+    end
+  end
+
+  describe "#value" do
+    it "returns the value to two decimal places with a currency symbol" do
+      expect(described_class.new(planned_disbursement).value).to eq("£100,000.00")
+    end
+  end
+
+  describe "#currency" do
+    it "returns the I18n string for the currency" do
+      expect(described_class.new(planned_disbursement).currency).to eq("Pound Sterling")
+    end
+  end
+end

--- a/spec/services/create_planned_disbursement_spec.rb
+++ b/spec/services/create_planned_disbursement_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe CreatePlannedDisbursement do
+  let(:activity) { create(:activity) }
+
+  describe "#call" do
+    subject { described_class.new(activity: create(:activity)) }
+    it_behaves_like "sanitises monetary field"
+
+    context "when the planned disbursement is valid" do
+      it "sets the parent activity" do
+        result = described_class.new(activity: activity).call
+        expect(result.object.parent_activity).to eq(activity)
+      end
+
+      it "returns a successful result" do
+        allow_any_instance_of(PlannedDisbursement).to receive(:valid?).and_return(true)
+        allow_any_instance_of(PlannedDisbursement).to receive(:save).and_return(true)
+
+        result = described_class.new(activity: activity).call(attributes: {})
+
+        expect(result.success?).to be true
+      end
+    end
+
+    context "when the planned disbursement isn't valid" do
+      it "returns a failed result" do
+        allow_any_instance_of(PlannedDisbursement).to receive(:valid?).and_return(false)
+
+        result = described_class.new(activity: activity).call(attributes: {})
+
+        expect(result.success?).to be false
+      end
+    end
+
+    context "when known attributes are passed in" do
+      it "sets the attributes passed in as planned disbursement attributes" do
+        attributes = ActionController::Parameters.new(value: 10000.50).permit!
+
+        result = described_class.new(activity: activity).call(attributes: attributes)
+
+        expect(result.object.value).to eq(10000.50)
+      end
+    end
+
+    context "when unknown attributes are passed in" do
+      it "raises an error" do
+        attributes = ActionController::Parameters.new(foo: "bar").permit!
+
+        expect { described_class.new(activity: activity).call(attributes: attributes) }
+          .to raise_error(ActiveModel::UnknownAttributeError)
+      end
+    end
+  end
+end

--- a/spec/services/update_planned_disbursement_spec.rb
+++ b/spec/services/update_planned_disbursement_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec .describe UpdatePlannedDisbursement do
+  let(:planned_disbursement) { create(:planned_disbursement) }
+
+  describe "#call" do
+    it "sets the attributes of the planned disbursement" do
+      attributes = attributes_for(:planned_disbursement, receiving_organisation_name: "An Organisation")
+
+      result = described_class.new(planned_disbursement: planned_disbursement).call(attributes: attributes)
+
+      expect(result.object.receiving_organisation_name).to eq("An Organisation")
+    end
+
+    it "returns a Result with the success set to true" do
+      allow(planned_disbursement).to receive(:valid?).and_return(true)
+      allow(planned_disbursement).to receive(:save!).and_return(true)
+
+      result = described_class.new(planned_disbursement: planned_disbursement).call(attributes: {})
+
+      expect(result.success?).to be true
+    end
+
+    subject { described_class.new(planned_disbursement: planned_disbursement) }
+    it_behaves_like "sanitises monetary field"
+
+    context "when the planned disbursment is not valid" do
+      it "returns a Result with the success set to false" do
+        allow(planned_disbursement).to receive(:valid?).and_return(false)
+
+        result = described_class.new(planned_disbursement: planned_disbursement).call(attributes: {})
+
+        expect(result.success?).to be false
+      end
+    end
+  end
+end

--- a/spec/validators/end_date_not_before_start_date_validator_spec.rb
+++ b/spec/validators/end_date_not_before_start_date_validator_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe EndDateNotBeforeStartDateValidator do
+  subject { create(:planned_disbursement) }
+
+  context "when the start date is the same as the end date" do
+    it "is valid" do
+      subject.period_start_date = Date.today
+      subject.period_end_date = Date.today
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the start date is before the end date" do
+    it "is valid" do
+      subject.period_start_date = Date.yesterday
+      subject.period_end_date = Date.today
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the start date is after the end date" do
+    it "is not valid" do
+      subject.period_start_date = Date.tomorrow
+      subject.period_end_date = Date.today
+
+      expect(subject).not_to be_valid
+    end
+
+    it "adds an error message to the :period_start_date" do
+      subject.period_start_date = Date.tomorrow
+      subject.period_end_date = Date.today
+
+      subject.valid?
+      expect(subject.errors.messages[:period_end_date]).to include I18n.t("activerecord.errors.validators.end_date_not_before_start_date")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
This work adds planned disbursements to projects and third-party projects. Users can add, view and edit them.

See:

http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/planned-disbursement/

As there has been no content design on this section of the user jounrney we've used the IATI description in the interface and expect this to change.

We also used IATI as a guide to what fields are required, there has been some thoughts around the dates on a planned activity, but nothing that would change this work here at this stage.

We couldn't see a way to add the FK constraint at the same time as the table – are we missing something?

To keep this PR small, work will follow to ingest and xml planned disbursements.

## Screenshots of UI changes
![Screenshot_2020-05-18 Activity Airbus Flood and Drought — Report your official development assistance](https://user-images.githubusercontent.com/480578/82206394-0e77bf80-9900-11ea-8da9-c632ed069e1b.png)

![Screenshot_2020-05-18 Add a planned disbursement — Report your official development assistance](https://user-images.githubusercontent.com/480578/82206410-13d50a00-9900-11ea-9b22-7b063ce9336f.png)

![Screenshot_2020-05-18 Activity Airbus Flood and Drought — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/82206415-18012780-9900-11ea-9441-616245702a46.png)
