### PR TITLE
Chore/add a tree structure to activity and test performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,13 +186,14 @@
 - Remove 3 unwanted activities from production
 - Content changes to fields for transaction value and activity identifier
 - Increase the width of the application layout
-- Activity show content is show in tabs for financials and details
 
 ## [unreleased]
 
 - Ingest RS Newton fund data from IATI
 - Allow BEIS users to redact activities from the IATI XML file, and to
   easily see on the Organisation show page which Activities are redacted
+- Activity show content is show in tabs for financials and details
+- Refactor how we can ask activities for their parents
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...HEAD
 [release-10]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-9...release-10

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "2.6.3"
 
 gem "auth0", "~> 4.13"
+gem "acts_as_tree"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "data_migrate"
 gem "govuk_design_system_formbuilder", "~> 1.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts_as_tree (2.9.1)
+      activerecord (>= 3.0.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
@@ -432,6 +434,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_tree
   auth0 (~> 4.13)
   better_errors
   bootsnap (>= 1.1.0)

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -4,7 +4,7 @@ class Staff::ActivitiesController < Staff::BaseController
   include Secured
 
   def index
-    @activities = policy_scope(Activity)
+    @activities = policy_scope(Activity).includes(:parent)
   end
 
   def show

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -13,7 +13,7 @@ module ActivityHelper
 
   def activity_back_path(current_user:, activity:)
     if activity.programme? && current_user.service_owner?
-      return organisation_activity_path(activity.parent_activity.organisation, activity.parent_activity)
+      return organisation_activity_path(activity.parent.organisation, activity.parent)
     end
 
     organisation_path(current_user.organisation)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -88,10 +88,6 @@ class Activity < ApplicationRecord
     organisation.default_currency
   end
 
-  def parent_activity
-    parent
-  end
-
   def has_funding_organisation?
     funding_organisation_reference.present? &&
       funding_organisation_name.present? &&

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -38,8 +38,9 @@ class Activity < ApplicationRecord
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation
 
-  belongs_to :activity, optional: true
-  has_many :child_activities, foreign_key: "activity_id", class_name: "Activity"
+  belongs_to :parent, optional: true, class_name: :Activity, foreign_key: "parent_id"
+
+  has_many :child_activities, foreign_key: "parent_id", class_name: "Activity"
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
   has_many :implementing_organisations
@@ -87,8 +88,8 @@ class Activity < ApplicationRecord
   end
 
   def parent_activity
-    return if activity_id.nil?
-    Activity.find(activity_id)
+    return if parent_id.nil?
+    Activity.find(parent_id)
   end
 
   def has_funding_organisation?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -38,6 +38,7 @@ class Activity < ApplicationRecord
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation
 
+  acts_as_tree
   belongs_to :parent, optional: true, class_name: :Activity, foreign_key: "parent_id"
 
   has_many :child_activities, foreign_key: "parent_id", class_name: "Activity"
@@ -88,8 +89,7 @@ class Activity < ApplicationRecord
   end
 
   def parent_activity
-    return if parent_id.nil?
-    Activity.find(parent_id)
+    parent
   end
 
   def has_funding_organisation?
@@ -113,10 +113,7 @@ class Activity < ApplicationRecord
   end
 
   def parent_activities
-    return [parent_activity] if programme?
-    return [parent_activity.parent_activity, parent_activity] if project?
-    return [parent_activity.parent_activity.parent_activity, parent_activity.parent_activity, parent_activity] if third_party_project?
-    []
+    ancestors.reverse
   end
 
   def providing_organisation

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -10,7 +10,7 @@ class FindProgrammeActivities
 
   def call
     programmes = policy_scope(Activity.programme, policy_scope_class: ProgrammePolicy::Scope)
-      .includes(:organisation)
+      .includes(:organisation, :parent)
       .order("created_at ASC")
     programmes = if organisation.service_owner
       programmes.all

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -10,7 +10,7 @@ class FindProjectActivities
 
   def call
     projects = policy_scope(Activity.project, policy_scope_class: ProjectPolicy::Scope)
-      .includes(:organisation)
+      .includes(:organisation, :parent)
       .order("created_at ASC")
     projects = if organisation.service_owner
       projects.all

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -10,7 +10,7 @@ class FindThirdPartyProjectActivities
 
   def call
     third_party_projects = policy_scope(Activity.third_party_project, policy_scope_class: ThirdPartyProjectPolicy::Scope)
-      .includes(:organisation)
+      .includes(:organisation, :parent)
       .order("created_at ASC")
     third_party_projects = if organisation.service_owner
       third_party_projects.all

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -48,7 +48,7 @@ class IngestIatiActivities
         add_budgets(legacy_activity: legacy_activity, roda_activity: roda_activity)
         add_planned_disbursements(legacy_activity: legacy_activity, roda_activity: roda_activity)
 
-        roda_activity.activity = legacy_activity.find_parent_programme
+        roda_activity.parent = legacy_activity.find_parent_programme
         roda_activity.legacy_iati_xml = legacy_activity.to_xml.squish
         roda_activity.ingested = true
 

--- a/app/views/staff/shared/activities/_projects.html.haml
+++ b/app/views/staff/shared/activities/_projects.html.haml
@@ -3,5 +3,5 @@
     %h2.govuk-heading-m
       = t("page_content.activity.projects")
     - if policy(:project).create?
-      = button_to t("page_content.organisation.button.create_project"), organisation_fund_programme_projects_path(current_user.organisation, activity.parent_activity, activity), class: "govuk-button"
+      = button_to t("page_content.organisation.button.create_project"), organisation_fund_programme_projects_path(current_user.organisation, activity.parent, activity), class: "govuk-button"
     = render partial: '/staff/shared/projects/table', locals: { projects: activities }

--- a/app/views/staff/shared/activities/_third_party_projects.html.haml
+++ b/app/views/staff/shared/activities/_third_party_projects.html.haml
@@ -3,5 +3,5 @@
     %h2.govuk-heading-m
       = t("page_content.activity.third_party_projects")
     - if policy(:third_party_project).create?
-      = button_to t("page_content.organisation.button.create_third_party_project"), organisation_fund_programme_project_third_party_projects_path(current_user.organisation, activity.parent_activity.parent_activity, activity.parent_activity, activity), class: "govuk-button"
+      = button_to t("page_content.organisation.button.create_third_party_project"), organisation_fund_programme_project_third_party_projects_path(current_user.organisation, activity.parent.parent, activity.parent, activity), class: "govuk-button"
     = render partial: '/staff/shared/third_party_projects/table', locals: { third_party_projects: activities }

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -17,7 +17,7 @@
       %tr.govuk-table__row{id: programme.id}
         %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
         %td.govuk-table__cell= programme.identifier
-        %td.govuk-table__cell= programme.parent_activity.title
+        %td.govuk-table__cell= programme.parent.title
         %td.govuk-table__cell
           - if programme.form_steps_completed?
             %strong.govuk-tag.govuk-tag--green

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -21,7 +21,7 @@
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.identifier
-          %td.govuk-table__cell= project.parent_activity.title
+          %td.govuk-table__cell= project.parent.title
           %td.govuk-table__cell
             - if project.form_steps_completed?
               %strong.govuk-tag.govuk-tag--green

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -21,7 +21,7 @@
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.identifier
-          %td.govuk-table__cell= project.parent_activity.title
+          %td.govuk-table__cell= project.parent.title
           %td.govuk-table__cell
             - if project.form_steps_completed?
               %strong.govuk-tag.govuk-tag--green

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true # raise an error if n+1 query occurs
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "User", association: :organisation
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :organisation
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
   end

--- a/db/migrate/20200626100128_change_activity_parent_relationship_name.rb
+++ b/db/migrate/20200626100128_change_activity_parent_relationship_name.rb
@@ -1,0 +1,27 @@
+class ChangeActivityParentRelationshipName < ActiveRecord::Migration[6.0]
+  def up
+    add_column :activities, :parent_id, :uuid
+    Activity.transaction do
+      Activity.all.each do |activity|
+        activity.parent_id = activity.activity_id
+        activity.save!(validate: false)
+      end
+    end
+    add_index :activities, :parent_id
+    add_foreign_key :activities, :activities, column: "parent_id", on_delete: :restrict
+    remove_column :activities, :activity_id
+  end
+
+  def down
+    add_column :activities, :activity_id, :uuid
+    Activity.transaction do
+      Activity.all.each do |activity|
+        activity.activity_id = activity.parent_id
+        activity.save!(validate: false)
+      end
+    end
+    add_index :activities, :activity_id
+    add_foreign_key :activities, :activities, column: "activity_id", on_delete: :restrict
+    remove_column :activities, :parent_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_132105) do
+ActiveRecord::Schema.define(version: 2020_06_26_100128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 2020_06_23_132105) do
     t.string "aid_type"
     t.string "form_state"
     t.string "level"
-    t.uuid "activity_id"
     t.string "funding_organisation_name"
     t.string "funding_organisation_reference"
     t.string "funding_organisation_type"
@@ -50,10 +49,11 @@ ActiveRecord::Schema.define(version: 2020_06_23_132105) do
     t.boolean "ingested", default: false
     t.string "legacy_iati_xml"
     t.boolean "publish_to_iati", default: true
-    t.index ["activity_id"], name: "index_activities_on_activity_id"
+    t.uuid "parent_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
+    t.index ["parent_id"], name: "index_activities_on_parent_id"
     t.index ["reporting_organisation_id"], name: "index_activities_on_reporting_organisation_id"
   end
 
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_132105) do
     t.index ["role"], name: "index_users_on_role"
   end
 
-  add_foreign_key "activities", "activities"
+  add_foreign_key "activities", "activities", column: "parent_id", on_delete: :restrict
   add_foreign_key "activities", "organisations", column: "extending_organisation_id"
   add_foreign_key "activities", "organisations", column: "reporting_organisation_id"
   add_foreign_key "activities", "organisations", on_delete: :restrict

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -11,7 +11,7 @@ delivery_partner = Organisation.find_by!(service_owner: false)
 first_programme_params = FactoryBot.build(:programme_activity,
   title: "International Partnerships",
   organisation: beis,
-  activity: fund,
+  parent: fund,
   extending_organisation: delivery_partner).attributes
 
 programme = Activity.find_or_create_by(first_programme_params)
@@ -19,7 +19,7 @@ programme = Activity.find_or_create_by(first_programme_params)
 second_programme_params = FactoryBot.build(:programme_activity,
   title: "Africa Catalyst Programme",
   organisation: beis,
-  activity: fund,
+  parent: fund,
   extending_organisation: delivery_partner).attributes
 
 Activity.find_or_create_by(second_programme_params)
@@ -27,7 +27,7 @@ Activity.find_or_create_by(second_programme_params)
 project_params = FactoryBot.build(:project_activity,
   title: "Airbus Flood and Drought",
   organisation: delivery_partner,
-  activity: programme,
+  parent: programme,
   extending_organisation: delivery_partner).attributes
 
 Activity.find_or_create_by(project_params)

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
     end
 
     factory :programme_activity do
-      activity factory: :fund_activity
+      parent factory: :fund_activity
       level { :programme }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
@@ -51,7 +51,7 @@ FactoryBot.define do
     end
 
     factory :project_activity do
-      activity factory: :programme_activity
+      parent factory: :programme_activity
       level { :project }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
@@ -75,7 +75,7 @@ FactoryBot.define do
     end
 
     factory :third_party_project_activity do
-      activity factory: :project_activity
+      parent factory: :project_activity
       level { :third_party_project }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -6,15 +6,15 @@ feature "Organisation show page" do
   let!(:incomplete_fund) { create(:fund_activity, :at_purpose_step, organisation: beis_user.organisation) }
   let(:programme) do
     create(:programme_activity,
-      activity: fund,
+      parent: fund,
       organisation: beis_user.organisation,
       extending_organisation: delivery_partner_user.organisation)
   end
   let!(:incomplete_programme) { create(:programme_activity, :at_purpose_step, extending_organisation: delivery_partner_user.organisation) }
-  let!(:project) { create(:project_activity, activity: programme, organisation: delivery_partner_user.organisation, created_at: Date.today) }
-  let!(:incomplete_project) { create(:project_activity, :at_geography_step, activity: programme, organisation: delivery_partner_user.organisation, created_at: Date.yesterday) }
-  let!(:third_party_project) { create(:third_party_project_activity, activity: project, organisation: delivery_partner_user.organisation) }
-  let!(:incomplete_third_party_project) { create(:third_party_project_activity, :at_region_step, activity: project, organisation: delivery_partner_user.organisation) }
+  let!(:project) { create(:project_activity, parent: programme, organisation: delivery_partner_user.organisation, created_at: Date.today) }
+  let!(:incomplete_project) { create(:project_activity, :at_geography_step, parent: programme, organisation: delivery_partner_user.organisation, created_at: Date.yesterday) }
+  let!(:third_party_project) { create(:third_party_project_activity, parent: project, organisation: delivery_partner_user.organisation) }
+  let!(:incomplete_third_party_project) { create(:third_party_project_activity, :at_region_step, parent: project, organisation: delivery_partner_user.organisation) }
   let!(:another_programme) { create(:programme_activity) }
   let!(:another_project) { create(:project_activity) }
 

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -58,13 +58,13 @@ feature "Organisation show page" do
         within("##{programme.id}") do
           expect(page).to have_link programme.title, href: organisation_activity_path(programme.organisation, programme)
           expect(page).to have_content programme.identifier
-          expect(page).to have_content programme.parent_activity.title
+          expect(page).to have_content programme.parent.title
         end
 
         within("##{another_programme.id}") do
           expect(page).to have_link another_programme.title, href: organisation_activity_path(another_programme.organisation, another_programme)
           expect(page).to have_content another_programme.identifier
-          expect(page).to have_content another_programme.parent_activity.title
+          expect(page).to have_content another_programme.parent.title
         end
       end
 
@@ -89,13 +89,13 @@ feature "Organisation show page" do
         within("##{project.id}") do
           expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
           expect(page).to have_content project.identifier
-          expect(page).to have_content project.parent_activity.title
+          expect(page).to have_content project.parent.title
         end
 
         within("##{another_project.id}") do
           expect(page).to have_link another_project.title, href: organisation_activity_path(another_project.organisation, another_project)
           expect(page).to have_content another_project.identifier
-          expect(page).to have_content another_project.parent_activity.title
+          expect(page).to have_content another_project.parent.title
         end
       end
 
@@ -120,7 +120,7 @@ feature "Organisation show page" do
         within("##{third_party_project.id}") do
           expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
           expect(page).to have_content third_party_project.identifier
-          expect(page).to have_content third_party_project.parent_activity.title
+          expect(page).to have_content third_party_project.parent.title
         end
       end
 
@@ -179,7 +179,7 @@ feature "Organisation show page" do
       within("##{programme.id}") do
         expect(page).to have_link programme.title, href: organisation_activity_path(programme.organisation, programme)
         expect(page).to have_content programme.identifier
-        expect(page).to have_content programme.parent_activity.title
+        expect(page).to have_content programme.parent.title
       end
     end
 
@@ -201,7 +201,7 @@ feature "Organisation show page" do
       within("##{project.id}") do
         expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
         expect(page).to have_content project.identifier
-        expect(page).to have_content project.parent_activity.title
+        expect(page).to have_content project.parent.title
       end
     end
 
@@ -232,7 +232,7 @@ feature "Organisation show page" do
       within("##{third_party_project.id}") do
         expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
         expect(page).to have_content third_party_project.identifier
-        expect(page).to have_content third_party_project.parent_activity.title
+        expect(page).to have_content third_party_project.parent.title
       end
     end
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Users can create a budget" do
     context "on a programme level activity" do
       scenario "successfully creates a budget" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
         click_on(programme_activity.parent_activity.title)
@@ -57,7 +57,7 @@ RSpec.describe "Users can create a budget" do
 
       scenario "sees validation errors for missing attributes" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
 
@@ -86,7 +86,7 @@ RSpec.describe "Users can create a budget" do
       scenario "they can view but not create budgets" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         programme_activity = create(:programme_activity,
-          activity: fund_activity,
+          parent: fund_activity,
           organisation: user.organisation,
           extending_organisation: user.organisation)
 
@@ -102,10 +102,10 @@ RSpec.describe "Users can create a budget" do
       scenario "successfully creates a budget" do
         fund_activity = create(:fund_activity)
         programme_activity = create(:programme_activity,
-          activity: fund_activity,
+          parent: fund_activity,
           extending_organisation: user.organisation)
         project_activity = create(:project_activity,
-          activity: programme_activity,
+          parent: programme_activity,
           organisation: user.organisation)
 
         visit organisation_path(user.organisation)

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Users can create a budget" do
         programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
 
         visit organisation_path(user.organisation)
-        click_on(programme_activity.parent_activity.title)
+        click_on(programme_activity.parent.title)
         click_on I18n.t("tabs.activity.details")
         click_on(programme_activity.title)
 
@@ -61,7 +61,7 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_path(user.organisation)
 
-        click_on(programme_activity.parent_activity.title)
+        click_on(programme_activity.parent.title)
         click_on I18n.t("tabs.activity.details")
         click_on(programme_activity.title)
 

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -257,7 +257,7 @@ RSpec.feature "Users can create a transaction" do
     scenario "they cannot create transactions on a programme" do
       fund_activity = create(:fund_activity, organisation: user.organisation)
       programme_activity = create(:programme_activity,
-        activity: fund_activity,
+        parent: fund_activity,
         organisation: user.organisation,
         extending_organisation: user.organisation)
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -235,7 +235,7 @@ RSpec.feature "Users can edit an activity" do
 
       it "also redacts any child third-party projects when a project is redacted" do
         project_activity = create(:project_activity, organisation: user.organisation)
-        third_party_project_activity = create(:third_party_project_activity, activity: project_activity, organisation: user.organisation)
+        third_party_project_activity = create(:third_party_project_activity, parent: project_activity, organisation: user.organisation)
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
         click_on I18n.t("tabs.activity.details")

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can manage the extending organisation" do
 
     context "and the activity is a programme" do
       let(:fund) { create(:fund_activity) }
-      let(:programme) { create(:programme_activity, activity_id: fund.id, extending_organisation: nil) }
+      let(:programme) { create(:programme_activity, parent_id: fund.id, extending_organisation: nil) }
 
       scenario "they can set the extending organisation" do
         delivery_partner = create(:delivery_partner_organisation)
@@ -88,7 +88,7 @@ RSpec.feature "Users can manage the extending organisation" do
 
     scenario "they cannot set the extending organisation" do
       fund = create(:fund_activity)
-      programme = create(:programme_activity, activity_id: fund.id)
+      programme = create(:programme_activity, parent_id: fund.id)
 
       visit organisation_activity_path(programme.organisation, programme)
 

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view a project" do
 
     scenario "can see a list of third-party projects on the project view" do
       project = create(:project_activity, organisation: user.organisation)
-      third_party_project = create(:third_party_project_activity, activity: project)
+      third_party_project = create(:third_party_project_activity, parent: project)
 
       visit organisation_activity_details_path(project.organisation, project)
 

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Users can view budgets on an activity page" do
     context "when the activity is programme level" do
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: programme_activity)
         budget_presenter = BudgetPresenter.new(budget)
@@ -55,8 +55,8 @@ RSpec.feature "Users can view budgets on an activity page" do
     context "when the activity is project level" do
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
-        project_activity = create(:project_activity, activity: programme_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
+        project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: project_activity)
         budget_presenter = BudgetPresenter.new(budget)
@@ -74,8 +74,8 @@ RSpec.feature "Users can view budgets on an activity page" do
 
       scenario "a BEIS user cannot edit/create a budget" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
-        programme_activity = create(:programme_activity, activity: fund_activity, organisation: user.organisation)
-        project_activity = create(:project_activity, activity: programme_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
+        project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: project_activity)
 
@@ -130,7 +130,7 @@ RSpec.feature "Users can view budgets on an activity page" do
     context "when the activity is project level" do
       scenario "budget information is shown on the page" do
         programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
-        project_activity = create(:project_activity, activity: programme_activity, organisation: user.organisation)
+        project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: project_activity)
         budget_presenter = BudgetPresenter.new(budget)
@@ -146,7 +146,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
       scenario "a delivery partner can edit/create a budget" do
         programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
-        project_activity = create(:project_activity, activity: programme_activity, organisation: user.organisation)
+        project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: project_activity)
 

--- a/spec/features/staff/users_can_view_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_view_programme_level_activity_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can view programme level activites" do
       fund_activity = create(:fund_activity, organisation: user.organisation)
       programme_activity = create(:programme_activity,
         organisation: user.organisation,
-        activity: fund_activity)
+        parent: fund_activity)
 
       visit organisation_path(user.organisation)
 
@@ -29,7 +29,7 @@ RSpec.feature "Users can view programme level activites" do
       fund_activity = create(:fund_activity, organisation: user.organisation)
       programme_activity = create(:programme_activity,
         organisation: user.organisation,
-        activity: fund_activity,
+        parent: fund_activity,
         extending_organisation: user.organisation)
 
       visit organisation_path(user.organisation)

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can view a third-party project" do
 
     scenario "can view a third-party project" do
       project = create(:project_activity, organisation: user.organisation)
-      third_party_project = create(:third_party_project_activity, activity: project)
+      third_party_project = create(:third_party_project_activity, parent: project)
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -54,8 +54,8 @@ RSpec.feature "Users can view transactions on an activity page" do
 
     context "when the activity is a project" do
       let(:fund_activity) { create(:fund_activity, organisation: user.organisation) }
-      let(:programme_activity) { create(:programme_activity, activity: fund_activity, organisation: user.organisation) }
-      let(:project_activity) { create(:project_activity, activity: programme_activity, organisation: user.organisation) }
+      let(:programme_activity) { create(:programme_activity, parent: fund_activity, organisation: user.organisation) }
+      let(:project_activity) { create(:project_activity, parent: programme_activity, organisation: user.organisation) }
 
       scenario "transaction information is shown on the page" do
         transaction = create(:transaction, parent_activity: project_activity)

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ActivityHelper, type: :helper do
           programme_activity = create(:programme_activity)
 
           result = activity_back_path(current_user: user, activity: programme_activity)
-          expect(result).to eq organisation_activity_path(programme_activity.parent_activity.organisation, programme_activity.parent_activity)
+          expect(result).to eq organisation_activity_path(programme_activity.parent.organisation, programme_activity.parent)
         end
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -263,17 +263,6 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:planned_disbursements) }
   end
 
-  describe "#parent_activity" do
-    it "returns the parent activity or nil if there is not one" do
-      fund_activity = create(:activity, level: :fund)
-      programme_activity = create(:activity, level: :programme)
-      fund_activity.child_activities << programme_activity
-
-      expect(programme_activity.parent_activity).to eql fund_activity
-      expect(fund_activity.parent_activity).to be_nil
-    end
-  end
-
   describe "#parent_activities" do
     context "when the activity is a fund" do
       it "returns an empty array" do
@@ -285,7 +274,7 @@ RSpec.describe Activity, type: :model do
     context "when the activity is a programme" do
       it "returns the fund" do
         programme = create(:programme_activity)
-        fund = programme.parent_activity
+        fund = programme.parent
 
         result = programme.parent_activities
         expect(result.first.id).to eq(fund.id)
@@ -295,8 +284,8 @@ RSpec.describe Activity, type: :model do
     context "when the activity is a project" do
       it "returns the fund and then the programme" do
         project = create(:project_activity)
-        programme = project.parent_activity
-        fund = programme.parent_activity
+        programme = project.parent
+        fund = programme.parent
 
         result = project.parent_activities
 
@@ -308,9 +297,9 @@ RSpec.describe Activity, type: :model do
     context "when the activity is a third party project" do
       it "returns the fund and then the programme and then the project" do
         third_party_project = create(:third_party_project_activity)
-        project = third_party_project.parent_activity
-        programme = project.parent_activity
-        fund = programme.parent_activity
+        project = third_party_project.parent
+        programme = project.parent
+        fund = programme.parent
 
         result = third_party_project.parent_activities
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -253,8 +253,8 @@ RSpec.describe Activity, type: :model do
 
   describe "associations" do
     it { should belong_to(:organisation) }
-    it { should belong_to(:activity).optional }
-    it { should have_many(:child_activities).with_foreign_key("activity_id") }
+    it { should belong_to(:parent).optional }
+    it { should have_many(:child_activities).with_foreign_key("parent_id") }
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
     it { should have_many(:implementing_organisations) }
     it { should belong_to(:reporting_organisation).with_foreign_key("reporting_organisation_id") }

--- a/spec/presenters/activity_xml_presenter_spec.rb
+++ b/spec/presenters/activity_xml_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ActivityXmlPresenter do
         it "returns an identifier with the reporting organisation, fund and programme" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           programme = create(:programme_activity, organisation: government_organisation)
-          fund = programme.parent_activity
+          fund = programme.parent
 
           expect(described_class.new(programme).iati_identifier)
             .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}")
@@ -29,8 +29,8 @@ RSpec.describe ActivityXmlPresenter do
         it "returns an identifier with the reporting organisation, fund, programme and project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           project = create(:project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
-          programme = project.parent_activity
-          fund = programme.parent_activity
+          programme = project.parent
+          fund = programme.parent
 
           expect(described_class.new(project).iati_identifier)
             .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}")
@@ -43,9 +43,9 @@ RSpec.describe ActivityXmlPresenter do
         it "returns an identifier with the reporting organisation, fund, programme, project and third-party project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           third_party_project = create(:third_party_project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
-          project = third_party_project.parent_activity
-          programme = project.parent_activity
-          fund = programme.parent_activity
+          project = third_party_project.parent
+          programme = project.parent
+          fund = programme.parent
 
           expect(described_class.new(third_party_project).iati_identifier)
             .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}-#{third_party_project.identifier}")

--- a/spec/services/create_programme_activity_spec.rb
+++ b/spec/services/create_programme_activity_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CreateProgrammeActivity do
     end
 
     it "sets the parent Activity to the fund" do
-      expect(result.parent_activity).to eq(fund)
+      expect(result.parent).to eq(fund)
     end
 
     it "sets the initial form_state" do

--- a/spec/services/create_project_activity_spec.rb
+++ b/spec/services/create_project_activity_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe CreateProjectActivity do
     end
 
     it "sets the parent Activity to the programme" do
-      expect(result.parent_activity).to eq(programme)
+      expect(result.parent).to eq(programme)
     end
 
     it "sets fund and programme to be parent activities of the project" do
-      fund = programme.parent_activity
-      programme = result.parent_activity
+      fund = programme.parent
+      programme = result.parent
 
       expect(result.parent_activities.first).to eq(fund)
       expect(result.parent_activities.last).to eq(programme)

--- a/spec/services/create_third_party_project_activity_spec.rb
+++ b/spec/services/create_third_party_project_activity_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe CreateThirdPartyProjectActivity do
     end
 
     it "sets the parent Activity to the project" do
-      expect(result.parent_activity).to eq(project)
+      expect(result.parent).to eq(project)
     end
 
     it "sets fund, programme & project to be parent activities of the third party project" do
-      programme = project.parent_activity
-      fund = programme.parent_activity
-      project = result.parent_activity
+      programme = project.parent
+      fund = programme.parent
+      project = result.parent
 
       expect(result.parent_activities.first).to eq(fund)
       expect(result.parent_activities.second).to eq(programme)

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -8,7 +8,24 @@ RSpec.describe FindProgrammeActivities do
   let!(:extending_organisation_programme) { create(:programme_activity, extending_organisation: other_organisation) }
   let!(:other_programme) { create(:programme_activity) }
 
+  before(:all) do
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
+  end
+
+  after(:all) do
+    Bullet.delete_whitelist(type: :unused_eager_loading, class_name: "Activity", association: :parent)
+  end
+
   describe "#call" do
+    it "eager loads the organisation and parent activity" do
+      expect_any_instance_of(ActiveRecord::Relation)
+        .to receive(:includes)
+        .with(:organisation, :parent)
+        .and_call_original
+
+      described_class.new(organisation: service_owner, current_user: user).call
+    end
+
     context "when the organisation is the service owner" do
       it "returns all programme activities" do
         result = described_class.new(organisation: service_owner, current_user: user).call

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -8,7 +8,24 @@ RSpec.describe FindThirdPartyProjectActivities do
   let!(:organisation_project) { create(:third_party_project_activity, organisation: other_organisation) }
   let!(:other_project) { create(:third_party_project_activity) }
 
+  before(:all) do
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
+  end
+
+  after(:all) do
+    Bullet.delete_whitelist(type: :unused_eager_loading, class_name: "Activity", association: :parent)
+  end
+
   describe "#call" do
+    it "eager loads the organisation and parent activity" do
+      expect_any_instance_of(ActiveRecord::Relation)
+        .to receive(:includes)
+        .with(:organisation, :parent)
+        .and_call_original
+
+      described_class.new(organisation: service_owner, current_user: user).call
+    end
+
     context "when the organisation is the service owner" do
       it "returns all third party project activities" do
         result = described_class.new(organisation: service_owner, current_user: user).call

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe IngestIatiActivities do
       described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
 
       activity = Activity.find_by(previous_identifier: "GB-GOV-13-GCRF-UKSA_NS_UKSA-019")
-      expect(activity.parent_activity).to eq(existing_programme)
-      expect(activity.parent_activity.organisation).to eql(beis)
+      expect(activity.parent).to eq(existing_programme)
+      expect(activity.parent.organisation).to eql(beis)
     end
 
     it "adds an activity with all mandatory fields" do

--- a/spec/support/bullet.rb
+++ b/spec/support/bullet.rb
@@ -1,8 +1,6 @@
 RSpec.configure do |config|
   if Bullet.enable?
     config.before(:each) do
-      Bullet.add_whitelist type: :unused_eager_loading, class_name: "User", association: :organisation
-      Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :organisation
       Bullet.start_request
     end
 


### PR DESCRIPTION
## Changes in this PR

- refactor the parent relationship of activities so that instead of `activity.activity_id` we have `activity.parent_id`. This follows a found convention for Rails gems that deal trees and enables the installation of the `acts_as_tree` with minimal impact
- refactor `activity.parent_activities` by instead telling the `acts_as_tree` gem. This gem allows us find out about ancestors and children for any given node without us having to have checks on the level of each activitiy to infer how many parents might exist - quite a fragile check. It also makes it easy to extend our hierarchy by adding or removing levels in the future.
- preload activity parents when querying collections of activities (unless it's a fund as there's no current parent)

As mentioned in the commit that added [acts_as_tree](https://github.com/amerine/acts_as_tree). I investigated Ancestry and Acts_as_nested as two alternative options first. Ready the commit for more info on why I ended up picking acts_as_tree.

## Screenshots of UI changes

I created a temporary view to demonstrate what the impact of maintaining a tree structure. For 1945 activities of all levels it took the browser 2.02 seconds in total to load - this reduced to 1.3 seconds after replacing the lost parent_id database index.

The code looked like this:

```
%table.govuk-table
  %thead.govuk-table__head
    %tr.govuk-table__row
      %th.govuk-table__header
        Title
      %th.govuk-table__header
        Fund
      %th.govuk-table__header
        Programme
      %th.govuk-table__header
        Project

  %tbody.govuk-table__body
    - @activities.each do |activity|
      %tr.govuk-table__row
        %td.govuk-table__cell= activity.title
        %td.govuk-table__cell= activity.parent_activities.first&.title
        %td.govuk-table__cell= activity.parent_activities.second&.title
        %td.govuk-table__cell= activity.parent_activities.third&.title

```

I think the case can be made that a page with 100+ activities all rendered at once is not usable, and that pagination or downloading to a spreadsheet would be more appropriate. I thought it was a useful exercise to see how performant the view would be in an extreme case and I think 2 seconds is a lot better than I feared.

![Screenshot 2020-06-26 at 15 17 52](https://user-images.githubusercontent.com/912473/85867026-393b1a80-b7c0-11ea-8054-70e7457717a7.png)

Rendered the same amount of content on `develop` without these changes the time is 5.3 seconds, up from 2 seconds. 

![Screenshot 2020-06-26 at 15 22 23](https://user-images.githubusercontent.com/912473/85867558-fb8ac180-b7c0-11ea-992a-ba2a541b3ece.png)

![Screenshot_2020-06-26 — Report your official development assistance](https://user-images.githubusercontent.com/912473/85866289-12c8af80-b7bf-11ea-8be0-272f644c95fd.png)

(there were sub-projects in this page but the screenshot cropped it :) )

### 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
