### PR TITLE
(752) Add basic all activities page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@
 - Activity show content is show in tabs for financials and details
 - Refactor how we can ask activities for their parents
 - Ingest BA Newton fund data from IATI
+- Add an activities page and navigation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...HEAD
 [release-10]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-9...release-10

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -4,7 +4,9 @@ class Staff::ActivitiesController < Staff::BaseController
   include Secured
 
   def index
-    @activities = policy_scope(Activity).includes(:parent)
+    @activities = policy_scope(Activity.project_activities)
+    authorize @activities
+    @activity_presenters = @activities.includes([:organisation, :parent]).map { |activity| ActivityPresenter.new(activity) }
   end
 
   def show

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -66,6 +66,7 @@ class Activity < ApplicationRecord
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
   scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
+  scope :project_activities, -> { where(level: :project).or(where(level: :third_party_project)) }
 
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -6,6 +6,10 @@
         %a{ href: organisation_path(current_user.organisation), class: 'govuk-header__link' }
           = t("page_title.home")
 
+      - unless current_user.organisation.service_owner
+        %li{ class: navigation_item_class(organisation_activities_path(current_user.organisation)) }
+          = link_to t("page_title.activity.index"), organisation_activities_path(current_user.organisation), class: "govuk-header__link"
+
       - if policy(Organisation).index?
         %li{ class: navigation_item_class(organisations_path) }
           = link_to t("page_title.organisation.index"), organisations_path, class: "govuk-header__link"

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -1,0 +1,11 @@
+= content_for :page_title_prefix, t("document_title.activity.index")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_title.activity.index")
+
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      = render partial: "staff/shared/activities/table", locals: { activities: @activities }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -1,0 +1,29 @@
+- unless activities.empty?
+  %table.govuk-table.activities
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.activity.identifier")
+        %th.govuk-table__header
+          = t("table.header.activity.title")
+        %th.govuk-table__header
+          = t("table.header.activity.level_a")
+        %th.govuk-table__header
+          = t("table.header.activity.level_b")
+        %th.govuk-table__header
+          = t("table.header.activity.level_c")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - activities.each do |activity|
+        %tr.govuk-table__row{ id: activity.id }
+          %td.govuk-table__cell= activity.identifier
+          %td.govuk-table__cell= activity.title
+          %td.govuk-table__cell= activity.parent_activities.first&.title
+          %td.govuk-table__cell= activity.parent_activities.second&.title
+          %td.govuk-table__cell= activity.parent_activities.third&.title
+          %td.govuk-table__cell
+            = a11y_action_link t("table.body.activity.view_activity"),
+              organisation_activity_path(activity.organisation, activity),
+              activity.title
+

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -4,6 +4,7 @@ en:
     activity:
       edit: Activity %{name} - Publish to IATI
       show: Activity %{name}
+      index: Activities
       details: Activity %{name} — Details
       financials: Activity %{name} — Financials
       extending_organisation: Activity %{name} — Extending organisation
@@ -88,6 +89,17 @@ en:
           label: Publish to IATI?
           'false': 'No'
           'true': 'Yes'
+  table:
+    header:
+      activity:
+        identifier: Identifier
+        title: Name
+        level_a: Level A activity
+        level_b: Level B activity
+        level_c: Level C activity
+    body:
+      activity:
+        view_activity: View
   page_content:
     activities:
       button:
@@ -126,6 +138,7 @@ en:
       financials: Financials
   page_title:
     activity:
+      index: Activities
       implementing_organisation:
         edit: Edit implemening organisation
         new: Add a new implementing organisation

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Activity, type: :model do
         expect(Activity.publishable_to_iati).to eq [complete_activity]
       end
     end
+
+    describe ".project_activities" do
+      it "only returns activities at level C and D i.e. Projects and Third party projects" do
+        fund = create(:fund_activity)
+        programme = create(:programme_activity, parent: fund)
+        project = create(:project_activity, parent: programme)
+        third_party_project = create(:third_party_project_activity, parent: project)
+
+        expect(Activity.project_activities).to include project
+        expect(Activity.project_activities).to include third_party_project
+
+        expect(Activity.project_activities).not_to include fund
+        expect(Activity.project_activities).not_to include programme
+      end
+    end
   end
 
   describe "sanitisation" do


### PR DESCRIPTION
## Changes in this PR

Create the navigation element and page itself.

The action and route were already in-place from a previous feature that
was later removed.

Shows a complete list of all activities at level C and D.

## Screenshots of UI changes
![Screenshot_2020-07-06 Actvities — Report your official development assistance](https://user-images.githubusercontent.com/480578/86587943-94b89580-bf82-11ea-8bd1-a9328cd9db29.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
