### PR TITLE
Redacted activities redact their children

### DIFF
--- a/app/controllers/staff/activity_redactions_controller.rb
+++ b/app/controllers/staff/activity_redactions_controller.rb
@@ -11,6 +11,8 @@ class Staff::ActivityRedactionsController < Staff::BaseController
     authorize @activity, :redact_from_iati?
 
     @activity.update(publish_to_iati: activity_params["publish_to_iati"])
+    @activity.child_activities.update(publish_to_iati: activity_params["publish_to_iati"])
+
     redirect_to organisation_activity_path(@activity.organisation, @activity)
   end
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -232,6 +232,34 @@ RSpec.feature "Users can edit an activity" do
           expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
         end
       end
+
+      it "also redacts any child third-party projects when a project is redacted" do
+        project_activity = create(:project_activity, organisation: user.organisation)
+        third_party_project_activity = create(:third_party_project_activity, activity: project_activity, organisation: user.organisation)
+
+        visit organisation_activity_path(project_activity.organisation, project_activity)
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          click_on(I18n.t("default.link.edit"))
+        end
+
+        choose I18n.t("summary.label.activity.publish_to_iati.false")
+        click_button I18n.t("form.button.activity.submit")
+
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        end
+
+        visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
+        click_on I18n.t("tabs.activity.details")
+
+        within ".publish_to_iati" do
+          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

A missed part of https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/501

Trello: https://trello.com/c/e8GbGaHP/715-redact-selected-activities-from-the-xml-file

When redacting an activity, all its children activities are redacted as well.

In theory this will only happen for level C activities at the moment, as only
level C & D can be redacted, and only level C can have children. But if we
begin publishing level B to IATI, this will be useful for redacting any children
that level B activities have.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
