### PR TITLE
Remove back links, except on Activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@
 - Activity XML includes only recipient-country OR recipient-region, not both
 - Activity creation journey changed to ask for a level and parent
 - Add an activities page and navigation
+- Remove Back links, except on the Activity form
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -10,12 +10,4 @@ module ActivityHelper
 
     presenter_position <= activity_position + 1
   end
-
-  def activity_back_path(current_user:, activity:)
-    if activity.parent.present? && activity.programme? && current_user.service_owner?
-      return organisation_activity_path(activity.parent.organisation, activity.parent)
-    end
-
-    organisation_path(current_user.organisation)
-  end
 end

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -1,6 +1,5 @@
 = content_for :page_title_prefix, t("document_title.activity.details", name: @activity.title)
 
-= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -1,7 +1,5 @@
 = content_for :page_title_prefix, t("document_title.activity.financials", name: @activity.title)
 
-= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
-
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activities/show.html.haml
+++ b/app/views/staff/activities/show.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("document_title.activity.show", name: @activity.title)
 
-= link_to t("default.link.back"), activity_back_path(current_user: current_user, activity: @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_forms/_wrapper.html.haml
+++ b/app/views/staff/activity_forms/_wrapper.html.haml
@@ -1,6 +1,6 @@
 =content_for :page_title_prefix, @page_title
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
+= link_to t("form.link.activity.back"), organisation_activity_details_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/activity_redactions/edit.html.haml
+++ b/app/views/staff/activity_redactions/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("document_title.activity.edit", name: @activity.title)
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/budgets/edit.html.haml
+++ b/app/views/staff/budgets/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.budget.edit")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/budgets/new.html.haml
+++ b/app/views/staff/budgets/new.html.haml
@@ -1,7 +1,5 @@
 =content_for :page_title_prefix, t("page_title.budget.new")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
-
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/extending_organisations/edit.html.haml
+++ b/app/views/staff/extending_organisations/edit.html.haml
@@ -1,6 +1,5 @@
 = content_for :page_title_prefix, t("document_title.activity.extending_organisation", name: @activity.title)
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/implementing_organisations/edit.html.haml
+++ b/app/views/staff/implementing_organisations/edit.html.haml
@@ -1,6 +1,5 @@
 = content_for :page_title_prefix, t("page_title.activity.implementing_organisation.edit", name: @activity.title)
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/implementing_organisations/new.html.haml
+++ b/app/views/staff/implementing_organisations/new.html.haml
@@ -1,6 +1,5 @@
 = content_for :page_title_prefix, t("page_title.activity.implementing_organisation.new", name: @activity.title)
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/edit.html.haml
+++ b/app/views/staff/organisations/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.organisation.edit")
 
-= link_to t("default.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/organisations/new.html.haml
+++ b/app/views/staff/organisations/new.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.organisation.new")
 
-= link_to t("default.link.back"), organisations_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/planned_disbursements/edit.html.haml
+++ b/app/views/staff/planned_disbursements/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.planned_disbursement.edit")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/planned_disbursements/new.html.haml
+++ b/app/views/staff/planned_disbursements/new.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.planned_disbursement.new")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/transactions/edit.html.haml
+++ b/app/views/staff/transactions/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.transaction.edit")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/transactions/new.html.haml
+++ b/app/views/staff/transactions/new.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.transaction.new")
 
-= link_to t("default.link.back"), organisation_activity_path(@activity.id, organisation_id: @activity.organisation.id), class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/edit.html.haml
+++ b/app/views/staff/users/edit.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.users.edit")
 
-= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/new.html.haml
+++ b/app/views/staff/users/new.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.users.new")
 
-= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -1,6 +1,5 @@
 =content_for :page_title_prefix, t("page_title.users.show", name: @user.name)
 
-= link_to t("default.link.back"), users_path, class: "govuk-back-link"
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -12,6 +12,9 @@ en:
     button:
       activity:
         submit: Continue
+    link:
+      activity:
+       back: Back to activity details
     label:
       activity:
         flow: What is the flow type?

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -114,13 +114,6 @@ RSpec.feature "BEIS users can invite new users to the service" do
           end
         end
       end
-
-      scenario "can go back to the previous page" do
-        visit new_user_path
-
-        click_on I18n.t("default.link.back")
-        expect(page).to have_current_path(users_path)
-      end
     end
 
     context "when the user does not belongs to BEIS" do

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -80,15 +80,5 @@ RSpec.feature "BEIS users can can view other users" do
 
       expect(page).to have_content(I18n.t("form.user.active.false"))
     end
-
-    scenario "can go back to the previous page" do
-      another_user = create(:administrator)
-
-      visit user_path(another_user)
-
-      click_on I18n.t("default.link.back")
-
-      expect(page).to have_current_path(users_path)
-    end
   end
 end

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -55,28 +55,12 @@ RSpec.feature "Users can choose a recipient country" do
         expect(page).to have_selector "li.autocomplete__option", text: "Afghanistan", visible: true
       end
 
-      scenario "typing a complete country name, clicking it in the list and clicking continue saves the country" do
-        fill_in I18n.t("form.label.activity.recipient_country"), with: "Saint Lucia"
-        find("li.autocomplete__option", text: "Saint Lucia").click
-        click_button I18n.t("form.button.activity.submit")
-        click_on I18n.t("default.link.back")
-        click_on I18n.t("tabs.activity.details")
-
-        within(".recipient_country") do
-          expect(page).to have_content "Saint Lucia"
-        end
-      end
-
       scenario "typing a partial match, clicking on the complete match and clicking continue saves the country " do
         fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
         click_button I18n.t("form.button.activity.submit")
-        click_on I18n.t("default.link.back")
-        click_on I18n.t("tabs.activity.details")
-
-        within(".recipient_country") do
-          expect(page).to have_content "Saint Lucia"
-        end
+        click_link I18n.t("default.link.back")
+        expect(page).to have_content "Saint Lucia"
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -65,20 +65,5 @@ RSpec.feature "Users can edit a transaction" do
         expect(auditable_event.owner_id).to eq user.id
       end
     end
-
-    scenario "going back to the previous page" do
-      visit organisation_path(user.organisation)
-
-      click_on(activity.title)
-
-      expect(page).to have_content(transaction.value)
-
-      within("##{transaction.id}") do
-        click_on(I18n.t("default.link.edit"))
-      end
-      click_on(I18n.t("default.link.back"))
-
-      expect(page).to have_content(activity.title)
-    end
   end
 end

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -169,17 +169,5 @@ RSpec.feature "Users can view activities" do
         end
       end
     end
-
-    scenario "can go back to the previous page" do
-      activity = create(:project_activity, organisation: user.organisation)
-
-      visit organisation_activity_path(user.organisation, activity)
-
-      click_on I18n.t("default.link.back")
-
-      expect(page).to have_current_path(
-        organisation_path(user.organisation)
-      )
-    end
   end
 end

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -83,17 +83,5 @@ RSpec.feature "Users can view an activity" do
         end
       end
     end
-
-    scenario "can go back to the previous page" do
-      activity = create(:activity, organisation: user.organisation)
-
-      visit organisation_activity_path(user.organisation, activity)
-
-      click_on I18n.t("default.link.back")
-
-      expect(page).to have_current_path(
-        organisation_path(user.organisation)
-      )
-    end
   end
 end

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -43,15 +43,5 @@ RSpec.feature "Users can view fund level activities" do
         expect(page).to have_content("Untitled (#{activity.id})")
       end
     end
-
-    scenario "can go back to the previous page" do
-      activity = create(:activity, organisation: user.organisation)
-
-      visit organisation_activity_path(user.organisation, activity)
-
-      click_on I18n.t("default.link.back")
-
-      expect(page).to have_current_path(organisation_path(user.organisation))
-    end
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -3,42 +3,6 @@ require "rails_helper"
 RSpec.describe ActivityHelper, type: :helper do
   let(:organisation) { create(:organisation) }
 
-  describe "#activity_back_path" do
-    context "when the activity is a fund level" do
-      it "returns the organistian path" do
-        user = create(:beis_user)
-        fund = create(:fund_activity)
-
-        result = activity_back_path(current_user: user, activity: fund)
-
-        expect(result).to eq organisation_path(user.organisation)
-      end
-    end
-
-    context "when the activity is a programme level" do
-      context "when the user is a BEIS user" do
-        it "returns the fund path" do
-          user = create(:beis_user)
-          programme_activity = create(:programme_activity)
-
-          result = activity_back_path(current_user: user, activity: programme_activity)
-          expect(result).to eq organisation_activity_path(programme_activity.parent.organisation, programme_activity.parent)
-        end
-      end
-
-      context "when the user is NOT a BEIS user" do
-        it "returns the organisation path" do
-          user = create(:delivery_partner_user)
-          programme_activity = create(:programme_activity)
-
-          result = activity_back_path(current_user: user, activity: programme_activity)
-
-          expect(result).to eq organisation_path(user.organisation)
-        end
-      end
-    end
-  end
-
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do
       it "returns true for the purpose fields" do


### PR DESCRIPTION
The back links are trying to mimic the action of the Back button in the browser
but are increasingly confusing as many pages can be accessed in different ways.

This commit removes them, except for the Back links on the activity create/edit
form as there is no other quick way to get back to the activity details page
without a back link. The back link on the Activity form has been amended to
point at the `details` view of the Activity.

**Suggestion for discussion:** on the Activity Form, would it make sense to replace the Back link with a secondary button? E.g. https://design-system.service.gov.uk/components/button/secondary-combo/index.html

<img width="265" alt="Screenshot 2020-07-13 at 15 26 06" src="https://user-images.githubusercontent.com/1089521/87316083-301aaf00-c51d-11ea-86e0-eff3680d7055.png">

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
