### PR TITLE
A programme's implementing organisation is the same as its extending organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@
 - XML download does not contain any incomplete activities   
 - XML download contains a `narrative` element for region & country containing the region or country name
 - Ingest AMS GCRF data from IATI
+- When a programme has an extending organisation set, the same organisation is set as the implementing organisation 
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/controllers/staff/extending_organisations_controller.rb
+++ b/app/controllers/staff/extending_organisations_controller.rb
@@ -13,6 +13,7 @@ class Staff::ExtendingOrganisationsController < Staff::BaseController
     @activity.assign_attributes(extending_organisation_id: extending_organisation_id)
 
     if @activity.valid?(:update_extending_organisation)
+      set_implementing_organisation
       @activity.save
       flash[:notice] = I18n.t("action.#{@activity.level}.update.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
@@ -22,6 +23,15 @@ class Staff::ExtendingOrganisationsController < Staff::BaseController
   end
 
   private
+
+  def set_implementing_organisation
+    extending_organisation = Organisation.find(extending_organisation_id)
+    implementing_organisation = ImplementingOrganisation.new(name: extending_organisation.name,
+                                                             organisation_type: extending_organisation.organisation_type,
+                                                             reference: extending_organisation.iati_reference,
+                                                             activity_id: activity_id)
+    implementing_organisation.save!
+  end
 
   def activity_id
     params[:activity_id]

--- a/db/data/20200615144002_add_implementing_organisations_to_programmes.rb
+++ b/db/data/20200615144002_add_implementing_organisations_to_programmes.rb
@@ -1,0 +1,19 @@
+class AddImplementingOrganisationsToProgrammes < ActiveRecord::Migration[6.0]
+  def up
+    programmes = Activity.programme
+    programmes.each do |programme|
+      next if programme.implementing_organisations.present?
+      next unless programme.extending_organisation_id
+      extending_organisation = Organisation.find(programme.extending_organisation_id)
+      implementing_organisation = ImplementingOrganisation.new(name: extending_organisation.name,
+                                                               organisation_type: extending_organisation.organisation_type,
+                                                               reference: extending_organisation.iati_reference,
+                                                               activity_id: programme.id)
+      implementing_organisation.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200615153832)
+DataMigrate::Data.define(version: 20200615144002)

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -19,6 +19,20 @@ RSpec.feature "Users can manage the extending organisation" do
         expect(page).to have_content delivery_partner.name
       end
 
+      scenario "when the extending organisation is set, the same organisation is set as the implementing organisation" do
+        delivery_partner = create(:delivery_partner_organisation)
+        visit organisation_activity_path(programme.organisation, programme)
+
+        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+        choose delivery_partner.name
+        click_on I18n.t("default.button.submit")
+
+        implementing_organisation = programme.reload.implementing_organisations.first
+        expect(implementing_organisation.name).to eq(delivery_partner.name)
+        expect(implementing_organisation.organisation_type).to eq(delivery_partner.organisation_type)
+        expect(implementing_organisation.reference).to eq(delivery_partner.iati_reference)
+      end
+
       scenario "they can change the extending organistion" do
         delivery_partner = create(:delivery_partner_organisation)
         programme.update(extending_organisation: delivery_partner)
@@ -34,6 +48,25 @@ RSpec.feature "Users can manage the extending organisation" do
 
         expect(page).to have_content("success")
         expect(page).to have_content another_delivery_partner.name
+      end
+
+      scenario "when the extending organisation is changed, the implementing organisation is changed" do
+        delivery_partner = create(:delivery_partner_organisation)
+        programme.update(extending_organisation: delivery_partner)
+        another_delivery_partner = create(:delivery_partner_organisation)
+
+        visit organisation_activity_path(programme.organisation, programme)
+        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+
+        expect(page).to have_checked_field delivery_partner.name
+
+        choose another_delivery_partner.name
+        click_on I18n.t("default.button.submit")
+
+        implementing_organisation = programme.reload.implementing_organisations.first
+        expect(implementing_organisation.name).to eq(another_delivery_partner.name)
+        expect(implementing_organisation.organisation_type).to eq(another_delivery_partner.organisation_type)
+        expect(implementing_organisation.reference).to eq(another_delivery_partner.iati_reference)
       end
 
       scenario "not selecting an extending organisation results in an error" do


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/usZXtaXu/501-programmes-have-an-implementing-organisation

When a programme has its extending organisation set, the same organisation is set
as the implementing organisation.

Previously we were not requiring an implementing organisation for programmes, but
if we are going to publish programmes to IATI we will need them to have an
implementing organisation set. This will always be the same as their extending
organisation.

The second commit contains a data migration to add the implementing organisations to existing programmes on staging/production.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
