### PR TITLE
(691) Address ingested activities with missing mandatory dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@
 - Transactions can have a negative value (but not zero)
 - Amend Activity date validations - either `planned_start_date` *OR* `actual_start_date`
   must be present, in line with the IATI `activity-date` XML standard
+- Amend ingest service to successfully ingest Activities without an `activity-date` type
+  2 (`actual_start_date`)  
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@
 ## [unreleased]
 
 - Transactions can have a negative value (but not zero)
+- Amend Activity date validations - either `planned_start_date` *OR* `actual_start_date`
+  must be present, in line with the IATI `activity-date` XML standard
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -32,7 +32,8 @@ class Activity < ApplicationRecord
   validates :aid_type, presence: true, on: :aid_type_step
 
   validates_uniqueness_of :identifier, allow_nil: true
-  validates :planned_start_date, :planned_end_date, presence: true, on: :dates_step
+  validates :planned_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.actual_start_date.present? }
+  validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -260,13 +260,13 @@ class IngestIatiActivities
 
   private def add_dates(legacy_activity:, new_activity:)
     planned_start_date_element = legacy_activity.elements.detect { |element| element.name.eql?("activity-date") && element.attributes["type"].value.eql?("1") }
-    new_activity.planned_start_date = planned_start_date_element.attributes["iso-date"].value || nil
+    new_activity.planned_start_date = planned_start_date_element ? planned_start_date_element.attributes["iso-date"].value : nil
     actual_start_date_element = legacy_activity.elements.detect { |element| element.name.eql?("activity-date") && element.attributes["type"].value.eql?("2") }
-    new_activity.actual_start_date = actual_start_date_element.attributes["iso-date"].value || nil
+    new_activity.actual_start_date = actual_start_date_element ? actual_start_date_element.attributes["iso-date"].value : nil
     planned_end_date_element = legacy_activity.elements.detect { |element| element.name.eql?("activity-date") && element.attributes["type"].value.eql?("3") }
-    new_activity.planned_end_date = planned_end_date_element.attributes["iso-date"].value || nil if planned_end_date_element
+    new_activity.planned_end_date = planned_end_date_element ? planned_end_date_element.attributes["iso-date"].value : nil
     actual_end_date_element = legacy_activity.elements.detect { |element| element.name.eql?("activity-date") && element.attributes["type"].value.eql?("4") }
-    new_activity.actual_end_date = actual_end_date_element.attributes["iso-date"].value || nil if actual_end_date_element
+    new_activity.actual_end_date = actual_end_date_element ? actual_end_date_element.attributes["iso-date"].value : nil
   end
 
   private def add_identifiers(legacy_activity:, new_activity:)

--- a/config/locales/models_and_forms.en.yml
+++ b/config/locales/models_and_forms.en.yml
@@ -72,6 +72,7 @@ en:
             actual_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Actual start date must not be in the future
+            dates: Enter an actual start date or a planned start date for the activity
             planned_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
             planned_start_date:
@@ -118,8 +119,8 @@ en:
     fieldset:
       activity:
         actual_end_date: Actual end date (optional)
-        actual_start_date: Actual start date (optional)
-        planned_end_date: Planned end date
+        actual_start_date: Actual start date
+        planned_end_date: Planned end date (optional)
         planned_start_date: Planned start date
         sector_category:
           html: What area of the economy or society is your %{level} helping? For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -153,8 +153,7 @@ RSpec.feature "Users can create a fund level activity" do
         expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
 
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Planned start date can't be blank"
-        expect(page).to have_content "Planned end date can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.dates")
 
         # Dates cannot contain only a zero
         fill_in "activity[planned_start_date(3i)]", with: 1
@@ -164,8 +163,7 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[planned_end_date(2i)]", with: 12
         fill_in "activity[planned_end_date(1i)]", with: 2010
         click_button I18n.t("form.activity.submit")
-        expect(page).to have_content "Planned start date can't be blank"
-        expect(page).to have_content "Planned end date can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.dates")
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12

--- a/spec/fixtures/activities/ams/newt/fake_activity_with_dates.xml
+++ b/spec/fixtures/activities/ams/newt/fake_activity_with_dates.xml
@@ -1,0 +1,103 @@
+<iati-activities generated-datetime="2019-09-18T14:57:06+00:00" version="2.03">
+  <iati-activity default-currency="GBP" hierarchy="2" last-updated-datetime="2019-09-18T15:28:04.680000+00:00">
+    <iati-identifier>GB-GOV-13-NEWT-AMS_ZAF_NAF0012</iati-identifier>
+    <reporting-org ref="GB-GOV-13" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Newton Advanced Fellowships 2020/21</narrative>
+    </title>
+    <description type="1">
+      <narrative>Grants to support international researchers to establish and develop collaborative partnerships with UK researchers.</narrative>
+    </description>
+    <description type="2">
+      <narrative>The primary aims of the Newton Advanced Fellowship programme are to:
+        &#8226; Support the development of a well - trained research community who can contribute to advancing economic development and social welfare of the partner country by transferring new skills and creating new knowledge.
+        &#8226; Strengthen research excellence in partner countries by supporting promising independent, early to mid-career researchers and their research groups and networks to develop their research through training, collaboration, reciprocal visits and the transfer of knowledge and skills from the UK.
+        &#8226; Establish long-term links between the best research groups and networks in partner countries and the UK to ensure that improvements in research capacity are sustainable in the longer term.
+        &#8226;10 fellowships (Newton Advanced Fellowships/Newton International Fellowships) between  &#163;100Kand &#163;111K over 2-3 years.</narrative>
+    </description>
+    <participating-org ref="GB-GOV-13" role="1" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org ref="GB-GOV-13" role="2" type="10">
+      <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+    </participating-org>
+    <participating-org role="3" type="80">
+      <narrative>Academy of Medical Sciences</narrative>
+    </participating-org>
+    <participating-org role="4" type="80">
+      <narrative>Academy of Medical Sciences</narrative>
+    </participating-org>
+    <activity-status code="1"/>
+    <activity-date iso-date="2020-07-01" type="1"/>
+    <activity-date iso-date="2020-09-30" type="3"/>
+    <contact-info type="1">
+      <organisation>
+        <narrative>Department of Business Energy and Industrial Strategy </narrative>
+      </organisation>
+      <department>
+        <narrative>Global Science and Innovation</narrative>
+      </department>
+      <person-name>
+        <narrative>NEWTON FUND</narrative>
+      </person-name>
+      <email>NewtonFund@ODAmanagement.org</email>
+      <website>https://www.gov.uk/government/publications/beis-official-development-assistance-research-and-innovation</website>
+      <mailing-address>
+        <narrative>Department of Business, Energy and Industrial Strategy, 4th Floor, 1 Victoria Street, SW1H 0ET</narrative>
+      </mailing-address>
+    </contact-info>
+    <recipient-country code="ZA">
+      <narrative>SOUTH AFRICA</narrative>
+    </recipient-country>
+    <recipient-region code="289" percentage="100" vocabulary="1"/>
+    <sector code="43081">
+      <narrative>Multisector education/training</narrative>
+    </sector>
+    <collaboration-type code="1"/>
+    <default-flow-type code="10"/>
+    <default-finance-type code="110"/>
+    <default-aid-type code="D02"/>
+    <default-tied-status code="5"/>
+    <budget status="2" type="1">
+      <period-start iso-date="2020-07-01"/>
+      <period-end iso-date="2023-06-30"/>
+      <value currency="GBP" value-date="2020-07-01">148000</value>
+    </budget>
+    <planned-disbursement type="2">
+      <period-start iso-date="2020-07-01"/>
+      <period-end iso-date="2020-09-30"/>
+      <value currency="GBP" value-date="2020-09-30">74000</value>
+      <provider-org provider-activity-id="GB-GOV-13-NEWT-AMS_ZAF_NAF0012" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Academy of Medical Sciences</narrative>
+      </receiver-org>
+    </planned-disbursement>
+    <capital-spend percentage="0"/>
+    <transaction>
+      <transaction-type code="2"/>
+      <transaction-date iso-date="2018-10-01"/>
+      <value currency="GBP" value-date="2018-10-01">148000</value>
+      <description>
+        <narrative>SOUTH AFRICA - Newton Advanced Fellowships 2020/21</narrative>
+      </description>
+      <provider-org provider-activity-id="GB-GOV-13-NEWT-AMS_ZAF_NAF0012" ref="GB-GOV-13">
+        <narrative>UK - Department for Business, Energy and Industrial Strategy</narrative>
+      </provider-org>
+      <receiver-org>
+        <narrative>Academy of Medical Sciences</narrative>
+      </receiver-org>
+    </transaction>
+    <document-link format="text/html" url="https://science-and-innovation-network.s3.eu-west-2.amazonaws.com/BEIS+R%26I+ODA+conditions+for+grants+and+contracts.docx">
+      <title>
+        <narrative>R&amp;I Conditions for Grants and Contracts</narrative>
+      </title>
+      <category code="A04"/>
+    </document-link>
+    <related-activity ref="GB-GOV-13-NEWT-AMS" type="1"/>
+    <conditions attached="1"/>
+  </iati-activity>
+</iati-activities>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when planned dates are blank" do
-      subject(:activity) { build(:activity, planned_start_date: nil, planned_end_date: nil) }
+    context "when planned start and actual start dates are blank" do
+      subject(:activity) { build(:activity, planned_start_date: nil, actual_start_date: nil) }
       it "should not be valid" do
         expect(activity.valid?(:dates_step)).to be_falsey
       end
@@ -107,17 +107,24 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when planned_start_date is blank" do
+    context "when planned_start_date is blank but actual_start_date is not nil" do
       subject(:activity) { build(:activity, planned_start_date: nil) }
-      it "should not be valid" do
-        expect(activity.valid?(:dates_step)).to be_falsey
+      it "should be valid" do
+        expect(activity.valid?(:dates_step)).to be_truthy
+      end
+    end
+
+    context "when actual_start_date is blank but planned_start_date is not nil" do
+      subject(:activity) { build(:activity, actual_start_date: nil) }
+      it "should be valid" do
+        expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when planned_end_date is blank" do
       subject(:activity) { build(:activity, planned_end_date: nil) }
-      it "should not be valid" do
-        expect(activity.valid?(:dates_step)).to be_falsey
+      it "should be valid" do
+        expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/bHOqDiH7/691-address-activities-with-missing-mandatory-dates

This PR is in two parts, and only the second commit is strictly necessary to address the issue in the trello card.

When ingesting AMS Newton fund activities locally, we found that 17 of the activities in the IATI XML file had only `activity-date` elements of type 1 (planned start date) and 3 (planned end date). According to the ingest script, types 1 & 2 are expected, so these activities were not ingested successfully.

This change is addressed in 44aaff9652e72401ffcd4f05276ccfab706b0abb

However while fixing this, we noticed that according to the IATI standard, activity dates 1 and 2 are the mandatory ones - and *either* 1 (planned start) *or* 2 (actual start) are expected https://andylolz.github.io/iatistandard-multilingual/en/203/codelists/ActivityDateType/

So our ActiveRecord validations, which expect both 1 (planned start) and 3 (planned end) to be present, do not line up with the IATI standard.

This change is addressed in 10bbd9c6891b85f79840908f3dd4632a5e4ba757 but it is not necessary to allow successful ingestion of the AMS Newton fund activities, as they all have dates 1 & 3 present. 

We can safely drop commit 10bbd9c6891b85f79840908f3dd4632a5e4ba757 and ingest AMS Newton fund activities, but our ActiveRecord validations will not match the mandatory fields in IATI. This means in future we may encounter problems with delivery partners who want to input activities without a planned end date (which in IATI they are permitted to do) but are unable to in the RODA interface. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
