### PR TITLE
(780) XML contains ONLY recipient country OR region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@
 - Activity identifiers are unique among siblings
 - add accessibility statement
 - Move budgets to the top of the programme activity financials tab
+- Activity XML includes only recipient-country OR recipient-region, not both
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -31,11 +31,12 @@
   %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
   - if activity.actual_end_date?
     %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
-  %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}
-    %narrative= region_name_from_code(activity.recipient_region)
   - if activity.recipient_country?
     %recipient-country{"code" => activity.recipient_country}
       %narrative= country_name_from_code(activity.recipient_country)
+  - elsif activity.recipient_region?
+    %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}
+      %narrative= region_name_from_code(activity.recipient_region)
   %sector{"vocabulary" => "1", "code" => activity.sector}/
   %default-flow-type{"code" => activity.flow}/
   %default-finance-type{"code" => activity.finance}/

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -89,12 +89,11 @@ RSpec.feature "Users can view an activity as XML" do
         }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
-        it "contains the recipient region code and recipient country code" do
+        it "contains only the recipient country code" do
           visit organisation_activity_path(organisation, activity, format: :xml)
 
           expect(xml.at("iati-activity/recipient-country/@code").text).to eq(activity.recipient_country)
-          expect(xml.at("iati-activity/recipient-region/@code").text).to eq(activity.recipient_region)
-          expect(xml.at("iati-activity/recipient-region/@vocabulary").text).to eq("1")
+          expect(xml.at("iati-activity/recipient-region")).to be_nil
         end
       end
 


### PR DESCRIPTION
## Changes in this PR

The IATI activity standard specifies that `<recipient-region/>` and `<recipient-country/>` should be mutually exclusive, unless we are providing the percentage splits amongst them.

For now, we'll only include the recipient region when the country is not available.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [X] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
