### PR TITLE
(fix) Tidy up old Activities which may not have a reporting_organisation

### DIFF
--- a/db/data/20200529093419_add_reporting_org_to_activities_where_missing.rb
+++ b/db/data/20200529093419_add_reporting_org_to_activities_where_missing.rb
@@ -1,0 +1,25 @@
+class AddReportingOrgToActivitiesWhereMissing < ActiveRecord::Migration[6.0]
+  def up
+    activities = Activity.where(reporting_organisation: nil)
+    service_owner = Organisation.find_by_service_owner(true)
+    activities.each do |activity|
+      creating_organisation = activity.organisation
+      reporting_organisation = case activity.level
+      when :fund
+        creating_organisation
+      when :programme
+        creating_organisation
+      when :project
+        service_owner
+      when :third_party_project
+        service_owner
+      end
+      activity.reporting_organisation = reporting_organisation
+      activity.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,2 @@
-DataMigrate::Data.define(version: 20200507142459)
+# encoding: UTF-8
+DataMigrate::Data.define(version: 20200529093419)


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/VAjGDwZs/671-practice-ingesting-uksa-iati-data-ontop-of-production-data#comment-5ecfc215edfc381404373ecd

While working on the pentest environment we discovered some Activities with a nil
reporting_organisation. These records are old and we are no longer able to create
activities without a reporting organisation.

This data migration ensures there are no old records without a reporting organisation.

It follows the same rules as those in the Create[Level]Activity services.

It is irreversible because Activities are not valid without a reporting organisation.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
