### PR TITLE
(824) BEIS users can filter activities by organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
 - Remove Back links, except on the Activity form
 - Refactor the activity update action
 - Replace generic Rails error pages with styled pages (404, 500 and 422)
+- Activities can be filtered to an organisation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/assets/stylesheets/partials/_page_actions.css.scss
+++ b/app/assets/stylesheets/partials/_page_actions.css.scss
@@ -1,0 +1,3 @@
+.page-actions {
+  text-align: right;
+}

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -4,6 +4,7 @@ class Staff::ActivitiesController < Staff::BaseController
   include Secured
 
   def index
+    @organisation_id = organisation_id
     @activities = policy_scope(Activity.where(organisation: organisation_id))
     authorize @activities
     @activity_presenters = @activities.includes(:organisation).map { |activity| ActivityPresenter.new(activity) }

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = t("page_title.activity.index")
 
+  .govuk-grid-row
+    .govuk-grid-column-full.page-actions
+      = form_tag(organisation_activities_path(@organisation_id), method: "post") do
+        = submit_tag t("page_content.organisation.button.create_activity"), class: "govuk-button"
+
   - if current_user.service_owner?
     = render partial: "staff/shared/activities/filter", locals: { organisation_id: @organisation_id }
 

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -6,6 +6,9 @@
       %h1.govuk-heading-xl
         = t("page_title.activity.index")
 
+  - if current_user.service_owner?
+    = render partial: "staff/shared/activities/filter", locals: { organisation_id: @organisation_id }
+
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
       = render partial: "staff/shared/activities/table", locals: { activities: @activities }

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -16,4 +16,4 @@
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
-      = render partial: "staff/shared/activities/table", locals: { activities: @activities }
+      = render partial: "staff/shared/activities/table", locals: { activities: @activity_presenters }

--- a/app/views/staff/shared/activities/_filter.html.haml
+++ b/app/views/staff/shared/activities/_filter.html.haml
@@ -1,0 +1,11 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-s
+      = t("filters.activity.title")
+    = form_with url: activities_path, method: :get do |f|
+      .govuk-form-group
+        %label{ class: "govuk-label", for: :organistaion_id }
+          = t("filters.activity.organisation")
+        = select_tag :organisation_id, options_from_collection_for_select(Organisation.all, :id, :name, organisation_id), { class: "govuk-select" }
+      .govuk-form-group
+        = submit_tag t("filters.activity.submit"), { class: "govuk-button", data: { module: "govuk-button" } }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -13,7 +13,7 @@
     %tbody.govuk-table__body
       - activities.each do |activity|
         %tr.govuk-table__row{ id: activity.id }
-          %td.govuk-table__cell= activity.title
+          %td.govuk-table__cell= activity.display_title
           %td.govuk-table__cell= activity.identifier
           %td.govuk-table__cell= t("table.body.activity.level.#{activity.level}")
           %td.govuk-table__cell

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -112,6 +112,11 @@ en:
           project: Project
           third_party_project: Third-party project
         view_activity: View
+  filters:
+    activity:
+      title: Filter activities
+      organisation: Organisation
+      submit: Apply filter
   page_content:
     activities:
       button:

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -1,0 +1,48 @@
+RSpec.feature "Users can filter activities" do
+  context "when the user is signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
+
+    scenario "they see the organisation filter on the activities index" do
+      visit root_path
+      within "#navigation" do
+        click_on "Activities"
+      end
+
+      expect(page).to have_content I18n.t("filters.activity.title")
+      expect(page).to have_select "organisation_id"
+    end
+
+    scenario "they can filter the activities to an organisation" do
+      delivery_partner_organisation = create(:delivery_partner_organisation)
+      programme = create(:programme_activity, organisation: user.organisation)
+      project = create(:project_activity, organisation: delivery_partner_organisation, parent: programme)
+
+      visit activities_path
+
+      expect(page).to have_content programme.title
+      expect(page).to have_content programme.identifier
+
+      select delivery_partner_organisation.name, from: "organisation_id"
+      click_on I18n.t("filters.activity.submit")
+
+      expect(page).to have_content project.title
+      expect(page).to have_content project.identifier
+    end
+  end
+
+  context "when the user is signed in as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "they do not see the organisation filter on the activities index" do
+      visit root_path
+      within "#navigation" do
+        click_on "Activities"
+      end
+
+      expect(page).not_to have_content I18n.t("filters.activity.title")
+      expect(page).not_to have_select "organisation_id"
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
This PR is part of the larger work to refactor how users view activities. To keep the PRs small and concise this one will come first.

We have the new activities view that shows a user the acitvities associated to their organisation, for BEIS users we introduce a filter that allows them to switch this view to show activities of any other delivery partner organisation.

As this activities view is becoming the single place for managing activities, it make sense to also move the new 'create activity' button to this page.

The activities view was not using the presenter so incomplete activities where not shown correctly, this has been resolved.

With this work in-place we will move on to make further refinements.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/480578/87541085-9bd55700-c698-11ea-9988-0c34e9759de2.png)

![image](https://user-images.githubusercontent.com/480578/87540996-72b4c680-c698-11ea-8dd3-a3f6804a70d5.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
