### PR TITLE
(fix) Planned disbursement budget type error message

### DIFF
--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -98,6 +98,8 @@ en:
               format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
         planned_disbursement:
           attributes:
+            planned_disbursement_type:
+              blank: Budget type can't be blank
             value:
               inclusion: Value must be between 0.01 and 99,999,999,999.00
         transaction:


### PR DESCRIPTION
## Changes in this PR
Something in the locales file is providing a set of keys as the value
for this error. By explicitly setting the value we avoid the issue.

## Screenshots of UI changes

### Before
![Screenshot_2020-05-19 Add a planned disbursement — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/82422000-cc728900-9a79-11ea-852c-796dd979b679.png)

### After
![Screenshot_2020-05-19 Add a planned disbursement — Report your official development assistance](https://user-images.githubusercontent.com/480578/82422078-e44a0d00-9a79-11ea-9909-11619092d841.png)


