### PR TITLE
(751) Split the activity show view into tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@
 - Remove 3 unwanted activities from production
 - Content changes to fields for transaction value and activity identifier
 - Increase the width of the application layout
+- Activity show content is show in tabs for financials and details
 
 ## [unreleased]
 

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -19,10 +19,7 @@ class Staff::ActivitiesController < Staff::BaseController
 
     respond_to do |format|
       format.html do
-        @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
-        @budget_presenters = @budgets.includes(:parent_activity).map { |budget| BudgetPresenter.new(budget) }
-        @planned_disbursement_presenters = @planned_disbursements.map { |planned_disbursement| PlannedDisbursementPresenter.new(planned_disbursement) }
-        @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
+        redirect_to organisation_activity_financials_path(@activity.organisation, @activity)
       end
       format.xml do |_format|
         @activity_xml_presenter = ActivityXmlPresenter.new(@activity)

--- a/app/controllers/staff/activity_details_controller.rb
+++ b/app/controllers/staff/activity_details_controller.rb
@@ -7,6 +7,9 @@ class Staff::ActivityDetailsController < Staff::BaseController
     @activity = Activity.find(params[:activity_id])
     authorize @activity
 
+    @activities = @activity.child_activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
+    @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
+
     render "staff/activities/details"
   end
 end

--- a/app/controllers/staff/activity_details_controller.rb
+++ b/app/controllers/staff/activity_details_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Staff::ActivityDetailsController < Staff::BaseController
+  include Secured
+
+  def show
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+
+    render "staff/activities/details"
+  end
+end

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -6,6 +6,15 @@ class Staff::ActivityFinancialsController < Staff::BaseController
   def show
     @activity = Activity.find(params[:activity_id])
     authorize @activity
+
+    @transactions = policy_scope(Transaction).where(parent_activity: @activity).order("date DESC")
+    @budgets = policy_scope(Budget).where(parent_activity: @activity).order("period_start_date DESC")
+    @planned_disbursements = policy_scope(PlannedDisbursement).where(parent_activity: @activity).order("period_start_date DESC")
+
+    @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
+    @budget_presenters = @budgets.includes(:parent_activity).map { |budget| BudgetPresenter.new(budget) }
+    @planned_disbursement_presenters = @planned_disbursements.map { |planned_disbursement| PlannedDisbursementPresenter.new(planned_disbursement) }
+    @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
     render "staff/activities/financials"
   end
 end

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Staff::ActivityFinancialsController < Staff::BaseController
+  include Secured
+
+  def show
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+    render "staff/activities/financials"
+  end
+end

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -98,7 +98,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   def finish_wizard_path
     flash[:notice] ||= I18n.t("action.#{@activity.level}.create.success")
     @activity.update(form_state: "complete")
-    organisation_activity_path(@activity.organisation, @activity)
+    organisation_activity_details_path(@activity.organisation, @activity)
   end
 
   def update_form_state

--- a/app/controllers/staff/extending_organisations_controller.rb
+++ b/app/controllers/staff/extending_organisations_controller.rb
@@ -16,7 +16,7 @@ class Staff::ExtendingOrganisationsController < Staff::BaseController
       set_implementing_organisation
       @activity.save
       flash[:notice] = I18n.t("action.#{@activity.level}.update.success")
-      redirect_to organisation_activity_path(@activity.organisation, @activity)
+      redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :edit
     end

--- a/app/controllers/staff/implementing_organisations_controller.rb
+++ b/app/controllers/staff/implementing_organisations_controller.rb
@@ -21,7 +21,7 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
     if @implementing_organisation.valid?
       @implementing_organisation.save
       flash[:notice] = I18n.t("action.implementing_organisation.create.success")
-      redirect_to organisation_activity_path(@activity.organisation, @activity)
+      redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :new
     end
@@ -37,7 +37,7 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
     if @implementing_organisation.valid?
       @implementing_organisation.save!
       flash[:notice] = I18n.t("action.implementing_organisation.update.success")
-      redirect_to organisation_activity_path(@activity.organisation, @activity)
+      redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :edit
     end

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -7,6 +7,14 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  .govuk-grid-row
+    .govuk-grid-column-full
+      - if @activity.project? || @activity.third_party_project?
+        - if policy(:project).download? || policy(:third_party_project).download?
+          = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
       .govuk-tabs
         %h2.govuk-tabs__title
           = t("tabs.activity.title")

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -32,3 +32,18 @@
         .govuk-tabs__panel
           %h2.govuk-heading-l
             = t("page_title.activity.details")
+
+          = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
+          - if @activity.fund? && policy(:fund).create?
+            = render partial: "staff/shared/activities/programmes", locals: { activity: @activity, activities: @activities }
+
+          - if @activity.programme?
+            = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
+          - if @activity.programme? && policy(:programme).create?
+            = render partial: "staff/shared/activities/extending_organisation", locals: { activity: @activity }
+
+          - if @activity.project?
+            = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
+
+          - if @activity.project? || @activity.third_party_project?
+            = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -1,0 +1,26 @@
+= content_for :page_title_prefix, t("document_title.activity.details", name: @activity.title)
+
+= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = @activity.title
+
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          = t("tabs.activity.title")
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.activity.financials"),
+              organisation_activity_financials_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "financials", selected: true } }
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.activity.details"),
+              organisation_activity_details_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: false } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activity.details")

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -1,0 +1,27 @@
+= content_for :page_title_prefix, t("document_title.activity.financials", name: @activity.title)
+
+= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = @activity.title
+
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to "Financials",
+              organisation_activity_financials_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "financials", selected: true } }
+          %li.govuk-tabs__list-item
+            = link_to "Details",
+              organisation_activity_details_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: false } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activity.financials")

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -33,3 +33,18 @@
         .govuk-tabs__panel
           %h2.govuk-heading-l
             = t("page_title.activity.financials")
+
+          - if @activity.fund? && policy(:fund).create?
+            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
+
+          - if @activity.programme? && policy(:programme).create?
+            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+
+          - if @activity.programme?
+            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
+
+          - if @activity.project? || @activity.third_party_project?
+            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
+            = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
+            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -8,6 +8,14 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  .govuk-grid-row
+    .govuk-grid-column-full
+      - if @activity.project? || @activity.third_party_project?
+        - if policy(:project).download? || policy(:third_party_project).download?
+          = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
       .govuk-tabs
         %h2.govuk-tabs__title
           Contents

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -13,28 +13,6 @@
         - if policy(:project).download? || policy(:third_party_project).download?
           = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
 
-  .govuk-grid-row.activity-page
-    .govuk-grid-column-full
-      = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
 
-  - if @activity.fund? && policy(:fund).create?
-    = render partial: "staff/shared/activities/programmes", locals: { activity: @activity, activities: @activities }
-    = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
-    = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
 
-  - if @activity.programme? && policy(:programme).create?
-    = render partial: "staff/shared/activities/extending_organisation", locals: { activity: @activity }
-    = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
 
-  - if @activity.programme?
-    = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-    = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
-
-  - if @activity.project?
-    = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
-
-  - if @activity.project? || @activity.third_party_project?
-    = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-    = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
-    = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
-    = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,4 +1,4 @@
-=content_for :page_title_prefix, t("page_title.activity.show", name: @activity.title)
+=content_for :page_title_prefix, t("document_title.activity.show", name: @activity.title)
 
 = link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -7,6 +7,12 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  .govuk-grid-row
+    .govuk-grid-column-full
+      - if @activity.project? || @activity.third_party_project?
+        - if policy(:project).download? || policy(:third_party_project).download?
+          = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
+
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
       = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
@@ -32,6 +38,3 @@
     = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
     = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
     = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
-
-    - if policy(:project).download? || policy(:third_party_project).download?
-      = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"

--- a/app/views/staff/extending_organisations/edit.html.haml
+++ b/app/views/staff/extending_organisations/edit.html.haml
@@ -7,7 +7,7 @@
       %h1.govuk-heading-xl
         = @activity.title
 
-      = form_with model: @activity, url: activity_extending_organisation_path(@activity) do |f|
+      = form_with model: @activity, url: activity_extending_organisations_path(@activity.id, @activity.extending_organisation_id) do |f|
         = f.govuk_error_summary
         = f.hidden_field :extending_organisation_id, value: nil
         = f.govuk_collection_radio_buttons :extending_organisation_id,

--- a/app/views/staff/extending_organisations/edit.html.haml
+++ b/app/views/staff/extending_organisations/edit.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title_prefix, t("page_title.activity.show", name: @activity.title)
+= content_for :page_title_prefix, t("document_title.activity.extending_organisation", name: @activity.title)
 
 = link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }

--- a/app/views/staff/shared/activities/_extending_organisation.html.haml
+++ b/app/views/staff/shared/activities/_extending_organisation.html.haml
@@ -9,4 +9,4 @@
       %p.govuk-body
         = activity.extending_organisation.name
 
-    = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisation_path(activity), class: "govuk-button")
+    = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisations_path(activity), class: "govuk-button")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -1,5 +1,11 @@
 ---
 en:
+  document_title:
+    activity:
+      show: Activity %{name}
+      details: Activity %{name} — Details
+      financials: Activity %{name} — Financials
+      extending_organisation: Activity %{name} — Extending organisation
   form:
     button:
       activity:
@@ -107,12 +113,18 @@ en:
         default_selection_value: Select a recipient country
       third_party_projects: Third-party projects
       transactions: Transactions
+  tabs:
+    activity:
+      title: Contents
+      details: Details
+      financials: Financials
   page_title:
     activity:
       implementing_organisation:
         edit: Edit implemening organisation
         new: Add a new implementing organisation
-      show: Activity %{name}
+      details: Details
+      financials: Financials
     activity_form:
       show:
         aid_type: Aid type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show
     resources :users
     resources :organisations, except: [:destroy] do
-      resources :activities, except: [:destroy]
+      resources :activities, except: [:destroy] do
+        get "financials" => "activity_financials#show"
+        get "details" => "activity_details#show"
+      end
       resources :funds, only: [:create] do
         resources :programmes, only: [:create] do
           resources :projects, only: [:create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
     resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable] do
       resources :steps, controller: "activity_forms"
-      resources :extending_organisations, only: [:edit, :update]
+      resource :extending_organisations, only: [:edit, :update]
       resources :implementing_organisations, only: [:new, :create, :edit, :update]
     end
   end

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature "Users can choose a recipient country" do
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
         click_on I18n.t("default.link.back")
+        click_on I18n.t("tabs.activity.details")
 
         within(".recipient_country") do
           expect(page).to have_content "Saint Lucia"
@@ -71,6 +72,7 @@ RSpec.feature "Users can choose a recipient country" do
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
         click_on I18n.t("default.link.back")
+        click_on I18n.t("tabs.activity.details")
 
         within(".recipient_country") do
           expect(page).to have_content "Saint Lucia"

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_path(user.organisation)
         click_on(programme_activity.parent_activity.title)
+        click_on I18n.t("tabs.activity.details")
         click_on(programme_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))
@@ -61,6 +62,7 @@ RSpec.describe "Users can create a budget" do
         visit organisation_path(user.organisation)
 
         click_on(programme_activity.parent_activity.title)
+        click_on I18n.t("tabs.activity.details")
         click_on(programme_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))
@@ -109,6 +111,7 @@ RSpec.describe "Users can create a budget" do
         visit organisation_path(user.organisation)
 
         click_on(programme_activity.title)
+        click_on I18n.t("tabs.activity.details")
         click_on(project_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Users can create a planned disbursement" do
       select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
       click_button I18n.t("default.button.submit")
 
-      expect(page).to have_current_path organisation_activity_path(user.organisation, project)
+      expect(page).to have_current_path organisation_activity_financials_path(user.organisation, project)
       expect(page).to have_content I18n.t("action.planned_disbursement.create.success")
     end
 

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Users can create a programme activity" do
 
       visit organisation_path(user.organisation)
       click_on fund.title
+      click_on I18n.t("tabs.activity.details")
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
       fill_in_activity_form(level: "programme")
@@ -24,6 +25,7 @@ RSpec.feature "Users can create a programme activity" do
 
       visit organisation_path(user.organisation)
       click_on fund.title
+      click_on I18n.t("tabs.activity.details")
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
       fill_in_activity_form(identifier: identifier, level: "programme")
@@ -40,6 +42,7 @@ RSpec.feature "Users can create a programme activity" do
 
       visit organisation_path(user.organisation)
       click_on fund.title
+      click_on I18n.t("tabs.activity.details")
       click_on(I18n.t("page_content.organisation.button.create_programme"))
 
       fill_in_activity_form(identifier: identifier, level: "programme")
@@ -56,6 +59,7 @@ RSpec.feature "Users can create a programme activity" do
       PublicActivity.with_tracking do
         visit organisation_path(user.organisation)
         click_on fund.title
+        click_on I18n.t("tabs.activity.details")
         click_on(I18n.t("page_content.organisation.button.create_programme"))
 
         fill_in_activity_form(identifier: "my-unique-identifier", level: "programme")

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Users can create a project" do
         visit organisation_path(user.organisation)
 
         click_on(programme.title)
+        click_on I18n.t("tabs.activity.details")
 
         click_on(I18n.t("page_content.organisation.button.create_project"))
 
@@ -32,6 +33,7 @@ RSpec.feature "Users can create a project" do
           visit organisation_path(user.organisation)
 
           click_on(programme.title)
+          click_on I18n.t("tabs.activity.details")
 
           click_on(I18n.t("page_content.organisation.button.create_project"))
 

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Users can create a project" do
         visit organisation_path(user.organisation)
 
         click_on(project.title)
+        click_on I18n.t("tabs.activity.details")
 
         click_on(I18n.t("page_content.organisation.button.create_third_party_project"))
 
@@ -30,6 +31,7 @@ RSpec.feature "Users can create a project" do
           visit organisation_path(user.organisation)
 
           click_on(project.title)
+          click_on I18n.t("tabs.activity.details")
 
           click_on(I18n.t("page_content.organisation.button.create_third_party_project"))
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can edit an activity" do
       it "shows edit link on the identifier, and add link on only the next step" do
         activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         # Click the first edit link that opens the form on step 1
         within(".identifier") do
@@ -28,10 +28,10 @@ RSpec.feature "Users can edit an activity" do
     end
 
     context "when the activity is complete" do
-      it "editing and saving a step returns the user to the activity page" do
+      it "editing and saving a step returns the user to the activity page details tab" do
         activity = create(:fund_activity, organisation: user.organisation)
         identifier = "AB-CDE-1234"
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".identifier") do
           click_on(I18n.t("default.link.edit"))
@@ -41,13 +41,13 @@ RSpec.feature "Users can edit an activity" do
         click_button I18n.t("form.button.activity.submit")
 
         expect(page).to have_content I18n.t("action.fund.update.success")
-        expect(page.current_path).to eq organisation_activity_path(activity.organisation, activity)
+        expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
       end
 
       it "all edit links are available to take the user to the right step" do
         activity = create(:fund_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
       end
@@ -56,7 +56,7 @@ RSpec.feature "Users can edit an activity" do
         activity = create(:fund_activity, organisation: user.organisation)
         identifier = "AB-CDE-1234"
         PublicActivity.with_tracking do
-          visit organisation_activity_path(activity.organisation, activity)
+          visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".identifier") do
             click_on(I18n.t("default.link.edit"))
@@ -79,7 +79,7 @@ RSpec.feature "Users can edit an activity" do
         activity = create(:fund_activity, :at_region_step, organisation: user.organisation)
         recipient_region = "Oceania, regional"
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".recipient_region") do
           click_on(I18n.t("default.link.edit"))
@@ -98,7 +98,7 @@ RSpec.feature "Users can edit an activity" do
       it "the call to action is 'Edit'" do
         activity = create(:fund_activity, organisation: user.organisation, form_state: :sector)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
           expect(page).to have_content(I18n.t("default.link.edit"))
@@ -110,7 +110,7 @@ RSpec.feature "Users can edit an activity" do
       it "the call to action is 'Add'" do
         activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
           expect(page).to have_content(I18n.t("default.link.add"))
@@ -126,7 +126,7 @@ RSpec.feature "Users can edit an activity" do
       it "shows an update success message" do
         activity = create(:programme_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
           click_on(I18n.t("default.link.edit"))
@@ -158,7 +158,7 @@ RSpec.feature "Users can edit an activity" do
       it "shows an update success message" do
         activity = create(:project_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
           click_on(I18n.t("default.link.edit"))
@@ -177,7 +177,7 @@ RSpec.feature "Users can edit an activity" do
       it "shows an update success message" do
         activity = create(:third_party_project_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
           click_on(I18n.t("default.link.edit"))
@@ -198,6 +198,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".sector") do
     click_on(I18n.t("default.link.edit"))
@@ -206,6 +207,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".title") do
     click_on(I18n.t("default.link.edit"))
@@ -214,6 +216,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".description") do
     click_on(I18n.t("default.link.edit"))
@@ -222,6 +225,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".status") do
     click_on(I18n.t("default.link.edit"))
@@ -230,6 +234,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".planned_start_date") do
     click_on(I18n.t("default.link.edit"))
@@ -238,6 +243,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".planned_end_date") do
     click_on(I18n.t("default.link.edit"))
@@ -246,6 +252,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".actual_start_date") do
     click_on(I18n.t("default.link.edit"))
@@ -254,6 +261,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".actual_end_date") do
     click_on(I18n.t("default.link.edit"))
@@ -262,6 +270,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".recipient_region") do
     click_on(I18n.t("default.link.edit"))
@@ -270,6 +279,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".flow") do
     click_on(I18n.t("default.link.edit"))
@@ -278,6 +288,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 
   within(".aid_type") do
     click_on(I18n.t("default.link.edit"))
@@ -286,4 +297,5 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     )
   end
   click_on(I18n.t("default.link.back"))
+  click_on I18n.t("tabs.activity.details")
 end

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Users can provide the geography for an activity" do
     context "with a completed activity" do
       scenario "they can change the geography from region to country" do
         activity = create(:activity, geography: :recipient_region, recipient_country: nil)
-        activity_path = organisation_activity_path(activity.organisation, activity)
+        activity_path = organisation_activity_details_path(activity.organisation, activity)
 
         visit activity_path
         within(".recipient_region") do
@@ -84,7 +84,7 @@ RSpec.feature "Users can provide the geography for an activity" do
 
       scenario "they can change the geography from country to region" do
         activity = create(:activity, geography: :recipient_country, recipient_region: nil, recipient_country: "AG")
-        activity_path = organisation_activity_path(activity.organisation, activity)
+        activity_path = organisation_activity_details_path(activity.organisation, activity)
 
         visit activity_path
         within(".recipient_country") do

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can manage Sectors" do
       let(:activity) { create(:activity, organisation: user.organisation) }
 
       scenario "they can edit the sector by changing the sector category and sector and retruning to the summary" do
-        visit organisation_activity_path(user.organisation, activity)
+        visit organisation_activity_details_path(user.organisation, activity)
         within ".sector" do
           click_on "Edit"
         end
@@ -31,7 +31,7 @@ RSpec.feature "Users can manage Sectors" do
         choose "Early childhood education"
         click_button I18n.t("form.button.activity.submit")
 
-        expect(page).to have_current_path(organisation_activity_path(user.organisation, activity))
+        expect(page).to have_current_path(organisation_activity_details_path(user.organisation, activity))
         within ".sector" do
           expect(page).to have_content "Early childhood education"
         end

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can manage the extending organisation" do
       scenario "they can set the extending organisation" do
         delivery_partner = create(:delivery_partner_organisation)
         visit organisation_activity_path(programme.organisation, programme)
-
+        click_on I18n.t("tabs.activity.details")
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
         choose delivery_partner.name
         click_on I18n.t("default.button.submit")
@@ -22,7 +22,7 @@ RSpec.feature "Users can manage the extending organisation" do
       scenario "when the extending organisation is set, the same organisation is set as the implementing organisation" do
         delivery_partner = create(:delivery_partner_organisation)
         visit organisation_activity_path(programme.organisation, programme)
-
+        click_on I18n.t("tabs.activity.details")
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
         choose delivery_partner.name
         click_on I18n.t("default.button.submit")
@@ -39,6 +39,7 @@ RSpec.feature "Users can manage the extending organisation" do
         another_delivery_partner = create(:delivery_partner_organisation)
 
         visit organisation_activity_path(programme.organisation, programme)
+        click_on I18n.t("tabs.activity.details")
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
 
         expect(page).to have_checked_field delivery_partner.name
@@ -56,6 +57,7 @@ RSpec.feature "Users can manage the extending organisation" do
         another_delivery_partner = create(:delivery_partner_organisation)
 
         visit organisation_activity_path(programme.organisation, programme)
+        click_on I18n.t("tabs.activity.details")
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
 
         expect(page).to have_checked_field delivery_partner.name
@@ -71,6 +73,7 @@ RSpec.feature "Users can manage the extending organisation" do
 
       scenario "not selecting an extending organisation results in an error" do
         visit organisation_activity_path(programme.organisation, programme)
+        click_on I18n.t("tabs.activity.details")
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
         click_on I18n.t("default.button.submit")
 

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can manage the implementing organisations" do
     scenario "they can add an implementing organisation" do
       other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "10", reference: "GB-COH-123456")
 
-      visit organisation_activity_path(project.organisation, project)
+      visit organisation_activity_details_path(project.organisation, project)
 
       expect(page).to have_content I18n.t("page_content.activity.implementing_organisation.button.new")
       click_on I18n.t("page_content.activity.implementing_organisation.button.new")
@@ -22,7 +22,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       fill_in I18n.t("form.label.implementing_organisation.reference"), with: other_public_sector_organisation.reference
       click_on I18n.t("default.button.submit")
 
-      expect(current_path).to eq organisation_activity_path(project.organisation, project)
+      expect(current_path).to eq organisation_activity_details_path(project.organisation, project)
       expect(page).to have_content I18n.t("action.implementing_organisation.create.success")
 
       expect(page).to have_content other_public_sector_organisation.name
@@ -33,7 +33,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
       project.implementing_organisations << other_public_sector_organisation
 
-      visit organisation_activity_path(project.organisation, project)
+      visit organisation_activity_details_path(project.organisation, project)
 
       expect(page).to have_content other_public_sector_organisation.name
       expect(page).to have_content other_public_sector_organisation.reference
@@ -62,7 +62,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
       project.implementing_organisations << other_public_sector_organisation
 
-      visit organisation_activity_path(project.organisation, project)
+      visit organisation_activity_details_path(project.organisation, project)
 
       expect(page).to have_content other_public_sector_organisation.name
       expect(page).to have_content other_public_sector_organisation.reference

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can view a project" do
       project = create(:project_activity, organisation: user.organisation)
       third_party_project = create(:third_party_project_activity, activity: project)
 
-      visit organisation_activity_path(project.organisation, project)
+      visit organisation_activity_details_path(project.organisation, project)
 
       expect(page).to have_content third_party_project.title
     end
@@ -32,7 +32,7 @@ RSpec.feature "Users can view a project" do
         project = create(:project_activity, organisation: user.organisation)
         programme.child_activities << project
 
-        visit organisation_activity_path(programme.organisation, programme)
+        visit organisation_activity_details_path(programme.organisation, programme)
 
         expect(page).to have_content programme.title
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -11,6 +11,25 @@ RSpec.feature "Users can view an activity" do
     let(:user) { create(:beis_user) }
     before { authenticate!(user: user) }
 
+    scenario "the activity financials can be viewed" do
+      activity = create(:activity, organisation: user.organisation)
+
+      visit organisation_activity_financials_path(activity.organisation, activity)
+      within ".govuk-tabs__list-item--selected" do
+        expect(page).to have_content "Financials"
+      end
+    end
+
+    scenario "the activity details can be viewed" do
+      activity = create(:activity, organisation: user.organisation)
+
+      visit organisation_activity_details_path(activity.organisation, activity)
+
+      within ".govuk-tabs__list-item--selected" do
+        expect(page).to have_content "Details"
+      end
+    end
+
     scenario "an activity can be viewed" do
       activity = create(:activity, organisation: user.organisation)
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -42,6 +42,8 @@ RSpec.feature "Users can view an activity" do
       visit organisation_path(user.organisation)
 
       click_on(activity.title)
+      click_on I18n.t("tabs.activity.details")
+
       activity_presenter = ActivityPresenter.new(activity)
 
       expect(page).to have_content activity_presenter.identifier
@@ -62,6 +64,7 @@ RSpec.feature "Users can view an activity" do
                                      actual_end_date: Date.new(2020, 1, 29))
 
         visit organisation_activity_path(user.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
 
         within(".planned_start_date") do
           expect(page).to have_content("3 Feb 2020")

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -13,11 +13,15 @@ RSpec.feature "Users can view an activity" do
 
     scenario "the activity financials can be viewed" do
       activity = create(:activity, organisation: user.organisation)
+      transaction = create(:transaction, parent_activity: activity)
+      budget = create(:budget, parent_activity: activity)
 
       visit organisation_activity_financials_path(activity.organisation, activity)
       within ".govuk-tabs__list-item--selected" do
         expect(page).to have_content "Financials"
       end
+      expect(page).to have_content transaction.value
+      expect(page).to have_content budget.value
     end
 
     scenario "the activity details can be viewed" do
@@ -28,6 +32,8 @@ RSpec.feature "Users can view an activity" do
       within ".govuk-tabs__list-item--selected" do
         expect(page).to have_content "Details"
       end
+      expect(page).to have_content activity.title
+      expect(page).to have_button I18n.t("page_content.organisation.button.create_programme")
     end
 
     scenario "an activity can be viewed" do

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link programme_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -63,7 +64,9 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -79,7 +82,9 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
@@ -133,6 +138,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -147,6 +153,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         expect(page).to have_content(I18n.t("page_content.budgets.button.create"))

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -27,7 +27,8 @@ RSpec.feature "Users can view fund level activities" do
       programme_activity = create(:activity, level: :programme)
       fund_activity.child_activities << programme_activity
       activity_presenter = ActivityPresenter.new(programme_activity)
-      visit organisation_activity_path(fund_activity.organisation, fund_activity)
+
+      visit organisation_activity_details_path(fund_activity.organisation, fund_activity)
 
       expect(page).to have_link activity_presenter.display_title
       expect(page).to have_button I18n.t("page_content.organisation.button.create_programme")

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -64,7 +64,9 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         expect(page).to have_content(transaction_presenter.transaction_type)
@@ -82,7 +84,9 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link programme_activity.title
+        click_on I18n.t("tabs.activity.details")
         click_link project_activity.title
 
         expect(page).to_not have_content(I18n.t("page_content.transactions.button.create"))

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -1,5 +1,6 @@
 module ActivityHelpers
   def page_displays_an_activity(activity_presenter:)
+    click_on I18n.t("tabs.activity.details")
     expect(page).to have_content activity_presenter.identifier
     expect(page).to have_content activity_presenter.title
     expect(page).to have_content activity_presenter.description


### PR DESCRIPTION
## Changes in this PR
This is the first piece of work to change the delivery partner views to focus on their activties and allow them to find the information they need quickly and simply regardless whether they are looking for financial or activity details data.

By splitting these two groups of information accross two tabs we can give equal weight to both needs.

Future works will add more tabs to this view but this was not part of this work.

It became clear through this work that the back link will need some thought/improvements but this work does not address this issue.

I decided to keep the tab view simple and not split the tabs into a partial whilst there are only two, this meant no logic is needed to work out which is the current tab.

I also decided to keep the tab views in the `activities` view directory rather than the convention of placing them in direcotries with the controller names - I was not sure if you can 'nest' controllers in this way?

## Screenshots of UI changes

### Before
![Screenshot_2020-06-30 Activity Airbus Flood and Drought — Report your official development assistance](https://user-images.githubusercontent.com/480578/86122033-fbdfd100-bace-11ea-8fef-ab730f128489.png)

### After
![Screenshot_2020-06-30 Activity Airbus Flood and Drought — Financials — Report your official development assistance](https://user-images.githubusercontent.com/480578/86122043-01d5b200-bacf-11ea-83c0-7a7ec5fa02d9.png)

![Screenshot_2020-06-30 Activity Airbus Flood and Drought — Details — Report your official development assistance](https://user-images.githubusercontent.com/480578/86122046-039f7580-bacf-11ea-9cc2-80043d9ca60c.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
