### PR TITLE
Allow the data_migrate gem to modify it's schema without linting errors

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,2 @@
+ignore:
+  - 'db/data_schema.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - Ingest tool creates or updates existing projects if they match on the IATI identifier
 - Ingest tool will try to set more meaningful identifiers for projects
 - The providing organisation is pre-filled in for new transactions
+- No longer lint the automatic schema changes made by the data_migrate gem
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6


### PR DESCRIPTION
## Changes in this PR

We cannot affect the syntax the gem produces each time we run `data:migrate` or any other command. 

Instead of running `rake standard:fix` every time we create and run one of these migrations, let's switch to ignore this file from any linting rules.

I stubmled across this when trying to add a new migration to capture the ingesting of UKSA IATI data. I can't commit that work yet as a data migration needs to be run first, but this work can still be proposed now.

## Screenshots of UI changes

### Before

![Screenshot 2020-05-27 at 17 41 00](https://user-images.githubusercontent.com/912473/83048303-4d64ee00-a041-11ea-8ea6-138558b39eed.png)

### After

There's no linting error to screenshot.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
