### PR TITLE
(442) Users can only download complete activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,8 @@
 - Amend Activity date validations - either `planned_start_date` *OR* `actual_start_date`
   must be present, in line with the IATI `activity-date` XML standard
 - Amend ingest service to successfully ingest Activities without an `activity-date` type
-  2 (`actual_start_date`)  
+  2 (`actual_start_date`) 
+- XML download does not contain any incomplete activities   
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -27,9 +27,9 @@ class Staff::OrganisationsController < Staff::BaseController
       format.xml do
         @activities = case level
         when "project"
-          project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+          project_activities.publishable_to_iati?.map { |activity| ActivityXmlPresenter.new(activity) }
         when "third_party_project"
-          third_party_project_activities.map { |activity| ActivityXmlPresenter.new(activity) }
+          third_party_project_activities.publishable_to_iati?.map { |activity| ActivityXmlPresenter.new(activity) }
         else
           []
         end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -63,6 +63,7 @@ class Activity < ApplicationRecord
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
+  scope :publishable_to_iati?, -> { where(form_state: :complete) }
 
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -108,6 +108,15 @@ RSpec.feature "Users can view an organisation as XML" do
         expect(xml.xpath("/iati-activities/iati-activity/budget/value").text).to eq "2000.0"
         expect(xml.xpath("/iati-activities/iati-activity/transaction/value").text).to eq "100.0"
       end
+
+      scenario "the XML file does not contain incomplete activities" do
+        _project = create(:project_activity, :at_purpose_step, organisation: organisation)
+        visit organisation_path(organisation)
+        click_link I18n.t("default.button.download_as_xml")
+        xml = Nokogiri::XML::Document.parse(page.body)
+
+        expect(xml.xpath("/iati-activities/iati-activity").count).to eq(0)
+      end
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Activity, type: :model do
         expect(Activity.programmes).to eq [programme_activity]
       end
     end
+
+    describe ".publishable_to_iati?" do
+      it "only returns activities with a `form_state` of :complete" do
+        complete_activity = create(:fund_activity)
+        _incomplete_activity = create(:fund_activity, :at_purpose_step)
+
+        expect(Activity.publishable_to_iati?).to eq [complete_activity]
+      end
+    end
   end
 
   describe "sanitisation" do


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/vpHhfQ1D/442-users-can-only-download-complete-activities

When a user clicks Download as XML on an Organisation page, the resulting XML
file should only contain complete activities which will meet IATI standards, not
any which are missing any of the required fields.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
