### PR TITLE
(672) Provider organisation pre filled for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
 - Planned disbursement dates are validated within boundaries
 - Ingest tool creates or updates existing projects if they match on the IATI identifier
 - Ingest tool will try to set more meaningful identifiers for projects
+- The providing organisation is pre-filled in for new transactions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -7,6 +7,7 @@ class Staff::TransactionsController < Staff::BaseController
     @activity = Activity.find(activity_id)
     @transaction = Transaction.new
     @transaction.parent_activity = @activity
+    pre_fill_providing_organisation
 
     authorize @transaction
   end
@@ -78,5 +79,11 @@ class Staff::TransactionsController < Staff::BaseController
 
   def id
     params[:id]
+  end
+
+  private def pre_fill_providing_organisation
+    @transaction.providing_organisation_name = @activity.providing_organisation.name
+    @transaction.providing_organisation_type = @activity.providing_organisation.organisation_type
+    @transaction.providing_organisation_reference = @activity.providing_organisation.iati_reference
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -115,8 +115,7 @@ class Activity < ApplicationRecord
   end
 
   def providing_organisation
-    return nil if fund? || programme?
-    return Organisation.find_by(service_owner: true) if organisation.is_government? || project?
-    organisation
+    return organisation if third_party_project? && !organisation.is_government?
+    Organisation.find_by(service_owner: true)
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -371,12 +371,13 @@ RSpec.describe Activity, type: :model do
 
   describe "#providing_organisation" do
     context "when the activity is a fund or a programme" do
-      it "returns nil" do
+      it "returns BEIS" do
+        beis = create(:beis_organisation)
         fund = build(:fund_activity)
-        expect(fund.providing_organisation).to be_nil
+        expect(fund.providing_organisation).to eql beis
 
         programme = build(:programme_activity)
-        expect(programme.providing_organisation).to be_nil
+        expect(programme.providing_organisation).to eql beis
       end
     end
 


### PR DESCRIPTION
## Changes in this PR
The providing organisation of a transaction can be derived from the activity level and the delivery partner organisation type.

- For government orgs all providing organisation at all levels is BEIS
- For non-governement orgs all proviging organisation at all level is BEIS, excpet Level D (Third-party projects) where it is the delivery partner.

This work builds on previous work done on planned disbursements which follows the same set of rules.

We could remove the providing org altogether and not ask the user at all, but it was felt we can build our confidence that this is a good call be testing with users before we remove it entirely, there may be edge cases we are not aware of and keeping the form means a user can override the values if needed.

## Screenshots of UI changes
![Screenshot_2020-05-27 Add a planned disbursement — Report your official development assistance(1)](https://user-images.githubusercontent.com/480578/83011447-c5b3bb00-a011-11ea-97ae-36685b7c3e3f.png)

![Screenshot_2020-05-27 Add a planned disbursement — Report your official development assistance](https://user-images.githubusercontent.com/480578/83011453-c77d7e80-a011-11ea-8e73-3005e98fd57e.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
