### PR TITLE
(715) Redact selected activities from the XML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,8 @@
 ## [unreleased]
 
 - Ingest RS Newton fund data from IATI
+- Allow BEIS users to redact activities from the IATI XML file, and to
+  easily see on the Organisation show page which Activities are redacted
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...HEAD
 [release-10]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-9...release-10

--- a/app/assets/stylesheets/partials/_tag.scss
+++ b/app/assets/stylesheets/partials/_tag.scss
@@ -7,3 +7,7 @@
   color: govuk-shade(govuk-colour("green"), 20);
   background: govuk-tint(govuk-colour("green"), 80);
 }
+.govuk-tag--red {
+  color: govuk-shade(govuk-colour("red"), 30);
+  background: govuk-tint(govuk-colour("red"), 80);
+}

--- a/app/controllers/staff/activity_redactions_controller.rb
+++ b/app/controllers/staff/activity_redactions_controller.rb
@@ -1,0 +1,26 @@
+class Staff::ActivityRedactionsController < Staff::BaseController
+  include Secured
+
+  def edit
+    @activity = Activity.find(activity_id)
+    authorize @activity, :redact_from_iati?
+  end
+
+  def update
+    @activity = Activity.find(activity_id)
+    authorize @activity, :redact_from_iati?
+
+    @activity.update(publish_to_iati: activity_params["publish_to_iati"])
+    redirect_to organisation_activity_path(@activity.organisation, @activity)
+  end
+
+  private
+
+  def activity_id
+    params[:activity_id]
+  end
+
+  def activity_params
+    params.require(:activity).permit(:publish_to_iati)
+  end
+end

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -27,9 +27,9 @@ class Staff::OrganisationsController < Staff::BaseController
       format.xml do
         @activities = case level
         when "project"
-          project_activities.publishable_to_iati?.map { |activity| ActivityXmlPresenter.new(activity) }
+          project_activities.publishable_to_iati.map { |activity| ActivityXmlPresenter.new(activity) }
         when "third_party_project"
-          third_party_project_activities.publishable_to_iati?.map { |activity| ActivityXmlPresenter.new(activity) }
+          third_party_project_activities.publishable_to_iati.map { |activity| ActivityXmlPresenter.new(activity) }
         else
           []
         end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -63,7 +63,7 @@ class Activity < ApplicationRecord
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
-  scope :publishable_to_iati?, -> { where(form_state: :complete, publish_to_iati: true) }
+  scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
 
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -63,7 +63,7 @@ class Activity < ApplicationRecord
 
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
-  scope :publishable_to_iati?, -> { where(form_state: :complete) }
+  scope :publishable_to_iati?, -> { where(form_state: :complete, publish_to_iati: true) }
 
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -18,6 +18,10 @@ class ActivityPolicy < ApplicationPolicy
       (record.project? || record.third_party_project?) && delivery_partner_user?
   end
 
+  def redact_from_iati?
+    beis_user? && record.project? || record.third_party_project?
+  end
+
   def destroy?
     false
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -23,6 +23,10 @@ class ProjectPolicy < ApplicationPolicy
     beis_user?
   end
 
+  def redact_from_iati?
+    beis_user?
+  end
+
   class Scope < Scope
     def resolve
       if user.organisation.service_owner?

--- a/app/views/staff/activity_redactions/edit.html.haml
+++ b/app/views/staff/activity_redactions/edit.html.haml
@@ -1,0 +1,17 @@
+=content_for :page_title_prefix, t("document_title.activity.edit", name: @activity.title)
+
+= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+
+      = form_for @activity, url: activity_redaction_path(@activity) do |f|
+
+        = f.govuk_collection_radio_buttons :publish_to_iati,
+          [OpenStruct.new(id: true, name: I18n.t("summary.label.activity.publish_to_iati.true")),
+            OpenStruct.new(id: false, name: I18n.t("summary.label.activity.publish_to_iati.false"))],
+          :id,
+          :name,
+          legend: { text: I18n.t("form.label.activity.publish_to_iati") }
+
+        = f.govuk_submit t("form.button.activity.submit")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -134,4 +134,4 @@
       %dd.govuk-summary-list__value
         = t("summary.label.activity.publish_to_iati.#{activity_presenter.publish_to_iati}")
       %dd.govuk-summary-list__actions
-
+        = link_to(t("default.link.edit"), edit_activity_redaction_path(activity_presenter), class: "govuk-link")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -126,3 +126,12 @@
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("summary.label.activity.aid_type"))
+
+  - if policy(activity_presenter).redact_from_iati?
+    .govuk-summary-list__row.publish_to_iati
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.publish_to_iati.label")
+      %dd.govuk-summary-list__value
+        = t("summary.label.activity.publish_to_iati.#{activity_presenter.publish_to_iati}")
+      %dd.govuk-summary-list__actions
+

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -12,6 +12,9 @@
           =t("table.header.project.programme")
         %th.govuk-table__header
           =t("summary.label.activity.stage")
+        - if policy(:project).redact_from_iati?
+          %th.govuk-table__header
+            = t("summary.label.activity.publish_to_iati.label")
 
     %tbody.govuk-table__body
       - projects.each do |project|
@@ -26,3 +29,11 @@
             - else
               %strong.govuk-tag.govuk-tag--yellow
                 = t("summary.label.activity.form_state.incomplete")
+          - if policy(:project).redact_from_iati?
+            %td.govuk-table__cell
+              - if project.publish_to_iati?
+                %strong.govuk-tag.govuk-tag--green
+                  = t("summary.label.activity.publish_to_iati.true")
+              - else
+                %strong.govuk-tag.govuk-tag--red
+                  = t("summary.label.activity.publish_to_iati.false")

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -12,6 +12,9 @@
           =t("table.header.third_party_project.project")
         %th.govuk-table__header
           =t("summary.label.activity.stage")
+        - if policy(:third_party_project).redact_from_iati?
+          %th.govuk-table__header
+            = t("summary.label.activity.publish_to_iati.label")
 
     %tbody.govuk-table__body
       - third_party_projects.each do |project|
@@ -26,3 +29,11 @@
             - else
               %strong.govuk-tag.govuk-tag--yellow
                 = t("summary.label.activity.form_state.incomplete")
+          - if policy(:third_party_project).redact_from_iati?
+            %td.govuk-table__cell
+              - if project.publish_to_iati?
+                %strong.govuk-tag.govuk-tag--green
+                  = t("summary.label.activity.publish_to_iati.true")
+              - else
+                %strong.govuk-tag.govuk-tag--red
+                  = t("summary.label.activity.publish_to_iati.false")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -2,6 +2,7 @@
 en:
   document_title:
     activity:
+      edit: Activity %{name} - Publish to IATI
       show: Activity %{name}
       details: Activity %{name} — Details
       financials: Activity %{name} — Financials
@@ -28,6 +29,7 @@ en:
           day: Day
           month: Month
           year: Year
+        publish_to_iati: Publish this activity to IATI?
     legend:
       activity:
         aid_type: Aid type

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -82,6 +82,10 @@ en:
         status: Status
         third_party_projects: Third-party projects
         title: '%{level} name'
+        publish_to_iati:
+          label: Publish to IATI?
+          'false': 'No'
+          'true': 'Yes'
   page_content:
     activities:
       button:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     end
 
     resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable] do
+      resource :redaction, only: [:edit, :update], controller: :activity_redactions
       resources :steps, controller: "activity_forms"
       resource :extending_organisations, only: [:edit, :update]
       resources :implementing_organisations, only: [:new, :create, :edit, :update]

--- a/db/migrate/20200623132105_add_publish_to_iati_field_to_activity.rb
+++ b/db/migrate/20200623132105_add_publish_to_iati_field_to_activity.rb
@@ -1,0 +1,9 @@
+class AddPublishToIatiFieldToActivity < ActiveRecord::Migration[6.0]
+  def up
+    add_column :activities, :publish_to_iati, :boolean, default: true
+  end
+
+  def down
+    remove_column :activities, :publish_to_iati
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_105959) do
+ActiveRecord::Schema.define(version: 2020_06_23_132105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_105959) do
     t.string "sector_category"
     t.boolean "ingested", default: false
     t.string "legacy_iati_xml"
+    t.boolean "publish_to_iati", default: true
     t.index ["activity_id"], name: "index_activities_on_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     flow { "10" }
     aid_type { "A01" }
     level { :fund }
+    publish_to_iati { true }
 
     form_state { "complete" }
 

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -40,6 +40,16 @@ feature "Organisation show page" do
         end
       end
 
+      scenario "they do not see a Publish to Iati column & status against funds" do
+        within(".funds") do
+          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+        end
+
+        within("##{fund.id}") do
+          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+        end
+      end
+
       scenario "they see a create fund button" do
         expect(page).to have_button I18n.t("page_content.organisation.button.create_fund")
       end
@@ -65,6 +75,16 @@ feature "Organisation show page" do
         end
       end
 
+      scenario "they do not see a Publish to Iati column & status against programmes" do
+        within(".programmes") do
+          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+        end
+
+        within("##{programme.id}") do
+          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+        end
+      end
+
       scenario "they see a list of all projects" do
         within("##{project.id}") do
           expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
@@ -86,6 +106,16 @@ feature "Organisation show page" do
         end
       end
 
+      scenario "they see a Publish to Iati column & status against projects" do
+        within(".projects") do
+          expect(page).to have_content I18n.t("summary.label.activity.publish_to_iati.label")
+        end
+
+        within("##{project.id}") do
+          expect(page).to have_content "Yes"
+        end
+      end
+
       scenario "they see a list of all third-party projects" do
         within("##{third_party_project.id}") do
           expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
@@ -98,6 +128,16 @@ feature "Organisation show page" do
         within("##{incomplete_third_party_project.id}") do
           expect(page).to have_link incomplete_third_party_project.title
           expect(page).to have_content I18n.t("summary.label.activity.form_state.incomplete")
+        end
+      end
+
+      scenario "they see a Publish to Iati column & status against third-party projects" do
+        within(".third-party-projects") do
+          expect(page).to have_content I18n.t("summary.label.activity.publish_to_iati.label")
+        end
+
+        within("##{third_party_project.id}") do
+          expect(page).to have_content "Yes"
         end
       end
 
@@ -147,6 +187,16 @@ feature "Organisation show page" do
       expect(page).not_to have_content another_programme.identifier
     end
 
+    scenario "they do not see a Publish to Iati column & status against programmes" do
+      within(".programmes") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+      end
+
+      within("##{programme.id}") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+      end
+    end
+
     scenario "they see a list of all their projects" do
       within("##{project.id}") do
         expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
@@ -164,6 +214,16 @@ feature "Organisation show page" do
       expect(page.find("table.projects  tbody tr:last-child")[:id]).to have_content(project.id)
     end
 
+    scenario "they do not see a Publish to Iati column & status against projects" do
+      within(".projects") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+      end
+
+      within("##{project.id}") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+      end
+    end
+
     scenario "they do not see projects that they are not the reporting organisation of" do
       expect(page).not_to have_content another_project.identifier
     end
@@ -173,6 +233,16 @@ feature "Organisation show page" do
         expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
         expect(page).to have_content third_party_project.identifier
         expect(page).to have_content third_party_project.parent_activity.title
+      end
+    end
+
+    scenario "they do not see a Publish to Iati column & status against third-party projects" do
+      within(".third-party-projects") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+      end
+
+      within("##{third_party_project.id}") do
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
       end
     end
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -117,6 +117,14 @@ RSpec.feature "Users can edit an activity" do
         end
       end
     end
+
+    it "does not show the Publish to Iati field" do
+      activity = create(:fund_activity, organisation: user.organisation)
+
+      visit organisation_activity_path(activity.organisation, activity)
+
+      expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+    end
   end
 
   context "when the activity is a programme" do
@@ -135,6 +143,14 @@ RSpec.feature "Users can edit an activity" do
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content(I18n.t("action.programme.update.success"))
       end
+
+      it "does not show the Publish to Iati field" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+      end
     end
 
     context "when the user is NOT a BEIS user" do
@@ -147,6 +163,14 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).not_to have_content("Edit")
         expect(page).not_to have_content("Add")
+      end
+
+      scenario "it does not show the Publish to Iati field" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
       end
     end
   end
@@ -167,6 +191,47 @@ RSpec.feature "Users can edit an activity" do
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content(I18n.t("action.project.update.success"))
       end
+
+      it "does not show the Publish to Iati field" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+      end
+    end
+
+    context "when the user is a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "shows the Publish to Iati field" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
+
+        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+      end
+
+      it "allows the user to redact the activity from Iati" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          click_on(I18n.t("default.link.edit"))
+        end
+
+        choose I18n.t("summary.label.activity.publish_to_iati.false")
+        click_button I18n.t("form.button.activity.submit")
+
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        end
+      end
     end
   end
 
@@ -185,6 +250,38 @@ RSpec.feature "Users can edit an activity" do
 
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content(I18n.t("action.third_party_project.update.success"))
+      end
+    end
+
+    context "when the user is a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "shows the Publish to Iati field" do
+        activity = create(:third_party_project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
+
+        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+      end
+
+      it "allows the user to redact the activity from Iati" do
+        activity = create(:third_party_project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(activity.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          click_on(I18n.t("default.link.edit"))
+        end
+
+        choose I18n.t("summary.label.activity.publish_to_iati.false")
+        click_button I18n.t("form.button.activity.submit")
+
+        click_on I18n.t("tabs.activity.details")
+        within ".publish_to_iati" do
+          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        end
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -40,6 +40,18 @@ RSpec.feature "Users can view an organisation as XML" do
           expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
           expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to eq project.title
         end
+
+        scenario "the XML file does not contain projects which should not be published to IATI" do
+          _redacted_project = create(:project_activity, organisation: organisation, publish_to_iati: false)
+
+          visit organisation_path(organisation)
+          within ".download-projects" do
+            click_link I18n.t("default.button.download_as_xml")
+          end
+          xml = Nokogiri::XML::Document.parse(page.body)
+
+          expect(xml.xpath("/iati-activities/iati-activity").count).to eq(0)
+        end
       end
 
       context "the organisation has third-party projects" do
@@ -65,6 +77,18 @@ RSpec.feature "Users can view an organisation as XML" do
           expect(xml.xpath("/iati-activities/iati-activity").count).to eq 1
           expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to eq third_party_project.title
           expect(xml.xpath("/iati-activities/iati-activity/title/narrative").text).to_not eq project.title
+        end
+
+        scenario "the XML file does not contain third-party projects which should not be published to IATI" do
+          _redacted_project = create(:third_party_project_activity, organisation: organisation, publish_to_iati: false)
+
+          visit organisation_path(organisation)
+          within ".download-third-party-projects" do
+            click_link I18n.t("default.button.download_as_xml")
+          end
+          xml = Nokogiri::XML::Document.parse(page.body)
+
+          expect(xml.xpath("/iati-activities/iati-activity").count).to eq(0)
         end
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Activity, type: :model do
         _complete_redacted_activity = create(:fund_activity, publish_to_iati: false)
         _incomplete_redacted_activity = create(:fund_activity, :at_identifier_step, publish_to_iati: false)
 
-        expect(Activity.publishable_to_iati?).to eq [complete_activity]
+        expect(Activity.publishable_to_iati).to eq [complete_activity]
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -35,9 +35,11 @@ RSpec.describe Activity, type: :model do
     end
 
     describe ".publishable_to_iati?" do
-      it "only returns activities with a `form_state` of :complete" do
+      it "only returns activities with a `form_state` of :complete and/or `publish_to_iati` of true" do
         complete_activity = create(:fund_activity)
         _incomplete_activity = create(:fund_activity, :at_purpose_step)
+        _complete_redacted_activity = create(:fund_activity, publish_to_iati: false)
+        _incomplete_redacted_activity = create(:fund_activity, :at_identifier_step, publish_to_iati: false)
 
         expect(Activity.publishable_to_iati?).to eq [complete_activity]
       end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to permit_action(:download) }
+    it { is_expected.to permit_action(:redact_from_iati) }
 
     it "includes all projects in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.project).resolve
@@ -32,6 +33,7 @@ RSpec.describe ProjectPolicy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to forbid_action(:download) }
+    it { is_expected.to forbid_action(:redact_from_iati) }
 
     it "includes only projects that the users organisation is reporting the project in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.project).resolve

--- a/spec/policies/third_party_project_policy_spec.rb
+++ b/spec/policies/third_party_project_policy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ThirdPartyProjectPolicy do
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to permit_action(:download) }
+    it { is_expected.to permit_action(:redact_from_iati) }
 
     it "includes all third party projects in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.third_party_project).resolve
@@ -32,6 +33,7 @@ RSpec.describe ThirdPartyProjectPolicy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to forbid_action(:download) }
+    it { is_expected.to forbid_action(:redact_from_iati) }
 
     it "includes only projects that the users organisation is reporting the project in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.third_party_project).resolve


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/e8GbGaHP/715-redact-selected-activities-from-the-xml-file

In order for BEIS users to redact certain activities from the IATI XML file, we have introduced a boolean field onto the Activity table which enables complete activities to be left out of the XML download. Activities are set to be published to IATI by default, the option has to be manually turned off. 

This option is only available to BEIS users.

Additionally, the list view of Activities on the Organisation show page now has a label to clearly show which activities are redacted or not. 

## Screenshots of UI changes

<img width="1249" alt="Screenshot 2020-07-01 at 14 30 02" src="https://user-images.githubusercontent.com/1089521/86268142-a59e8b00-bbbf-11ea-9966-877d1ceaf45c.png">

<img width="1317" alt="Screenshot 2020-07-01 at 17 24 41" src="https://user-images.githubusercontent.com/1089521/86268231-c535b380-bbbf-11ea-8d97-799bb267d85c.png">

<img width="1225" alt="Screenshot 2020-07-01 at 17 12 15" src="https://user-images.githubusercontent.com/1089521/86268155-aafbd580-bbbf-11ea-8c91-8c44340e5761.png">

<img width="1017" alt="Screenshot 2020-07-01 at 17 12 23" src="https://user-images.githubusercontent.com/1089521/86268167-adf6c600-bbbf-11ea-9e96-e4c7ed66fcdc.png">

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
