### PR TITLE
Add Newton fund activity to seeds

### DIFF
--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -1,17 +1,23 @@
 beis = Organisation.find_by(service_owner: true)
 
-fund_params = FactoryBot.build(:fund_activity,
+gcrf_fund_params = FactoryBot.build(:fund_activity,
   title: "GCRF",
   organisation: beis).attributes
 
-fund = Activity.find_or_create_by(fund_params)
+gcrf_fund = Activity.find_or_create_by(gcrf_fund_params)
+
+newton_fund_params = FactoryBot.build(:fund_activity,
+  title: "Newton Fund",
+  organisation: beis).attributes
+
+_newton_fund = Activity.find_or_create_by(newton_fund_params)
 
 delivery_partner = Organisation.find_by!(service_owner: false)
 
 first_programme_params = FactoryBot.build(:programme_activity,
   title: "International Partnerships",
   organisation: beis,
-  parent: fund,
+  parent: gcrf_fund,
   extending_organisation: delivery_partner).attributes
 
 programme = Activity.find_or_create_by(first_programme_params)
@@ -19,7 +25,7 @@ programme = Activity.find_or_create_by(first_programme_params)
 second_programme_params = FactoryBot.build(:programme_activity,
   title: "Africa Catalyst Programme",
   organisation: beis,
-  parent: fund,
+  parent: gcrf_fund,
   extending_organisation: delivery_partner).attributes
 
 Activity.find_or_create_by(second_programme_params)


### PR DESCRIPTION

## Changes in this PR

The data migration `AddSubmissionsForAllOrganisationsAndFunds` added in
https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/527
will fail if the environment doesn't have both GCRF and Newton Fund activities
present. This update ot the seeds ensures everyone will have both Funds in their
local db.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
