### PR TITLE
(581) strip whitespace from iati identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,8 +149,9 @@
 - User role hint text is shown
 
 ## [unreleased]
-- The IATI identifier on an activity is stripped of leading and trailing
-  whitespace
+- The IATI identifier on an activity, transaction, planned disbursement,
+  organisation and implementing organisation  is stripped of leading and
+  trailing whitespace
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@
 - User role hint text is shown
 
 ## [unreleased]
+- The IATI identifier on an activity is stripped of leading and trailing
+  whitespace
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "skylight"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"
 gem "wicked"
+gem "strip_attributes"
 
 # Authentication
 gem "omniauth-auth0", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,6 +378,8 @@ GEM
     standard (0.1.8)
       rubocop (~> 0.77.0)
       rubocop-performance (~> 1.5.1)
+    strip_attributes (1.11.0)
+      activemodel (>= 3.0, < 7.0)
     temple (0.8.2)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -472,6 +474,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   standard
+  strip_attributes
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -18,6 +18,8 @@ class Activity < ApplicationRecord
     :aid_type,
   ]
 
+  strip_attributes only: [:identifier]
+
   validates :identifier, presence: true, on: :identifier_step
   validates :title, :description, presence: true, on: :purpose_step
   validates :sector_category, presence: true, on: :sector_category_step

--- a/app/models/implementing_organisation.rb
+++ b/app/models/implementing_organisation.rb
@@ -1,5 +1,7 @@
 class ImplementingOrganisation < ApplicationRecord
   validates_presence_of :name, :organisation_type
 
+  strip_attributes only: [:reference]
+
   belongs_to :activity
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,7 @@
 class Organisation < ApplicationRecord
   include PublicActivity::Common
 
+  strip_attributes only: [:iati_reference]
   has_many :users
   has_many :funds
 

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -2,6 +2,8 @@ class PlannedDisbursement < ApplicationRecord
   include PublicActivity::Common
   PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
 
+  strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
+
   belongs_to :parent_activity, class_name: "Activity"
 
   validates_presence_of :planned_disbursement_type,

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,6 +1,8 @@
 class Transaction < ApplicationRecord
   include PublicActivity::Common
 
+  strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
+
   belongs_to :parent_activity, class_name: "Activity"
   validates_presence_of :description,
     :transaction_type,

--- a/spec/factories/implementing_organisation.rb
+++ b/spec/factories/implementing_organisation.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     name { Faker::Company.name }
     reference
     organisation_type { "10" }
+
+    association :activity, factory: :project_activity
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "sanitisation" do
+    it { should strip_attribute(:identifier) }
+  end
+
   describe "validations" do
     context "overall activity state" do
       context "when the activity form is a draft" do

--- a/spec/models/implementing_organisation_spec.rb
+++ b/spec/models/implementing_organisation_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ImplementingOrganisation, type: :model do
     it { should validate_presence_of(:organisation_type) }
   end
 
+  describe "sanitation" do
+    it { should strip_attribute(:reference) }
+  end
+
   describe "associations" do
     it { should belong_to(:activity) }
   end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Organisation, type: :model do
 
     it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
 
+    describe "sanitation" do
+      it { should strip_attribute(:iati_reference) }
+    end
+
     describe "#iati_reference" do
       it "returns true if it does matches a known structure XX-XXX-" do
         organisation = build(:organisation, iati_reference: "GB-GOV-13")

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe PlannedDisbursement, type: :model do
     end
   end
 
+  describe "sanitation" do
+    it { should strip_attribute(:providing_organisation_reference) }
+    it { should strip_attribute(:receiving_organisation_reference) }
+  end
+
   describe "validations" do
     context "when the planned_disbursement_type is blank" do
       it "displays the appropriate error message" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Transaction, type: :model do
     it { should validate_presence_of(:receiving_organisation_type) }
   end
 
+  describe "sanitation" do
+    it { should strip_attribute(:providing_organisation_reference) }
+    it { should strip_attribute(:receiving_organisation_reference) }
+  end
+
   describe "#value" do
     context "value must be between 1 and 99,999,999,999.00 (100 billion minus one)" do
       it "allows the maximum possible value" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,9 @@ require "mock_redis"
 require "public_activity/testing"
 PublicActivity.enabled = false
 
+# testing strip_attributes
+require "strip_attributes/matchers"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -43,6 +46,7 @@ RSpec.configure do |config|
   config.include EmailHelpers
   config.include FormHelpers
   config.include ActivityHelpers
+  config.include StripAttributes::Matchers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
## Changes in this PR
We have seen an instance where leading whitespace in the IATI
Identifier value caused the XML to fail the IATI validator.

The IATI spec states 'The iati-identifier should have no leading or
trailing whitespace.' therefore we should strip the whitespace before we
save the value.

http://reference.iatistandard.org/203/activity-standard/overview/iati-identifier/

The strip_attributes gem was chosen:

https://github.com/rmm5t/strip_attributes

This was after much discussion around the various approaches could
take. We felt the gem was simple enough and gave us the functionality we
wanted without a large overhead. Under the hood, it uses the before_save
callback, which was one of the preferred approaches, but the gem has a
nice interface to allow targeting the attributes to act upon.

Configure RSpec to use the strip_attribute matchers so we can use them
in our specs.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
