### PR TITLE
Booting the app with missing env variables will give a meaningful error

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -9,3 +9,7 @@ DATABASE_URL=postgres://postgres@localhost:5432/roda_test
 NOTIFY_KEY=abc
 NOTIFY_WELCOME_EMAIL_TEMPLATE=123
 REDIS_URL=redis://localhost:6379
+SECRET_KEY_BASE=super secret
+AUTH0_CLIENT_ID=stand-in
+AUTH0_CLIENT_SECRET=stand-in
+AUTH0_DOMAIN=stand-in.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,13 @@ RUN cp -R $DEPS_HOME/node_modules/govuk-frontend/govuk/assets $APP_HOME/app/asse
 
 RUN \
   RAILS_ENV=$RAILS_ENV \
+  DOMAIN="stand-in.local" \
   SECRET_KEY_BASE="super secret" \
-  REDIS_URL="redis://build.local:6379" \
+  DATABASE_URL="postgres://stand-in:5432" \
+  REDIS_URL="redis://stand-in.local:6379" \
+  AUTH0_CLIENT_ID="stand-in" \
+  AUTH0_CLIENT_SECRET="stand-in" \
+  AUTH0_DOMAIN="stand-in.local" \
   bundle exec rake assets:precompile --quiet
 
 # create tmp/pids

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,3 +1,13 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
-Dotenv.require_keys if defined?(Dotenv)
+if defined?(Dotenv)
+  Dotenv.require_keys(
+    "DOMAIN",
+    "DATABASE_URL",
+    "REDIS_URL",
+    "SECRET_KEY_BASE",
+    "AUTH0_CLIENT_ID",
+    "AUTH0_CLIENT_SECRET",
+    "AUTH0_DOMAIN",
+  )
+end


### PR DESCRIPTION
## Changes in this PR

We noticed that as a result of change to session_store.rb which rqeuired REDIS_URL to be present. This change was order to make sure our session storage was consistent across environments and to fail loudly if it wasn't, removing the chance of obscure errors that were inconsistent to debug. Eg, cookie overflows.

After rolling this change out we found out that existing members of the dev team and new joiners got tripped up by this new requirement.

This change moves to make `rails s` produce a meaninful error to developers so that they can quickly establish that they are missing environment variables. Rather than hunting through the errors that occur when an expected value was missing further down the line.

Since we are using Dotenv to load our environment variables I've used their recommended approach [1] and added what I believe are the required keys for a successful boot and sign in. Skylight, rollbar and google analytics are not required.

There is a trade off that this file will need to be maintained with new environment variables and that if we forget we will run into the same issue. The app is 6 months old now so I don't expect an avalanche of new dependencies that would make this less valuable to include now.

[1] https://github.com/bkeepers/dotenv#required-keys

## Screenshots of UI changes

### Before

![Screenshot 2020-06-05 at 10 45 08](https://user-images.githubusercontent.com/912473/83862322-aefc1b00-a719-11ea-9540-3891bcce7d02.png)

### After

![Screenshot 2020-06-05 at 10 38 31](https://user-images.githubusercontent.com/912473/83862331-b15e7500-a719-11ea-928f-298e9ae32c26.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
