### PR TITLE
(792) Every delivery partner Organisation has a Submission created for each Fund they are associated with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,8 @@
 - Selecting an activity level now includes more explanation of the hierarchy
 - Activities show their child activities in a tab
 - Activities link to their parent activity in the details tab
+- Add Submission model, tests and fixtures. Seed database with a Submission per 
+  Organisation/Fund pair. Show a basic Submission table on the user's home page. 
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -16,6 +16,7 @@ class Staff::OrganisationsController < Staff::BaseController
     programme_activities = FindProgrammeActivities.new(organisation: organisation, user: current_user).call
     project_activities = FindProjectActivities.new(organisation: organisation, user: current_user).call
     third_party_project_activities = FindThirdPartyProjectActivities.new(organisation: organisation, user: current_user).call
+    submissions = SubmissionPolicy::Scope.new(current_user, Submission).resolve.includes(:organisation, :fund)
 
     respond_to do |format|
       format.html do
@@ -23,6 +24,7 @@ class Staff::OrganisationsController < Staff::BaseController
         @programme_activities = programme_activities.map { |activity| ActivityPresenter.new(activity) }
         @project_activities = project_activities.map { |activity| ActivityPresenter.new(activity) }
         @third_party_project_activities = third_party_project_activities.map { |activity| ActivityPresenter.new(activity) }
+        @submissions = submissions.map { |submission| SubmissionPresenter.new(submission) }
       end
       format.xml do
         @activities = case level

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,21 @@
+class Submission < ApplicationRecord
+  include PublicActivity::Common
+
+  validates_presence_of :description
+  validates_presence_of :state
+
+  belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"
+  belongs_to :organisation
+
+  validates_uniqueness_of :fund, scope: :organisation
+  validate :activity_must_be_a_fund
+
+  enum state: [:inactive]
+
+  def activity_must_be_a_fund
+    return unless fund.present?
+    unless fund.fund?
+      errors.add(:fund, I18n.t("errors.models.submission.attributes.fund"))
+    end
+  end
+end

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -1,0 +1,31 @@
+class SubmissionPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    beis_user?
+  end
+
+  def update?
+    beis_user?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope < Scope
+    def resolve
+      if user.organisation.service_owner?
+        scope.all
+      else
+        scope.where(organisation: user.organisation)
+      end
+    end
+  end
+end

--- a/app/presenters/submission_presenter.rb
+++ b/app/presenters/submission_presenter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SubmissionPresenter < SimpleDelegator
+  def state
+    return if super.blank?
+    I18n.t("label.submission.state.#{super.downcase}")
+  end
+end

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -59,6 +59,12 @@
           = t("page_content.organisation.download.third-party-projects.explanation")
         = link_to t("default.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :third_party_project), class: "govuk-button"
 
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.submissions")
+      = render partial: "staff/shared/submissions/table", locals: { submissions: @submissions }
+
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/shared/submissions/_table.html.haml
+++ b/app/views/staff/shared/submissions/_table.html.haml
@@ -1,0 +1,23 @@
+- unless submissions.empty?
+  %table.govuk-table.submissions
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.submissions")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("table.header.submission.description")
+        %th.govuk-table__header
+          =t("table.header.submission.fund")
+        %th.govuk-table__header
+          = t("table.header.submission.organisation")
+        %th.govuk-table__header
+          =t("table.header.submission.state")
+
+    %tbody.govuk-table__body
+      - submissions.each do |submission|
+        %tr.govuk-table__row{id: submission.id}
+          %td.govuk-table__cell= submission.description
+          %td.govuk-table__cell= submission.fund.title
+          %td.govuk-table__cell= submission.organisation.name
+          %td.govuk-table__cell= submission.state
+

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -1,0 +1,20 @@
+---
+en:
+  table:
+    header:
+      submission:
+        state: State
+        description: Reporting period
+        organisation: Organisation
+        fund: Level A
+  page_content:
+    submissions: Submissions
+  label:
+    submission:
+     state:
+       inactive: Inactive
+  errors:
+    models:
+      submission:
+        attributes:
+          fund: must be a fund-level Activity

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -18,3 +18,4 @@ en:
       submission:
         attributes:
           fund: must be a fund-level Activity
+

--- a/db/data/20200716142425_add_submissions_for_all_organisations_and_funds.rb
+++ b/db/data/20200716142425_add_submissions_for_all_organisations_and_funds.rb
@@ -1,0 +1,32 @@
+require "csv"
+
+class AddSubmissionsForAllOrganisationsAndFunds < ActiveRecord::Migration[6.0]
+  def up
+    newton_fund = Activity.funds.where("title ILIKE ?", "Newton fund").first
+    gcrf = Activity.funds.where("title ILIKE ?", "GCRF").first
+
+    rows = CSV.read("#{Rails.root}/vendor/data/dp_to_fund_mappings/dp_mappings_072020.csv", headers: [:title, :identifier, :gcrf, :newton_fund])
+    rows_without_headers = rows[1..-1]
+    organisation_hash = rows_without_headers.each_with_object({}) { |row, hash|
+      next if row[:identifier].nil?
+      hash[row[:identifier]] = {title: row[:title], gcrf: row[:gcrf], newton_fund: row[:newton_fund]}
+    }
+
+    organisation_hash.each do |key, value|
+      organisation = Organisation.find_by(iati_reference: key)
+      if value[:gcrf] == "true"
+        gcrf_submission = Submission.new(fund: gcrf, organisation: organisation, description: "Historic tracker data (GCRF)")
+        gcrf_submission.save!
+      end
+
+      if value[:newton_fund] == "true"
+        newt_submission = Submission.new(fund: newton_fund, organisation: organisation, description: "Historic tracker data (Newton fund)")
+        newt_submission.save!
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200701162318)
+DataMigrate::Data.define(version: 20200716142425)

--- a/db/migrate/20200716130243_create_submissions.rb
+++ b/db/migrate/20200716130243_create_submissions.rb
@@ -1,0 +1,11 @@
+class CreateSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submissions, id: :uuid do |t|
+      t.integer :state, default: 0, null: false
+      t.string :description
+      t.references :fund, type: :uuid
+      t.references :organisation, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_100128) do
+ActiveRecord::Schema.define(version: 2020_07_16_130243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -127,6 +127,17 @@ ActiveRecord::Schema.define(version: 2020_06_26_100128) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["parent_activity_id"], name: "index_planned_disbursements_on_parent_activity_id"
+  end
+
+  create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "state", default: 0, null: false
+    t.string "description"
+    t.uuid "fund_id"
+    t.uuid "organisation_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["fund_id"], name: "index_submissions_on_fund_id"
+    t.index ["organisation_id"], name: "index_submissions_on_organisation_id"
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :submission do
+    description { Faker::Lorem.paragraph }
+    state { :inactive }
+
+    association :fund, factory: :fund_activity
+    association :organisation
+  end
+end

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -17,9 +17,11 @@ feature "Organisation show page" do
   let!(:incomplete_third_party_project) { create(:third_party_project_activity, :at_region_step, parent: project, organisation: delivery_partner_user.organisation) }
   let!(:another_programme) { create(:programme_activity) }
   let!(:another_project) { create(:project_activity) }
+  let!(:submission) { create(:submission, organisation: delivery_partner_user.organisation) }
+  let!(:other_submission) { create(:submission, organisation: create(:organisation)) }
 
   context "when signed in as a BEIS user" do
-    context "when viewing the BEIS oganisation" do
+    context "when viewing the BEIS organisation" do
       before do
         authenticate!(user: beis_user)
         visit organisation_path(beis_user.organisation)
@@ -149,6 +151,17 @@ feature "Organisation show page" do
       scenario "they see a edit details button" do
         expect(page).to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
       end
+
+      scenario "they see all submissions" do
+        expect(page).to have_content "Submissions"
+
+        within(".submissions") do
+          expect(page).to have_content submission.organisation.name
+          expect(page).to have_content submission.description
+          expect(page).to have_content other_submission.organisation.name
+          expect(page).to have_content other_submission.description
+        end
+      end
     end
 
     context "when viewing a delivery partners organisation" do
@@ -254,6 +267,21 @@ feature "Organisation show page" do
 
     scenario "they do not see the edit detials button" do
       expect(page).not_to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)
+    end
+
+    scenario "they see their own submissions" do
+      expect(page).to have_content "Submissions"
+      within(".submissions") do
+        expect(page).to have_content submission.organisation.name
+        expect(page).to have_content submission.description
+      end
+    end
+
+    scenario "they do not see submissions belonging to other organisations" do
+      within(".submissions") do
+        expect(page).to_not have_content other_submission.organisation.name
+        expect(page).to_not have_content other_submission.description
+      end
     end
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Submission, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:state) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:fund).class_name("Activity") }
+    it { should belong_to(:organisation) }
+  end
+
+  it "does not allow an association to an Activity that is not level = fund" do
+    programme = create(:programme_activity)
+    submission = build(:submission, fund: programme)
+    expect(submission).not_to be_valid
+    expect(submission.errors[:fund]).to include I18n.t("errors.models.submission.attributes.fund")
+  end
+
+  it "does not allow more than one Submission for the same Fund and Organisation combination" do
+    organisation = create(:delivery_partner_organisation)
+    fund = create(:fund_activity)
+    _existing_submission = create(:submission, organisation: organisation, fund: fund)
+
+    new_submission = build(:submission, organisation: organisation, fund: fund)
+    expect(new_submission).not_to be_valid
+  end
+end

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe SubmissionPolicy do
+  let(:organisation) { create(:delivery_partner_organisation) }
+  let(:submission) { create(:submission, organisation: organisation) }
+  let(:another_submission) { create(:submission, organisation: create(:organisation)) }
+
+  subject { described_class.new(user, Submission) }
+
+  context "as a user that belongs to BEIS" do
+    let(:user) { build_stubbed(:beis_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_new_and_create_actions }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "includes all submissions in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Submission).resolve
+      expect(resolved_scope).to include submission, another_submission
+    end
+  end
+
+  context "as a user that does NOT belong to BEIS" do
+    let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "includes only submissions that the users organisation is reporting in the resolved scope" do
+      resolved_scope = described_class::Scope.new(user, Submission).resolve
+      expect(resolved_scope).to contain_exactly submission
+    end
+  end
+end

--- a/spec/presenters/submission_presenter_spec.rb
+++ b/spec/presenters/submission_presenter_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubmissionPresenter do
+  describe "#state" do
+    it "returns the string for the state" do
+      submission = build(:submission, state: "inactive")
+      result = described_class.new(submission).state
+      expect(result).to eql("Inactive")
+    end
+  end
+end

--- a/vendor/data/dp_to_fund_mappings/dp_mappings_072020.csv
+++ b/vendor/data/dp_to_fund_mappings/dp_mappings_072020.csv
@@ -1,0 +1,18 @@
+title,identifier,gcrf,newton_fund
+British Council,GB-GOV-OT313,false,true
+Met Office,GB-GOV-EA46,false,true
+UK Space Agency,GB-GOV-EA31,true,false
+Academy of Medical Sciences,GB-COH-03520281,true,true
+Royal Society,GB-COH-RC000519,true,true
+Royal Academy of Engineering,GB-CHC-293074,true,true
+British Academy,GB-COH-RC000053,true,true
+UKRI - Central,,true,true
+UKRI - ESRC,,true,true
+UKRI - EPSRC,,true,true
+UKRI - AHRC,,true,true
+UKRI - STFC,,true,true
+UKRI - BBSRC,,true,true
+UKRI - NERC,,true,true
+UKRI - MRC,,true,true
+UKRI - InnovateUK,,true,true
+UKRI - Research England,,true,false


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/4qRgkMw5/792-every-delivery-partner-organisation-has-a-submission-created-for-each-fund-they-are-associated-with

In this PR:

- Create a Submission model and associated tests & test fixtures
- Constrain Submissions by Fund and Organisation. At this point, we should not have more than one Submission per Fund/Organisation pair. This may change in future as we add more Submissions for each pair, on a quarterly basis.
- A data migration to seed the database with a Submission per Organisation/Fund pair
- A Pundit policy to control access to Submissions
- A SubmissionPresenter to style the Submission for the front end
- Show Submissions on the organisation home pages. For BEIS users, they will see all Submissions for all Organisation/Fund pairs. Delivery partner users will only see their own Submissions.

## Screenshots of UI changes

### After

Delivery partner user home page:

<img width="1268" alt="Screenshot 2020-07-20 at 14 39 56" src="https://user-images.githubusercontent.com/1089521/87944151-ed198800-ca96-11ea-8877-d4a4181fddb7.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
