### PR TITLE
(752) Add activities index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
 - Move budgets to the top of the programme activity financials tab
 - Activity XML includes only recipient-country OR recipient-region, not both
 - Activity creation journey changed to ask for a level and parent
+- Add an activities page and navigation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -51,17 +51,12 @@ class Staff::ActivitiesController < Staff::BaseController
 
     return current_user.organisation.id unless Organisation.exists?(organisation_id)
     return current_user.organisation.id if organisation_id.blank?
-    return current_user.organisation.id if requested_organisation_is_not_current_users?(organisation_id) && current_user_is_not_service_owner?
+    return current_user.organisation.id if requested_organisation_is_not_current_users?(organisation_id) && current_user.delivery_partner?
     organisation_id
   end
 
   def requested_organisation_is_not_current_users?(requested_organisation_id)
     requested_organisation_id != current_user.organisation.id
-  end
-
-  def current_user_is_not_service_owner?
-    return false if current_user.organisation.service_owner?
-    true
   end
 
   def fund_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,8 @@ class User < ApplicationRecord
   def service_owner?
     organisation.service_owner?
   end
+
+  def delivery_partner?
+    !service_owner?
+  end
 end

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -6,6 +6,9 @@
         %a{ href: organisation_path(current_user.organisation), class: 'govuk-header__link' }
           = t("page_title.home")
 
+      %li{ class: navigation_item_class(activities_path(organisation_id: current_user.organisation_id)) }
+        = link_to t("page_title.activity.index"), activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
+
       - if policy(Organisation).index?
         %li{ class: navigation_item_class(organisations_path) }
           = link_to t("page_title.organisation.index"), organisations_path, class: "govuk-header__link"

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -1,0 +1,11 @@
+= content_for :page_title_prefix, t("document_title.activity.index")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_title.activity.index")
+
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      = render partial: "staff/shared/activities/table", locals: { activities: @activities }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -1,0 +1,23 @@
+- unless activities.empty?
+  %table.govuk-table.activities
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.activity.title")
+        %th.govuk-table__header
+          = t("table.header.activity.identifier")
+        %th.govuk-table__header
+          = t("table.header.activity.level")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - activities.each do |activity|
+        %tr.govuk-table__row{ id: activity.id }
+          %td.govuk-table__cell= activity.title
+          %td.govuk-table__cell= activity.identifier
+          %td.govuk-table__cell= t("table.body.activity.level.#{activity.level}")
+          %td.govuk-table__cell
+            = a11y_action_link t("table.body.activity.view_activity"),
+              organisation_activity_path(activity.organisation, activity),
+              activity.title
+

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -4,6 +4,7 @@ en:
     activity:
       edit: Activity %{name} - Publish to IATI
       show: Activity %{name}
+      index: Activities
       details: Activity %{name} — Details
       financials: Activity %{name} — Financials
       extending_organisation: Activity %{name} — Extending organisation
@@ -94,6 +95,20 @@ en:
           label: Publish to IATI?
           'false': 'No'
           'true': 'Yes'
+  table:
+    header:
+      activity:
+        identifier: Identifier
+        title: Name
+        level: Level
+    body:
+      activity:
+        level:
+          fund: Fund
+          programme: Programme
+          project: Project
+          third_party_project: Third-party project
+        view_activity: View
   page_content:
     activities:
       button:
@@ -132,6 +147,7 @@ en:
       financials: Financials
   page_title:
     activity:
+      index: Activities
       implementing_organisation:
         edit: Edit implemening organisation
         new: Add a new implementing organisation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,9 @@ Rails.application.routes.draw do
   scope module: "staff" do
     resource :dashboard, only: :show
     resources :users
+    resources :activities, only: [:index]
     resources :organisations, except: [:destroy] do
-      resources :activities, except: [:destroy] do
+      resources :activities, except: [:index, :destroy] do
         get "financials" => "activity_financials#show"
         get "details" => "activity_details#show"
       end

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -1,0 +1,185 @@
+RSpec.feature "Users can view activities" do
+  context "when the user is not logged in" do
+    it "redirects the user to the root path" do
+      activity = create(:activity)
+      visit organisation_activity_path(activity.organisation, activity)
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "when the user is signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    scenario "the activities index shows activities associated to the BEIS organisation" do
+      activities = create_list(:programme_activity, 2, organisation: user.organisation)
+      another_activity = create(:project_activity)
+
+      visit activities_path(organisation_id: user.organisation)
+      expect(page).to have_content I18n.t("page_title.activity.index")
+
+      first_activity = activities.first
+      last_activity = activities.last
+
+      expect(page).to have_content first_activity.identifier
+      expect(page).to have_content last_activity.identifier
+      expect(page).not_to have_content another_activity.identifier
+    end
+
+    scenario "they can view another organisations activities" do
+      delivery_partner = create(:delivery_partner_organisation)
+      activity = create(:project_activity, organisation: delivery_partner)
+
+      visit activities_path(organisation_id: activity.organisation)
+
+      expect(page).to have_content activity.identifier
+    end
+
+    context "when an organisation id query parameter is not supplied" do
+      scenario "it defaults to showing the current users organisation activities" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit activities_path(organisation_id: "")
+
+        expect(page).to have_content activity.identifier
+      end
+    end
+
+    context "when the organisation id query parameter is not the BEIS organisation id" do
+      scenario "it shows the supplied organisation activities" do
+        delivery_partner = create(:delivery_partner_organisation)
+        activity = create(:project_activity, organisation: delivery_partner)
+
+        visit activities_path(organisation_id: delivery_partner.id)
+
+        expect(page).to have_content activity.identifier
+      end
+    end
+
+    context "when the organisation id query parameter is not a know organisation" do
+      scenario "it defaults to showing the current users organisation activities" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit activities_path(organisation_id: "this-is-no-a-know-organisation")
+
+        expect(page).to have_content activity.identifier
+      end
+    end
+  end
+
+  context "when the user is signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "the activity financials can be viewed" do
+      activity = create(:project_activity, organisation: user.organisation)
+      transaction = create(:transaction, parent_activity: activity)
+      budget = create(:budget, parent_activity: activity)
+
+      visit organisation_activity_financials_path(activity.organisation, activity)
+      within ".govuk-tabs__list-item--selected" do
+        expect(page).to have_content "Financials"
+      end
+      expect(page).to have_content transaction.value
+      expect(page).to have_content budget.value
+    end
+
+    scenario "the activity details can be viewed" do
+      activity = create(:project_activity, organisation: user.organisation)
+
+      visit organisation_activity_details_path(activity.organisation, activity)
+
+      within ".govuk-tabs__list-item--selected" do
+        expect(page).to have_content "Details"
+      end
+      expect(page).to have_content activity.title
+      expect(page).to have_link I18n.t("page_content.activity.implementing_organisation.button.new")
+    end
+
+    scenario "all activities can be viewed" do
+      activities = create_list(:project_activity, 5, organisation: user.organisation)
+
+      visit activities_path(organisation_id: user.organisation)
+
+      expect(page).to have_content I18n.t("page_title.activity.index")
+
+      first_activity = activities.first
+      last_activity = activities.last
+
+      expect(page).to have_content first_activity.identifier
+
+      expect(page).to have_content last_activity.identifier
+    end
+
+    scenario "an activity can be viewed" do
+      activity = create(:project_activity, organisation: user.organisation)
+
+      visit organisation_path(user.organisation)
+
+      click_on(activity.title)
+      click_on I18n.t("tabs.activity.details")
+
+      activity_presenter = ActivityPresenter.new(activity)
+
+      expect(page).to have_content activity_presenter.identifier
+      expect(page).to have_content activity_presenter.sector
+      expect(page).to have_content activity_presenter.title
+      expect(page).to have_content activity_presenter.description
+      expect(page).to have_content activity_presenter.planned_start_date
+      expect(page).to have_content activity_presenter.planned_end_date
+      expect(page).to have_content activity_presenter.recipient_region
+      expect(page).to have_content activity_presenter.flow
+    end
+
+    context "when the organisation id query parameter is not the delivery_partners organisation id" do
+      scenario "it defaults to showing the current users organisation activities" do
+        another_delivery_partner = create(:delivery_partner_organisation)
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit activities_path(organisation_id: another_delivery_partner.id)
+
+        expect(page).to have_content activity.identifier
+      end
+    end
+
+    scenario "activities have human readable date format" do
+      travel_to Time.zone.local(2020, 1, 29) do
+        activity = create(:project_activity, planned_start_date: Date.new(2020, 2, 3),
+                                             planned_end_date: Date.new(2024, 6, 22),
+                                             actual_start_date: Date.new(2020, 1, 2),
+                                             actual_end_date: Date.new(2020, 1, 29))
+
+        visit organisation_activity_path(user.organisation, activity)
+        click_on I18n.t("tabs.activity.details")
+
+        within(".planned_start_date") do
+          expect(page).to have_content("3 Feb 2020")
+        end
+
+        within(".planned_end_date") do
+          expect(page).to have_content("22 Jun 2024")
+        end
+
+        within(".actual_start_date") do
+          expect(page).to have_content("2 Jan 2020")
+        end
+
+        within(".actual_end_date") do
+          expect(page).to have_content("29 Jan 2020")
+        end
+      end
+    end
+
+    scenario "can go back to the previous page" do
+      activity = create(:project_activity, organisation: user.organisation)
+
+      visit organisation_activity_path(user.organisation, activity)
+
+      click_on I18n.t("default.link.back")
+
+      expect(page).to have_current_path(
+        organisation_path(user.organisation)
+      )
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#delivery_partner?" do
+    context "when the user organisation is a service owner" do
+      it "returns false" do
+        organisation = build_stubbed(:organisation, service_owner: true)
+        result = described_class.new(organisation: organisation).delivery_partner?
+        expect(result).to be false
+      end
+    end
+
+    context "when the user organisation is NOT a service owner" do
+      it "returns true" do
+        organisation = build_stubbed(:organisation, service_owner: false)
+        result = described_class.new(organisation: organisation).delivery_partner?
+        expect(result).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

This is a simple view of an organisations activities.

The view takes a organisation_id and displays all the activities that
are associated with that organisation through the `organisation`
association.

BEIS users can supply a delivery partners organisation id and see those
activities. This functionality is not exposed in the UI as yet, but is
supported by the view, we expect later work to add this UI.

Delivery partners cannot use another organisation id.

The view can be augmented later with additional filters as we learn what
users want to see.

When an unexpected organisation_id is encountered we try to show the
current users own organisation activities instead, those instances might
be:

- no organisation id parameter
- an unknown organisation id
- an empty organisation id
- another organisations id when the user is not a BEIS user

We chose to handle these cases and display the current users activities
as we shouldn't encounter these situations under normal conditions.

There is a lot of change in `spec/features/staff/users_can_view_activities_spec.rb` as I had to reconfigure this spec and rename it.

## Screenshots of UI changes
BEIS user view BEIS actvities:
![Screenshot_2020-07-09 Activities — Report your official development assistance](https://user-images.githubusercontent.com/480578/87045939-62ac6b00-c1f0-11ea-9e59-1c596290a7ea.png)

BEIS user viewing another organisations activties:
![beis - uksa](https://user-images.githubusercontent.com/480578/87045961-6e982d00-c1f0-11ea-9391-d62afe4cbb69.png)

Delivery partner:
![Screenshot_2020-07-09 Activities — Report your official development assistance](https://user-images.githubusercontent.com/480578/87046201-c0d94e00-c1f0-11ea-9e87-041414af92c3.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak wich has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation]
