### PR TITLE
(665) Ingesting updates existing projects before creating new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 - The new planned disbursement form pre-fills the providing organisation details
 - Add cookie policy
 - Planned disbursement dates are validated within boundaries
+- Ingest tool creates or updates existing projects if they match on the IATI identifier
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -19,6 +19,8 @@ class IngestIatiActivities
       legacy_activity = LegacyActivity.new(activity_node_set: legacy_activity_node, delivery_partner: delivery_partner)
       existing_activity = Activity.find_by(previous_identifier: legacy_activity.identifier)
 
+      next if existing_activity&.ingested?
+
       ActiveRecord::Base.transaction do
         roda_activity = if existing_activity.present?
           existing_activity

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -26,18 +26,12 @@ class IngestIatiActivities
 
         add_participating_organisation(delivery_partner: delivery_partner, new_activity: new_activity, legacy_activity: legacy_activity)
 
-        title = legacy_activity.elements[2].children.detect { |child| child.name.eql?("narrative") }.children.text if legacy_activity.elements[2].name.eql?("title")
-        new_activity.title = normalize_string(title)
-        description = legacy_activity.elements[3].children.detect { |child| child.name.eql?("narrative") }.children.text if legacy_activity.elements[3].name.eql?("description")
-        new_activity.description = normalize_string(description)
-        new_activity.status = legacy_activity.elements.detect { |element| element.name.eql?("activity-status") }.attributes["code"].value
-
-        sector = legacy_activity.elements.detect { |element| element.name.eql?("sector") }.attributes["code"].value
-        new_activity.sector_category = sector_category_code(sector_code: sector)
-        new_activity.sector = sector
-        new_activity.flow = legacy_activity.elements.detect { |element| element.name.eql?("default-flow-type") }.attributes["code"].value
-        new_activity.aid_type = legacy_activity.elements.detect { |element| element.name.eql?("default-aid-type") }.attributes["code"].value
-
+        add_title(legacy_activity: legacy_activity, new_activity: new_activity)
+        add_description(legacy_activity: legacy_activity, new_activity: new_activity)
+        add_status(legacy_activity: legacy_activity, new_activity: new_activity)
+        add_sector(legacy_activity: legacy_activity, new_activity: new_activity)
+        add_flow(legacy_activity: legacy_activity, new_activity: new_activity)
+        add_aid_type(legacy_activity: legacy_activity, new_activity: new_activity)
         add_dates(legacy_activity: legacy_activity, new_activity: new_activity)
         add_geography(legacy_activity: legacy_activity, new_activity: new_activity)
         add_transactions(legacy_activity: legacy_activity, new_activity: new_activity)
@@ -52,6 +46,34 @@ class IngestIatiActivities
         new_activity.save
       end
     end
+  end
+
+  private def add_title(legacy_activity:, new_activity:)
+    title = legacy_activity.elements[2].children.detect { |child| child.name.eql?("narrative") }.children.text if legacy_activity.elements[2].name.eql?("title")
+    new_activity.title = normalize_string(title)
+  end
+
+  private def add_description(legacy_activity:, new_activity:)
+    description = legacy_activity.elements[3].children.detect { |child| child.name.eql?("narrative") }.children.text if legacy_activity.elements[3].name.eql?("description")
+    new_activity.description = normalize_string(description)
+  end
+
+  private def add_status(legacy_activity:, new_activity:)
+    new_activity.status = legacy_activity.elements.detect { |element| element.name.eql?("activity-status") }.attributes["code"].value
+  end
+
+  private def add_sector(legacy_activity:, new_activity:)
+    sector = legacy_activity.elements.detect { |element| element.name.eql?("sector") }.attributes["code"].value
+    new_activity.sector_category = sector_category_code(sector_code: sector)
+    new_activity.sector = sector
+  end
+
+  private def add_flow(legacy_activity:, new_activity:)
+    new_activity.flow = legacy_activity.elements.detect { |element| element.name.eql?("default-flow-type") }.attributes["code"].value
+  end
+
+  private def add_aid_type(legacy_activity:, new_activity:)
+    new_activity.aid_type = legacy_activity.elements.detect { |element| element.name.eql?("default-aid-type") }.attributes["code"].value
   end
 
   private def add_participating_organisation(delivery_partner:, new_activity:, legacy_activity:)

--- a/db/data/20200521165254_add_iati_ids_to_existing_uksa_data.rb
+++ b/db/data/20200521165254_add_iati_ids_to_existing_uksa_data.rb
@@ -1,0 +1,71 @@
+class AddIatiIdsToExistingUksaData < ActiveRecord::Migration[6.0]
+  def up
+    lookup_hash = {
+      "UKSA_C2_07ab" => "GB-GOV-13-GCRF-UKSA_CO_UKSA-34",
+      "UKSA_C2_07a" => "GB-GOV-13-GCRF-UKSA_CO_UKSA-34",
+      "UKSA_C1_01" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-029",
+      "UKSA_C1_02" => "GB-GOV-13-GCRF-UKSA_SN_UKSA-030",
+      "UKSA_C2_03" => "GB-GOV-13-GCRF-UKSA_KE_UKSA-04",
+      "UKSA_C2_04" => "GB-GOV-13-GCRF-UKSA_TZ_NP_UKSA-07",
+      "UKSA_C1_03" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-031",
+      "UKSA_C2_09" => "GB-GOV-13-GCRF-UKSA_ID-MY_UKSA-08",
+      "UKSA_C1_05" => "GB-GOV-13-GCRF-UKSA_ZA_UKSA-034",
+      "UKSA_C2_06" => "GB-GOV-13-GCRF-UKSA_KE-RW_UKSA-13",
+      "UKSA_C1_06" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-035",
+      "UKSA_C1_07" => "GB-GOV-13-GCRF-UKSA_PE_UKSA-036",
+      "UKSA_C2_01" => "GB-GOV-13-GCRF-UKSA_MN_UKSA-16",
+      "UKSA_C1_08" => "GB-GOV-13-GCRF-UKSA_ZA_UKSA-037",
+      "UKSA_C2_08" => "GB-GOV-13-GCRF-UKSA_PE_UKSA-22",
+      "UKSA_C2_02a" => "GB-GOV-13-GCRF-UKSA_VN_UKSA-21",
+      "UKSA_C1_10" => "GB-GOV-13-GCRF-UKSA_NG_UKSA-039",
+      "UKSA_C1_11" => "GB-GOV-13-GCRF-UKSA_PH_UKSA-040",
+      "UKSA_C1_09" => "GB-GOV-13-GCRF-UKSA_ID_UKSA-038",
+      "UKSA_C1_17" => "GB-GOV-13-GCRF-UKSA_MU_UKSA-46",
+      "UKSA_C1_12" => "GB-GOV-13-GCRF-UKSA_MX_UKSA-041",
+      "UKSA_C1_13" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-042",
+      "UKSA_C1_04" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-032",
+      "UKSA_C1_14" => "GB-GOV-13-GCRF-UKSA_NS_UKSA-043",
+      "UKSA_C2_10a" => "GB-GOV-13-GCRF-UKSA_FJ_SB_VU_UKSA-43",
+      "UKSA_C1_18" => "GB-GOV-13-GCRF-UKSA_CI_UKSA-047",
+    }
+    lookup_hash.each_pair do |roda_id, iati_id|
+      project = Activity.find_by(identifier: roda_id)
+      next unless project.present?
+
+      project.update(previous_identifier: iati_id)
+    end
+  end
+
+  def down
+    updated_activity_ids = [
+      "GB-GOV-13-GCRF-UKSA_CO_UKSA-34",
+      "GB-GOV-13-GCRF-UKSA_CO_UKSA-34",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-029",
+      "GB-GOV-13-GCRF-UKSA_SN_UKSA-030",
+      "GB-GOV-13-GCRF-UKSA_KE_UKSA-04",
+      "GB-GOV-13-GCRF-UKSA_TZ_NP_UKSA-07",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-031",
+      "GB-GOV-13-GCRF-UKSA_ID-MY_UKSA-08",
+      "GB-GOV-13-GCRF-UKSA_ZA_UKSA-034",
+      "GB-GOV-13-GCRF-UKSA_KE-RW_UKSA-13",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-035",
+      "GB-GOV-13-GCRF-UKSA_PE_UKSA-036",
+      "GB-GOV-13-GCRF-UKSA_MN_UKSA-16",
+      "GB-GOV-13-GCRF-UKSA_ZA_UKSA-037",
+      "GB-GOV-13-GCRF-UKSA_PE_UKSA-22",
+      "GB-GOV-13-GCRF-UKSA_VN_UKSA-21",
+      "GB-GOV-13-GCRF-UKSA_NG_UKSA-039",
+      "GB-GOV-13-GCRF-UKSA_PH_UKSA-040",
+      "GB-GOV-13-GCRF-UKSA_ID_UKSA-038",
+      "GB-GOV-13-GCRF-UKSA_MU_UKSA-46",
+      "GB-GOV-13-GCRF-UKSA_MX_UKSA-041",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-042",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-032",
+      "GB-GOV-13-GCRF-UKSA_NS_UKSA-043",
+      "GB-GOV-13-GCRF-UKSA_FJ_SB_VU_UKSA-43",
+      "GB-GOV-13-GCRF-UKSA_CI_UKSA-047",
+    ]
+    updated_activities = Activity.where(updated_activity_ids)
+    updated_activities.update(previous_identifier: nil)
+  end
+end

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -310,5 +310,24 @@ RSpec.describe IngestIatiActivities do
         end
       end
     end
+
+    context "when an activity has already been ingested" do
+      it "skip it making no changes to the database" do
+        uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        _existing_project = create(:project_activity,
+          previous_identifier: "GB-GOV-13-GCRF-UKSA_TZ_UKSA-021",
+          organisation: uksa,
+          ingested: true)
+
+        legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_transactions.xml")
+
+        described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
+
+        expect_any_instance_of(Activity).not_to receive(:save!)
+        expect_any_instance_of(Transaction).not_to receive(:save!)
+        expect_any_instance_of(Budget).not_to receive(:save!)
+        expect_any_instance_of(PlannedDisbursement).not_to receive(:save!)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

- Update existing UKSA production data with the associated IATI identifiers to provide a reliable way to update existing records
- Never ingest the same activity twice to avoid double entry
- If the ingest finds an existing activity that matches the IATI activity, it will do a smaller set of actions. Namely creating transactions, budgets and planned descriptions, as well as saving the XML onto the record for future updates
- if the ingest cannot find a matching record (as is the case for 11 activities) then it will seek to create new records

## Screenshots of UI changes

### Before

### After

![Screenshot 2020-05-21 at 17 59 10](https://user-images.githubusercontent.com/912473/82585002-3596f100-9b8d-11ea-9169-09b184423787.png)

![Screenshot 2020-05-22 at 10 47 40](https://user-images.githubusercontent.com/912473/82655250-cf0be480-9c19-11ea-9ccb-83e902a5d2e0.png)
![Screenshot 2020-05-22 at 10 47 47](https://user-images.githubusercontent.com/912473/82655254-d03d1180-9c19-11ea-97aa-025ab2ae5745.png)



![Screenshot 2020-05-21 at 18 01 00](https://user-images.githubusercontent.com/912473/82585005-37f94b00-9b8d-11ea-8efb-6302f1727599.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
