### PR TITLE
(fix) Do not show download buttons on BEIS home page

### DIFF
--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -20,6 +20,7 @@ class OrganisationPolicy < ApplicationPolicy
   end
 
   def download?
+    return false if record.service_owner?
     beis_user?
   end
 

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -8,7 +8,7 @@
       %h1.govuk-heading-xl
         = @organisation_presenter.name
 
-  - if policy(:fund).index? & @organisation_presenter.service_owner?
+  - if policy(:fund).index? && @organisation_presenter.service_owner?
     .govuk-grid-row
       .govuk-grid-column-full
         %h2.govuk-heading-m
@@ -36,7 +36,7 @@
 
         = render partial: "staff/shared/projects/table", locals: { projects: @project_activities }
 
-  - if policy(:organisation).download? && @project_activities.present?
+  - if policy(@organisation_presenter).download? && @project_activities.present?
     .govuk-grid-row
       .govuk-grid-column-full.download-projects
         %div.govuk-body
@@ -52,7 +52,7 @@
 
         = render partial: "staff/shared/third_party_projects/table", locals: { third_party_projects: @third_party_project_activities }
 
-  - if policy(:organisation).download? && @third_party_project_activities.present?
+  - if policy(@organisation_presenter).download? && @third_party_project_activities.present?
     .govuk-grid-row
       .govuk-grid-column-full.download-third-party-projects
         %div.govuk-body

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -5,7 +5,19 @@ RSpec.feature "Users can view an organisation as XML" do
   context "when the user belongs to BEIS" do
     before { authenticate!(user: user) }
 
-    context "when the user is viewing any organisation show page" do
+    context "when the user is viewing the BEIS organisation show page" do
+      scenario "they cannot download the organisation's projects as XML" do
+        beis = user.organisation
+        _project = create(:project_activity, organisation: beis)
+
+        visit organisation_path(beis)
+
+        expect(page).to have_content(beis.name)
+        expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+      end
+    end
+
+    context "when the user is viewing any other organisation show page" do
       context "whe organisation has projects" do
         scenario "they can download the organisation's projects as XML" do
           _project = create(:project_activity, organisation: organisation)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/XpXfmNXM/636-a-beis-transparency-user-can-download-the-xml-for-all-activities-for-each-delivery-partner-in-a-single-file#comment-5ecf7d2bbc620c0aaac7a273

During testing we discovered that the "Download XML" buttons were appearing
on the BEIS home page which they should not do. Only delivery partner organisations
should have downloadable activity XML.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
