### PR TITLE
(725) Activity region & country names are exposed in a `narrative` element in the XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,9 +169,10 @@
   must be present, in line with the IATI `activity-date` XML standard
 - Amend ingest service to successfully ingest Activities without an `activity-date` type
   2 (`actual_start_date`) 
-- XML download does not contain any incomplete activities    
 - Ingest AMS Newton fund data from IATI   
 - Flag incomplete activities in the activity table views
+- XML download does not contain any incomplete activities   
+- XML download contains a `narrative` element for region & country containing the region or country name
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -49,6 +49,18 @@ module CodelistHelper
     objects.unshift(OpenStruct.new(name: I18n.t("page_content.activity.recipient_country.default_selection_value"), code: "")).uniq
   end
 
+  def region_name_from_code(code)
+    region = region_select_options.find { |option| option.code == code }
+    return "" unless region
+    region.name
+  end
+
+  def country_name_from_code(code)
+    country = country_select_options.find { |option| option.code == code }
+    return "" unless country
+    country.name
+  end
+
   def flow_select_options
     objects = yaml_to_objects(entity: "activity", type: "flow", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -31,9 +31,11 @@
   %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
   - if activity.actual_end_date?
     %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
-  %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}/
+  %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}
+    %narrative= region_name_from_code(activity.recipient_region)
   - if activity.recipient_country?
-    %recipient-country{"code" => activity.recipient_country}/
+    %recipient-country{"code" => activity.recipient_country}
+      %narrative= country_name_from_code(activity.recipient_country)
   %sector{"vocabulary" => "1", "code" => activity.sector}/
   %default-flow-type{"code" => activity.flow}/
   %default-finance-type{"code" => activity.finance}/

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -47,6 +47,12 @@ RSpec.feature "Users can view an activity as XML" do
           expect(xml.at("iati-activity/recipient-region/@code").text).to eq(activity.recipient_region)
           expect(xml.at("iati-activity/recipient-region/@vocabulary").text).to eq("1")
         end
+
+        it "contains the recipient region name as a narrative element" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/recipient-region/narrative").text).to eq("South America, regional")
+        end
       end
 
       context "when the activity has recipient_country geography" do
@@ -55,7 +61,7 @@ RSpec.feature "Users can view an activity as XML" do
             organisation: organisation,
             identifier: "IND-ENT-IFIER",
             geography: :recipient_country,
-            recipient_country: "CL")
+            recipient_country: "CV")
         }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
@@ -63,6 +69,12 @@ RSpec.feature "Users can view an activity as XML" do
           visit organisation_activity_path(organisation, activity, format: :xml)
 
           expect(xml.at("iati-activity/recipient-country/@code").text).to eq(activity.recipient_country)
+        end
+
+        it "contains the recipient country name as a narrative element" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.at("iati-activity/recipient-country/narrative").text).to eq("Cabo Verde")
         end
       end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -122,10 +122,22 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
+    describe "#region_name_from_code" do
+      it "returns the name of the region from a code number" do
+        expect(helper.region_name_from_code("998")).to eq("Developing countries, unspecified")
+      end
+    end
+
     describe "#country_select_options" do
       it "returns an array of country objects with '' as the first (default) option" do
         expect(helper.country_select_options.first)
           .to eq(OpenStruct.new(name: I18n.t("page_content.activity.recipient_country.default_selection_value"), code: ""))
+      end
+    end
+
+    describe "#country_name_from_code" do
+      it "returns the name of the country from a code number" do
+        expect(helper.country_name_from_code("DZ")).to eq("Algeria")
       end
     end
 


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/c2twcAzs/725-expose-the-country-region-name-as-a-narrative-element-in-the-xml

The `recipient-region` and `recipient-country` elements in the Activity XML
should contain the region/country name in a nested `narrative` element like so:

```
<recipient-region code="589" vocabulary="1">
        <narrative>Middle East, regional<narrative>
</recipient-region>
```

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
