### PR TITLE
Omniauth failures don't log to stdout in test

### DIFF
--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -5,6 +5,8 @@ OmniAuth.config.on_failure = proc { |env|
 }
 
 RSpec.configure do |config|
+  OmniAuth.config.logger = Logger.new("/dev/null")
+
   # Teardown mocked SSO
   config.after(:each) do |_example|
     OmniAuth.config.mock_auth[:auth0] = nil


### PR DESCRIPTION
## Changes in this PR

* This problem is especially noticeable when the local rspec output is configured to output in dots rather than cascading vertically with the verbose descriptions
* I could have added this logging config to each test that was causing a failure however I couldn't think of a case when any omniauth output to the logs would be valuable when running the test suite. I've turned it off across the test suite to solve the immediate issue and prevent it popping up again in future in any new tests

The 2 tests that cause these messages are: 

- features/staff/users_can_sign_in_spec:90
- features/staff/users_can_sign_in_spec:109

## Screenshots of UI changes

### Before

![Screenshot 2020-05-22 at 11 10 59](https://user-images.githubusercontent.com/912473/82657531-6888c580-9c1d-11ea-8b58-1ad5f59d7888.png)

### After

![Screenshot 2020-05-22 at 11 11 19](https://user-images.githubusercontent.com/912473/82657521-645ca800-9c1d-11ea-8608-2048b96d03f3.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
