### PR TITLE
(789) Add hierarchy explanations to the level step of the activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@
 - Refactor the activity update action
 - Replace generic Rails error pages with styled pages (404, 500 and 422)
 - Activities can be filtered to an organisation
+- Selecting an activity level now includes more explanation of the hierarchy
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -70,6 +70,7 @@ module FormHelper
       OpenStruct.new(
         level: level,
         name: I18n.t("page_content.activity.level.#{level}").capitalize,
+        description: I18n.t("form.hint.activity.level_step.#{level}")
       )
     end
   end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -67,7 +67,10 @@ module FormHelper
       policy.create? || policy.update?
     }
     authorised_levels.keys.map do |level|
-      OpenStruct.new(level: level, description: I18n.t("page_content.activity.level.#{level}").capitalize)
+      OpenStruct.new(
+        level: level,
+        name: I18n.t("page_content.activity.level.#{level}").capitalize,
+      )
     end
   end
 end

--- a/app/views/staff/activity_forms/level.html.haml
+++ b/app/views/staff/activity_forms/level.html.haml
@@ -4,5 +4,6 @@
     create_activity_level_options(user: current_user),
     :level,
     :name,
+    :description,
     legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.level") },
     hint_text: I18n.t("form.hint.activity.level")

--- a/app/views/staff/activity_forms/level.html.haml
+++ b/app/views/staff/activity_forms/level.html.haml
@@ -3,6 +3,6 @@
   = f.govuk_collection_radio_buttons :level,
     create_activity_level_options(user: current_user),
     :level,
-    :description,
+    :name,
     legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.level") },
     hint_text: I18n.t("form.hint.activity.level")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -40,7 +40,7 @@ en:
         actual_end_date: Actual end date (optional)
         actual_start_date: Actual start date (optional)
         geography: Will the benefitting recipient be a region or country?
-        level: Hierarchy level
+        level: Add new activity
         parent: Select the parent activity
         planned_end_date: Planned end date
         planned_start_date: Planned start date
@@ -59,7 +59,12 @@ en:
         planned_start_date: For example, 27 3 2020
         sector_category: What area of the economy or society is your %{level} helping? For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
         title: A short title that explains the purpose of the %{level}
-        level: Which level does this activity represent in the hierarchy?
+        level: Select the type of activity
+        level_step:
+          fund: Total fund allocation to BEIS from the Treasury
+          programme: Breakdown of funds to delivery partners from BEIS. This is confirmed in the allocation letter or in the memorandum of understanding (MOU). For example, how a £50m fund will be allocated to different activities or spending
+          project: Records a set of activities of a delivery partner and details of how the money is forecast and/or spent. A delivery partner can record if it plans to award to third parties or a delivery partner could spend these funds on its own activities. For example, on workshops
+          third_party_project: How funding from delivery partners to third parties like universities and research institutes is forecast and spent. For example, spending on 10 research grants of £500k totalling £5m
         parent: Which existing %{parent_level} will this new %{level} belong to?
       organisation:
         hint: The organisation this activity is associated with

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe FormHelper, type: :helper do
         user = create(:beis_user)
         result = helper.create_activity_level_options(user: user)
         expect(result).to eq([
-          OpenStruct.new(level: "fund", description: "Fund"),
-          OpenStruct.new(level: "programme", description: "Programme"),
+          OpenStruct.new(level: "fund", name: "Fund"),
+          OpenStruct.new(level: "programme", name: "Programme"),
         ])
       end
     end
@@ -82,8 +82,8 @@ RSpec.describe FormHelper, type: :helper do
           user = create(:delivery_partner_user)
           result = helper.create_activity_level_options(user: user)
           expect(result).to eq([
-            OpenStruct.new(level: "project", description: "Project"),
-            OpenStruct.new(level: "third_party_project", description: "Third-party project"),
+            OpenStruct.new(level: "project", name: "Project"),
+            OpenStruct.new(level: "third_party_project", name: "Third-party project"),
           ])
         end
       end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -81,10 +81,8 @@ RSpec.describe FormHelper, type: :helper do
         it "tells Pundit to return only the levels of activity a user can create or update" do
           user = create(:delivery_partner_user)
           result = helper.create_activity_level_options(user: user)
-          expect(result).to eq([
-            OpenStruct.new(level: "project", name: "Project"),
-            OpenStruct.new(level: "third_party_project", name: "Third-party project"),
-          ])
+          expect(result.detect { |options| options.name.eql?("Project") }).to be_truthy
+          expect(result.detect { |options| options.name.eql?("Third-party project") }).to be_truthy
         end
       end
     end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -70,8 +70,16 @@ RSpec.describe FormHelper, type: :helper do
         user = create(:beis_user)
         result = helper.create_activity_level_options(user: user)
         expect(result).to eq([
-          OpenStruct.new(level: "fund", name: "Fund"),
-          OpenStruct.new(level: "programme", name: "Programme"),
+          OpenStruct.new(
+            level: "fund",
+            name: "Fund",
+            description: I18n.t("form.hint.activity.level_step.fund"),
+          ),
+          OpenStruct.new(
+            level: "programme",
+            name: "Programme",
+            description: I18n.t("form.hint.activity.level_step.programme"),
+          ),
         ])
       end
     end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -28,6 +28,7 @@ module FormHelpers
 
     expect(page).to have_content I18n.t("form.legend.activity.level")
     expect(page).to have_content I18n.t("form.hint.activity.level")
+    expect(page).to have_content I18n.t("form.hint.activity.level_step.#{level}")
     choose I18n.t("page_content.activity.level.#{level}").capitalize
     click_button I18n.t("form.button.activity.submit")
 


### PR DESCRIPTION
## Changes in this PR

- refactor the way the previous content was displayed to free up the `description` field
- refactor a test so it was decoupled enough to not need a change for this feature
- add new content onto each radio button on the activity level step. Depending on which user you are, you will continue to see the options available to you. The new change adds more explanation/hint text to help the user make the correct choice

Content was taken from the Trello comments Louise left: https://trello.com/c/qHVAHCHx/789-add-hierarchy-definitions-to-roda. We also discussed the labels and decided to start by leaving it as "Fund" rather than "Fund (Level A)" for now.

## Screenshots of UI changes

### Before

## BEIS
![Screenshot 2020-07-16 at 15 43 49](https://user-images.githubusercontent.com/912473/87685324-2b533680-c77b-11ea-8bf7-7f69fb28347b.png)

## Delivery partner
![Screenshot 2020-07-16 at 15 43 39](https://user-images.githubusercontent.com/912473/87685321-2a220980-c77b-11ea-935a-fb4638a08b02.png)


### After

## BEIS
![Screenshot 2020-07-16 at 15 12 04](https://user-images.githubusercontent.com/912473/87685259-15de0c80-c77b-11ea-803d-edab038c8d76.png)

## Delivery partner
![Screenshot 2020-07-16 at 15 40 09](https://user-images.githubusercontent.com/912473/87685251-14acdf80-c77b-11ea-97fe-1a8b8d024afc.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
