### PR TITLE
(194) Fix user role hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 - No longer lint the automatic schema changes made by the data_migrate gem
 - Switched to the latest form builder gem version from our fork
 - Planned disbursement create and update actions are recorded
+- User role hint text is shown
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -145,3 +145,5 @@ en:
       transaction:
         date: If you're reporting quarterly data, select the last day of the quarter. For example, 31 12 2020
         description: For example, Quarter one spend on the Early Career Research Network project.
+      user:
+        role: Choose a role for this user.


### PR DESCRIPTION
## Changes in this PR
This one is old,  the view has changed alot, but is now resolved.

Now we are not using the fork of the GOVUK form builder, we can use the
hint text on the user > role field.

## Screenshots of UI changes

### Before
![Screenshot_2020-01-09_Edit_user_—_Report_Official_Development_Assistance](https://user-images.githubusercontent.com/480578/83261051-a902b900-a1b2-11ea-9125-5b37f05308e3.png)

### After
![Screenshot_2020-05-29 Create user — Report your official development assistance](https://user-images.githubusercontent.com/480578/83261118-c768b480-a1b2-11ea-8bbf-38f33c97dbe8.png)
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
