### PR TITLE
(668) improve create fund content - status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@
 
 ## [unreleased]
 
+- Improve content on "Create Activity" form steps
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6

--- a/app/views/staff/activity_forms/country.html.haml
+++ b/app/views/staff/activity_forms/country.html.haml
@@ -4,6 +4,6 @@
     :code,
     :name,
     options: { selected: f.object.recipient_country || country_select_options.first.code},
-    label: { size: "xl", tag: "h1" }
+    label: { size: "xl", tag: "h1", text: I18n.t("helpers.fieldset.activity.recipient_country") }
   %script
     accessibleAutocomplete.enhanceSelectElement({ defaultValue: "", selectElement: document.getElementsByTagName("select")[0], showAllValues: true})

--- a/app/views/staff/activity_forms/dates.html.haml
+++ b/app/views/staff/activity_forms/dates.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
-  %h1.govuk-heading-xl= @page_title
+  %h1.govuk-heading-xl= I18n.t("helpers.fieldset.activity.dates", level: t("page_content.activity.level.#{f.object.level}"))
 
   = f.govuk_date_field :planned_start_date
   = f.govuk_date_field :planned_end_date

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl' }, hint_text: I18n.t("helpers.hint.activity.flow_html").html_safe
+  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl', text: I18n.t("helpers.fieldset.activity.flow") }, hint_text: I18n.t("helpers.hint.activity.flow_html").html_safe

--- a/app/views/staff/activity_forms/identifier.html.haml
+++ b/app/views/staff/activity_forms/identifier.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_text_field :identifier, label: { tag: 'h1', size: 'xl' }
+  = f.govuk_text_field :identifier, label: { tag: 'h1', size: 'xl', text: I18n.t("helpers.fieldset.activity.identifier") }

--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
-  %h1.govuk-heading-xl= t("page_title.activity_form.show.purpose_level", level: t("page_content.activity.level.#{f.object.level}"))
+  %h1.govuk-heading-xl= t("helpers.fieldset.activity.purpose", level: t("page_content.activity.level.#{f.object.level}"))
 
   = f.govuk_text_field :title
   = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,5 +1,5 @@
 = render layout: "wrapper" do |f|
   %h1.govuk-heading-xl= t("helpers.fieldset.activity.purpose", level: t("page_content.activity.level.#{f.object.level}"))
 
-  = f.govuk_text_field :title
+  = f.govuk_text_field :title, label: { text: I18n.t("helpers.fieldset.activity.title", level: t("page_content.activity.level.#{f.object.level}").titlecase) }
   = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/activity_forms/region.html.haml
+++ b/app/views/staff/activity_forms/region.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :recipient_region, region_select_options, :code, :name, options: { selected: f.object.recipient_region || region_select_options.first.code }, label: { tag: 'h1', size: 'xl' }
+  = f.govuk_collection_select :recipient_region, region_select_options, :code, :name, options: { selected: f.object.recipient_region || region_select_options.first.code }, label: { tag: 'h1', size: 'xl', text: I18n.t("helpers.fieldset.activity.recipient_region") }

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :status, value: nil
-  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: "Status" }, hint_text: I18n.t("helpers.hint.activity.status", level: t("page_content.activity.level.#{f.object.level}"))
+  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("helpers.fieldset.activity.status", level: t("page_content.activity.level.#{f.object.level}")) }, hint_text: I18n.t("helpers.hint.activity.status", level: t("page_content.activity.level.#{f.object.level}"))

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -118,10 +118,17 @@ en:
       activity:
         actual_end_date: Actual end date (optional)
         actual_start_date: Actual start date (optional)
+        dates: What are the start and end dates for this %{level}?
+        flow: What is the flow type?
+        identifier: Enter a unique identifier
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        purpose: What is the purpose of the %{level}?
+        recipient_country: What country will benefit from this activity?
+        recipient_region: What region will benefit from this activity?
         sector_category:
           html: What area of the economy or society is your %{level} helping? For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
+        status: What is the status of the %{level}?
       user:
         organisation_ids: Organisations
         role: Role

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -129,6 +129,7 @@ en:
         sector_category:
           html: What area of the economy or society is your %{level} helping? For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
         status: What is the status of the %{level}?
+        title: "%{level} name"
       user:
         organisation_ids: Organisations
         role: Role

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can choose a recipient country" do
 
     context "with JavaScript disabled" do
       scenario "countries are choosen from a select box" do
-        expect(page).to have_select(I18n.t("page_title.activity_form.show.country"))
+        expect(page).to have_select(I18n.t("helpers.fieldset.activity.recipient_country"))
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do
@@ -26,13 +26,13 @@ RSpec.feature "Users can choose a recipient country" do
 
     context "with JavaScript enabled", js: true do
       scenario "countries are choosen from an autocomplete" do
-        expect(page).not_to have_select(I18n.t("page_title.activity_form.show.country"))
-        expect(page).to have_field(I18n.t("page_title.activity_form.show.country"))
+        expect(page).not_to have_select(I18n.t("helpers.fieldset.activity.recipient_country"))
+        expect(page).to have_field(I18n.t("helpers.fieldset.activity.recipient_country"))
         expect(page).to have_css("input.autocomplete__input")
       end
 
       scenario "typing a partial match displays all the matching countries" do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("helpers.fieldset.activity.recipient_country"), with: "saint"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Lucia", visible: true
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Vincent and the Grenadines", visible: true
@@ -50,13 +50,13 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a known country displays that country in the list of countries" do
-        fill_in "Country", with: "afghanistan"
+        fill_in I18n.t("helpers.fieldset.activity.recipient_country"), with: "afghanistan"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Afghanistan", visible: true
       end
 
       scenario "typing a complete country name, clicking it in the list and clicking continue saves the country" do
-        fill_in "Country", with: "Saint Lucia"
+        fill_in I18n.t("helpers.fieldset.activity.recipient_country"), with: "Saint Lucia"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.activity.submit")
         click_on I18n.t("generic.link.back")
@@ -67,7 +67,7 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a partial match, clicking on the complete match and clicking continue saves the country " do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("helpers.fieldset.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.activity.submit")
         click_on I18n.t("generic.link.back")
@@ -78,7 +78,7 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("helpers.fieldset.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.activity.submit")
         expect(activity.reload.recipient_region).to eq("380") # West Indies

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[identifier]", with: "foo"
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Purpose of fund"
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.purpose", level: "fund")
 
         # Don't provide a title and description
         click_button I18n.t("form.activity.submit")
@@ -141,7 +141,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose "Primary education"
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.status")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.status", level: "fund")
 
         # Don't provide a status
         click_button I18n.t("form.activity.submit")
@@ -150,7 +150,7 @@ RSpec.feature "Users can create a fund level activity" do
         choose("activity[status]", option: "2")
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.dates", level: "fund")
 
         click_button I18n.t("form.activity.submit")
         expect(page).to have_content "Planned start date can't be blank"
@@ -181,12 +181,12 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose "Region"
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.region")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.recipient_region")
 
         # region has the default value already selected
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.flow")
 
         # Flow has a default and can't be set to blank so we skip
         select "ODA", from: "activity[flow]"

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "Users can edit an activity" do
         select recipient_region, from: "activity[recipient_region]"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.flow")
         expect(page).not_to have_content activity.title
       end
     end

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -16,13 +16,13 @@ RSpec.feature "Users can provide the geography for an activity" do
         choose "Country"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.recipient_country")
         expect(page).to have_current_path(activity_step_path(activity, :country))
 
         select "Uganda"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.flow")
         expect(page).to have_current_path(activity_step_path(activity, :flow))
       end
 
@@ -31,7 +31,7 @@ RSpec.feature "Users can provide the geography for an activity" do
         choose "Country"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.country")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.recipient_country")
         expect(page).to have_current_path(activity_step_path(activity, :country))
 
         select "Uganda"
@@ -47,12 +47,12 @@ RSpec.feature "Users can provide the geography for an activity" do
         choose "Region"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.region")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.recipient_region")
 
         select "Developing countries, unspecified", from: "activity[recipient_region]"
         click_button I18n.t("form.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
+        expect(page).to have_content I18n.t("helpers.fieldset.activity.flow")
         expect(page).to have_current_path(activity_step_path(activity, :flow))
       end
     end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CodelistHelper, type: :helper do
           .to include(
             OpenStruct.new(name: "Pipeline/identification", code: "1", description: "The activity is being scoped or planned"),
             OpenStruct.new(name: "Implementation", code: "2", description: "The activity is currently being implemented"),
-            OpenStruct.new(name: "Completion", code: "3", description: "Physical activity is complete or the final disbursement has been made."),
+            OpenStruct.new(name: "Completion", code: "3", description: "Physical activity is complete or the final disbursement has been made"),
             OpenStruct.new(name: "Post-completion", code: "4", description: "Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&E"),
             OpenStruct.new(name: "Cancelled", code: "5", description: "The activity has been cancelled"),
             OpenStruct.new(name: "Suspended", code: "6", description: "The activity has been temporarily suspended")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -25,12 +25,12 @@ module FormHelpers
     level:
   )
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.identifier")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.identifier")
     expect(page).to have_content I18n.t("helpers.hint.activity.identifier")
     fill_in "activity[identifier]", with: identifier
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.purpose_level", level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.purpose", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content I18n.t("activerecord.attributes.activity.title")
     expect(page).to have_content I18n.t("activerecord.attributes.activity.description")
     fill_in "activity[title]", with: title
@@ -51,7 +51,7 @@ module FormHelpers
     choose sector
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.status")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.status", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content "The activity is being scoped or planned"
     expect(page).to have_content "The activity is currently being implemented"
     expect(page).to have_content "Physical activity is complete or the final disbursement has been made"
@@ -62,7 +62,7 @@ module FormHelpers
     choose("activity[status]", option: status)
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.dates", level: I18n.t("page_content.activity.level.#{level}"))
 
     expect(page).to have_content I18n.t("helpers.fieldset.activity.planned_start_date")
     fill_in "activity[planned_start_date(3i)]", with: planned_start_date_day
@@ -90,13 +90,11 @@ module FormHelpers
     choose "Region"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.region")
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.recipient_region")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.recipient_region")
     select recipient_region, from: "activity[recipient_region]"
     click_button I18n.t("form.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.flow")
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.flow")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.flow")
     expect(page).to have_content "International Aid Transparency Initiative (IATI) descriptions of each flow type (opens in new window)"
     select flow, from: "activity[flow]"
     click_button I18n.t("form.activity.submit")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -31,7 +31,7 @@ module FormHelpers
     click_button I18n.t("form.activity.submit")
 
     expect(page).to have_content I18n.t("helpers.fieldset.activity.purpose", level: I18n.t("page_content.activity.level.#{level}"))
-    expect(page).to have_content I18n.t("activerecord.attributes.activity.title")
+    expect(page).to have_content I18n.t("helpers.fieldset.activity.title", level: I18n.t("page_content.activity.level.#{level}").titlecase)
     expect(page).to have_content I18n.t("activerecord.attributes.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description

--- a/vendor/data/codelists/IATI/2_03/activity/status.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/status.yml
@@ -12,7 +12,7 @@ data:
     description: The activity is currently being implemented
   - code: '3'
     name: Completion
-    description: Physical activity is complete or the final disbursement has been made.
+    description: Physical activity is complete or the final disbursement has been made
   - code: '4'
     name: Post-completion
     description: Physical activity is complete or the final disbursement has been made,


### PR DESCRIPTION
## Changes in this PR

To be merged *after* https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/436

Trello: https://trello.com/c/rR0rbCSQ/668-improve-create-fund-content-economic-societal-area-and-status

This text has been lifted from IATI's official codelists, so if we ever update
the codelists from 2.03, this change might be undone.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
