### PR TITLE
(760) Activity identifiers are only unique between sibling activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,8 @@
 
 ## [unreleased]
 
+- Activity identifiers are unique among siblings
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11
 [release-10]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-9...release-10

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -31,7 +31,7 @@ class Activity < ApplicationRecord
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
 
-  validates_uniqueness_of :identifier, allow_nil: true
+  validates :identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :planned_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.actual_start_date.present? }
   validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -70,10 +70,32 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when identifier is not unique" do
-      before(:each) { create(:activity, identifier: "GB-GOV-13") }
-      subject { build(:activity, identifier: "GB-GOV-13") }
-      it { should validate_uniqueness_of(:identifier) }
+    describe "#identifier" do
+      context "when an activity exists with the same identifier" do
+        context "shares the same parent" do
+          it "should be invalid" do
+            fund = create(:fund_activity)
+            create(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+
+            new_programme_activity = build(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+
+            expect(new_programme_activity).not_to be_valid
+          end
+        end
+
+        context "does NOT share the same parent" do
+          it "should be valid" do
+            create(:fund_activity) do |fund|
+              create(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+            end
+
+            other_fund = create(:fund_activity)
+            new_programme_activity = build(:programme_activity, identifier: "GB-GOV-13-001", parent: other_fund)
+
+            expect(new_programme_activity).to be_valid
+          end
+        end
+      end
     end
 
     context "when title is blank" do


### PR DESCRIPTION
## Changes in this PR

Activities can now have the same identifier, but only when they belong to different parent activities.

We are loosening up the uniqueness validation on activity identifiers because we believe it is likely that the project and third-party project identifiers currently used by delivery partners have the possibility of being the same.

When using this reference to publish to IATI we think this approach would continue to work. The fund, programme and project identifiers are all combined which should guarantee uniqueness across all activities.

*NB: We originally added this because we found in practice that programme identifiers were being reused by BEIS. However, because they would still share a common fund activity, this change wouldn't actual have fixed this issue. In that specific case, we chose to change the identifier to suffix the delivery partner's initials.*

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
