### PR TITLE
(690) Allow negative transaction values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,8 @@
 
 ## [unreleased]
 
+- Transactions can have a negative value (but not zero)
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -13,6 +13,6 @@ class Transaction < ApplicationRecord
     :providing_organisation_type,
     :receiving_organisation_name,
     :receiving_organisation_type
-  validates :value, inclusion: 0.01..99_999_999_999.00
+  validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :date, date_not_in_future: true, date_within_boundaries: true
 end

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -106,7 +106,8 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Date must not be in the future
             value:
-              inclusion: Value must be between 0.01 and 99,999,999,999.00
+              less_than_or_equal_to: Value must be less than or equal to 99,999,999,999.00
+              other_than: Value must not be zero
         user:
           attributes:
             organisation_ids:

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe Transaction, type: :model do
   end
 
   describe "#value" do
-    context "value must be between 1 and 99,999,999,999.00 (100 billion minus one)" do
+    context "value must be a maximum of 99,999,999,999.00 (100 billion minus one)" do
       it "allows the maximum possible value" do
         transaction = build(:transaction, parent_activity: activity, value: 99_999_999_999.00)
         expect(transaction.valid?).to be true
       end
 
-      it "allows the minimum possible value" do
+      it "allows one penny" do
         transaction = build(:transaction, parent_activity: activity, value: 0.01)
         expect(transaction.valid?).to be true
       end
 
-      it "does not allow a value of less than 0.01" do
+      it "does not allow a value of 0" do
         transaction = build(:transaction, parent_activity: activity, value: 0)
         expect(transaction.valid?).to be false
       end
@@ -45,6 +45,11 @@ RSpec.describe Transaction, type: :model do
 
       it "allows a value between 1 and 99,999,999,999.00" do
         transaction = build(:transaction, parent_activity: activity, value: 500_000.00)
+        expect(transaction.valid?).to be true
+      end
+
+      it "allows a negative value" do
+        transaction = build(:transaction, parent_activity: activity, value: -500_000.00)
         expect(transaction.valid?).to be true
       end
     end


### PR DESCRIPTION

## Changes in this PR
Trello: https://trello.com/c/ubB87WqW/690-change-validations-to-accept-negative-values-but-not-zero

When doing a test ingest of AMS Netwon Fund data we discovered some transactions
with negative values, which break our validations.

Transactions should be able to have a negative value when a DP sends a refund to
a fund.

However transactions cannot have a value of zero.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
