### PR TITLE
(fix) Validate boundaries of planned_disbursement dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@
 - Planned disbursements are exported in the IATI XML
 - The new planned disbursement form pre-fills the providing organisation details
 - Add cookie policy
+- Planned disbursement dates are validated within boundaries
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -25,8 +25,8 @@ module FormHelper
       PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.map do |id, name|
         OpenStruct.new(
           id: id,
-          name: I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.#{name}.name"),
-          description: I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.#{name}.description")
+          name: I18n.t("form.planned_disbursement.planned_disbursement_type.#{name}.name"),
+          description: I18n.t("form.planned_disbursement.planned_disbursement_type.#{name}.description")
         )
       end
     end

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -13,6 +13,7 @@ class PlannedDisbursement < ApplicationRecord
     :receiving_organisation_type
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
   validates_with EndDateNotBeforeStartDateValidator, if: -> { period_start_date.present? && period_end_date.present? }
+  validates :period_start_date, :period_end_date, date_within_boundaries: true
 
   def unknown_receiving_organisation_type?
     receiving_organisation_type == "0"

--- a/app/validators/date_within_boundaries_validator.rb
+++ b/app/validators/date_within_boundaries_validator.rb
@@ -8,7 +8,7 @@ class DateWithinBoundariesValidator < ActiveModel::EachValidator
     unless value.between?(MIN.years.ago, MAX.years.from_now)
       record.errors.add(
         attribute,
-        I18n.t("activerecord.errors.models.#{record.class.name.downcase}.attributes.#{attribute}.between", min: MIN, max: MAX)
+        I18n.t("activerecord.errors.models.#{record.class.name.underscore.downcase}.attributes.#{attribute}.between", min: MIN, max: MAX)
       )
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,12 @@ en:
       planned_disbursement_type:
         hint: Whether this is an original plan (prepared when the original commitment was made) or has subsequently been revised
         label: Budget type
+        original:
+          description: The original budget allocated to the activity
+          name: Original
+        revised:
+          description: The updated budget for an activity
+          name: Revised
       providing_organisation:
         hint: The organisation where this planned disbursement is coming from
         label: Provider

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -40,13 +40,7 @@ en:
         name: Name
         organisation_type: Organisation type
       planned_disbursement:
-        planned_disbursement_type:
-          original:
-            description: The original budget allocated to the activity
-            name: Original
-          revised:
-            description: The updated budget for an activity
-            name: Revised
+        planned_disbursement_type: Budget type
         providing_organisation_name: Providing organisation name
         providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name
@@ -98,6 +92,10 @@ en:
               format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
         planned_disbursement:
           attributes:
+            period_end_date:
+              between: Date must be between %{min} years ago and %{max} years in the future
+            period_start_date:
+              between: Date must be between %{min} years ago and %{max} years in the future
             planned_disbursement_type:
               blank: Budget type can't be blank
             value:

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Users can create a planned disbursement" do
 
       expect(page).to have_content I18n.t("page_title.planned_disbursement.new")
 
-      choose I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.name")
+      choose I18n.t("form.planned_disbursement.planned_disbursement_type.original.name")
       fill_in "planned_disbursement[period_start_date(3i)]", with: "01"
       fill_in "planned_disbursement[period_start_date(2i)]", with: "01"
       fill_in "planned_disbursement[period_start_date(1i)]", with: "2020"

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe FormHelper, type: :helper do
     it "builds a list of budget types for a planned disbursement" do
       budget_types = helper.list_of_planned_disbursement_budget_types
 
-      expect(budget_types[0].name).to eq I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.name")
-      expect(budget_types[0].description).to eq I18n.t("activerecord.attributes.planned_disbursement.planned_disbursement_type.original.description")
+      expect(budget_types[0].name).to eq I18n.t("form.planned_disbursement.planned_disbursement_type.original.name")
+      expect(budget_types[0].description).to eq I18n.t("form.planned_disbursement.planned_disbursement_type.original.description")
     end
   end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -17,4 +17,59 @@ RSpec.describe PlannedDisbursement, type: :model do
       expect(planned_disbursement.unknown_receiving_organisation_type?).to be false
     end
   end
+
+  describe "validations" do
+    context "when the planned_disbursement_type is blank" do
+      it "displays the appropriate error message" do
+        planned_disbursement = build(:planned_disbursement, planned_disbursement_type: nil)
+        expect(planned_disbursement.valid?).to be_falsey
+        expect(planned_disbursement.errors[:planned_disbursement_type]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.blank")
+      end
+    end
+    context "when period_start_date is not blank" do
+      let(:planned_disbursement) { build(:planned_disbursement) }
+
+      it "does not allow a period_start_date more than 10 years ago" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: 11.years.ago)
+        expect(planned_disbursement.valid?).to be_falsey
+        expect(planned_disbursement.errors[:period_start_date]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.period_start_date.between", min: 10, max: 25)
+      end
+
+      it "does not allow a period_start_date more than 25 years in the future" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: 26.years.from_now)
+        expect(planned_disbursement.valid?).to be_falsey
+      end
+
+      it "allows a period_start_date between 10 years ago and 25 years in the future" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: Date.today)
+        expect(planned_disbursement.valid?).to be_truthy
+      end
+    end
+
+    context "when the period_end_date is not blank" do
+      let(:planned_disbursement) { build(:planned_disbursement) }
+
+      it "does not allow the period_end_date to be before the period_start_date" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: Date.today + 1.month, period_end_date: Date.today)
+        expect(planned_disbursement.valid?).to be_falsey
+        expect(planned_disbursement.errors[:period_end_date]).to include I18n.t("activerecord.errors.validators.end_date_not_before_start_date")
+      end
+
+      it "does not allow a period_end_date more than 10 years ago" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: 12.years.ago, period_end_date: 11.years.ago)
+        expect(planned_disbursement.valid?).to be_falsey
+        expect(planned_disbursement.errors[:period_end_date]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.period_end_date.between", min: 10, max: 25)
+      end
+
+      it "does not allow a period_end_date more than 25 years in the future" do
+        planned_disbursement = build(:planned_disbursement, period_end_date: 26.years.from_now)
+        expect(planned_disbursement.valid?).to be_falsey
+      end
+
+      it "allows a period_end_date between 10 years ago and 25 years in the future" do
+        planned_disbursement = build(:planned_disbursement, period_start_date: Date.yesterday, period_end_date: Date.today)
+        expect(planned_disbursement.valid?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
We already have a custom validator to keep dates within boundaries.

The custom validator has been updated to underscore the class name when
deriving the error message keys, we haven't had a class with an
underscore in yet and `planneddisbursement` feels a but odd in the locales file.

Added some validation coverage for planned disbursements and sorted the
locales.

## Screenshots of UI changes

### Before
![Screenshot_2020-05-22 Activity Airbus Flood and Drought — Report your official development assistance](https://user-images.githubusercontent.com/480578/82690251-c3d5aa80-9c53-11ea-974a-f0cb4e4a1bc3.png)

### After

![Screenshot_2020-05-22 Edit planned disbursement — Report your official development assistance](https://user-images.githubusercontent.com/480578/82690299-d9e36b00-9c53-11ea-99aa-1e5dffc75cc0.png)



