### PR TITLE
Switch our version of the form builder gem to the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 - Ingest tool will try to set more meaningful identifiers for projects
 - The providing organisation is pre-filled in for new transactions
 - No longer lint the automatic schema changes made by the data_migrate gem
+- Switched to the latest form builder gem version from our fork
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "2.6.3"
 gem "auth0", "~> 4.11"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "data_migrate"
-gem "govuk_design_system_formbuilder", github: "dxw/govuk_design_system_formbuilder", branch: "i18n"
+gem "govuk_design_system_formbuilder", "~> 1.1.10"
 gem "haml-rails"
 gem "high_voltage"
 gem "ipaddr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/dxw/govuk_design_system_formbuilder.git
-  revision: ecbfc40682d469f9dcbf7ab7bd59e063fadad4ba
-  branch: i18n
-  specs:
-    govuk_design_system_formbuilder (0.9.8)
-      actionview (>= 5.2)
-      activemodel (>= 5.2)
-      activesupport (>= 5.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -132,6 +122,10 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk_design_system_formbuilder (1.1.10)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -438,7 +432,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  govuk_design_system_formbuilder!
+  govuk_design_system_formbuilder (~> 1.1.10)
   haml-rails
   high_voltage
   html2haml

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :aid_type
-  = f.govuk_collection_radio_buttons :aid_type, yaml_to_objects_with_description(entity: "activity", type: "aid_type"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.aid_type") }, hint_text: I18n.t("helpers.hint.activity.aid_type.html").html_safe?
+  = f.govuk_collection_radio_buttons :aid_type, yaml_to_objects_with_description(entity: "activity", type: "aid_type"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("activerecord.attributes.activity.aid_type") }, hint_text: I18n.t("helpers.hint.activity.aid_type_html").html_safe

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code },  label: { tag: 'h1', size: 'xl' }
+  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl' }, hint_text: I18n.t("helpers.hint.activity.flow_html").html_safe

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -4,28 +4,13 @@ Rails.application.config.action_view.default_form_builder = GOVUKDesignSystemFor
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Use activerecord.attributes.model.attribute_name for label scope
+
 module GOVUKDesignSystemFormBuilder
+  GOVUKDesignSystemFormBuilder.configure do |conf|
+    conf.localisation_schema_label = %i[activerecord attributes]
+    conf.localisation_schema_legend = %i[helpers fieldset]
+  end
   class Base
-    private def localised_text(context)
-      key = localisation_key(context)
-
-      return nil unless I18n.exists?(key)
-
-      translation = I18n.translate(key)
-      translation = translation.fetch(:html).html_safe if translation.is_a?(Hash) && translation.key?(:html)
-      translation
-    end
-
-    private def localisation_key(context)
-      return nil unless @object_name.present? && @attribute_name.present?
-
-      if context == "label"
-        ["activerecord", "attributes", @object_name, @attribute_name].join(".")
-      else
-        ["helpers", context, @object_name, @attribute_name].join(".")
-      end
-    end
-
     def has_errors?
       @builder.object.errors.any? &&
         @builder.object.errors.messages.dig(

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -129,10 +129,8 @@ en:
       activity:
         actual_end_date: For example, 2 2 2020
         actual_start_date: For example, 11 1 2020
-        aid_type:
-          html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions can be found here (Opens in new window)</a>
-        flow:
-          html: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions</a> of each flow type (opens in new window)
+        aid_type_html: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions can be found here (Opens in new window)</a>
+        flow_html: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions</a> of each flow type (opens in new window)
         identifier: This could be the reference you use in your internal systems
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -5,7 +5,7 @@ The GOVUKDesignSystemFormBuilder will by default use the following keys within
 
 - `activerecord.attributes.model_name.attribute_name` - form element labels
 - `helpers.hint.model_name.attribute_name` - form element hints
-- `helpers.legend.model_name.attribute_name` - form element legends
+- `helpers.fieldset.model_name.attribute_name` - form element legends
 
 The standard validation error messages are defined in
 `generic_validation_errors.en.yml`, with the overrides in the


### PR DESCRIPTION
## Changes in this PR

- During a separate piece of work we have been trying to take advantage
of a new feature of this gem.
- Since we were using a dxw fork, we were unable to do this, so had to
either switch away from it or update our fork. Given that it looked like
the gem was now providing the feature that caused us to originally fork,
we think that it is safe to switch back.
- On updating the gem we found that there were able to remove the monkey
patching for Internationalisation and replace it with gem configuration
https://govuk-form-builder.netlify.app/building-blocks/localisation/#customising-locale-structure
- We found that we needed to continue to provide an override so that we
could continue to use a single set of local values rather than have it
duplicated. This is consist with the initial approach our application
was using.
- Whilst by default the gem looks for locale values under helpers.legend
we were already using helpers.fieldset, so we made another configuration
change to allow us to continue to use helpers.fieldset
- We have changed html_safe? to html_safe without a question mark after
a test failure made us aware of the fact that this hint text was never
being used. Since the update to the gem we found that we do need to have
this line for the hint text appear.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
