### PR TITLE
(680) Planned disbursement activity is recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 - The providing organisation is pre-filled in for new transactions
 - No longer lint the automatic schema changes made by the data_migrate gem
 - Switched to the latest form builder gem version from our fork
+- Planned disbursement create and update actions are recorded
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -18,6 +18,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     @planned_disbursement = result.object
 
     if result.success?
+      @planned_disbursement.create_activity key: "planned_disbursement.create", owner: current_user
       flash[:notice] = I18n.t("form.planned_disbursement.create.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
@@ -41,6 +42,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
       .call(attributes: planned_disbursement_params)
 
     if result.success?
+      @planned_disbursement.create_activity key: "planned_disbursement.update", owner: current_user
       flash[:notice] = I18n.t("form.planned_disbursement.update.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -1,4 +1,5 @@
 class PlannedDisbursement < ApplicationRecord
+  include PublicActivity::Common
   PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
 
   belongs_to :parent_activity, class_name: "Activity"

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -22,5 +22,24 @@ RSpec.describe "Users can edit a planned disbursement" do
       expect(page).to have_content I18n.t("form.planned_disbursement.update.success")
       expect(page).to have_content "An Organisation"
     end
+
+    scenario "the action is recorded with public_activity" do
+      PublicActivity.with_tracking do
+        project = create(:project_activity, organisation: user.organisation)
+        planned_disbursement = create(:planned_disbursement, parent_activity: project)
+
+        visit organisation_path(user.organisation)
+        click_on(project.title)
+        within("##{planned_disbursement.id}") do
+          click_on(I18n.t("generic.link.edit"))
+        end
+
+        fill_in_planned_disbursement_form(value: "2000.51")
+
+        auditable_event = PublicActivity::Activity.find_by(trackable_id: planned_disbursement.id)
+        expect(auditable_event.key).to eq "planned_disbursement.update"
+        expect(auditable_event.owner_id).to eq user.id
+      end
+    end
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -173,6 +173,36 @@ module FormHelpers
     end
   end
 
+  def fill_in_planned_disbursement_form(planned_disbursement_type: "Original",
+    period_start_date_day: "1",
+    period_start_date_month: "1",
+    period_start_date_year: "2020",
+    period_end_date_day: "28",
+    period_end_date_month: "4",
+    period_end_date_year: "2020",
+    currency: "Pound Sterling",
+    value: "100000",
+    receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-987", type: "Private Sector"))
+
+    choose planned_disbursement_type
+    fill_in "planned_disbursement[period_start_date(3i)]", with: period_start_date_day
+    fill_in "planned_disbursement[period_start_date(2i)]", with: period_start_date_month
+    fill_in "planned_disbursement[period_start_date(1i)]", with: period_start_date_year
+
+    fill_in "planned_disbursement[period_end_date(3i)]", with: period_end_date_day
+    fill_in "planned_disbursement[period_end_date(2i)]", with: period_end_date_month
+    fill_in "planned_disbursement[period_end_date(1i)]", with: period_end_date_year
+
+    select currency, from: "planned_disbursement[currency]"
+    fill_in "planned_disbursement[value]", with: value
+
+    fill_in "planned_disbursement[receiving_organisation_name]", with: receiving_organisation.name
+    select receiving_organisation.type, from: "planned_disbursement[receiving_organisation_type]"
+    fill_in "planned_disbursement[receiving_organisation_reference]", with: receiving_organisation.reference
+
+    click_on(I18n.t("generic.button.submit"))
+  end
+
   def localise_date_from_input_fields(year:, month:, day:)
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
   end


### PR DESCRIPTION
## Changes in this PR

Record planned disbursement create and update actions with public
activity.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
