### PR TITLE
(669, 666, 668, 670) Update create activity journey content

### DIFF
--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,4 +1,4 @@
 = render layout: "wrapper" do |f|
   = f.govuk_fieldset legend: { text: t("form.legend.activity.purpose", level: t("page_content.activity.level.#{f.object.level}")), tag: :h1, size: "xl" } do
-    = f.govuk_text_field :title
+    = f.govuk_text_field :title, label: { text: t("form.label.activity.title", level: t("page_content.activity.level.#{f.object.level}")).humanize }
     = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,3 +1,8 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :status, value: nil
-  = f.govuk_collection_radio_buttons :status, yaml_to_objects_with_description(entity: "activity", type: "status"), :code, :name, :description, legend: { tag: 'h1', size: 'xl' }
+  = f.govuk_collection_radio_buttons :status,
+    yaml_to_objects_with_description(entity: "activity", type: "status"),
+    :code,
+    :name,
+    :description,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.status", level: t("page_content.activity.level.#{f.object.level}")) }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -6,8 +6,6 @@ en:
         submit: Continue
     label:
       activity:
-        country: Country
-        dates: Dates
         flow: Flow
         geography_options:
           recipient_region: Region
@@ -17,8 +15,8 @@ en:
         actual_end_date: Actual end date
         actual_start_date: Actual start date
         description: Description
-        recipient_country: Country
-        recipient_region: Region
+        recipient_country: What country will benefit from this activity?
+        recipient_region: What region will benefit from this activity?
         title: Title
         date:
           day: Day
@@ -118,14 +116,14 @@ en:
     activity_form:
       show:
         aid_type: Aid type
-        country: Country
-        dates: Dates
+        country: What country will benefit from this activity?
+        dates: What are the start and end dates for the %{level}?
         flow: Flow
         geography: Will the benefitting recipient be a region or country?
         identifier: Your unique identifier
         purpose: Purpose
         purpose_level: Purpose of %{level}
-        region: Recipient region
+        region: What region will benefit from this activity?
         sector: Which %{sector_category} sector is the focus area for this %{level}
         sector_category: What is the focus area category for this %{level}?
         status: Status

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -33,7 +33,7 @@ en:
         purpose: What is the purpose of the %{level}?
         sector: Which %{sector_category} sector is the focus area for this %{level}?
         sector_category: What is the focus area category for this %{level}?
-        status: What is the the development status?
+        status: What is the status of the %{level}?
     hint:
       activity:
         actual_end_date: For example, 2 2 2020

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -6,7 +6,7 @@ en:
         submit: Continue
     label:
       activity:
-        flow: Flow
+        flow: What is the flow type?
         geography_options:
           recipient_region: Region
           recipient_country: Country
@@ -39,7 +39,7 @@ en:
         actual_end_date: For example, 2 2 2020
         actual_start_date: For example, 11 1 2020
         aid_type: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions can be found here (Opens in new window)</a>
-        flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions</a> of each flow type (opens in new window)
+        flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         identifier: This could be the reference you use in your internal systems
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -17,7 +17,7 @@ en:
         description: Description
         recipient_country: What country will benefit from this activity?
         recipient_region: What region will benefit from this activity?
-        title: Title
+        title: '%{level} title'
         date:
           day: Day
           month: Month
@@ -30,7 +30,7 @@ en:
         geography: Will the benefitting recipient be a region or country?
         planned_end_date: Planned end date
         planned_start_date: Planned start date
-        purpose: Purpose of %{level}
+        purpose: What is the purpose of the %{level}?
         sector: Which %{sector_category} sector is the focus area for this %{level}?
         sector_category: What is the focus area category for this %{level}?
         status: What is the the development status?
@@ -121,8 +121,7 @@ en:
         flow: Flow
         geography: Will the benefitting recipient be a region or country?
         identifier: Your unique identifier
-        purpose: Purpose
-        purpose_level: Purpose of %{level}
+        purpose: What is the purpose of the %{level}?
         region: What region will benefit from this activity?
         sector: Which %{sector_category} sector is the focus area for this %{level}
         sector_category: What is the focus area category for this %{level}?

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a partial match displays all the matching countries" do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Lucia", visible: true
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Vincent and the Grenadines", visible: true
@@ -50,13 +50,13 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a known country displays that country in the list of countries" do
-        fill_in "Country", with: "afghanistan"
+        fill_in I18n.t("form.label.activity.recipient_country"), with: "afghanistan"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Afghanistan", visible: true
       end
 
       scenario "typing a complete country name, clicking it in the list and clicking continue saves the country" do
-        fill_in "Country", with: "Saint Lucia"
+        fill_in I18n.t("form.label.activity.recipient_country"), with: "Saint Lucia"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
         click_on I18n.t("default.link.back")
@@ -67,7 +67,7 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a partial match, clicking on the complete match and clicking continue saves the country " do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
         click_on I18n.t("default.link.back")
@@ -78,7 +78,7 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do
-        fill_in "Country", with: "saint"
+        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
         expect(activity.reload.recipient_region).to eq("380") # West Indies

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature "Users can create a fund level activity" do
         choose("activity[status]", option: "2")
         click_button I18n.t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+        expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: "fund")
 
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.dates")

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[identifier]", with: "foo"
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "Purpose of fund"
+        expect(page).to have_content I18n.t("form.legend.activity.purpose", level: "fund")
 
         # Don't provide a title and description
         click_button I18n.t("form.button.activity.submit")
@@ -141,7 +141,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose "Primary education"
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.status")
+        expect(page).to have_content I18n.t("form.legend.activity.status", level: "fund")
 
         # Don't provide a status
         click_button I18n.t("form.button.activity.submit")

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CodelistHelper, type: :helper do
           .to include(
             OpenStruct.new(name: "Pipeline/identification", code: "1", description: "The activity is being scoped or planned"),
             OpenStruct.new(name: "Implementation", code: "2", description: "The activity is currently being implemented"),
-            OpenStruct.new(name: "Completion", code: "3", description: "Physical activity is complete or the final disbursement has been made."),
+            OpenStruct.new(name: "Completion", code: "3", description: "Physical activity is complete or the final disbursement has been made"),
             OpenStruct.new(name: "Post-completion", code: "4", description: "Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&E"),
             OpenStruct.new(name: "Cancelled", code: "5", description: "The activity has been cancelled"),
             OpenStruct.new(name: "Suspended", code: "6", description: "The activity has been temporarily suspended")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -30,14 +30,14 @@ module FormHelpers
     fill_in "activity[identifier]", with: identifier
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.purpose", level: I18n.t("page_content.activity.level.#{level}"))
-    expect(page).to have_content I18n.t("form.label.activity.title", level: I18n.t("page_content.activity.level.#{level}")).humanize
+    expect(page).to have_content I18n.t("form.legend.activity.purpose", level: activity_level(level))
+    expect(page).to have_content I18n.t("form.label.activity.title", level: activity_level(level).humanize)
     expect(page).to have_content I18n.t("form.label.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.sector_category", level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("form.legend.activity.sector_category", level: activity_level(level))
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
         I18n.t("form.legend.activity.sector_category", level: I18n.t("page_content.activity.level.#{level}"))
@@ -46,12 +46,12 @@ module FormHelpers
     choose sector_category
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: sector_category, level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: sector_category, level: activity_level(level))
 
     choose sector
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.status", level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("form.legend.activity.status", level: activity_level(level))
     expect(page).to have_content "The activity is being scoped or planned"
     expect(page).to have_content "The activity is currently being implemented"
     expect(page).to have_content "Physical activity is complete or the final disbursement has been made"
@@ -62,7 +62,7 @@ module FormHelpers
     choose("activity[status]", option: status)
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: I18n.t("page_content.activity.level.#{level}"))
+    expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: activity_level(level))
 
     expect(page).to have_content I18n.t("form.legend.activity.planned_start_date")
     fill_in "activity[planned_start_date(3i)]", with: planned_start_date_day
@@ -203,5 +203,9 @@ module FormHelpers
 
   def localise_date_from_input_fields(year:, month:, day:)
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
+  end
+
+  private def activity_level(level)
+    I18n.t("page_content.activity.level.#{level}")
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -95,7 +95,7 @@ module FormHelpers
     click_button I18n.t("form.button.activity.submit")
 
     expect(page).to have_content I18n.t("form.label.activity.flow")
-    expect(page).to have_content "International Aid Transparency Initiative (IATI) descriptions of each flow type (opens in new window)"
+    expect(page.html).to include I18n.t("form.hint.activity.flow")
     select flow, from: "activity[flow]"
     click_button I18n.t("form.button.activity.submit")
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -51,7 +51,7 @@ module FormHelpers
     choose sector
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.status")
+    expect(page).to have_content I18n.t("form.legend.activity.status", level: I18n.t("page_content.activity.level.#{level}"))
     expect(page).to have_content "The activity is being scoped or planned"
     expect(page).to have_content "The activity is currently being implemented"
     expect(page).to have_content "Physical activity is complete or the final disbursement has been made"

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -31,7 +31,7 @@ module FormHelpers
     click_button I18n.t("form.button.activity.submit")
 
     expect(page).to have_content I18n.t("form.legend.activity.purpose", level: I18n.t("page_content.activity.level.#{level}"))
-    expect(page).to have_content I18n.t("form.label.activity.title")
+    expect(page).to have_content I18n.t("form.label.activity.title", level: I18n.t("page_content.activity.level.#{level}")).humanize
     expect(page).to have_content I18n.t("form.label.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -62,7 +62,7 @@ module FormHelpers
     choose("activity[status]", option: status)
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.dates")
+    expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: I18n.t("page_content.activity.level.#{level}"))
 
     expect(page).to have_content I18n.t("form.legend.activity.planned_start_date")
     fill_in "activity[planned_start_date(3i)]", with: planned_start_date_day

--- a/vendor/data/codelists/IATI/2_03/activity/status.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/status.yml
@@ -12,7 +12,7 @@ data:
     description: The activity is currently being implemented
   - code: '3'
     name: Completion
-    description: Physical activity is complete or the final disbursement has been made.
+    description: Physical activity is complete or the final disbursement has been made
   - code: '4'
     name: Post-completion
     description: Physical activity is complete or the final disbursement has been made,


### PR DESCRIPTION
## Changes in this PR

https://trello.com/c/4bIfITjU
https://trello.com/c/lJ2WeJYc
https://trello.com/c/rR0rbCSQ
https://trello.com/c/db3pSCgg

These are the cards that drove a refactoring of the locales. Now this is complete we can redo this work on the more structured locale files.

You can view more detaills on the Trello cards. All of the changes are around the activity form steps.