### PR TITLE
(726) Reduce logging in production to reduce Papertrail usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
 - XML download contains a `narrative` element for region & country containing the region or country name
 - Ingest AMS GCRF data from IATI
 - When a programme has an extending organisation set, the same organisation is set as the implementing organisation 
+- Use the `lograge` gem to reduce logging in production
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...HEAD
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,7 @@ group :test do
   gem "selenium-webdriver"
   gem "webmock", "~> 3.8"
 end
+
+group :production do
+  gem "lograge"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,13 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -298,6 +305,8 @@ GEM
     redis-store (1.8.2)
       redis (>= 4, < 5)
     regexp_parser (1.7.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -446,6 +455,7 @@ DEPENDENCIES
   jbuilder (~> 2.10)
   launchy
   listen (>= 3.0.5, < 3.3)
+  lograge
   mail-notify
   mini_racer
   mock_redis

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,9 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
+  # Use lograge on production to minimise logging
+  config.lograge.enabled = true
+
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/doc/architecture/decisions/0021-use-lograge-gem.md
+++ b/doc/architecture/decisions/0021-use-lograge-gem.md
@@ -1,0 +1,25 @@
+# 21. use-lograge-gem
+
+Date: 2020-06-16
+
+## Status
+
+Accepted
+
+## Context
+
+RODA uses Papertrail for logging. Our Papertrail account has a log data
+transfer limit of 50 MB. Extending this limit means moving to another tier
+on Papertrail's platform, which we would prefer to avoid.
+
+## Decision
+
+- Reduce the default logging level on production to `info` instead of `debug`
+- Use the [lograge gem](https://github.com/roidrage/lograge) to turn Rails'
+  default multiline logs into a single line, without losing information or
+  context
+
+## Consequences
+
+Our Papertrail usage will be reduced with no loss of critical information.
+


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/5uzKx5du/726-turn-off-debug-mode-in-production-to-reduce-logging-use

This PR:

- Reduces the default logging output level in production to `info`
- Adds the lograge gem, which turns Rails' default multiline logs into a single line, e.g. 

```
method=GET path=/organisations/f1584f98-aa3b-4158-9bf9-fd1ea4af7b67/activities/3e71cf8d-7f7a-4a72-8504-958da0712469 format=html controller=Staff::ActivitiesController action=show status=200 duration=54.78 view=41.16 db=3.41
```

## Screenshots of UI changes

### Before

### After

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
