### PR TITLE
(594) Additional planned disbursement features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 ## [unreleased]
 
 - If an activity has a recipient_country set, the recipient_region is inferred from the recipient_country
+- Planned disbursements are exported in the IATI XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 
 - If an activity has a recipient_country set, the recipient_region is inferred from the recipient_country
 - Planned disbursements are exported in the IATI XML
+- The new planned disbursement form pre-fills the providing organisation details
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -5,6 +5,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     @activity = Activity.find(params["activity_id"])
     @planned_disbursement = PlannedDisbursement.new
     @planned_disbursement.parent_activity = @activity
+    pre_fill_providing_organisation
 
     authorize @planned_disbursement
   end
@@ -63,5 +64,11 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
       :receiving_organisation_type,
       :receiving_organisation_reference
     )
+  end
+
+  def pre_fill_providing_organisation
+    @planned_disbursement.providing_organisation_name = @activity.providing_organisation.name
+    @planned_disbursement.providing_organisation_type = @activity.providing_organisation.organisation_type
+    @planned_disbursement.providing_organisation_reference = @activity.providing_organisation.iati_reference
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -109,4 +109,10 @@ class Activity < ApplicationRecord
     return [parent_activity.parent_activity.parent_activity, parent_activity.parent_activity, parent_activity] if third_party_project?
     []
   end
+
+  def providing_organisation
+    return nil if fund? || programme?
+    return Organisation.find_by(service_owner: true) if organisation.is_government? || project?
+    organisation
+  end
 end

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -13,4 +13,8 @@ class PlannedDisbursement < ApplicationRecord
     :receiving_organisation_type
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
   validates_with EndDateNotBeforeStartDateValidator, if: -> { period_start_date.present? && period_end_date.present? }
+
+  def unknown_receiving_organisation_type?
+    receiving_organisation_type == "0"
+  end
 end

--- a/app/presenters/planned_disbursement_xml_presenter.rb
+++ b/app/presenters/planned_disbursement_xml_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PlannedDisbursementXmlPresenter < SimpleDelegator
+  include ActionView::Helpers::NumberHelper
+
+  def period_start_date
+    return if super.blank?
+    I18n.l(super, format: :iati)
+  end
+
+  def period_end_date
+    return if super.blank?
+    I18n.l(super, format: :iati)
+  end
+
+  def value
+    number_to_currency(super, unit: "", delimiter: "")
+  end
+end

--- a/app/views/staff/activities/show.xml.haml
+++ b/app/views/staff/activities/show.xml.haml
@@ -1,4 +1,4 @@
 !!! XML
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
-  = render partial: "staff/shared/xml/activity", locals: { activity: @activity_xml_presenter, transactions: @transactions, budgets: @budgets }
+  = render partial: "staff/shared/xml/activity", locals: { activity: @activity_xml_presenter, transactions: @transactions, budgets: @budgets, planned_disbursements: @planned_disbursements }

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -42,6 +42,9 @@
   - if budgets
     - budgets.each do |budget|
       = render partial: "staff/shared/xml/budget", locals: { budget: BudgetXmlPresenter.new(budget) }
+  -if planned_disbursements
+    - planned_disbursements.each do |planned_disbursement|
+      = render partial: "staff/shared/xml/planned_disbursement", locals: { planned_disbursement: PlannedDisbursementXmlPresenter.new(planned_disbursement) }
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/app/views/staff/shared/xml/_planned_disbursement.xml.haml
+++ b/app/views/staff/shared/xml/_planned_disbursement.xml.haml
@@ -1,0 +1,9 @@
+%planned-disbursement{"type" => planned_disbursement.planned_disbursement_type}
+  %period-start{"iso-date" => planned_disbursement.period_start_date}
+  - if planned_disbursement.period_end_date.present?
+    %period-end{"iso-date" => planned_disbursement.period_end_date}
+  %value{"currency" => planned_disbursement.currency, "value-date" => planned_disbursement.period_start_date}= planned_disbursement.value
+  %provider-org{"provider-activity-id" => "", "type" => planned_disbursement.providing_organisation_type, "ref" => planned_disbursement.providing_organisation_reference}
+    %narrative=planned_disbursement.providing_organisation_name
+  %receiver-org{"receiver-activity-id" => "", "type" => planned_disbursement.receiving_organisation_type, "ref" => planned_disbursement.receiving_organisation_reference}
+    %narrative=planned_disbursement.receiving_organisation_name

--- a/app/views/staff/shared/xml/_planned_disbursement.xml.haml
+++ b/app/views/staff/shared/xml/_planned_disbursement.xml.haml
@@ -5,5 +5,8 @@
   %value{"currency" => planned_disbursement.currency, "value-date" => planned_disbursement.period_start_date}= planned_disbursement.value
   %provider-org{"provider-activity-id" => "", "type" => planned_disbursement.providing_organisation_type, "ref" => planned_disbursement.providing_organisation_reference}
     %narrative=planned_disbursement.providing_organisation_name
-  %receiver-org{"receiver-activity-id" => "", "type" => planned_disbursement.receiving_organisation_type, "ref" => planned_disbursement.receiving_organisation_reference}
-    %narrative=planned_disbursement.receiving_organisation_name
+  - if planned_disbursement.unknown_receiving_organisation_type?
+    %receiver-org
+  - else
+    %receiver-org{"receiver-activity-id" => "", "type" => planned_disbursement.receiving_organisation_type, "ref" => planned_disbursement.receiving_organisation_reference}
+      %narrative=planned_disbursement.receiving_organisation_name

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -33,6 +33,76 @@ RSpec.describe "Users can create a planned disbursement" do
       expect(page).to have_current_path organisation_activity_path(user.organisation, project)
       expect(page).to have_content I18n.t("form.planned_disbursement.create.success")
     end
+
+    context "when the delivery partner is a government organisation" do
+      context "and the activity is a project" do
+        it "pre fills the providing organisation details with those of BEIS" do
+          beis = create(:beis_organisation)
+          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
+          user.update(organisation: government_devlivery_partner)
+          project = create(:project_activity, organisation: user.organisation)
+
+          visit organisation_path(user.organisation)
+          click_on project.title
+          click_on I18n.t("page_content.planned_disbursements.button.create")
+
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(I18n.t("form.planned_disbursement.providing_organisation_reference.label"), with: beis.iati_reference)
+        end
+      end
+
+      context "and the activity is a third-party project" do
+        it "pre fills the providing organisation details with those of BEIS" do
+          beis = create(:beis_organisation)
+          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
+          user.update(organisation: government_devlivery_partner)
+          project = create(:third_party_project_activity, organisation: user.organisation)
+
+          visit organisation_path(user.organisation)
+          click_on project.title
+          click_on I18n.t("page_content.planned_disbursements.button.create")
+
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(I18n.t("form.planned_disbursement.providing_organisation_reference.label"), with: beis.iati_reference)
+        end
+      end
+    end
+
+    context "when the delivery partner is a non-government organisation" do
+      context "and the activity is a project" do
+        it "pre fills the providing organisation details with those of BEIS" do
+          beis = create(:beis_organisation)
+          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
+          user.update(organisation: government_devlivery_partner)
+          project = create(:project_activity, organisation: user.organisation)
+
+          visit organisation_path(user.organisation)
+          click_on project.title
+          click_on I18n.t("page_content.planned_disbursements.button.create")
+
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(I18n.t("form.planned_disbursement.providing_organisation_reference.label"), with: beis.iati_reference)
+        end
+      end
+      context "and the activity is a third-party project" do
+        it "pre fills the providing organisation detauls with those of the delivery partner" do
+          non_government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "22")
+          user.update(organisation: non_government_devlivery_partner)
+          project = create(:third_party_project_activity, organisation: user.organisation)
+
+          visit organisation_path(user.organisation)
+          click_on project.title
+          click_on I18n.t("page_content.planned_disbursements.button.create")
+
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_name"), with: non_government_devlivery_partner.name)
+          expect(page).to have_field(I18n.t("activerecord.attributes.planned_disbursement.providing_organisation_type"), with: non_government_devlivery_partner.organisation_type)
+          expect(page).to have_field(I18n.t("form.planned_disbursement.providing_organisation_reference.label"), with: non_government_devlivery_partner.iati_reference)
+        end
+      end
+    end
   end
 
   context "when signed in as a beis user" do

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -217,6 +217,18 @@ RSpec.feature "Users can view an activity as XML" do
           expect(xml.xpath("//iati-activity/planned-disbursement/period-start/@iso-date").text).to eq planned_disbursement_presenter.period_start_date
           expect(xml.xpath("//iati-activity/planned-disbursement/period-end/@iso-date").text).to eq planned_disbursement_presenter.period_end_date
         end
+
+        context "when the planned disbursment receiving organisation type is 0" do
+          it "does not output attributes on the receiving organisation element" do
+            _planned_disbursement = create(:planned_disbursement, parent_activity: activity, receiving_organisation_type: "0")
+
+            visit organisation_activity_path(organisation, activity, format: :xml)
+
+            expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@type")).to be_empty
+            expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@ref")).to be_empty
+            expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@receiver-activity-id")).to be_empty
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/activities/uksa/fake_with_complete_planned_disbursement.xml
+++ b/spec/fixtures/activities/uksa/fake_with_complete_planned_disbursement.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iati-activities generated-datetime="2019-09-25T22:01:44.470000+00:00" version="2.03">
+
+  <iati-activity default-currency="GBP" hierarchy="2" last-updated-datetime="2019-09-25T22:01:44.470000+00:00">
+    <iati-identifier>GB-GOV-13-GCRF-UKSA_NS_UKSA-029</iati-identifier>
+    <reporting-org ref="GB-GOV-13" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </reporting-org>
+    <title>
+      <narrative>02 Airbus Flood and Drought Resilience - Call 1</narrative>
+    </title>
+    <description type="1">
+      <narrative>Both Ethiopia and Kenya are flood and drought prone with significant mortality and economic losses attributed to these events in each country. This project focuses on building resilience to these events
+to both lessen risk and support economic resilience.In Ethiopia it will focus on building an improved understanding of flood and drought hazards and risks to help build social and economic resilience to water-related hazards. In Kenya it will focus on the effectiveness of EO data for the micro-insurance market and Government Institutions; an important tool for farmers who currently have little or no access to insurance. This will be supported by the development of a flexible dashboard with tailored information to assist decision making related to flood and drought at the following geographical levels:
+•
+Ethiopia: at basin level (working with the Ministry of Finance and Economic Cooperation).
+•
+Kenya: at local level (working with women farmer intermediaries and micro-insurance actors) and
+at county and sub-county level (working with
+the National Drought Management Authority).</narrative>
+    </description>
+    <description type="2">
+      <narrative>Earth Observation-enabled decision support for flood and drought resilience in Ethipoia and Kenya </narrative>
+    </description>
+    <participating-org ref="GB-GOV-13" role="1" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org ref="GB-GOV-13" role="2" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org role="3" type="10">
+      <narrative>UK Space Agency</narrative>
+    </participating-org>
+    <participating-org role="4" type="70">
+      <narrative>Airbus Defence and Space</narrative>
+    </participating-org>
+    <activity-status code="2"/>
+    <activity-date iso-date="2016-11-01" type="1"/>
+    <activity-date iso-date="2016-11-01" type="2"/>
+    <activity-date iso-date="2019-10-31" type="3"/>
+    <contact-info type="1">
+      <organisation>
+        <narrative>UK Space Agency</narrative>
+      </organisation>
+      <department>
+        <narrative>UK Space Agency</narrative>
+      </department>
+      <person-name>
+        <narrative>International Partnership Programme</narrative>
+      </person-name>
+      <email>ipp@ukspaceagency.bis.gsi.uk</email>
+      <website>https://www.gov.uk/government/organisations/uk-space-agency</website>
+      <mailing-address>
+        <narrative>UKSA, Polaris House, North Star Avenue, Swindon, Wiltshire SN2 1SZ</narrative>
+      </mailing-address>
+    </contact-info>
+    <recipient-region code="998" percentage="100" vocabulary="1"/>
+    <sector code="74010">
+      <narrative>Disaster prevention and preparedness</narrative>
+    </sector>
+    <collaboration-type code="1"/>
+    <default-flow-type code="10"/>
+    <default-finance-type code="110"/>
+    <default-aid-type code="C01"/>
+    <default-tied-status code="5"/>
+    <budget status="2" type="1">
+      <period-start iso-date="2016-11-01"/>
+      <period-end iso-date="2019-10-31"/>
+      <value currency="GBP" value-date="2016-12-01">1868000</value>
+    </budget>
+    <planned-disbursement type="1">
+      <period-start iso-date="2019-07-01"/>
+      <period-end iso-date="2020-04-30"/>
+      <value currency="GBP" value-date="2016-12-22">983052</value>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13" type="15">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org ref="GB-COH-" type="21">
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </planned-disbursement>
+    <capital-spend percentage="0"/>
+    <transaction>
+      <transaction-type code="2"/>
+      <transaction-date iso-date="2016-11-01"/>
+      <value currency="GBP" value-date="2016-11-01">1868000</value>
+      <description>
+        <narrative>02 Airbus Flood and Drought Resilience - Call 1</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>UK Space Agency</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2016-12-22"/>
+      <value currency="GBP" value-date="2016-12-22">70118</value>
+      <description>
+        <narrative>Project start and archive data purchase</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-03-28"/>
+      <value currency="GBP" value-date="2017-03-28">55059.21</value>
+      <description>
+        <narrative>Requirements stage (interim)</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-03-28"/>
+      <value currency="GBP" value-date="2017-03-28">22313</value>
+      <description>
+        <narrative>Method inception report</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-10-26"/>
+      <value currency="GBP" value-date="2017-10-26">297341.86</value>
+      <description>
+        <narrative>Completion of user requirements</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-12-19"/>
+      <value currency="GBP" value-date="2017-12-19">216229.99</value>
+      <description>
+        <narrative>Design</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2018-03-29"/>
+      <value currency="GBP" value-date="2018-03-29">424166.87</value>
+      <description>
+        <narrative>Development</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2018-12-12"/>
+      <value currency="GBP" value-date="2018-12-12">76952.3</value>
+      <description>
+        <narrative>Development</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <document-link format="text/html" url="https://science-and-innovation-network.s3.eu-west-2.amazonaws.com/BEIS+R%26I+ODA+conditions+for+grants+and+contracts.docx">
+      <title>
+        <narrative>R&amp;I ODA Conditions for Grants and Contracts</narrative>
+      </title>
+      <category code="A04"/>
+    </document-link>
+    <document-link format="application/xhtml+xml" url="https://www.gov.uk/government/case-studies/airbus-africa-flood-draught-resilience">
+      <title>
+        <narrative>Airbus (Africa) Flood and Drought resilience</narrative>
+      </title>
+      <category code="A12"/>
+      <language code="en"/>
+      <document-date iso-date="2017-01-26"/>
+    </document-link>
+    <related-activity ref="GB-GOV-13-GCRF-UKSA" type="1"/>
+    <conditions attached="1"/>
+  </iati-activity>
+</iati-activities>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -365,4 +365,59 @@ RSpec.describe Activity, type: :model do
       expect(activity.has_implementing_organisations?).to be true
     end
   end
+
+  describe "#providing_organisation" do
+    context "when the activity is a fund or a programme" do
+      it "returns nil" do
+        fund = build(:fund_activity)
+        expect(fund.providing_organisation).to be_nil
+
+        programme = build(:programme_activity)
+        expect(programme.providing_organisation).to be_nil
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when the activity organisation is a government type" do
+        it "returns BEIS" do
+          beis = create(:beis_organisation)
+          government_delivery_partner = build(:delivery_partner_organisation, organisation_type: "10")
+
+          project = build(:project_activity, organisation: government_delivery_partner)
+          expect(project.providing_organisation).to eql beis
+        end
+      end
+
+      context "when the activity organisation is a non-government type" do
+        it "returns BEIS" do
+          beis = create(:beis_organisation)
+          non_government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "22")
+
+          project = build(:project_activity, organisation: non_government_delivery_partner)
+          expect(project.providing_organisation).to eql beis
+        end
+      end
+    end
+
+    context "when the activity is a third-party project" do
+      context "when the activity organisation is a government type" do
+        it "returns BEIS" do
+          beis = create(:beis_organisation)
+          government_delivery_partner = build(:delivery_partner_organisation, organisation_type: "10")
+
+          project = build(:project_activity, organisation: government_delivery_partner)
+          expect(project.providing_organisation).to eql beis
+        end
+      end
+
+      context "when the activity organisation is a non-government type" do
+        it "returns the activity organisation i.e the delivery partner" do
+          non_government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "22")
+
+          third_party_project = build(:third_party_project_activity, organisation: non_government_delivery_partner)
+          expect(third_party_project.providing_organisation).to eql non_government_delivery_partner
+        end
+      end
+    end
+  end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe PlannedDisbursement, type: :model do
     it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:value) }
   end
+
+  describe "#unknown_receiving_organisation_type?" do
+    it "returns true when receiving organisation type is 0" do
+      planned_disbursement = create(:planned_disbursement, receiving_organisation_type: "0")
+      expect(planned_disbursement.unknown_receiving_organisation_type?).to be true
+
+      planned_disbursement.update(receiving_organisation_type: "10")
+      expect(planned_disbursement.unknown_receiving_organisation_type?).to be false
+    end
+  end
 end

--- a/spec/presenters/planned_disbursement_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PlannedDisbursementPresenter do
   let(:planned_disbursement) { build_stubbed(:planned_disbursement) }
 
   describe "#planned_disbursement_type" do
-    it "returns the I18n string for the b#planned_disbursement_type" do
+    it "returns the I18n string for the planned_disbursement_type" do
       expect(described_class.new(planned_disbursement).planned_disbursement_type).to eq("Original")
     end
   end

--- a/spec/presenters/planned_disbursement_xml_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_xml_presenter_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe PlannedDisbursementXmlPresenter do
+  let(:planned_disbursement) { build_stubbed(:planned_disbursement) }
+
+  describe "#period_start_date" do
+    it "returns a date formatted for IATI XML" do
+      planned_disbursement.period_start_date = "25 June 2020"
+      expect(described_class.new(planned_disbursement).period_start_date).to eq("2020-06-25")
+    end
+  end
+
+  describe "#period_end_date" do
+    it "returns a human readable date" do
+      planned_disbursement.period_end_date = "October 20, 2020"
+      expect(described_class.new(planned_disbursement).period_end_date).to eq("2020-10-20")
+    end
+  end
+
+  describe "#value" do
+    it "returns the value to two decimal places formatted for IATI XML" do
+      expect(described_class.new(planned_disbursement).value).to eq("100000.00")
+    end
+  end
+end

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -82,4 +82,28 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/budget/period-start/@iso-date").text).to eq(budget.period_start_date.strftime("%Y-%m-%d"))
     expect(xml.at("iati-activity/budget/period-end/@iso-date").text).to eq(budget.period_end_date.strftime("%Y-%m-%d"))
   end
+
+  it "contains the planned disbursement XML" do
+    planned_disbursement = create(:planned_disbursement, parent_activity: activity)
+    planned_disbursement_presenter = PlannedDisbursementXmlPresenter.new(planned_disbursement)
+
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    expect(xml.xpath("//iati-activity/planned-disbursement/@type").text).to eq planned_disbursement_presenter.planned_disbursement_type
+    expect(xml.xpath("//iati-activity/planned-disbursement/period-start/@iso-date").text).to eq planned_disbursement_presenter.period_start_date
+
+    expect(xml.xpath("//iati-activity/planned-disbursement/value").text).to eq planned_disbursement_presenter.value
+    expect(xml.xpath("//iati-activity/planned-disbursement/value/@currency").text).to eq planned_disbursement_presenter.currency
+    expect(xml.xpath("//iati-activity/planned-disbursement/value/@value-date").text).to eq planned_disbursement_presenter.period_start_date
+
+    expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/@type").text).to eq planned_disbursement_presenter.providing_organisation_type
+    expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/@provider-activity-id").text).to eq ""
+    expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/@ref").text).to eq planned_disbursement_presenter.providing_organisation_reference
+    expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/narrative").text).to eq planned_disbursement_presenter.providing_organisation_name
+
+    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@type").text).to eq planned_disbursement_presenter.receiving_organisation_type
+    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@provider-activity-id").text).to eq ""
+    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@ref").text).to eq planned_disbursement_presenter.receiving_organisation_reference
+    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/narrative").text).to eq planned_disbursement_presenter.receiving_organisation_name
+  end
 end


### PR DESCRIPTION
## Changes in this PR
This work introduces the addiitonal features to Planned disbursments.

## Export to XML
Valid IATI XML is produced that includes planned disbursements.

https://test-validator.iatistandard.org/view/dqf/files/292a5e17-6e8d-4bb7-86af-7d0464954145?isTestfiles=true

## Ingest
Although the ingest work is not yet finalised it was a good oportunity for me to look at the ingest code. There is a great deal of complexity around ingested legacy data that is not well-formed in RODA's world so this is just the basics in-line with the rest of the ingest code.

When we ingest and there is no IATI reference for the receiving organisation, we don't export the XML attributes, this keeps the IATI XML valid.

## Pre-filll providing organisation details on new form
This was picked up in user research so I stretched to complete this.  The providing organisation can be derived from the Activity organisation type and level:

when the acitivty is a project (level C)
and the organisation is government type
the providing organisation is BEIS

when the acitivty is a third-party project (level D)
and the organisation is government type
the providing organisation is BEIS

when the activity is a project (level C)
and the organisation is non-government type
the providing organisation is the BEIS

when the acitivty is a third-party project (level D)
and the organisation is non-government type
the providing organisationis the delivery partner

See discussion here:

https://dxw.slack.com/archives/CN0H2L066/p1589901111126800

I decided to keep the UI rather than just set the attributes, this allows users to change the values when circustances arise that we didn't anticiapate.

We may want to update the content on the form to reflect this, but we should also look at the existing planned disbursement content as a whole anyway and this can be factored in there.

## Screenshots of UI changes

![Screenshot_2020-05-20 Add a planned disbursement — Report your official development assistance](https://user-images.githubusercontent.com/480578/82444258-dc4e9500-9a9a-11ea-8b1a-34533b5d9e17.png)

![Screenshot_2020-05-20 Add a planned disbursement — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/82444392-10c25100-9a9b-11ea-855e-450a9d5bd3e1.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)

