### PR TITLE
Users can see codes when selecting aid type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,8 @@
 
 ## [unreleased]
 
+- Users can see codes when selecting aid type
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-9...HEAD
 [release-9]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-8...release-9
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -17,11 +17,16 @@ module CodelistHelper
     objects
   end
 
-  def yaml_to_objects_with_description(entity:, type:)
+  def yaml_to_objects_with_description(entity:, type:, code_displayed_in_name: false)
     data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
 
-    data.collect { |item| OpenStruct.new(name: item["name"], code: item["code"], description: item["description"]) }.sort_by(&:code)
+    data = data.collect { |item|
+      name = code_displayed_in_name ? "#{item["name"]} (#{item["code"]})" : item["name"]
+      OpenStruct.new(name: name, code: item["code"], description: item["description"])
+    }
+
+    data.sort_by(&:code)
   end
 
   def yaml_to_objects_with_categories(entity:, type:, include_withdrawn: false)
@@ -81,6 +86,10 @@ module CodelistHelper
 
   def all_sectors
     yaml_to_objects_with_categories(entity: "activity", type: "sector", include_withdrawn: true)
+  end
+
+  def aid_type_radio_options
+    yaml_to_objects_with_description(entity: "activity", type: "aid_type", code_displayed_in_name: true)
   end
 
   def load_yaml(entity:, type:)

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :aid_type
-  = f.govuk_collection_radio_buttons :aid_type, yaml_to_objects_with_description(entity: "activity", type: "aid_type"), :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.aid_type") }, hint_text: I18n.t("form.hint.activity.aid_type").html_safe
+  = f.govuk_collection_radio_buttons :aid_type, aid_type_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.aid_type") }, hint_text: I18n.t("form.hint.activity.aid_type").html_safe

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -177,5 +177,15 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(sectors).to include withdrawn_sector
       end
     end
+
+    describe "#aid_type_radio_options" do
+      it "returns the aid type with the code appended to the name" do
+        options = helper.aid_type_radio_options
+
+        expect(options.length).to eq 15
+        expect(options.first.name).to eq "General budget support (A01)"
+        expect(options.last.name).to eq "Refugees in donor countries (H02)"
+      end
+    end
   end
 end


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/2xrjDcXk/477-delivery-partners-can-see-codes-when-selecting-aid-type

When selecting an aid type for an Activity, the aid type code is displayed
alongside the Aid Type name for clarity.

## Screenshots of UI changes

### After

<img width="773" alt="Screenshot 2020-06-18 at 14 44 58" src="https://user-images.githubusercontent.com/1089521/85029224-f8198980-b173-11ea-8d06-a73db251529b.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
