### PR TITLE
Data migration can be rolled back

### DIFF
--- a/db/data/20200521165254_add_iati_ids_to_existing_uksa_data.rb
+++ b/db/data/20200521165254_add_iati_ids_to_existing_uksa_data.rb
@@ -65,7 +65,7 @@ class AddIatiIdsToExistingUksaData < ActiveRecord::Migration[6.0]
       "GB-GOV-13-GCRF-UKSA_FJ_SB_VU_UKSA-43",
       "GB-GOV-13-GCRF-UKSA_CI_UKSA-047",
     ]
-    updated_activities = Activity.where(updated_activity_ids)
+    updated_activities = Activity.where(previous_identifier: updated_activity_ids)
     updated_activities.update(previous_identifier: nil)
   end
 end


### PR DESCRIPTION
## Changes in this PR

Previously this was querying activities by their `id` rather than their `previous_identifier`. This was noticed when running the task by hand due to other complications when setting up the pentest environment.

## Screenshots of UI changes

### Before

![Screenshot 2020-05-27 at 17 02 55](https://user-images.githubusercontent.com/912473/83044339-f3adf500-a03b-11ea-94ee-ae8d31713c9e.png)

### After

![Screenshot 2020-05-27 at 17 02 30](https://user-images.githubusercontent.com/912473/83044368-fd375d00-a03b-11ea-8962-c23a7fa7f088.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
