### PR TITLE
(fix) Transaction date ingest element

### DIFF
--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -121,7 +121,7 @@ class IngestIatiActivities
     transaction_elements = legacy_activity.elements.select { |element| element.name.eql?("transaction") }
     transaction_elements.each do |transaction_element|
       currency = transaction_element.children.detect { |child| child.name.eql?("value") }.attributes["currency"].value
-      date = transaction_element.children.detect { |child| child.name.eql?("value") }.attributes["value-date"].value
+      date = transaction_element.children.detect { |child| child.name.eql?("transaction-date") }.attributes["iso-date"].value
       value = transaction_element.children.detect { |child| child.name.eql?("value") }.children.text
       transaction_type = transaction_element.children.detect { |child| child.name.eql?("transaction-type") }.attributes["code"].value
       disbursement_channel = if transaction_element.children.detect { |child| child.name.eql?("disbursement-channel") }.present?


### PR DESCRIPTION
## Changes in this PR
The value-date element is different to the transaction-date element.
Whilst they are likely to be the same, we export the transaction-date as
the value-date ourselves, we should ingest from the correct xml element.
Transaction reference docs:

http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/transaction/
