### PR TITLE
Ingest tool fails loudly if it was unable to save for any reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,9 +155,10 @@
   organisation and implementing organisation  is stripped of leading and
   trailing whitespace
 - Header navigation follows GOVUK frontend pattern
-- Infer a transaction's and planned disbursement's `receiving-org type` from its 
-  parent activity's `implementing organisation`, if the `receiving-org type` on the 
+- Infer a transaction's and planned disbursement's `receiving-org type` from its
+  parent activity's `implementing organisation`, if the `receiving-org type` on the
   element is missing
+- Ingest tool fails loudly if any activity fails to be created
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -49,7 +49,7 @@ class IngestIatiActivities
         roda_activity.legacy_iati_xml = legacy_activity.to_xml.squish
         roda_activity.ingested = true
 
-        roda_activity.save
+        roda_activity.save!
       end
     end
   end

--- a/spec/fixtures/activities/uksa/invalid_activity.xml
+++ b/spec/fixtures/activities/uksa/invalid_activity.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iati-activities generated-datetime="2019-09-25T22:01:44.470000+00:00" version="2.03">
+  <iati-activity default-currency="GBP" hierarchy="2" last-updated-datetime="2019-09-25T22:01:44.470000+00:00">
+  <iati-identifier>GB-GOV-13-GCRF-UKSA_TZ_UKSA-021</iati-identifier>
+  <reporting-org ref="GB-GOV-13" type="10">
+    <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+  </reporting-org>
+  <title>
+    <narrative>02 Airbus Flood and Drought Resilience - Call 1</narrative>
+  </title>
+  <description type="1">
+    <narrative>
+      <!-- Missing content that is required -->
+    </narrative>
+  </description>
+  <description type="2">
+    <narrative>
+      <!-- Missing content that is required -->
+    </narrative>
+  </description>
+  <participating-org ref="GB-GOV-13" role="1" type="10">
+    <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+  </participating-org>
+  <participating-org ref="GB-GOV-13" role="2" type="10">
+    <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+  </participating-org>
+  <participating-org role="3" type="10">
+    <narrative>UK Space Agency</narrative>
+  </participating-org>
+  <participating-org role="4" type="70">
+    <narrative>Airbus Defence and Space</narrative>
+  </participating-org>
+  <activity-status code="2"/>
+  <activity-date iso-date="2016-11-01" type="1"/>
+  <activity-date iso-date="2016-11-01" type="2"/>
+  <activity-date iso-date="2019-10-31" type="3"/>
+  <contact-info type="1">
+    <organisation>
+      <narrative>UK Space Agency</narrative>
+    </organisation>
+    <department>
+      <narrative>UK Space Agency</narrative>
+    </department>
+    <person-name>
+      <narrative>International Partnership Programme</narrative>
+    </person-name>
+    <email>ipp@ukspaceagency.bis.gsi.uk</email>
+    <website>https://www.gov.uk/government/organisations/uk-space-agency</website>
+    <mailing-address>
+      <narrative>UKSA, Polaris House, North Star Avenue, Swindon, Wiltshire SN2 1SZ</narrative>
+    </mailing-address>
+  </contact-info>
+  <recipient-region code="998" percentage="100" vocabulary="1"/>
+  <!-- Required code omitted -->
+  <sector code="">
+    <narrative>Disaster prevention and preparedness</narrative>
+  </sector>
+  <collaboration-type code="1"/>
+  <default-flow-type code="10"/>
+  <default-finance-type code="110"/>
+  <default-aid-type code="C01"/>
+  <default-tied-status code="5"/>
+  <budget status="2" type="1">
+    <period-start iso-date="2016-11-01"/>
+    <period-end iso-date="2019-10-31"/>
+    <value currency="GBP" value-date="2016-12-01">1868000</value>
+  </budget>
+  <planned-disbursement type="1">
+    <period-start iso-date="2019-07-01"/>
+    <period-end iso-date="2020-04-30"/>
+    <value currency="GBP" value-date="2016-12-22">983052</value>
+    <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </provider-org>
+    <receiver-org>
+      <narrative>Airbus</narrative>
+    </receiver-org>
+  </planned-disbursement>
+  <capital-spend percentage="0"/>
+  </iati-activity>
+</iati-activities>

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -357,5 +357,16 @@ RSpec.describe IngestIatiActivities do
         expect_any_instance_of(PlannedDisbursement).not_to receive(:save!)
       end
     end
+
+    context "when an activity is invalid" do
+      it "raises an error loudly so the team are aware a record didn't save and can review the data" do
+        uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/invalid_activity.xml")
+
+        service = described_class.new(delivery_partner: uksa, file_io: legacy_activities)
+
+        expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

* Whilst for UKSA we have been able to ingest every activity without issue, there is a risk that future ingests will fail to create new activities silently. The more activities we ingest, the harder it will be to review these within the service by eye.
* Fail the ingest loudly if for any reason an activity fails to save
* If there is a failure the script should be able to run idempotently with the check for existing records on ID and never ingesting a file already marked as ingested
* This approach completes the fail loudly strategy used already with: `Transaction.save!`, `Budget.save!` and `PlannedDisbursement.save!`
* I've tested this locally on production data and fortunantly there were no activities failing silently and not creating

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
