### PR TITLE
(705) Refactor locale files – part 1

### DIFF
--- a/app/controllers/concerns/auth.rb
+++ b/app/controllers/concerns/auth.rb
@@ -8,7 +8,7 @@ module Auth
 
     rescue_from(UserNotAuthorised, Pundit::NotAuthorizedError) do |exception|
       error_message = if exception.respond_to?(:policy)
-        t("#{exception.policy.class.to_s.underscore}.#{exception.query}", scope: "pundit", default: :default)
+        t("#{exception.policy.class.to_s.underscore}.#{exception.query}", scope: "not_authorised", default: :default)
       else
         t("page_content.errors.not_authorised.explanation")
       end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -3,7 +3,7 @@ module OrganisationHelper
     if current_user_on_home_page?(current_user, params)
       nil
     else
-      link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
+      link_to t("default.link.back"), organisations_path, class: "govuk-back-link"
     end
   end
 

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -30,7 +30,7 @@ class CreateUser
     begin
       message = JSON.parse(result.message)["message"]
     rescue JSON::ParserError
-      message = I18n.t("generic.error.unknown")
+      message = I18n.t("default.error.unknown")
     end
     message
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -65,9 +65,9 @@
               Support links
             %ul.govuk-footer__inline-list
               %li.govuk-footer__inline-list-item
-                = link_to t("page_content.generic.link.privacy_policy"), privacy_policy_path, class: "govuk-footer__link"
+                = link_to t("footer.link.privacy_policy"), privacy_policy_path, class: "govuk-footer__link"
               %li.govuk-footer__inline-list-item
-                = link_to t("page_content.generic.link.cookie_statement"), cookie_statement_path, class: "govuk-footer__link"
+                = link_to t("footer.link.cookie_statement"), cookie_statement_path, class: "govuk-footer__link"
 
             %svg.govuk-footer__licence-logo{focusable: "false", height: "17", role: "presentation", viewbox: "0 0 483.2 195.7", width: "41", xmlns: "http://www.w3.org/2000/svg"}
               %path{d: "M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145", fill: "currentColor"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,7 +38,7 @@
               = t('app.title')
 
             %button{type:'button', class:'govuk-header__menu-button govuk-js-header-toggle', aria: {label: 'Show or hide Top Level Navigation', controls: 'navigation'}}
-              = t("generic.button.menu")
+              = t("default.button.menu")
 
             = render partial: "shared/navigation"
         - else

--- a/app/views/public/cookie_statement/index.html.haml
+++ b/app/views/public/cookie_statement/index.html.haml
@@ -1,33 +1,33 @@
-= content_for :page_title_prefix, t("page_title.cookie_statement.title")
+= content_for :page_title_prefix, t("cookie_statement.title")
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full.app-visitor-welcome
       %h1.govuk-heading-xl
-        = t("page_title.cookie_statement.title")
+        = t("cookie_statement.title")
       %p.govuk-body
-        = t("page_title.cookie_statement.introduction")
+        = t("cookie_statement.introduction")
       %h2.govuk-heading-m
-        = t("page_title.cookie_statement.website_use.title")
-      - t("page_title.cookie_statement.website_use.paragraph").each do |paragraph|
+        = t("cookie_statement.website_use.title")
+      - t("cookie_statement.website_use.paragraph").each do |paragraph|
         %p.govuk-body
           = paragraph
       %ul.govuk-list.govuk-list--bullet
-        - t("page_title.cookie_statement.website_use.list").each do |item|
+        - t("cookie_statement.website_use.list").each do |item|
           %li
             = item
       %p.govuk-body
-        = t("page_title.cookie_statement.website_use.google_analytics.title")
-      = t("page_title.cookie_statement.website_use.google_analytics.table").html_safe
+        = t("cookie_statement.website_use.google_analytics.title")
+      = t("cookie_statement.website_use.google_analytics.table").html_safe
 
       %h2.govuk-heading-m
-        = t("page_title.cookie_statement.strictly_necessary_cookies.title")
+        = t("cookie_statement.strictly_necessary_cookies.title")
       %p.govuk-body
-        = t("page_title.cookie_statement.strictly_necessary_cookies.paragraph")
-        = t("page_title.cookie_statement.strictly_necessary_cookies.table").html_safe
+        = t("cookie_statement.strictly_necessary_cookies.paragraph")
+        = t("cookie_statement.strictly_necessary_cookies.table").html_safe
       %h2.govuk-heading-m
-        = t("page_title.cookie_statement.gathering_feedback.title")
-      - t("page_title.cookie_statement.gathering_feedback.paragraph").each do |paragraph|
+        = t("cookie_statement.gathering_feedback.title")
+      - t("cookie_statement.gathering_feedback.paragraph").each do |paragraph|
         %p.govuk-body
           = paragraph.html_safe
       %p.govuk-body.published-dates

--- a/app/views/public/visitors/index.html.haml
+++ b/app/views/public/visitors/index.html.haml
@@ -1,19 +1,19 @@
-=content_for :page_title_prefix, t("page_title.home")
+=content_for :page_title_prefix, t("start_page.document_title")
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds.app-visitor-welcome
       %h1.govuk-heading-xl
-        = t("page_title.welcome")
+        = t("start_page.title")
 
       %p.govuk-body
-        = t("page_content.start_page.introduction")
+        = t("start_page.introduction")
 
       %p.govuk-body
-        = t("page_content.start_page.use_this_page_to")
+        = t("start_page.use_this_page_to")
 
       %ul.govuk-list.govuk-list--bullet
-        - t("page_content.start_page.uses").each do |use|
+        - t("start_page.uses").each do |use|
           %li
             = use
 

--- a/app/views/public/visitors/index.html.haml
+++ b/app/views/public/visitors/index.html.haml
@@ -18,6 +18,6 @@
             = use
 
       = button_to '/auth/auth0', class: 'govuk-button', role: 'button', draggable: 'false' do
-        = t("generic.link.sign_in")
+        = t("header.link.sign_in")
         %svg.govuk-button__start-icon{ xmlns: "http://www.w3.org/2000/svg", width: "17.5", height: "19", viewBox: "0 0 33 40", role: "presentation", focusable: "false" }
           %path{ fill: "currentColor", d: "M0 0h13l20 20-20 20H0l20-20z" }

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -17,10 +17,10 @@
       - if authenticated?
         %li{ class: navigation_item_class(users_path) }
           %a{ href: sign_out_path, class: 'govuk-header__link' }
-            = t("generic.link.sign_out")
+            = t("header.link.sign_out")
 
       - else
         %li{ class: navigation_item_class(users_path) }
           .govuk-header__content.app-header__user-links.app-visitor
             %a.govuk-header__link{ data: { method: "post" }, href: "/auth/auth0" }
-              = t('generic.link.sign_in')
+              = t('header.link.sign_in')

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -34,4 +34,4 @@
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
 
     - if policy(:project).download? || policy(:third_party_project).download?
-      = link_to t("generic.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
+      = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.activity.show", name: @activity.title)
 
-= link_to t("generic.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_forms/_wrapper.html.haml
+++ b/app/views/staff/activity_forms/_wrapper.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, @page_title
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -19,4 +19,4 @@
                                :name
 = f.govuk_text_field :value
 
-= f.govuk_submit t("generic.button.submit")
+= f.govuk_submit t("default.button.submit")

--- a/app/views/staff/budgets/edit.html.haml
+++ b/app/views/staff/budgets/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.budget.edit")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/budgets/new.html.haml
+++ b/app/views/staff/budgets/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.budget.new")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row

--- a/app/views/staff/extending_organisations/edit.html.haml
+++ b/app/views/staff/extending_organisations/edit.html.haml
@@ -14,4 +14,4 @@
           list_of_delivery_partners,
           :id,
           :name
-        = f.govuk_submit t("generic.button.submit")
+        = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/extending_organisations/edit.html.haml
+++ b/app/views/staff/extending_organisations/edit.html.haml
@@ -1,6 +1,6 @@
 = content_for :page_title_prefix, t("page_title.activity.show", name: @activity.title)
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/implementing_organisations/edit.html.haml
+++ b/app/views/staff/implementing_organisations/edit.html.haml
@@ -16,4 +16,4 @@
                      :code,
                      :name
         = f.govuk_text_field :reference
-        = f.govuk_submit t("generic.button.submit")
+        = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/implementing_organisations/edit.html.haml
+++ b/app/views/staff/implementing_organisations/edit.html.haml
@@ -1,6 +1,6 @@
 = content_for :page_title_prefix, t("page_title.activity.implementing_organisation.edit", name: @activity.title)
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/implementing_organisations/new.html.haml
+++ b/app/views/staff/implementing_organisations/new.html.haml
@@ -16,4 +16,4 @@
                      :code,
                      :name
         = f.govuk_text_field :reference
-        = f.govuk_submit t("generic.button.submit")
+        = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/implementing_organisations/new.html.haml
+++ b/app/views/staff/implementing_organisations/new.html.haml
@@ -1,6 +1,6 @@
 = content_for :page_title_prefix, t("page_title.activity.implementing_organisation.new", name: @activity.title)
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -15,4 +15,4 @@
                      :code,
                      :name,
                      hint_text: t("form.organisation.default_currency.hint")
-= f.govuk_submit t("generic.button.submit")
+= f.govuk_submit t("default.button.submit")

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -15,6 +15,6 @@
         %td.govuk-table__cell= organisation.iati_reference
         %td.govuk-table__cell
           - if policy(organisation).show?
-            = a11y_action_link(t("generic.link.show"), organisation_path(organisation), organisation.name)
+            = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
           - if policy(organisation).edit?
             = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name)

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -17,4 +17,4 @@
           - if policy(organisation).show?
             = a11y_action_link(t("generic.link.show"), organisation_path(organisation), organisation.name)
           - if policy(organisation).edit?
-            = a11y_action_link(t("generic.link.edit"), edit_organisation_path(organisation), organisation.name)
+            = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name)

--- a/app/views/staff/organisations/edit.html.haml
+++ b/app/views/staff/organisations/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.organisation.edit")
 
-= link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
+= link_to t("default.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/new.html.haml
+++ b/app/views/staff/organisations/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.organisation.new")
 
-= link_to t("generic.link.back"), organisations_path, class: "govuk-back-link"
+= link_to t("default.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -41,7 +41,7 @@
       .govuk-grid-column-full.download-projects
         %div.govuk-body
           = t("page_content.organisation.download.projects.explanation")
-        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :project), class: "govuk-button"
+        = link_to t("default.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :project), class: "govuk-button"
 
 
   - if policy(:third_party_project).index?
@@ -57,7 +57,7 @@
       .govuk-grid-column-full.download-third-party-projects
         %div.govuk-body
           = t("page_content.organisation.download.third-party-projects.explanation")
-        = link_to t("generic.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :third_party_project), class: "govuk-button"
+        = link_to t("default.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :third_party_project), class: "govuk-button"
 
 
   .govuk-grid-row

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -48,4 +48,4 @@
                      label: { text: t("form.planned_disbursement.receiving_organisation_reference.label") },
                      hint_text: t("form.planned_disbursement.receiving_organisation_reference.hint").html_safe
 
-= f.govuk_submit t("generic.button.submit")
+= f.govuk_submit t("default.button.submit")

--- a/app/views/staff/planned_disbursements/edit.html.haml
+++ b/app/views/staff/planned_disbursements/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.planned_disbursement.edit")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/planned_disbursements/new.html.haml
+++ b/app/views/staff/planned_disbursements/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.planned_disbursement.new")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -13,7 +13,7 @@
       = activity_presenter.identifier
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :identifier)
-        = a11y_action_link(t("generic.link.edit"), activity_step_path(activity_presenter, :identifier), t("page_content.activity.identitfier.label").downcase)
+        = a11y_action_link(t("default.link.edit"), activity_step_path(activity_presenter, :identifier), t("page_content.activity.identitfier.label").downcase)
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
@@ -22,7 +22,7 @@
       = activity_presenter.title
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:title)}"),
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:title)}"),
         activity_step_path(activity_presenter, :purpose), t("page_content.activity.title.label"))
 
   .govuk-summary-list__row.description
@@ -32,7 +32,7 @@
       = activity_presenter.description
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
-        = a11y_action_link(I18n.t("generic.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
+        = a11y_action_link(I18n.t("default.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("page_content.activity.description.label").downcase)
 
   .govuk-summary-list__row.sector
     %dt.govuk-summary-list__key
@@ -41,7 +41,7 @@
       = activity_presenter.sector
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("page_content.activity.sector.label"))
 
   .govuk-summary-list__row.status
     %dt.govuk-summary-list__key
@@ -50,7 +50,7 @@
       = activity_presenter.status
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :status)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), t("page_content.activity.status.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), t("page_content.activity.status.label"))
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key
@@ -59,7 +59,7 @@
       = activity_presenter.planned_start_date
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_start_date.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_start_date.label"))
 
 
   .govuk-summary-list__row.planned_end_date
@@ -69,7 +69,7 @@
       = activity_presenter.planned_end_date
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_end_date.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.planned_end_date.label"))
 
   .govuk-summary-list__row.actual_start_date
     %dt.govuk-summary-list__key
@@ -78,7 +78,7 @@
       = activity_presenter.actual_start_date
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_start_date.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_start_date.label"))
 
   .govuk-summary-list__row.actual_end_date
     %dt.govuk-summary-list__key
@@ -87,7 +87,7 @@
       = activity_presenter.actual_end_date
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_end_date.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("page_content.activity.actual_end_date.label"))
 
   - if activity_presenter.recipient_region?
     .govuk-summary-list__row.recipient_region
@@ -97,7 +97,7 @@
         = activity_presenter.recipient_region
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :region)
-          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_region.label"))
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:recipient_region)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_region.label"))
 
   - if activity_presenter.recipient_country?
     .govuk-summary-list__row.recipient_country
@@ -107,7 +107,7 @@
         = activity_presenter.recipient_country
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :country)
-          = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:recipient_country)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_country.label"))
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:recipient_country)}"), activity_step_path(activity_presenter, :geography), t("page_content.activity.recipient_country.label"))
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
@@ -116,7 +116,7 @@
       = activity_presenter.flow
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :flow)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("page_content.activity.flow.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("page_content.activity.flow.label"))
 
   .govuk-summary-list__row.aid_type
     %dt.govuk-summary-list__key
@@ -125,4 +125,4 @@
       = activity_presenter.aid_type
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
-        = a11y_action_link(t("generic.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("page_content.activity.aid_type.label"))
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("page_content.activity.aid_type.label"))

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -27,4 +27,4 @@
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).create?
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("page_content.budgets.edit_noun"))
+              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("page_content.budgets.edit_noun"))

--- a/app/views/staff/shared/implementing_organisations/_table.html.haml
+++ b/app/views/staff/shared/implementing_organisations/_table.html.haml
@@ -17,4 +17,4 @@
         %td.govuk-table__cell= organisation.reference
         %td.govuk-table__cell
           - if policy(:project).edit?
-            = link_to t("generic.link.edit"), edit_activity_implementing_organisation_path(@activity, organisation), class: "govuk-link govuk-link--no-visited-state"
+            = link_to t("default.link.edit"), edit_activity_implementing_organisation_path(@activity, organisation), class: "govuk-link govuk-link--no-visited-state"

--- a/app/views/staff/shared/planned_disbursements/_table.html.haml
+++ b/app/views/staff/shared/planned_disbursements/_table.html.haml
@@ -31,4 +31,4 @@
           %td.govuk-table__cell= planned_disbursement.receiving_organisation_name
           - if policy(planned_disbursement.parent_activity).edit?
             %td.govuk-table__cell
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_planned_disbursement_path(planned_disbursement.parent_activity, planned_disbursement), t("form.planned_disbursement.edit_noun"))
+              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_planned_disbursement_path(planned_disbursement.parent_activity, planned_disbursement), t("form.planned_disbursement.edit_noun"))

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -30,4 +30,4 @@
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(transaction).create?
-              = a11y_action_link(I18n.t('generic.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))
+              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -23,4 +23,4 @@
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = a11y_action_link(t("generic.link.show"), user_path(user), user.name)
-          = a11y_action_link(I18n.t("generic.link.edit"), edit_user_path(user), user.name)
+          = a11y_action_link(I18n.t("default.link.edit"), edit_user_path(user), user.name)

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -22,5 +22,5 @@
         %td.govuk-table__cell.organisation= user.organisation.name
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
-          = a11y_action_link(t("generic.link.show"), user_path(user), user.name)
+          = a11y_action_link(t("default.link.show"), user_path(user), user.name)
           = a11y_action_link(I18n.t("default.link.edit"), edit_user_path(user), user.name)

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -42,4 +42,4 @@
                      hint_text: t("form.transaction.receiving_organisation_reference.hint").html_safe
 
 
-= f.govuk_submit t("generic.button.submit")
+= f.govuk_submit t("default.button.submit")

--- a/app/views/staff/transactions/edit.html.haml
+++ b/app/views/staff/transactions/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.transaction.edit")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/transactions/new.html.haml
+++ b/app/views/staff/transactions/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.transaction.new")
 
-= link_to t("generic.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
+= link_to t("default.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/edit.html.haml
+++ b/app/views/staff/users/edit.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.users.edit")
 
-= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/new.html.haml
+++ b/app/views/staff/users/new.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.users.new")
 
-= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, t("page_title.users.show", name: @user.name)
 
-= link_to t("generic.link.back"), users_path, class: "govuk-back-link"
+= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module Roda
     # the framework and any gems in your application.
 
     # Add IATI locales (:en is the default locale)
-    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "codelists", "**", "*.{rb,yml}")]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     config.i18n.default_locale = :en
     config.i18n.enforce_available_locales = false
 

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -18,3 +18,4 @@ en:
       add: Add
       back: Back
       edit: Edit
+      show: Show

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  app:
+    title: Report your official development assistance
+  date:
+    formats:
+      default: "%-d %b %Y"
+      iati: "%Y-%m-%d"
+  time:
+    formats:
+      default: "%Y-%m-%d"

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -12,3 +12,4 @@ en:
   default:
     button:
       download_as_xml: Download as XML
+      menu: Menu

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -9,3 +9,6 @@ en:
   time:
     formats:
       default: "%Y-%m-%d"
+  default:
+    button:
+      download_as_xml: Download as XML

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -13,3 +13,4 @@ en:
     button:
       download_as_xml: Download as XML
       menu: Menu
+      submit: Submit

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -16,3 +16,4 @@ en:
       submit: Submit
     link:
       add: Add
+      back: Back

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -19,3 +19,5 @@ en:
       back: Back
       edit: Edit
       show: Show
+    error:
+      unknown: Unknown error

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -14,3 +14,5 @@ en:
       download_as_xml: Download as XML
       menu: Menu
       submit: Submit
+    link:
+      add: Add

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -17,3 +17,4 @@ en:
     link:
       add: Add
       back: Back
+      edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,7 +163,6 @@ en:
         success: User successfully updated
   generic:
     button:
-      download_as_xml: Download as XML
       menu: Menu
       submit: Submit
     error:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,6 @@ en:
     error:
       unknown: Unknown error
     link:
-      back: Back
       edit: Edit
       show: Show
       sign_in: Sign in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,13 +309,6 @@ en:
       planned_disbursement_type:
         '1': Original
         '2': Revised
-    start_page:
-      introduction: This service is for reporting BEIS research and innovation ODA.
-      use_this_page_to: 'Use this service to:'
-      uses:
-      - add and manage information about funds and related activities
-      - report actual and forecast spend on activities
-      - see a summary of your ODA activity
     transactions:
       button:
         create: Add a transaction
@@ -401,7 +394,6 @@ en:
       index: Users
       new: Create user
       show: User
-    welcome: Report your official development assistance (ODA)
   user:
     active: Active?
     email: Email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,9 +161,6 @@ en:
       update:
         failed: The service is experiencing issues updating users and the team has been alerted to the problem.
         success: User successfully updated
-  generic:
-    error:
-      unknown: Unknown error
   page_content:
     activities:
       button:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,6 @@ en:
     error:
       unknown: Unknown error
     link:
-      add: Add
       back: Back
       edit: Edit
       show: Show

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,6 @@ en:
     error:
       unknown: Unknown error
     link:
-      edit: Edit
       show: Show
       sign_in: Sign in
       sign_out: Sign out

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,6 @@ en:
     error:
       unknown: Unknown error
     link:
-      show: Show
       sign_in: Sign in
       sign_out: Sign out
   header:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,10 +264,6 @@ en:
       support_prompt: If you believe this to be in error, please contact the person who invited you to the service.
     feedback:
       html: This is a new service – your <a href="https://docs.google.com/forms/d/e/1FAIpQLSfk9abTLRNZdB9tPdtoF_t_1z7q6uPQiZks8NfzGeqg-8UQtQ/viewform" class="govuk-link">feedback</a> will help us to improve it.
-    generic:
-      link:
-        cookie_statement: Cookies
-        privacy_policy: Privacy policy
     organisation:
       button:
         choose_extending_organisation: Choose extending organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,11 +1,5 @@
 ---
 en:
-  app:
-    title: Report your official development assistance
-  date:
-    formats:
-      default: "%-d %b %Y"
-      iati: "%Y-%m-%d"
   form:
     activity:
       create:
@@ -408,9 +402,6 @@ en:
       new: Create user
       show: User
     welcome: Report your official development assistance (ODA)
-  time:
-    formats:
-      default: "%Y-%m-%d"
   user:
     active: Active?
     email: Email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,31 +343,6 @@ en:
     budget:
       edit: Edit budget
       new: Create budget
-    cookie_statement:
-      gathering_feedback:
-        paragraph:
-        - We use Google Forms software to collect information about what you thought of the RODA service. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
-        - For more information on Google‘s cookies, please see the <a href="https://policies.google.com/technologies/cookies?hl=en-UK" class="govuk-link">Google Privacy and Terms</a> site.
-        title: Gathering your feedback
-      introduction: Report official development assistance (RODA) puts small files (known as 'cookies') onto your computer to collect information about how you browse the site and allow the site to operate. Find out more about the cookies we use, what they're for and when they expire.
-      strictly_necessary_cookies:
-        paragraph: These cookies do not store your personal data but are required for the service to operate.
-        table: <table class="govuk-table"> <thead class="govuk-table__head"> <tr class="govuk-table__row"> <th scope="col" class="govuk-table__header">Name</th> <th scope="col" class="govuk-table__header">Purpose</th> <th scope="col" class="govuk-table__header">Expires</th> </tr> </thead> <tbody class="govuk-table__body"> <tr class="govuk-table__row"> <td class="govuk-table__cell">_roda_session</td> <td class="govuk-table__cell">Identifies your session in RODA</td> <td class="govuk-table__cell">When you close your browser or 24 hours</td> </tr> </tbody> </table>
-        title: Strictly necessary cookies
-      title: Details about cookies on Report official development assistance
-      website_use:
-        google_analytics:
-          table: <table class="govuk-table"> <thead class="govuk-table__head"> <tr class="govuk-table__row"> <th scope="col" class="govuk-table__header">Name</th> <th scope="col" class="govuk-table__header">Purpose</th> <th scope="col" class="govuk-table__header">Expires</th> </tr> </thead> <tbody class="govuk-table__body"> <tr class="govuk-table__row"> <td class="govuk-table__cell">_ga</td> <td class="govuk-table__cell">These help us count how many people visit RODA by tracking if you’ve visited before</td> <td class="govuk-table__cell">2 years</td> </tr> <tr class="govuk-table__row"> <td class="govuk-table__cell">_gid</td> <td class="govuk-table__cell">These help us count how many people visit RODA by tracking if you’ve visited before</td> <td class="govuk-table__cell">24 hours</td> </tr> <tr class="govuk-table__row"> <td class="govuk-table__cell">_gat_UA-151431879-2</td> <td class="govuk-table__cell">Used to  control the number of requests RODA makes to Google Analytics</td> <td class="govuk-table__cell">1 minute</td> </tr> </tbody> </table>
-          title: 'Google Analytics sets the following cookies:'
-        list:
-        - how you got to the site
-        - the pages you visit on RODA and how long you spend on them
-        - what you click on while you’re visiting the site
-        paragraph:
-        - We use Google Analytics software to collect anonymised information about how you use RODA. We do this to help make sure the site is meeting the needs of its users and to help us make improvements to the site.
-        - We do not allow Google to use or share the data about how you use this site.
-        - 'Google Analytics stores information about:'
-        title: Cookies that measure website use
     errors:
       auth0:
         failed: Sign in failed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,12 +164,6 @@ en:
   generic:
     error:
       unknown: Unknown error
-    link:
-      sign_in: Sign in
-      sign_out: Sign out
-  header:
-    show:
-      welcome: "%{name}"
   page_content:
     activities:
       button:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,9 +162,6 @@ en:
         failed: The service is experiencing issues updating users and the team has been alerted to the problem.
         success: User successfully updated
   generic:
-    button:
-      menu: Menu
-      submit: Submit
     error:
       unknown: Unknown error
     link:

--- a/config/locales/pundit.en.yml
+++ b/config/locales/pundit.en.yml
@@ -1,4 +1,0 @@
----
-en:
-  pundit:
-    default: You have not been authorised to see this page.

--- a/config/locales/views/cookie_statement.en.yml
+++ b/config/locales/views/cookie_statement.en.yml
@@ -1,0 +1,27 @@
+---
+en:
+  cookie_statement:
+    gathering_feedback:
+      paragraph:
+      - we use google forms software to collect information about what you thought of the roda service. we do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+      - for more information on google‘s cookies, please see the <a href="https://policies.google.com/technologies/cookies?hl=en-uk" class="govuk-link">google privacy and terms</a> site.
+      title: gathering your feedback
+    introduction: Report your official development assistance (boda) puts small files (known as 'cookies') onto your computer to collect information about how you browse the site and allow the site to operate. find out more about the cookies we use, what they're for and when they expire.
+    strictly_necessary_cookies:
+      paragraph: these cookies do not store your personal data but are required for the service to operate.
+      table: <table class="govuk-table"> <thead class="govuk-table__head"> <tr class="govuk-table__row"> <th scope="col" class="govuk-table__header">name</th> <th scope="col" class="govuk-table__header">purpose</th> <th scope="col" class="govuk-table__header">expires</th> </tr> </thead> <tbody class="govuk-table__body"> <tr class="govuk-table__row"> <td class="govuk-table__cell">_roda_session</td> <td class="govuk-table__cell">identifies your session in roda</td> <td class="govuk-table__cell">when you close your browser or 24 hours</td> </tr> </tbody> </table>
+      title: strictly necessary cookies
+    title: Details about cookies on Report your official development assistance
+    website_use:
+      google_analytics:
+        table: <table class="govuk-table"> <thead class="govuk-table__head"> <tr class="govuk-table__row"> <th scope="col" class="govuk-table__header">Name</th> <th scope="col" class="govuk-table__header">Purpose</th> <th scope="col" class="govuk-table__header">Expires</th> </tr> </thead> <tbody class="govuk-table__body"> <tr class="govuk-table__row"> <td class="govuk-table__cell">_ga</td> <td class="govuk-table__cell">These help us count how many people visit RODA by tracking if you’ve visited before</td> <td class="govuk-table__cell">2 years</td> </tr> <tr class="govuk-table__row"> <td class="govuk-table__cell">_gid</td> <td class="govuk-table__cell">These help us count how many people visit RODA by tracking if you’ve visited before</td> <td class="govuk-table__cell">24 hours</td> </tr> <tr class="govuk-table__row"> <td class="govuk-table__cell">_gat_UA-151431879-2</td> <td class="govuk-table__cell">Used to  control the number of requests RODA makes to Google Analytics</td> <td class="govuk-table__cell">1 minute</td> </tr> </tbody> </table>
+        title: 'Google Analytics sets the following cookies:'
+      list:
+      - how you got to the site
+      - the pages you visit on RODA and how long you spend on them
+      - what you click on while you’re visiting the site
+      paragraph:
+      - We use Google Analytics software to collect anonymised information about how you use RODA. We do this to help make sure the site is meeting the needs of its users and to help us make improvements to the site.
+      - We do not allow Google to use or share the data about how you use this site.
+      - 'Google Analytics stores information about:'
+      title: Cookies that measure website use

--- a/config/locales/views/footer.en.yml
+++ b/config/locales/views/footer.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  footer:
+    link:
+      cookie_statement: Cookies
+      privacy_policy: Privacy policy

--- a/config/locales/views/header.en.yml
+++ b/config/locales/views/header.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  header:
+    link:
+      sign_in: Sign in
+      sign_out: Sign out

--- a/config/locales/views/not_authorised.en.yml
+++ b/config/locales/views/not_authorised.en.yml
@@ -1,0 +1,13 @@
+# This translation file is used for Pundit errors
+# Use the Pundit polciy class name as the key
+# otherwise the default is used
+#
+# For example one might add:
+#
+# not_authorised:
+#   organisation_policy:
+#     show?: You have not been authorised to see this organiastion.
+---
+en:
+  not_authorised:
+    default: You have not been authorised to see this page.

--- a/config/locales/views/start.en.yml
+++ b/config/locales/views/start.en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  start_page:
+    document_title: Report your official development assistance (ODA)
+    introduction: This service is for reporting BEIS research and innovation ODA.
+    title: Report your official development assistance (ODA)
+    use_this_page_to: 'Use this service to:'
+    uses:
+    - add and manage information about funds and related activities
+    - report actual and forecast spend on activities
+    - see a summary of your ODA activity

--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -30,7 +30,7 @@ feature "Home page" do
 
     scenario "they are shown the start page" do
       visit root_path
-      expect(page).to have_button(I18n.t("generic.link.sign_in"))
+      expect(page).to have_button(I18n.t("header.link.sign_in"))
     end
   end
 end

--- a/spec/features/public/visitors/user_can_view_privacy_policy_spec.rb
+++ b/spec/features/public/visitors/user_can_view_privacy_policy_spec.rb
@@ -5,13 +5,13 @@ RSpec.feature "Users can view the privacy policy" do
     visit root_path
 
     within("footer") do
-      expect(page).to have_link I18n.t("page_content.generic.link.privacy_policy")
+      expect(page).to have_link I18n.t("footer.link.privacy_policy")
     end
   end
 
   scenario "the linked privacy policy page can be viewed" do
     visit root_path
-    click_on I18n.t("page_content.generic.link.privacy_policy")
+    click_on I18n.t("footer.link.privacy_policy")
 
     expect(page).to have_content I18n.t("page_title.privacy_policy")
   end

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "BEIS users can create organisations" do
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
-      click_button I18n.t("generic.button.submit")
+      click_button I18n.t("default.button.submit")
     end
 
     scenario "organisation creation is tracked with public_activity" do
@@ -38,7 +38,7 @@ RSpec.feature "BEIS users can create organisations" do
         select "Government", from: "organisation[organisation_type]"
         select "Swedish", from: "organisation[language_code]"
         select "US Dollar", from: "organisation[default_currency]"
-        click_button I18n.t("generic.button.submit")
+        click_button I18n.t("default.button.submit")
 
         organisation = Organisation.find_by(name: "My New Organisation")
         auditable_event = PublicActivity::Activity.find_by(trackable_id: organisation.id)
@@ -56,7 +56,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(page).to have_content(I18n.t("page_title.organisation.new"))
       fill_in "organisation[name]", with: "My New Organisation"
 
-      click_button I18n.t("generic.button.submit")
+      click_button I18n.t("default.button.submit")
       expect(page).to_not have_content I18n.t("form.organisation.create.success")
       expect(page).to have_content "can't be blank"
     end

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "BEIS users can editing other users" do
     find("tr", text: user.name).click_link("Edit")
 
     choose I18n.t("form.user.active.inactive")
-    click_on I18n.t("generic.button.submit")
+    click_on I18n.t("default.button.submit")
 
     expect(user.reload.active).to be false
   end
@@ -87,7 +87,7 @@ RSpec.feature "BEIS users can editing other users" do
     find("tr", text: user.name).click_link("Edit")
 
     choose I18n.t("form.user.active.active")
-    click_on I18n.t("generic.button.submit")
+    click_on I18n.t("default.button.submit")
 
     expect(user.reload.active).to be true
   end

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
           fill_in "user[name]", with: "" # deliberately omit a value
           fill_in "user[email]", with: "" # deliberately omit a value
 
-          click_button I18n.t("generic.button.submit")
+          click_button I18n.t("default.button.submit")
 
           expect(page).to have_content("Name can't be blank")
           expect(page).to have_content("Email can't be blank")
@@ -89,7 +89,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
             choose organisation.name
 
             expect {
-              click_button I18n.t("generic.button.submit")
+              click_button I18n.t("default.button.submit")
             }.not_to change { User.count }
 
             expect(page).to have_content(I18n.t("form.user.create.failed", error: "The user already exists."))
@@ -107,7 +107,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
             fill_in "user[email]", with: "tom"
             choose organisation.name
 
-            click_button I18n.t("generic.button.submit")
+            click_button I18n.t("default.button.submit")
 
             expect(page).to have_content("Email is invalid")
             expect(page).not_to have_content(I18n.t("form.user.create.failed"))
@@ -151,6 +151,6 @@ RSpec.feature "BEIS users can invite new users to the service" do
     choose organisation.name
 
     # Submit the form
-    click_button I18n.t("generic.button.submit")
+    click_button I18n.t("default.button.submit")
   end
 end

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
       scenario "can go back to the previous page" do
         visit new_user_path
 
-        click_on I18n.t("generic.link.back")
+        click_on I18n.t("default.link.back")
         expect(page).to have_current_path(users_path)
       end
     end

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "BEIS users can can view other users" do
 
       visit user_path(another_user)
 
-      click_on I18n.t("generic.link.back")
+      click_on I18n.t("default.link.back")
 
       expect(page).to have_current_path(users_path)
     end

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Users can choose a recipient country" do
         fill_in "Country", with: "Saint Lucia"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.activity.submit")
-        click_on I18n.t("generic.link.back")
+        click_on I18n.t("default.link.back")
 
         within(".recipient_country") do
           expect(page).to have_content "Saint Lucia"
@@ -70,7 +70,7 @@ RSpec.feature "Users can choose a recipient country" do
         fill_in "Country", with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.activity.submit")
-        click_on I18n.t("generic.link.back")
+        click_on I18n.t("default.link.back")
 
         within(".recipient_country") do
           expect(page).to have_content "Saint Lucia"

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Users can create a budget" do
 
         click_on(I18n.t("page_content.budgets.button.create"))
 
-        click_button I18n.t("generic.button.submit")
+        click_button I18n.t("default.button.submit")
 
         expect(page).to have_content("There is a problem")
         expect(page).to have_content("Budget type can't be blank")
@@ -131,6 +131,6 @@ RSpec.describe "Users can create a budget" do
     fill_in "budget[period_end_date(1i)]", with: "2020"
     select "Pound Sterling", from: "budget[currency]"
     fill_in "budget[value]", with: "1000.00"
-    click_button I18n.t("generic.button.submit")
+    click_button I18n.t("default.button.submit")
   end
 end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Users can create a planned disbursement" do
       select "Government", from: "planned_disbursement[providing_organisation_type]"
       fill_in "planned_disbursement[receiving_organisation_name]", with: "another org"
       select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
-      click_button I18n.t("generic.button.submit")
+      click_button I18n.t("default.button.submit")
 
       expect(page).to have_current_path organisation_activity_path(user.organisation, project)
       expect(page).to have_content I18n.t("form.planned_disbursement.create.success")

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Users can create a transaction" do
       click_on(activity.title)
 
       click_on(I18n.t("page_content.transactions.button.create"))
-      click_on(I18n.t("generic.button.submit"))
+      click_on(I18n.t("default.button.submit"))
 
       expect(page).to_not have_content(I18n.t("form.transaction.create.success"))
       expect(page).to have_content("Description can't be blank")
@@ -73,7 +73,7 @@ RSpec.feature "Users can create a transaction" do
 
       click_on(I18n.t("page_content.transactions.button.create"))
       expect(page).to have_content("Disbursement channel (optional)")
-      click_on(I18n.t("generic.button.submit"))
+      click_on(I18n.t("default.button.submit"))
 
       expect(page).to_not have_content("Disbursement channel can't be blank")
     end
@@ -96,7 +96,7 @@ RSpec.feature "Users can create a transaction" do
         fill_in "transaction[value]", with: "100000000000"
         select "Money is disbursed through central Ministry of Finance or Treasury", from: "transaction[disbursement_channel]"
         select "Pound Sterling", from: "transaction[currency]"
-        click_on(I18n.t("generic.button.submit"))
+        click_on(I18n.t("default.button.submit"))
 
         expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.inclusion")
       end

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("generic.link.edit")
+        click_on I18n.t("default.link.edit")
       end
 
       fill_in "budget[value]", with: "20"
@@ -32,7 +32,7 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("generic.link.edit")
+        click_on I18n.t("default.link.edit")
       end
 
       fill_in "budget[value]", with: "20"
@@ -51,7 +51,7 @@ RSpec.describe "Users can edit a budget" do
       PublicActivity.with_tracking do
         visit organisation_activity_path(user.organisation, activity)
         within("##{budget.id}") do
-          click_on I18n.t("generic.link.edit")
+          click_on I18n.t("default.link.edit")
         end
 
         fill_in "budget[value]", with: "20"
@@ -71,7 +71,7 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("generic.link.edit")
+        click_on I18n.t("default.link.edit")
       end
 
       fill_in "budget[value]", with: ""

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Users can edit a budget" do
 
       fill_in "budget[value]", with: "20"
       choose("budget[budget_type]", option: "2")
-      click_on I18n.t("generic.button.submit")
+      click_on I18n.t("default.button.submit")
 
       expect(page).to have_content(I18n.t("form.budget.update.success"))
       expect(page).to have_content("20.00")
@@ -37,7 +37,7 @@ RSpec.describe "Users can edit a budget" do
 
       fill_in "budget[value]", with: "20"
       choose("budget[budget_type]", option: "2")
-      click_on I18n.t("generic.button.submit")
+      click_on I18n.t("default.button.submit")
 
       expect(page).to have_content(I18n.t("form.budget.update.success"))
       expect(page).to have_content("20.00")
@@ -56,7 +56,7 @@ RSpec.describe "Users can edit a budget" do
 
         fill_in "budget[value]", with: "20"
         choose("budget[budget_type]", option: "2")
-        click_on I18n.t("generic.button.submit")
+        click_on I18n.t("default.button.submit")
 
         budget = Budget.last
         auditable_event = PublicActivity::Activity.find_by(trackable_id: budget.id)
@@ -78,7 +78,7 @@ RSpec.describe "Users can edit a budget" do
       fill_in "budget[period_start_date(3i)]", with: ""
       fill_in "budget[period_start_date(2i)]", with: ""
       fill_in "budget[period_start_date(1i)]", with: ""
-      click_on I18n.t("generic.button.submit")
+      click_on I18n.t("default.button.submit")
 
       expect(page).to have_content("There is a problem")
       expect(page).to have_content("can't be blank")

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can edit a transaction" do
       expect(page).to have_content(transaction.value)
 
       within("##{transaction.id}") do
-        click_on(I18n.t("generic.link.edit"))
+        click_on(I18n.t("default.link.edit"))
       end
 
       fill_in_transaction_form(
@@ -46,7 +46,7 @@ RSpec.feature "Users can edit a transaction" do
         expect(page).to have_content(transaction.value)
 
         within("##{transaction.id}") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         fill_in_transaction_form(
@@ -74,7 +74,7 @@ RSpec.feature "Users can edit a transaction" do
       expect(page).to have_content(transaction.value)
 
       within("##{transaction.id}") do
-        click_on(I18n.t("generic.link.edit"))
+        click_on(I18n.t("default.link.edit"))
       end
       click_on(I18n.t("default.link.back"))
 

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Users can edit a transaction" do
       within("##{transaction.id}") do
         click_on(I18n.t("generic.link.edit"))
       end
-      click_on(I18n.t("generic.link.back"))
+      click_on(I18n.t("default.link.back"))
 
       expect(page).to have_content(activity.title)
     end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can edit an activity" do
 
         # Click the first edit link that opens the form on step 1
         within(".identifier") do
-          expect(page).to have_content(I18n.t("generic.link.edit"))
+          expect(page).to have_content(I18n.t("default.link.edit"))
         end
 
         within(".title") do
@@ -34,7 +34,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".identifier") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         fill_in "activity[identifier]", with: identifier
@@ -59,7 +59,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_path(activity.organisation, activity)
 
           within(".identifier") do
-            click_on(I18n.t("generic.link.edit"))
+            click_on(I18n.t("default.link.edit"))
           end
 
           fill_in "activity[identifier]", with: identifier
@@ -82,7 +82,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".recipient_region") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
         choose "Region"
         click_button I18n.t("form.activity.submit")
@@ -101,7 +101,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".title") do
-          expect(page).to have_content(I18n.t("generic.link.edit"))
+          expect(page).to have_content(I18n.t("default.link.edit"))
         end
       end
     end
@@ -129,7 +129,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         click_button I18n.t("form.activity.submit")
@@ -161,7 +161,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         click_button I18n.t("form.activity.submit")
@@ -180,7 +180,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         click_button I18n.t("form.activity.submit")
@@ -192,7 +192,7 @@ end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   within(".identifier") do
-    click_on I18n.t("generic.link.edit")
+    click_on I18n.t("default.link.edit")
     expect(page).to have_current_path(
       activity_step_path(activity, :identifier)
     )
@@ -200,7 +200,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".sector") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :sector_category)
     )
@@ -208,7 +208,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".title") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :purpose)
     )
@@ -216,7 +216,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".description") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :purpose)
     )
@@ -224,7 +224,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".status") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :status)
     )
@@ -232,7 +232,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".planned_start_date") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
@@ -240,7 +240,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".planned_end_date") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
@@ -248,7 +248,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".actual_start_date") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
@@ -256,7 +256,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".actual_end_date") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
@@ -264,7 +264,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".recipient_region") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :geography)
     )
@@ -272,7 +272,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".flow") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :flow)
     )
@@ -280,7 +280,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
 
   within(".aid_type") do
-    click_on(I18n.t("generic.link.edit"))
+    click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :aid_type)
     )

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -18,11 +18,11 @@ RSpec.feature "Users can edit an activity" do
         end
 
         within(".title") do
-          expect(page).to have_content(I18n.t("generic.link.add"))
+          expect(page).to have_content(I18n.t("default.link.add"))
         end
 
         within(".sector") do
-          expect(page).to_not have_content(I18n.t("generic.link.add"))
+          expect(page).to_not have_content(I18n.t("default.link.add"))
         end
       end
     end
@@ -113,7 +113,7 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_path(activity.organisation, activity)
 
         within(".title") do
-          expect(page).to have_content(I18n.t("generic.link.add"))
+          expect(page).to have_content(I18n.t("default.link.add"))
         end
       end
     end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -197,7 +197,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :identifier)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".sector") do
     click_on(I18n.t("generic.link.edit"))
@@ -205,7 +205,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :sector_category)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".title") do
     click_on(I18n.t("generic.link.edit"))
@@ -213,7 +213,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :purpose)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".description") do
     click_on(I18n.t("generic.link.edit"))
@@ -221,7 +221,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :purpose)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".status") do
     click_on(I18n.t("generic.link.edit"))
@@ -229,7 +229,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :status)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".planned_start_date") do
     click_on(I18n.t("generic.link.edit"))
@@ -237,7 +237,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".planned_end_date") do
     click_on(I18n.t("generic.link.edit"))
@@ -245,7 +245,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".actual_start_date") do
     click_on(I18n.t("generic.link.edit"))
@@ -253,7 +253,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".actual_end_date") do
     click_on(I18n.t("generic.link.edit"))
@@ -261,7 +261,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".recipient_region") do
     click_on(I18n.t("generic.link.edit"))
@@ -269,7 +269,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :geography)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".flow") do
     click_on(I18n.t("generic.link.edit"))
@@ -277,7 +277,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :flow)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 
   within(".aid_type") do
     click_on(I18n.t("generic.link.edit"))
@@ -285,5 +285,5 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
       activity_step_path(activity, :aid_type)
     )
   end
-  click_on(I18n.t("generic.link.back"))
+  click_on(I18n.t("default.link.back"))
 end

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Users can edit organisations" do
     visit organisation_path(beis_organisation)
     click_link I18n.t("page_title.organisation.index")
     within("##{another_organisation.id}") do
-      click_link I18n.t("generic.link.edit")
+      click_link I18n.t("default.link.edit")
     end
 
     expect(page).to have_content(I18n.t("page_title.organisation.edit"))
@@ -53,7 +53,7 @@ RSpec.feature "Users can edit organisations" do
     click_link I18n.t("page_title.organisation.index")
 
     within("##{another_organisation.id}") do
-      click_link I18n.t("generic.link.edit")
+      click_link I18n.t("default.link.edit")
     end
 
     expect(page).to have_content(I18n.t("page_title.organisation.edit"))

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Users can edit organisations" do
     expect(page).to have_content(I18n.t("page_title.organisation.edit"))
     fill_in "organisation[name]", with: ""
 
-    click_button I18n.t("generic.button.submit")
+    click_button I18n.t("default.button.submit")
     expect(page).to_not have_content I18n.t("form.organisation.update.success")
     expect(page).to have_content "can't be blank"
   end
@@ -62,7 +62,7 @@ RSpec.feature "Users can edit organisations" do
     select "Government", from: "organisation[organisation_type]"
     select "Czech", from: "organisation[language_code]"
     select "Zloty", from: "organisation[default_currency]"
-    click_button I18n.t("generic.button.submit")
+    click_button I18n.t("default.button.submit")
     expect(page).to have_content I18n.t("form.organisation.update.success")
   end
 end

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Users can edit a planned disbursement" do
         visit organisation_path(user.organisation)
         click_on(project.title)
         within("##{planned_disbursement.id}") do
-          click_on(I18n.t("generic.link.edit"))
+          click_on(I18n.t("default.link.edit"))
         end
 
         fill_in_planned_disbursement_form(value: "2000.51")

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can manage the extending organisation" do
 
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
         choose delivery_partner.name
-        click_on I18n.t("generic.button.submit")
+        click_on I18n.t("default.button.submit")
 
         expect(page).to have_content("success")
         expect(page).to have_content delivery_partner.name
@@ -30,7 +30,7 @@ RSpec.feature "Users can manage the extending organisation" do
         expect(page).to have_checked_field delivery_partner.name
 
         choose another_delivery_partner.name
-        click_on I18n.t("generic.button.submit")
+        click_on I18n.t("default.button.submit")
 
         expect(page).to have_content("success")
         expect(page).to have_content another_delivery_partner.name
@@ -39,7 +39,7 @@ RSpec.feature "Users can manage the extending organisation" do
       scenario "not selecting an extending organisation results in an error" do
         visit organisation_activity_path(programme.organisation, programme)
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
-        click_on I18n.t("generic.button.submit")
+        click_on I18n.t("default.button.submit")
 
         expect(page).to have_content "Error: Extending organisation can't be blank"
       end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_link I18n.t("generic.link.edit"), href: edit_activity_implementing_organisation_path(project, other_public_sector_organisation)
+      expect(page).not_to have_link I18n.t("default.link.edit"), href: edit_activity_implementing_organisation_path(project, other_public_sector_organisation)
     end
 
     scenario "they cannot add implementing organisations" do

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       fill_in I18n.t("activerecord.attributes.implementing_organisation.name"), with: other_public_sector_organisation.name
       select("Other Public Sector", from: I18n.t("activerecord.attributes.implementing_organisation.organisation_type"))
       fill_in I18n.t("activerecord.attributes.implementing_organisation.reference"), with: other_public_sector_organisation.reference
-      click_on I18n.t("generic.button.submit")
+      click_on I18n.t("default.button.submit")
 
       expect(current_path).to eq organisation_activity_path(project.organisation, project)
       expect(page).to have_content I18n.t("form.implementing_organisation.create.success")
@@ -45,7 +45,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       expect(find_field(I18n.t("activerecord.attributes.implementing_organisation.name")).value).to eq other_public_sector_organisation.name
 
       fill_in I18n.t("activerecord.attributes.implementing_organisation.name"), with: "It is a charity"
-      click_on I18n.t("generic.button.submit")
+      click_on I18n.t("default.button.submit")
 
       expect(page).to have_content I18n.t("form.implementing_organisation.update.success")
       expect(page).to have_content "It is a charity"

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -10,11 +10,11 @@ RSpec.feature "Users can sign in with Auth0" do
     visit root_path
     expect(page).to have_content(I18n.t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("generic.link.sign_in"))
-    click_on I18n.t("generic.link.sign_in")
+    expect(page).to have_content(I18n.t("header.link.sign_in"))
+    click_on I18n.t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
-    expect(page).to have_content(I18n.t("generic.link.sign_out"))
+    expect(page).to have_content(I18n.t("header.link.sign_out"))
   end
 
   scenario "successful sign in via button link" do
@@ -26,11 +26,11 @@ RSpec.feature "Users can sign in with Auth0" do
     visit dashboard_path
     expect(page).to have_content(I18n.t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("generic.link.sign_in"))
-    click_on I18n.t("generic.link.sign_in")
+    expect(page).to have_content(I18n.t("header.link.sign_in"))
+    click_on I18n.t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
-    expect(page).to have_content(I18n.t("generic.link.sign_out"))
+    expect(page).to have_content(I18n.t("header.link.sign_out"))
   end
 
   scenario "any user lands on their organisation page" do
@@ -43,8 +43,8 @@ RSpec.feature "Users can sign in with Auth0" do
     visit root_path
     expect(page).to have_content(I18n.t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("generic.link.sign_in"))
-    click_on I18n.t("generic.link.sign_in")
+    expect(page).to have_content(I18n.t("header.link.sign_in"))
+    click_on I18n.t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
   end
@@ -64,8 +64,8 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("generic.link.sign_in"))
-      click_on I18n.t("generic.link.sign_in")
+      expect(page).to have_content(I18n.t("header.link.sign_in"))
+      click_on I18n.t("header.link.sign_in")
 
       expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
       expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))
@@ -80,8 +80,8 @@ RSpec.feature "Users can sign in with Auth0" do
     it "displays the error message so they can try to correct the problem themselves" do
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("generic.link.sign_in"))
-      click_on I18n.t("generic.link.sign_in")
+      expect(page).to have_content(I18n.t("header.link.sign_in"))
+      click_on I18n.t("header.link.sign_in")
 
       expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.explanation"))
       expect(page).to have_content(I18n.t("page_content.errors.auth0.error_messages.invalid_credentials"))
@@ -99,7 +99,7 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit root_path
 
-      click_button I18n.t("generic.link.sign_in")
+      click_button I18n.t("header.link.sign_in")
 
       expect(page).not_to have_content("unknown_failure")
       expect(page).to have_content(I18n.t("page_content.errors.auth0.error_messages.generic"))
@@ -116,8 +116,8 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("generic.link.sign_in"))
-      click_on I18n.t("generic.link.sign_in")
+      expect(page).to have_content(I18n.t("header.link.sign_in"))
+      click_on I18n.t("header.link.sign_in")
 
       expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
       expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(I18n.t("page_title.welcome"))
+    expect(page).to have_content(I18n.t("start_page.title"))
 
     expect(page).to have_content(I18n.t("generic.link.sign_in"))
     click_on I18n.t("generic.link.sign_in")
@@ -24,7 +24,7 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit dashboard_path
-    expect(page).to have_content(I18n.t("page_title.welcome"))
+    expect(page).to have_content(I18n.t("start_page.title"))
 
     expect(page).to have_content(I18n.t("generic.link.sign_in"))
     click_on I18n.t("generic.link.sign_in")
@@ -41,7 +41,7 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(I18n.t("page_title.welcome"))
+    expect(page).to have_content(I18n.t("start_page.title"))
 
     expect(page).to have_content(I18n.t("generic.link.sign_in"))
     click_on I18n.t("generic.link.sign_in")
@@ -52,7 +52,7 @@ RSpec.feature "Users can sign in with Auth0" do
   scenario "protected pages cannot be visited unless signed in" do
     visit dashboard_path
 
-    expect(page).to have_content(I18n.t("page_title.welcome"))
+    expect(page).to have_content(I18n.t("start_page.title"))
   end
 
   context "when the Auth0 identifier does not match a user record" do

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Users can view a project" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to_not have_content I18n.t("generic.button.download_as_xml")
+      expect(page).to_not have_content I18n.t("default.button.download_as_xml")
     end
   end
 
@@ -81,9 +81,9 @@ RSpec.feature "Users can view a project" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to have_content I18n.t("generic.button.download_as_xml")
+      expect(page).to have_content I18n.t("default.button.download_as_xml")
 
-      click_on I18n.t("generic.button.download_as_xml")
+      click_on I18n.t("default.button.download_as_xml")
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Users can view an activity" do
 
       visit organisation_activity_path(user.organisation, activity)
 
-      click_on I18n.t("generic.link.back")
+      click_on I18n.t("default.link.back")
 
       expect(page).to have_current_path(
         organisation_path(user.organisation)

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can view an organisation as XML" do
         visit organisation_path(beis)
 
         expect(page).to have_content(beis.name)
-        expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+        expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
+          expect(page).to have_content(I18n.t("default.button.download_as_xml"))
         end
 
         scenario "the XML file contains an `iati-activity` element for the project activities in the organisation" do
@@ -33,7 +33,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-projects" do
-            click_link I18n.t("generic.button.download_as_xml")
+            click_link I18n.t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -49,7 +49,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to have_content(I18n.t("generic.button.download_as_xml"))
+          expect(page).to have_content(I18n.t("default.button.download_as_xml"))
         end
 
         scenario "the XML file contains an `iati-activity` element for the third-party project activity in the organisation" do
@@ -58,7 +58,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-third-party-projects" do
-            click_link I18n.t("generic.button.download_as_xml")
+            click_link I18n.t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -73,7 +73,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+          expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
         end
       end
 
@@ -82,7 +82,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+          expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.feature "Users can view an organisation as XML" do
         _transaction = create(:transaction, parent_activity: project, value: 100)
 
         visit organisation_path(organisation)
-        click_link I18n.t("generic.button.download_as_xml")
+        click_link I18n.t("default.button.download_as_xml")
         xml = Nokogiri::XML::Document.parse(page.body)
 
         expect(xml.xpath("/iati-activities/iati-activity/budget/value").text).to eq "2000.0"
@@ -125,7 +125,7 @@ RSpec.feature "Users can view an organisation as XML" do
         visit organisation_path(organisation)
 
         expect(page).to have_content(organisation.name)
-        expect(page).to_not have_content(I18n.t("generic.button.download_as_xml"))
+        expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
       end
     end
 

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Users can view an organisation" do
       scenario "does not see a back link on their organisation page" do
         visit organisation_path(user.organisation)
 
-        expect(page).to_not have_content(I18n.t("generic.link.back"))
+        expect(page).to_not have_content(I18n.t("default.link.back"))
       end
 
       scenario "can see a list of fund activities" do
@@ -93,7 +93,7 @@ RSpec.feature "Users can view an organisation" do
           click_link I18n.t("generic.link.show")
         end
         expect(page).to have_content(other_organisation.name)
-        click_on I18n.t("generic.link.back")
+        click_on I18n.t("default.link.back")
 
         expect(page).to have_current_path(organisations_path)
       end
@@ -116,7 +116,7 @@ RSpec.feature "Users can view an organisation" do
     scenario "does not see a back link on their organisation home page" do
       visit organisation_path(organisation)
 
-      expect(page).to_not have_content(I18n.t("generic.link.back"))
+      expect(page).to_not have_content(I18n.t("default.link.back"))
     end
 
     scenario "can see a list of programme activities" do

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Users can view an organisation" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")
         within("##{other_organisation.id}") do
-          click_link I18n.t("generic.link.show")
+          click_link I18n.t("default.link.show")
         end
         expect(page).to have_content(other_organisation.name)
       end
@@ -64,7 +64,7 @@ RSpec.feature "Users can view an organisation" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")
         within("##{other_organisation.id}") do
-          click_link I18n.t("generic.link.show")
+          click_link I18n.t("default.link.show")
         end
 
         expect(page).to have_content(programme.title)
@@ -78,7 +78,7 @@ RSpec.feature "Users can view an organisation" do
         visit organisation_path(user.organisation)
         click_link I18n.t("page_title.organisation.index")
         within("##{other_organisation.id}") do
-          click_link I18n.t("generic.link.show")
+          click_link I18n.t("default.link.show")
         end
 
         expect(page).to_not have_content(other_programme.title)
@@ -90,7 +90,7 @@ RSpec.feature "Users can view an organisation" do
         click_link I18n.t("page_title.organisation.index")
 
         within("##{other_organisation.id}") do
-          click_link I18n.t("generic.link.show")
+          click_link I18n.t("default.link.show")
         end
         expect(page).to have_content(other_organisation.name)
         click_on I18n.t("default.link.back")

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
         within("tr##{budget.id}") do
-          expect(page).not_to have_content(I18n.t("generic.link.edit"))
+          expect(page).not_to have_content(I18n.t("default.link.edit"))
         end
       end
     end
@@ -117,7 +117,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         click_link programme_activity.title
 
         within "##{budget.id}" do
-          expect(page).to_not have_content I18n.t("generic.link.edit")
+          expect(page).to_not have_content I18n.t("default.link.edit")
         end
       end
     end
@@ -151,7 +151,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         expect(page).to have_content(I18n.t("page_content.budgets.button.create"))
         within("tr##{budget.id}") do
-          expect(page).to have_content(I18n.t("generic.link.edit"))
+          expect(page).to have_content(I18n.t("default.link.edit"))
         end
       end
     end

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Users can view fund level activities" do
 
       visit organisation_activity_path(user.organisation, activity)
 
-      click_on I18n.t("generic.link.back")
+      click_on I18n.t("default.link.back")
 
       expect(page).to have_current_path(organisation_path(user.organisation))
     end

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Users can view a third-party project" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to_not have_content I18n.t("generic.button.download_as_xml")
+      expect(page).to_not have_content I18n.t("default.button.download_as_xml")
     end
 
     scenario "can view and add budgets and transactions on a third-party project" do
@@ -60,9 +60,9 @@ RSpec.feature "Users can view a third-party project" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to have_content I18n.t("generic.button.download_as_xml")
+      expect(page).to have_content I18n.t("default.button.download_as_xml")
 
-      click_on I18n.t("generic.button.download_as_xml")
+      click_on I18n.t("default.button.download_as_xml")
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Users can view transactions on an activity page" do
 
         expect(page).to_not have_content(I18n.t("page_content.transactions.button.create"))
         within("tr##{transaction.id}") do
-          expect(page).not_to have_content(I18n.t("generic.link.edit"))
+          expect(page).not_to have_content(I18n.t("default.link.edit"))
         end
       end
     end

--- a/spec/features/user_can_view_static_pages_spec.rb
+++ b/spec/features/user_can_view_static_pages_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature "Users can view the static pages" do
       visit root_path
 
       within("footer") do
-        expect(page).to have_link I18n.t("page_content.generic.link.privacy_policy")
+        expect(page).to have_link I18n.t("footer.link.privacy_policy")
       end
     end
 
     scenario "the linked privacy policy page can be viewed" do
       visit root_path
-      click_on I18n.t("page_content.generic.link.privacy_policy")
+      click_on I18n.t("footer.link.privacy_policy")
 
       expect(page).to have_content I18n.t("page_title.privacy_policy")
     end
@@ -21,13 +21,13 @@ RSpec.feature "Users can view the static pages" do
       visit root_path
 
       within("footer") do
-        expect(page).to have_link I18n.t("page_content.generic.link.cookie_statement")
+        expect(page).to have_link I18n.t("footer.link.cookie_statement")
       end
     end
 
     scenario "the linked cookie statement page can be viewed" do
       visit root_path
-      click_on I18n.t("page_content.generic.link.cookie_statement")
+      click_on I18n.t("footer.link.cookie_statement")
 
       expect(page).to have_content I18n.t("page_title.cookie_statement.title")
     end

--- a/spec/features/user_can_view_static_pages_spec.rb
+++ b/spec/features/user_can_view_static_pages_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Users can view the static pages" do
       visit root_path
       click_on I18n.t("footer.link.cookie_statement")
 
-      expect(page).to have_content I18n.t("page_title.cookie_statement.title")
+      expect(page).to have_content I18n.t("cookie_statement.title")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.feature "Users can view the static pages" do
 
       visit cookie_statement_path
 
-      expect(page).to have_content I18n.t("page_title.cookie_statement.title")
+      expect(page).to have_content I18n.t("cookie_statement.title")
     end
   end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -10,12 +10,4 @@ RSpec.describe "I18n" do
     expect(missing_keys).to be_empty,
       "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
-
-  it "files are normalized" do
-    non_normalized = i18n.non_normalized_paths
-    error_message = "The following files need to be normalized:\n" \
-                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
-                    "Please run `i18n-tasks normalize` to fix"
-    expect(non_normalized).to be_empty, error_message
-  end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -25,6 +25,6 @@ module AuthenticationHelpers
   def stub_authenticated_session(uid: "123456789", name: "Alex", email: "alex@example.com")
     mock_successful_authentication(uid: uid, name: name, email: email)
     visit root_path
-    click_on I18n.t("generic.link.sign_in")
+    click_on I18n.t("header.link.sign_in")
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -154,7 +154,7 @@ module FormHelpers
     select receiving_organisation.type, from: "transaction[receiving_organisation_type]"
     fill_in "transaction[receiving_organisation_reference]", with: receiving_organisation.reference
 
-    click_on(I18n.t("generic.button.submit"))
+    click_on(I18n.t("default.button.submit"))
 
     if expectations
       within ".transactions" do
@@ -200,7 +200,7 @@ module FormHelpers
     select receiving_organisation.type, from: "planned_disbursement[receiving_organisation_type]"
     fill_in "planned_disbursement[receiving_organisation_reference]", with: receiving_organisation.reference
 
-    click_on(I18n.t("generic.button.submit"))
+    click_on(I18n.t("default.button.submit"))
   end
 
   def localise_date_from_input_fields(year:, month:, day:)


### PR DESCRIPTION
## Changes in this PR
This is the first part of the work to refactor our locales into better shape to help the team manage them.

The work has been discussed with the team and thsoe thoughts are here:

https://miro.com/app/board/o9J_kv27qEM=/?moveToWidget=3074457348258073280&cot=13

Part 1 delivers:

- start to bring the new structure to the locales on disk
- extract any pages into their own files in a views directory to contextualise them
- configure Rails (8191d7b)
- stop enforcing I18n-task normalization (2165b2a)
- move the old 'generic' strings into the new default domain
- start to be clear about html page titles and content page titles as we think the may be different

## Next
- Work to extract each model to it's own file
- configure the GOVUK form builder to use the new model files
- contrinue to extract strings from `en.yml` to the new structure
- generally make the locales more approachable (remains to be seen! 😄 )

After this we can get back to @duffylouise cards and get them sorted.
