### PR TITLE
(hotfix) (pentest only) Run db:schema:load before running migrations

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,8 @@ setup_database()
 
 run_data_migrations()
 {
+  echo "Loading schema (pentest hotfix)…"
+  bundle exec rake db:schema:load
   echo "Running data migrations…"
   bundle exec rake data:migrate
   echo "Finished running data migrations."


### PR DESCRIPTION
2020-06-03 a failed manual terraform deploy means the database on pentest
needs to have its schema reloaded before migrations are run.
