### PR TITLE
(682) Fix transaction date boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@
 - Switched to the latest form builder gem version from our fork
 - Planned disbursement create and update actions are recorded
 - User role hint text is shown
+- Transaction dates are validated to be no more than 10 years ago and 25 years
+  in the future
 
 ## [unreleased]
 - The IATI identifier on an activity, transaction, planned disbursement,

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -14,5 +14,5 @@ class Transaction < ApplicationRecord
     :receiving_organisation_name,
     :receiving_organisation_type
   validates :value, inclusion: 0.01..99_999_999_999.00
-  validates :date, date_not_in_future: true
+  validates :date, date_not_in_future: true, date_within_boundaries: true
 end

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -182,7 +182,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(I18n.t("page_content.transactions.button.create"))
 
-        fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 1900, expectations: false)
+        fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2.years.ago, expectations: false)
 
         expect(page).to_not have_content "Date must not be in the future"
         expect(page).to have_content I18n.t("form.transaction.create.success")

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Transaction, type: :model do
       end
     end
   end
+
   describe "#date" do
     context "date must not be in the future" do
       it "allows a date in the past" do
@@ -70,6 +71,13 @@ RSpec.describe Transaction, type: :model do
       it "allows a nil date" do
         transaction = build(:transaction, parent_activity: activity, date: Date.today)
         expect(transaction.valid?).to be true
+      end
+    end
+
+    context "when the value is more than 10 years in the past" do
+      it "is not valid" do
+        transaction = build(:transaction, date: 10.years.ago)
+        expect(transaction).to be_invalid
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
We have seen instances of users inputting unlikely, but valid years,
0202 for example.

We have a date_within_boundaries custom validator already that will help
here.

The validator will stop future dates being more than 25 years in the
future from the current date, but this feels reasonable.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
