### PR TITLE
(643) Flag incomplete activities in the activity table views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,8 +168,10 @@
 - Amend Activity date validations - either `planned_start_date` *OR* `actual_start_date`
   must be present, in line with the IATI `activity-date` XML standard
 - Amend ingest service to successfully ingest Activities without an `activity-date` type
+  2 (`actual_start_date`) 
 - XML download does not contain any incomplete activities    
-- Ingest AMS Newton fund data from IATI  
+- Ingest AMS Newton fund data from IATI   
+- Flag incomplete activities in the activity table views
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/assets/stylesheets/partials/_tag.scss
+++ b/app/assets/stylesheets/partials/_tag.scss
@@ -1,0 +1,9 @@
+
+.govuk-tag--yellow {
+  color: govuk-shade(govuk-colour("yellow"), 65);
+  background: govuk-tint(govuk-colour("yellow"), 75);
+}
+.govuk-tag--green {
+  color: govuk-shade(govuk-colour("green"), 20);
+  background: govuk-tint(govuk-colour("green"), 80);
+}

--- a/app/views/staff/shared/funds/_table.html.haml
+++ b/app/views/staff/shared/funds/_table.html.haml
@@ -5,12 +5,20 @@
     %tr.govuk-table__row
       %th.govuk-table__header
         =t("table.header.fund.title")
-
       %th.govuk-table__header
         = t("table.header.fund.identifier")
+      %th.govuk-table__header
+        =t("summary.label.activity.stage")
 
   %tbody.govuk-table__body
     - funds.each do |fund|
       %tr.govuk-table__row{id: fund.id}
         %td.govuk-table__cell= link_to fund.display_title, organisation_activity_path(fund.organisation, fund), class: "govuk-link govuk-link--no-visited-state"
         %td.govuk-table__cell= fund.identifier
+        %td.govuk-table__cell
+          - if fund.form_steps_completed?
+            %strong.govuk-tag.govuk-tag--green
+              = t("summary.label.activity.form_state.complete")
+          - else
+            %strong.govuk-tag.govuk-tag--yellow
+              = t("summary.label.activity.form_state.incomplete")

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -9,6 +9,8 @@
         = t("table.header.programme.identifier")
       %th.govuk-table__header
         =t("table.header.programme.fund")
+      %th.govuk-table__header
+        =t("summary.label.activity.stage")
 
   %tbody.govuk-table__body
     - programmes.each do |programme|
@@ -16,3 +18,10 @@
         %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
         %td.govuk-table__cell= programme.identifier
         %td.govuk-table__cell= programme.parent_activity.title
+        %td.govuk-table__cell
+          - if programme.form_steps_completed?
+            %strong.govuk-tag.govuk-tag--green
+              = t("summary.label.activity.form_state.complete")
+          - else
+            %strong.govuk-tag.govuk-tag--yellow
+              = t("summary.label.activity.form_state.incomplete")

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -10,6 +10,8 @@
           = t("table.header.project.identifier")
         %th.govuk-table__header
           =t("table.header.project.programme")
+        %th.govuk-table__header
+          =t("summary.label.activity.stage")
 
     %tbody.govuk-table__body
       - projects.each do |project|
@@ -17,3 +19,10 @@
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.identifier
           %td.govuk-table__cell= project.parent_activity.title
+          %td.govuk-table__cell
+            - if project.form_steps_completed?
+              %strong.govuk-tag.govuk-tag--green
+                = t("summary.label.activity.form_state.complete")
+            - else
+              %strong.govuk-tag.govuk-tag--yellow
+                = t("summary.label.activity.form_state.incomplete")

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -10,6 +10,8 @@
           = t("table.header.third_party_project.identifier")
         %th.govuk-table__header
           =t("table.header.third_party_project.project")
+        %th.govuk-table__header
+          =t("summary.label.activity.stage")
 
     %tbody.govuk-table__body
       - third_party_projects.each do |project|
@@ -17,3 +19,10 @@
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.identifier
           %td.govuk-table__cell= project.parent_activity.title
+          %td.govuk-table__cell
+            - if project.form_steps_completed?
+              %strong.govuk-tag.govuk-tag--green
+                = t("summary.label.activity.form_state.complete")
+            - else
+              %strong.govuk-tag.govuk-tag--yellow
+                = t("summary.label.activity.form_state.incomplete")

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -21,6 +21,7 @@ en:
       show: Show
     error:
       unknown: Unknown error
+    warning: Warning
   activerecord:
     errors:
       format: "%{attribute} %{message}"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -60,6 +60,9 @@ en:
         button:
           create: Create activity
         description: Description
+        form_state:
+          complete: Complete
+          incomplete: Incomplete
         flow: Flow
         geography: Benefitting recipient geography
         identifier: Identifier
@@ -72,6 +75,7 @@ en:
         recipient_region: Recipient region
         sector: Focus area
         sector_category: Focus area category
+        stage: Stage
         status: Status
         third_party_projects: Third-party projects
         title: Title


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/2hbGT0GG/643-user-can-see-the-reporting-status-of-an-activity-in-all-tables

To ensure a user can quickly see which Activities are missing required attributes,
we have added a complete/incomplete flag to the Activity tables on organisation & activity
views.

I have used the Gov.uk tag pattern here https://design-system.service.gov.uk/components/tag/
but have had to add CSS overrides t get the colours working correctly (after pairing with @deberny )


## Screenshots of UI changes

### After

<img width="1120" alt="Screenshot 2020-06-11 at 16 58 15" src="https://user-images.githubusercontent.com/1089521/84409016-c600a880-ac04-11ea-894f-efb3e44d7e0e.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
