### PR TITLE
Release 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@
 - User can add, view and edit planned disbursements to projects and third-party projects
 - BEIS users can download all of an Organisation's project (or third-party project) activities as XML from the organisation show page
 
-## [unreleased]
+## [release-7] - 2020-06-01
 
 - Ingest tool no longer creates programmes but is instructed to look for existing records
 - If an activity has a recipient_country set, the recipient_region is inferred from the recipient_country
@@ -148,7 +148,10 @@
 - Planned disbursement create and update actions are recorded
 - User role hint text is shown
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
+[release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4


### PR DESCRIPTION
- Ingest tool no longer creates programmes but is instructed to look for existing records
- If an activity has a recipient_country set, the recipient_region is inferred from the recipient_country
- Planned disbursements are exported in the IATI XML
- The new planned disbursement form pre-fills the providing organisation details
- Add cookie policy
- Planned disbursement dates are validated within boundaries
- Ingest tool creates or updates existing projects if they match on the IATI identifier
- Ingest tool will try to set more meaningful identifiers for projects
- The providing organisation is pre-filled in for new transactions
- No longer lint the automatic schema changes made by the data_migrate gem
- Switched to the latest form builder gem version from our fork
- Planned disbursement create and update actions are recorded
- User role hint text is shown
