### PR TITLE
(825) Child activities are shown in their own tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@
 - Replace generic Rails error pages with styled pages (404, 500 and 422)
 - Activities can be filtered to an organisation
 - Selecting an activity level now includes more explanation of the hierarchy
+- Activities show their child activities in a tab
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@
 - Activities can be filtered to an organisation
 - Selecting an activity level now includes more explanation of the hierarchy
 - Activities show their child activities in a tab
+- Activities link to their parent activity in the details tab
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/controllers/staff/activity_children_controller.rb
+++ b/app/controllers/staff/activity_children_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Staff::ActivityChildrenController < Staff::BaseController
+  include Secured
+
+  def show
+    @activity = Activity.find(params[:activity_id])
+    authorize @activity
+
+    @activities = @activity.child_activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
+
+    render "staff/activities/children"
+  end
+end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -4,6 +4,7 @@ module ActivityHelper
 
     return false if activity.form_state.nil?
     return true if activity.form_steps_completed?
+    return true if activity.fund? && step == :identifier
 
     presenter_position = steps.index(step.to_sym)
     activity_position = steps.index(activity.form_state.to_sym)

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -10,4 +10,10 @@ module ActivityHelper
 
     presenter_position <= activity_position + 1
   end
+
+  def link_to_activity_parent(parent:, user:)
+    return if parent.nil?
+    return parent.title if parent.fund? && user.delivery_partner?
+    link_to parent.title, organisation_activity_path(parent.organisation, parent), {class: "govuk-link govuk-link--no-visited-state"}
+  end
 end

--- a/app/views/staff/activities/children.html.haml
+++ b/app/views/staff/activities/children.html.haml
@@ -22,15 +22,15 @@
           %li.govuk-tabs__list-item
             = link_to t("tabs.activity.financials"),
               organisation_activity_financials_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "financials", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: true } }
           %li.govuk-tabs__list-item
             = link_to t("tabs.activity.details"),
               organisation_activity_details_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: true } }
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
             = link_to t("tabs.activity.children"),
               organisation_activity_children_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "children", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "children", selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/activities/children.html.haml
+++ b/app/views/staff/activities/children.html.haml
@@ -1,0 +1,46 @@
+= content_for :page_title_prefix, t("document_title.activity.children", name: @activity.title)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = @activity.title
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      - if @activity.project? || @activity.third_party_project?
+        - if policy(:project).download? || policy(:third_party_project).download?
+          = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          = t("tabs.activity.title")
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.activity.financials"),
+              organisation_activity_financials_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "financials", selected: true } }
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.activity.details"),
+              organisation_activity_details_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: true } }
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.activity.children"),
+              organisation_activity_children_path(@activity.organisation, @activity),
+              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "children", selected: false } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activity.children")
+
+          - if @activity.fund? && policy(:fund).create?
+            = render partial: "staff/shared/activities/programmes", locals: { activity: @activity, activities: @activities }
+
+          - if @activity.programme?
+            = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
+
+          - if @activity.project?
+            = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -22,16 +22,16 @@
           %li.govuk-tabs__list-item
             = link_to t("tabs.activity.financials"),
               organisation_activity_financials_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "financials", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: true } }
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
             = link_to t("tabs.activity.details"),
               organisation_activity_details_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "details", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: false } }
           - unless @activity.third_party_project?
             %li.govuk-tabs__list-item
               = link_to t("tabs.activity.children"),
                 organisation_activity_children_path(@activity.organisation, @activity),
-                { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "children", selected: false } }
+                { class: "govuk-tabs__tab", role: "tab", aria: { controls: "children", selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -22,27 +22,25 @@
           %li.govuk-tabs__list-item
             = link_to t("tabs.activity.financials"),
               organisation_activity_financials_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "financials", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "financials", selected: true } }
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
             = link_to t("tabs.activity.details"),
               organisation_activity_details_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "details", selected: false } }
+          - unless @activity.third_party_project?
+            %li.govuk-tabs__list-item
+              = link_to t("tabs.activity.children"),
+                organisation_activity_children_path(@activity.organisation, @activity),
+                { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "children", selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l
             = t("page_title.activity.details")
 
           = render partial: "staff/shared/activities/activity", locals: { activity_presenter: ActivityPresenter.new(@activity) }
-          - if @activity.fund? && policy(:fund).create?
-            = render partial: "staff/shared/activities/programmes", locals: { activity: @activity, activities: @activities }
 
-          - if @activity.programme?
-            = render partial: "staff/shared/activities/projects", locals: { activity: @activity, activities: @activities }
           - if @activity.programme? && policy(:programme).create?
             = render partial: "staff/shared/activities/extending_organisation", locals: { activity: @activity }
-
-          - if @activity.project?
-            = render partial: "staff/shared/activities/third_party_projects", locals: { activity: @activity, activities: @activities }
 
           - if @activity.project? || @activity.third_party_project?
             = render partial: "staff/shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -22,16 +22,16 @@
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
             = link_to t("tabs.activity.financials"),
               organisation_activity_financials_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "financials", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: true } }
           %li.govuk-tabs__list-item
             = link_to t("tabs.activity.details"),
               organisation_activity_details_path(@activity.organisation, @activity),
-              { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: false } }
           - unless @activity.third_party_project?
             %li.govuk-tabs__list-item
               = link_to t("tabs.activity.children"),
                 organisation_activity_children_path(@activity.organisation, @activity),
-                { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "children", selected: false } }
+                { class: "govuk-tabs__tab", role: "tab", aria: { controls: "children", selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -20,13 +20,18 @@
 
         %ul.govuk-tabs__list
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
-            = link_to "Financials",
+            = link_to t("tabs.activity.financials"),
               organisation_activity_financials_path(@activity.organisation, @activity),
               { class: "govuk-tabs__tab", role: "tab", tabindex: 0, aria: { controls: "financials", selected: true } }
           %li.govuk-tabs__list-item
-            = link_to "Details",
+            = link_to t("tabs.activity.details"),
               organisation_activity_details_path(@activity.organisation, @activity),
               { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "details", selected: false } }
+          - unless @activity.third_party_project?
+            %li.govuk-tabs__list-item
+              = link_to t("tabs.activity.children"),
+                organisation_activity_children_path(@activity.organisation, @activity),
+                { class: "govuk-tabs__tab", role: "tab", tabindex: -1, aria: { controls: "children", selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -20,7 +20,7 @@
       %dt.govuk-summary-list__key
         = t("summary.label.activity.parent")
       %dd.govuk-summary-list__value
-        = activity_presenter.parent_title
+        = link_to_activity_parent(parent: activity_presenter.parent, user: current_user)
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && activity_presenter.level.present? && activity_presenter.parent.blank?
           = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :parent), t("summary.label.activity.parent").downcase)

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -15,7 +15,7 @@
         %tr.govuk-table__row{ id: activity.id }
           %td.govuk-table__cell= activity.display_title
           %td.govuk-table__cell= activity.identifier
-          %td.govuk-table__cell= t("table.body.activity.level.#{activity.level}")
+          %td.govuk-table__cell= activity.level
           %td.govuk-table__cell
             = a11y_action_link t("table.body.activity.view_activity"),
               organisation_activity_path(activity.organisation, activity),

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -85,9 +85,9 @@ en:
         flow: Flow
         geography: Benefitting recipient geography
         identifier: Identifier
-        level: Hierarchy
+        level: Level
         organisation: Organisation
-        parent: Belongs to
+        parent: Parent activity
         planned_disbursements: Planned disbursements
         planned_end_date: Planned end date
         planned_start_date: Planned start date

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -7,6 +7,7 @@ en:
       index: Activities
       details: Activity %{name} — Details
       financials: Activity %{name} — Financials
+      children: Activity %{name} — Child activities
       extending_organisation: Activity %{name} — Extending organisation
   form:
     button:
@@ -158,6 +159,7 @@ en:
       title: Contents
       details: Details
       financials: Financials
+      children: Child activities
   page_title:
     activity:
       index: Activities
@@ -166,6 +168,7 @@ en:
         new: Add a new implementing organisation
       details: Details
       financials: Financials
+      children: Child activities
     activity_form:
       show:
         aid_type: Aid type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resources :activities, except: [:index, :destroy] do
         get "financials" => "activity_financials#show"
         get "details" => "activity_details#show"
+        get "children" => "activity_children#show"
       end
     end
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -169,6 +169,7 @@ FactoryBot.define do
   trait :level_form_state do
     form_state { "level" }
     level { nil }
+    identifier { nil }
     title { nil }
     description { nil }
     sector { nil }
@@ -189,6 +190,7 @@ FactoryBot.define do
   trait :parent_form_state do
     form_state { "parent" }
     level { "programme" }
+    identifier { nil }
     title { nil }
     description { nil }
     sector { nil }

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_path(user.organisation)
         click_on(programme_activity.parent.title)
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_on(programme_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))
@@ -62,7 +62,7 @@ RSpec.describe "Users can create a budget" do
         visit organisation_path(user.organisation)
 
         click_on(programme_activity.parent.title)
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_on(programme_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))
@@ -110,7 +110,7 @@ RSpec.describe "Users can create a budget" do
         visit organisation_path(user.organisation)
 
         click_on(programme_activity.title)
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_on(project_activity.title)
 
         click_on(I18n.t("page_content.budgets.button.create"))

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Users can create a programme activity" do
 
       visit organisation_path(user.organisation)
       click_on fund.title
-      click_on I18n.t("tabs.activity.details")
+      click_on I18n.t("tabs.activity.children")
       click_on(I18n.t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
@@ -40,7 +40,7 @@ RSpec.feature "Users can create a programme activity" do
 
       visit organisation_path(user.organisation)
       click_on fund.title
-      click_on I18n.t("tabs.activity.details")
+      click_on I18n.t("tabs.activity.children")
       click_on(I18n.t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
@@ -57,7 +57,7 @@ RSpec.feature "Users can create a programme activity" do
       PublicActivity.with_tracking do
         visit organisation_path(user.organisation)
         click_on fund.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_on(I18n.t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(identifier: "my-unique-identifier", level: "programme", parent: fund)

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can create a project" do
         visit organisation_path(user.organisation)
 
         click_on(programme.title)
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
 
         click_on(I18n.t("page_content.organisation.button.create_activity"))
 
@@ -33,7 +33,7 @@ RSpec.feature "Users can create a project" do
           visit organisation_path(user.organisation)
 
           click_on(programme.title)
-          click_on I18n.t("tabs.activity.details")
+          click_on I18n.t("tabs.activity.children")
 
           click_on(I18n.t("page_content.organisation.button.create_activity"))
 

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can create a project" do
         visit organisation_path(user.organisation)
 
         click_on(project.title)
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
 
         click_on(I18n.t("page_content.organisation.button.create_activity"))
 
@@ -31,7 +31,7 @@ RSpec.feature "Users can create a project" do
           visit organisation_path(user.organisation)
 
           click_on(project.title)
-          click_on I18n.t("tabs.activity.details")
+          click_on I18n.t("tabs.activity.children")
 
           click_on(I18n.t("page_content.organisation.button.create_activity"))
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,12 +1,82 @@
 RSpec.feature "Users can edit an activity" do
   include ActivityHelper
 
-  before { authenticate!(user: user) }
-
-  context "when the activity is a fund" do
+  context "when signed in as a BEIS user" do
     let(:user) { create(:beis_user) }
+    before { authenticate!(user: user) }
 
-    context "when the activity is a fund" do
+    it "shows the Publish to Iati field" do
+      activity = create(:third_party_project_activity, organisation: user.organisation)
+
+      visit organisation_activity_path(activity.organisation, activity)
+      click_on I18n.t("tabs.activity.details")
+
+      expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+    end
+
+    it "allows the user to redact the activity from Iati" do
+      activity = create(:third_party_project_activity, organisation: user.organisation)
+
+      visit organisation_activity_path(activity.organisation, activity)
+      click_on I18n.t("tabs.activity.details")
+
+      within ".publish_to_iati" do
+        click_on(I18n.t("default.link.edit"))
+      end
+
+      choose I18n.t("summary.label.activity.publish_to_iati.false")
+      click_button I18n.t("form.button.activity.submit")
+
+      click_on I18n.t("tabs.activity.details")
+      within ".publish_to_iati" do
+        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+      end
+    end
+
+    it "also redacts any child third-party projects when a project is redacted" do
+      project_activity = create(:project_activity, organisation: user.organisation)
+      third_party_project_activity = create(:third_party_project_activity, parent: project_activity, organisation: user.organisation)
+
+      visit organisation_activity_path(project_activity.organisation, project_activity)
+      click_on I18n.t("tabs.activity.details")
+
+      within ".publish_to_iati" do
+        click_on(I18n.t("default.link.edit"))
+      end
+
+      choose I18n.t("summary.label.activity.publish_to_iati.false")
+      click_button I18n.t("form.button.activity.submit")
+
+      click_on I18n.t("tabs.activity.details")
+
+      within ".publish_to_iati" do
+        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+      end
+
+      visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
+      click_on I18n.t("tabs.activity.details")
+
+      within ".publish_to_iati" do
+        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+      end
+    end
+    context "before the activity has a level" do
+      it "shows add link on the level step" do
+        activity = create(:activity, :level_form_state, organisation: user.organisation)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within(".level") do
+          expect(page).to have_content(I18n.t("default.link.add"))
+        end
+
+        within(".parent") do
+          expect(page).not_to have_content(I18n.t("default.link.add"))
+        end
+      end
+    end
+
+    context "when the activity is a fund level activity" do
       it "does not show the parent field" do
         activity = create(:fund_activity, organisation: user.organisation)
 
@@ -14,109 +84,44 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).not_to have_content(I18n.t("summary.activity.parent"))
       end
-    end
 
-    context "when the activity was left at the level step" do
-      it "shows add link on the level step" do
-        activity = create(:fund_activity, :level_form_state, organisation: user.organisation)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".level") do
-          expect(page).to have_content(I18n.t("default.link.add"))
-        end
-
-        within(".parent") do
-          expect(page).not_to have_content(I18n.t("default.link.add"))
-        end
-      end
-    end
-
-    context "when the activity was left at the parent step" do
-      it "shows add link on the level step" do
-        activity = create(:programme_activity, :parent_form_state, organisation: user.organisation)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".parent") do
-          expect(page).to have_content(I18n.t("default.link.add"))
-        end
-
-        within(".identifier") do
-          expect(page).not_to have_content(I18n.t("default.link.add"))
-        end
-      end
-    end
-
-    # Changing the level means the IATI identifier we construct changes
-    # If this is changed after publishing to IATI the effect will be a branch
-    # new IATI publiciation.
-    context "when the activity has a level and a parent" do
-      it "it cannot be edited" do
-        activity = create(:programme_activity, organisation: user.organisation)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".level") do
-          expect(page).not_to have_content(I18n.t("default.link.add"))
-        end
-
-        within(".parent") do
-          expect(page).not_to have_content(I18n.t("default.link.add"))
-        end
-      end
-    end
-
-    context "when the activity only has an identifier (and is incomplete)" do
-      it "shows edit link on the identifier, and add link on only the next step" do
-        activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        # Click the first edit link that opens the form on step 1
-        within(".identifier") do
-          expect(page).to have_content(I18n.t("default.link.edit"))
-        end
-
-        within(".title") do
-          expect(page).to have_content(I18n.t("default.link.add"))
-        end
-
-        within(".sector") do
-          expect(page).to_not have_content(I18n.t("default.link.add"))
-        end
-      end
-    end
-
-    context "when the activity is complete" do
-      it "editing and saving a step returns the user to the activity page details tab" do
-        activity = create(:fund_activity, organisation: user.organisation)
-        identifier = "AB-CDE-1234"
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".identifier") do
-          click_on(I18n.t("default.link.edit"))
-        end
-
-        fill_in "activity[identifier]", with: identifier
-        click_button I18n.t("form.button.activity.submit")
-
-        expect(page).to have_content I18n.t("action.fund.update.success")
-        expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
-      end
-
-      it "all edit links are available to take the user to the right step" do
+      it "does not show the Publish to Iati field" do
         activity = create(:fund_activity, organisation: user.organisation)
 
-        visit organisation_activity_details_path(activity.organisation, activity)
+        visit organisation_activity_path(activity.organisation, activity)
 
-        assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
       end
 
-      it "tracks activity updates with public_activity" do
-        activity = create(:fund_activity, organisation: user.organisation)
-        identifier = "AB-CDE-1234"
-        PublicActivity.with_tracking do
+      context "when a title attribute is present" do
+        let(:user) { create(:beis_user) }
+        it "the call to action is 'Edit'" do
+          activity = create(:fund_activity, organisation: user.organisation, form_state: :sector)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".title") do
+            expect(page).to have_content(I18n.t("default.link.edit"))
+          end
+        end
+      end
+
+      context "when an activity attribute is not present" do
+        it "the call to action is 'Add'" do
+          activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".title") do
+            expect(page).to have_content(I18n.t("default.link.add"))
+          end
+        end
+      end
+
+      context "when the activity is complete" do
+        it "editing and saving a step returns the user to the activity page details tab" do
+          activity = create(:fund_activity, organisation: user.organisation)
+          identifier = "AB-CDE-1234"
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".identifier") do
@@ -126,72 +131,83 @@ RSpec.feature "Users can edit an activity" do
           fill_in "activity[identifier]", with: identifier
           click_button I18n.t("form.button.activity.submit")
 
-          # grab the most recently created auditable_event
-          auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
-          expect(auditable_events.first.key).to eq "activity.update.identifier"
-          expect(auditable_events.first.owner_id).to eq user.id
-          expect(auditable_events.first.trackable_id).to eq activity.id
+          expect(page).to have_content I18n.t("action.fund.update.success")
+          expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
+        end
+
+        it "all edit links are available to take the user to the right step" do
+          activity = create(:fund_activity, organisation: user.organisation)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+        end
+
+        it "tracks activity updates with public_activity" do
+          activity = create(:fund_activity, organisation: user.organisation)
+          identifier = "AB-CDE-1234"
+          PublicActivity.with_tracking do
+            visit organisation_activity_details_path(activity.organisation, activity)
+
+            within(".identifier") do
+              click_on(I18n.t("default.link.edit"))
+            end
+
+            fill_in "activity[identifier]", with: identifier
+            click_button I18n.t("form.button.activity.submit")
+
+            # grab the most recently created auditable_event
+            auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
+            expect(auditable_events.first.key).to eq "activity.update.identifier"
+            expect(auditable_events.first.owner_id).to eq user.id
+            expect(auditable_events.first.trackable_id).to eq activity.id
+          end
+        end
+      end
+
+      context "when the activity is incomplete" do
+        it "editing and saving a step goes to the next step in the form" do
+          activity = create(:fund_activity, :at_region_step, organisation: user.organisation)
+          recipient_region = "Oceania, regional"
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".recipient_region") do
+            click_on(I18n.t("default.link.edit"))
+          end
+          choose "Region"
+          click_button I18n.t("form.button.activity.submit")
+          select recipient_region, from: "activity[recipient_region]"
+          click_button I18n.t("form.button.activity.submit")
+
+          expect(page).to have_content I18n.t("form.label.activity.flow")
+          expect(page).not_to have_content activity.title
+        end
+
+        context "when the activity only has an identifier" do
+          it "shows edit link on the identifier, and add link on only the next step" do
+            activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
+
+            visit organisation_activity_details_path(activity.organisation, activity)
+
+            # Click the first edit link that opens the form on step 1
+            within(".identifier") do
+              expect(page).to have_content(I18n.t("default.link.edit"))
+            end
+
+            within(".title") do
+              expect(page).to have_content(I18n.t("default.link.add"))
+            end
+
+            within(".sector") do
+              expect(page).to_not have_content(I18n.t("default.link.add"))
+            end
+          end
         end
       end
     end
 
-    context "when the activity is incomplete" do
-      it "editing and saving a step goes to the next step in the form" do
-        activity = create(:fund_activity, :at_region_step, organisation: user.organisation)
-        recipient_region = "Oceania, regional"
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".recipient_region") do
-          click_on(I18n.t("default.link.edit"))
-        end
-        choose "Region"
-        click_button I18n.t("form.button.activity.submit")
-        select recipient_region, from: "activity[recipient_region]"
-        click_button I18n.t("form.button.activity.submit")
-
-        expect(page).to have_content I18n.t("form.label.activity.flow")
-        expect(page).not_to have_content activity.title
-      end
-    end
-
-    context "when a title attribute is present" do
-      it "the call to action is 'Edit'" do
-        activity = create(:fund_activity, organisation: user.organisation, form_state: :sector)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".title") do
-          expect(page).to have_content(I18n.t("default.link.edit"))
-        end
-      end
-    end
-
-    context "when an activity attribute is not present" do
-      it "the call to action is 'Add'" do
-        activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
-
-        visit organisation_activity_details_path(activity.organisation, activity)
-
-        within(".title") do
-          expect(page).to have_content(I18n.t("default.link.add"))
-        end
-      end
-    end
-
-    it "does not show the Publish to Iati field" do
-      activity = create(:fund_activity, organisation: user.organisation)
-
-      visit organisation_activity_path(activity.organisation, activity)
-
-      expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
-    end
-  end
-
-  context "when the activity is a programme" do
-    context "when the user is a BEIS user" do
-      let(:user) { create(:beis_user) }
-
+    context "when the activity is programme level activity" do
       it "shows an update success message" do
         activity = create(:programme_activity, organisation: user.organisation)
 
@@ -212,11 +228,47 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
       end
+
+      context "when the activity was left at the parent step" do
+        it "shows add link on the parent step" do
+          activity = create(:programme_activity, :parent_form_state, organisation: user.organisation)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+          within(".parent") do
+            expect(page).to have_content(I18n.t("default.link.add"))
+          end
+          within(".identifier") do
+            expect(page).not_to have_content(I18n.t("default.link.add"))
+          end
+        end
+      end
+
+      # Changing the level means the IATI identifier we construct changes
+      # If this is changed after publishing to IATI the effect will be a branch
+      # new IATI publiciation.
+      context "when the activity has a level and a parent" do
+        it "it cannot be edited" do
+          activity = create(:programme_activity, organisation: user.organisation)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".level") do
+            expect(page).not_to have_content(I18n.t("default.link.add"))
+          end
+
+          within(".parent") do
+            expect(page).not_to have_content(I18n.t("default.link.add"))
+          end
+        end
+      end
     end
+  end
 
-    context "when the user is NOT a BEIS user" do
-      let(:user) { create(:delivery_partner_user) }
+  context "when signed in as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
 
+    context "and the activity is a programme" do
       scenario "the user should not be shown edit/add actions" do
         activity = create(:programme_activity, :at_purpose_step)
 
@@ -234,12 +286,8 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
       end
     end
-  end
 
-  context "when the activity is a project" do
-    context "when the user is a delivery_partner_user" do
-      let(:user) { create(:delivery_partner_user) }
-
+    context "when the activity is a project" do
       it "shows an update success message" do
         activity = create(:project_activity, organisation: user.organisation)
 
@@ -262,72 +310,7 @@ RSpec.feature "Users can edit an activity" do
       end
     end
 
-    context "when the user is a BEIS user" do
-      let(:user) { create(:beis_user) }
-
-      it "shows the Publish to Iati field" do
-        activity = create(:project_activity, organisation: user.organisation)
-
-        visit organisation_activity_path(activity.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
-
-        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
-      end
-
-      it "allows the user to redact the activity from Iati" do
-        activity = create(:project_activity, organisation: user.organisation)
-
-        visit organisation_activity_path(activity.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          click_on(I18n.t("default.link.edit"))
-        end
-
-        choose I18n.t("summary.label.activity.publish_to_iati.false")
-        click_button I18n.t("form.button.activity.submit")
-
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
-        end
-      end
-
-      it "also redacts any child third-party projects when a project is redacted" do
-        project_activity = create(:project_activity, organisation: user.organisation)
-        third_party_project_activity = create(:third_party_project_activity, parent: project_activity, organisation: user.organisation)
-
-        visit organisation_activity_path(project_activity.organisation, project_activity)
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          click_on(I18n.t("default.link.edit"))
-        end
-
-        choose I18n.t("summary.label.activity.publish_to_iati.false")
-        click_button I18n.t("form.button.activity.submit")
-
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
-        end
-
-        visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
-        end
-      end
-    end
-  end
-
-  context "when the activity is a third-party project" do
-    context "when the user is a delivery_partner_user" do
-      let(:user) { create(:delivery_partner_user) }
-
+    context "when the activity is a third-party project" do
       it "shows an update success message" do
         activity = create(:third_party_project_activity, organisation: user.organisation)
 
@@ -339,38 +322,6 @@ RSpec.feature "Users can edit an activity" do
 
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content(I18n.t("action.third_party_project.update.success"))
-      end
-    end
-
-    context "when the user is a BEIS user" do
-      let(:user) { create(:beis_user) }
-
-      it "shows the Publish to Iati field" do
-        activity = create(:third_party_project_activity, organisation: user.organisation)
-
-        visit organisation_activity_path(activity.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
-
-        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
-      end
-
-      it "allows the user to redact the activity from Iati" do
-        activity = create(:third_party_project_activity, organisation: user.organisation)
-
-        visit organisation_activity_path(activity.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
-
-        within ".publish_to_iati" do
-          click_on(I18n.t("default.link.edit"))
-        end
-
-        choose I18n.t("summary.label.activity.publish_to_iati.false")
-        click_button I18n.t("form.button.activity.submit")
-
-        click_on I18n.t("tabs.activity.details")
-        within ".publish_to_iati" do
-          expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
-        end
       end
     end
   end

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can view a project" do
       project = create(:project_activity, organisation: user.organisation)
       third_party_project = create(:third_party_project_activity, parent: project)
 
-      visit organisation_activity_details_path(project.organisation, project)
+      visit organisation_activity_children_path(project.organisation, project)
 
       expect(page).to have_content third_party_project.title
     end
@@ -32,7 +32,7 @@ RSpec.feature "Users can view a project" do
         project = create(:project_activity, organisation: user.organisation)
         programme.child_activities << project
 
-        visit organisation_activity_details_path(programme.organisation, programme)
+        visit organisation_activity_children_path(programme.organisation, programme)
 
         expect(page).to have_content programme.title
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -24,7 +24,19 @@ RSpec.feature "Users can view an activity" do
       expect(page).to have_content budget.value
     end
 
-    scenario "the activity details can be viewed" do
+    scenario "the activity child activities can be viewed in a tab" do
+      activity = create(:activity, organisation: user.organisation)
+
+      visit organisation_activity_children_path(activity.organisation, activity)
+
+      within ".govuk-tabs__list-item--selected" do
+        expect(page).to have_content "Child activities"
+      end
+      expect(page).to have_content activity.title
+      expect(page).to have_button I18n.t("page_content.organisation.button.create_activity")
+    end
+
+    scenario "the activity details tab can be viewed" do
       activity = create(:activity, organisation: user.organisation)
 
       visit organisation_activity_details_path(activity.organisation, activity)
@@ -32,18 +44,6 @@ RSpec.feature "Users can view an activity" do
       within ".govuk-tabs__list-item--selected" do
         expect(page).to have_content "Details"
       end
-      expect(page).to have_content activity.title
-      expect(page).to have_button I18n.t("page_content.organisation.button.create_activity")
-    end
-
-    scenario "an activity can be viewed" do
-      activity = create(:activity, organisation: user.organisation)
-
-      visit organisation_path(user.organisation)
-
-      click_on(activity.title)
-      click_on I18n.t("tabs.activity.details")
-
       activity_presenter = ActivityPresenter.new(activity)
 
       expect(page).to have_content activity_presenter.identifier

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -56,6 +56,15 @@ RSpec.feature "Users can view an activity" do
       expect(page).to have_content activity_presenter.flow
     end
 
+    scenario "the activity links to the parent activity" do
+      activity = create(:programme_activity, organisation: user.organisation)
+      parent_activity = activity.parent
+
+      visit organisation_activity_details_path(activity.organisation, activity)
+
+      expect(page).to have_link parent_activity.title, href: organisation_activity_path(parent_activity.organisation, parent_activity)
+    end
+
     scenario "a fund activity has human readable date format" do
       travel_to Time.zone.local(2020, 1, 29) do
         activity = create(:activity, planned_start_date: Date.new(2020, 2, 3),
@@ -82,6 +91,21 @@ RSpec.feature "Users can view an activity" do
           expect(page).to have_content("29 Jan 2020")
         end
       end
+    end
+  end
+
+  context "when the user is signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    before { authenticate!(user: user) }
+
+    scenario "a programme activity does not link to its parent activity" do
+      activity = create(:programme_activity, organisation: user.organisation)
+      parent_activity = activity.parent
+
+      visit organisation_activity_details_path(activity.organisation, activity)
+
+      expect(page).not_to have_link parent_activity.title, href: organisation_activity_path(parent_activity.organisation, parent_activity)
+      expect(page).to have_content parent_activity.title
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link programme_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -65,9 +65,9 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -83,9 +83,9 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
@@ -139,7 +139,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -154,7 +154,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         expect(page).to have_content(I18n.t("page_content.budgets.button.create"))

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Users can view fund level activities" do
       fund_activity.child_activities << programme_activity
       activity_presenter = ActivityPresenter.new(programme_activity)
 
-      visit organisation_activity_details_path(fund_activity.organisation, fund_activity)
+      visit organisation_activity_children_path(fund_activity.organisation, fund_activity)
 
       expect(page).to have_link activity_presenter.display_title
       expect(page).to have_button I18n.t("page_content.organisation.button.create_activity")

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -65,9 +65,9 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         expect(page).to have_content(transaction_presenter.transaction_type)
@@ -85,9 +85,9 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit organisation_path(user.organisation)
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.details")
+        click_on I18n.t("tabs.activity.children")
         click_link project_activity.title
 
         expect(page).to_not have_content(I18n.t("page_content.transactions.button.create"))

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe ActivityHelper, type: :helper do
         end
       end
     end
+
+    context "when the activity is a fund" do
+      context "and is at the indetifer step i.e. the parent step has been skipped" do
+        it "returns true" do
+          activity = build(:activity, :level_form_state, level: :fund, parent: nil)
+
+          expect(helper.step_is_complete_or_next?(activity: activity, step: :identifier)).to be(true)
+        end
+      end
+    end
   end
 
   describe "#link_to_activity_parent" do

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -62,4 +62,35 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
   end
+
+  describe "#link_to_activity_parent" do
+    context "when there is no parent" do
+      it "returns nil" do
+        expect(helper.link_to_activity_parent(parent: nil, user: nil)).to be_nil
+      end
+    end
+
+    context "when the parent is a fund" do
+      context "and the user is delivery partner" do
+        it "returns the parent title without a link" do
+          parent_activity = create(:fund_activity)
+          _activity = create(:programme_activity, parent: parent_activity)
+          user = create(:delivery_partner_user)
+
+          expect(helper.link_to_activity_parent(parent: parent_activity, user: user)).to eql parent_activity.title
+        end
+      end
+    end
+
+    context "when there is a parent" do
+      it "returns a link to the parent" do
+        parent_activity = create(:fund_activity)
+        _activity = create(:programme_activity, parent: parent_activity)
+        user = create(:beis_user)
+
+        expect(helper.link_to_activity_parent(parent: parent_activity, user: user)).to include organisation_activity_path(parent_activity.organisation, parent_activity)
+        expect(helper.link_to_activity_parent(parent: parent_activity, user: user)).to include parent_activity.title
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Moving child activities to their own tab allows users to view and navigate the activity hierarchy without having to hunt around the interface.

For this work, what is displayed in the tab remains as before, we may want to change this in future work, removing the level titles and 'create activity' buttons, for example.
    
I've intentionally avoided the language issue by labelling the tab as generic as possible, we still don't know how or when we will have to bring the 'level' language into the interface and I feel like 'Child activities' is actually clearer than 'Level C activities', etc

Whilst delivery partners cannot edit programme level activities, they may want to use them as a way of understanding the hierarchy of activities.
    
As we already show the parent activity in the details tab, we can simply link to the parent activity, delivery partners already have the persmission to view the parent programmes when the delivery partner is viewing a programme we do not link to the parent as it would be a fund and they would not be able to view it.

During this work I struggled with the `users_can_edit_an_activity` spec, it's seen a lot of change and is getting unwieldly, I've taken a stab at re-organising it to be clearer and I hope a bit more readable – it's getting a little deep in nested context but it is trying to do a lot of things - let me know what you think and apologies for the massive diff! I would recommended reading and running the spec to review it!

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/480578/87677069-3e610900-c771-11ea-98dc-9a6a1e776610.png)

### After
![image](https://user-images.githubusercontent.com/480578/87677022-33a67400-c771-11ea-9e75-337aab415e28.png)

![image](https://user-images.githubusercontent.com/480578/87677494-bc251480-c771-11ea-971e-690f7ead8777.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
