### PR TITLE
Infer transaction & planned disbursement receiver-org type from parent activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,9 @@
   organisation and implementing organisation  is stripped of leading and
   trailing whitespace
 - Header navigation follows GOVUK frontend pattern
+- Infer a transaction's and planned disbursement's `receiving-org type` from its 
+  parent activity's `implementing organisation`, if the `receiving-org type` on the 
+  element is missing
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...HEAD
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7

--- a/spec/fixtures/activities/uksa/fake_with_transaction.xml
+++ b/spec/fixtures/activities/uksa/fake_with_transaction.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iati-activities generated-datetime="2019-09-25T22:01:44.470000+00:00" version="2.03">
+
+  <iati-activity default-currency="GBP" hierarchy="2" last-updated-datetime="2019-09-25T22:01:44.470000+00:00">
+    <iati-identifier>GB-GOV-13-GCRF-UKSA_NS_UKSA-029</iati-identifier>
+    <reporting-org ref="GB-GOV-13" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </reporting-org>
+    <title>
+      <narrative>02 Airbus Flood and Drought Resilience - Call 1</narrative>
+    </title>
+    <description type="1">
+      <narrative>Both Ethiopia and Kenya are flood and drought prone with significant mortality and economic losses attributed to these events in each country. This project focuses on building resilience to these events
+        to both lessen risk and support economic resilience.In Ethiopia it will focus on building an improved understanding of flood and drought hazards and risks to help build social and economic resilience to water-related hazards. In Kenya it will focus on the effectiveness of EO data for the micro-insurance market and Government Institutions; an important tool for farmers who currently have little or no access to insurance. This will be supported by the development of a flexible dashboard with tailored information to assist decision making related to flood and drought at the following geographical levels:
+        •
+        Ethiopia: at basin level (working with the Ministry of Finance and Economic Cooperation).
+        •
+        Kenya: at local level (working with women farmer intermediaries and micro-insurance actors) and
+        at county and sub-county level (working with
+        the National Drought Management Authority).</narrative>
+    </description>
+    <description type="2">
+      <narrative>Earth Observation-enabled decision support for flood and drought resilience in Ethipoia and Kenya </narrative>
+    </description>
+    <participating-org ref="GB-GOV-13" role="1" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org ref="GB-GOV-13" role="2" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org role="3" type="10">
+      <narrative>UK Space Agency</narrative>
+    </participating-org>
+    <participating-org role="4" type="80">
+      <narrative>Institute for Environmental Analytics, University of Reading</narrative>
+    </participating-org>
+    <activity-status code="2"/>
+    <activity-date iso-date="2016-11-01" type="1"/>
+    <activity-date iso-date="2016-11-01" type="2"/>
+    <activity-date iso-date="2019-10-31" type="3"/>
+    <contact-info type="1">
+      <organisation>
+        <narrative>UK Space Agency</narrative>
+      </organisation>
+      <department>
+        <narrative>UK Space Agency</narrative>
+      </department>
+      <person-name>
+        <narrative>International Partnership Programme</narrative>
+      </person-name>
+      <email>ipp@ukspaceagency.bis.gsi.uk</email>
+      <website>https://www.gov.uk/government/organisations/uk-space-agency</website>
+      <mailing-address>
+        <narrative>UKSA, Polaris House, North Star Avenue, Swindon, Wiltshire SN2 1SZ</narrative>
+      </mailing-address>
+    </contact-info>
+    <recipient-region code="998" percentage="100" vocabulary="1"/>
+    <sector code="74010">
+      <narrative>Disaster prevention and preparedness</narrative>
+    </sector>
+    <collaboration-type code="1"/>
+    <default-flow-type code="10"/>
+    <default-finance-type code="110"/>
+    <default-aid-type code="C01"/>
+    <default-tied-status code="5"/>
+    <budget status="2" type="1">
+      <period-start iso-date="2016-11-01"/>
+      <period-end iso-date="2019-10-31"/>
+      <value currency="GBP" value-date="2016-12-01">1868000</value>
+    </budget>
+    <capital-spend percentage="0"/>
+    <transaction>
+      <transaction-type code="2"/>
+      <transaction-date iso-date="2016-11-01"/>
+      <value currency="GBP" value-date="2016-11-01">1868000</value>
+      <description>
+        <narrative>02 Airbus Flood and Drought Resilience - Call 1</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Satellite Oceanographic Consultants</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2016-12-22"/>
+      <value currency="GBP" value-date="2016-12-22">70118</value>
+      <description>
+        <narrative>Project start and archive data purchase</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-03-28"/>
+      <value currency="GBP" value-date="2017-03-28">55059.21</value>
+      <description>
+        <narrative>Requirements stage (interim)</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-03-28"/>
+      <value currency="GBP" value-date="2017-03-28">22313</value>
+      <description>
+        <narrative>Method inception report</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-10-26"/>
+      <value currency="GBP" value-date="2017-10-26">297341.86</value>
+      <description>
+        <narrative>Completion of user requirements</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2017-12-19"/>
+      <value currency="GBP" value-date="2017-12-19">216229.99</value>
+      <description>
+        <narrative>Design</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2018-03-29"/>
+      <value currency="GBP" value-date="2018-03-29">424166.87</value>
+      <description>
+        <narrative>Development</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <transaction>
+      <transaction-type code="3"/>
+      <transaction-date iso-date="2018-12-12"/>
+      <value currency="GBP" value-date="2018-12-12">76952.3</value>
+      <description>
+        <narrative>Development</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-GCRF-UKSA_NS_UKSA-029" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Airbus</narrative>
+      </receiver-org>
+    </transaction>
+    <document-link format="text/html" url="https://science-and-innovation-network.s3.eu-west-2.amazonaws.com/BEIS+R%26I+ODA+conditions+for+grants+and+contracts.docx">
+      <title>
+        <narrative>R&amp;I ODA Conditions for Grants and Contracts</narrative>
+      </title>
+      <category code="A04"/>
+    </document-link>
+    <document-link format="application/xhtml+xml" url="https://www.gov.uk/government/case-studies/airbus-africa-flood-draught-resilience">
+      <title>
+        <narrative>Airbus (Africa) Flood and Drought resilience</narrative>
+      </title>
+      <category code="A12"/>
+      <language code="en"/>
+      <document-date iso-date="2017-01-26"/>
+    </document-link>
+    <related-activity ref="GB-GOV-13-GCRF-UKSA" type="1"/>
+    <conditions attached="1"/>
+  </iati-activity>
+</iati-activities>


### PR DESCRIPTION
## Changes in this PR
Trello: https://trello.com/c/pvFOkc7c/692-infer-transaction-receiver-org-type-from-activity-implementing-org-type

On ingesting the UKSA data we noticed that all transactions had a receiving organisation
type of 0.

This is due to all the transaction receiver-org elements in the exported IATI XML
having no `@type` elements.

After discussion with BEIS, we have decided to try to infer the transaction
receiving organisation type from the transaction's parent activity. The parent
activity will have implementing organisations of type 4, which is the same as
the child transaction's receiving organisation.

We can infer the same logic for planned disbursements.

Activities can potentially have multiple implementing organisations. However a transaction can only have one receiving organisation. After discussion with BEIS it's been decided that if we need to infer a receiving organisation's `@type` from multiple implementing organisations, it is safe to choose the first implementing organisation from the list of implementing organisations (https://dxw.slack.com/archives/CN0H2L066/p1591104455027800?thread_ts=1591022224.022000&cid=CN0H2L066)

When the transactions go through QA on RODA this can be changed manually.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
