### PR TITLE
(793) a BEIS user can edit Submissions to set or change a deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,9 @@
   Organisation/Fund pair. Show a basic Submission table on the user's home page. 
 - Fund, programme, project and third-party project activities are no longer 
   shown on the home page
+- Submission descriptions can be edited. A deadline attribute has also been added 
+  to the Submission model; setting a deadline moves the Submission into the "active"
+  state  
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...HEAD
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/controllers/staff/submissions_controller.rb
+++ b/app/controllers/staff/submissions_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Staff::SubmissionsController < Staff::BaseController
+  include Secured
+
+  def edit
+    @submission = Submission.find(id)
+    authorize @submission
+  end
+
+  def update
+    @submission = Submission.find(id)
+    authorize @submission
+
+    @submission.assign_attributes(submission_params)
+    if @submission.valid?
+      @submission.save!
+      @submission.create_activity key: "submission.update", owner: current_user
+      flash[:notice] = I18n.t("action.submission.update.success")
+      redirect_to organisation_path(current_user.organisation)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def id
+    params[:id]
+  end
+
+  def submission_params
+    params.require(:submission).permit(:deadline, :description)
+  end
+end

--- a/app/controllers/staff/submissions_controller.rb
+++ b/app/controllers/staff/submissions_controller.rb
@@ -16,6 +16,7 @@ class Staff::SubmissionsController < Staff::BaseController
     if @submission.valid?
       @submission.save!
       @submission.create_activity key: "submission.update", owner: current_user
+      activate_submission
       flash[:notice] = I18n.t("action.submission.update.success")
       redirect_to organisation_path(current_user.organisation)
     else
@@ -31,5 +32,13 @@ class Staff::SubmissionsController < Staff::BaseController
 
   def submission_params
     params.require(:submission).permit(:deadline, :description)
+  end
+
+  def activate_submission
+    if @submission.deadline.present? && @submission.deadline > Date.today
+      @submission.state = :active
+      @submission.save!
+      @submission.create_activity key: "submission.activate", owner: current_user
+    end
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -15,7 +15,7 @@ class Submission < ApplicationRecord
   def activity_must_be_a_fund
     return unless fund.present?
     unless fund.fund?
-      errors.add(:fund, I18n.t("errors.models.submission.attributes.fund"))
+      errors.add(:fund, I18n.t("activerecord.errors.models.submission.attributes.fund.level"))
     end
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,7 +9,7 @@ class Submission < ApplicationRecord
 
   validates_uniqueness_of :fund, scope: :organisation
   validate :activity_must_be_a_fund
-  validates :deadline, date_not_in_past: true
+  validates :deadline, date_not_in_past: true, date_within_boundaries: true
 
   enum state: [:inactive, :active]
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -11,7 +11,7 @@ class Submission < ApplicationRecord
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true
 
-  enum state: [:inactive]
+  enum state: [:inactive, :active]
 
   def activity_must_be_a_fund
     return unless fund.present?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,6 +9,7 @@ class Submission < ApplicationRecord
 
   validates_uniqueness_of :fund, scope: :organisation
   validate :activity_must_be_a_fund
+  validates :deadline, date_not_in_past: true
 
   enum state: [:inactive]
 

--- a/app/presenters/submission_presenter.rb
+++ b/app/presenters/submission_presenter.rb
@@ -5,4 +5,9 @@ class SubmissionPresenter < SimpleDelegator
     return if super.blank?
     I18n.t("label.submission.state.#{super.downcase}")
   end
+
+  def deadline
+    return if super.blank?
+    I18n.l(super)
+  end
 end

--- a/app/validators/date_not_in_past_validator.rb
+++ b/app/validators/date_not_in_past_validator.rb
@@ -1,0 +1,16 @@
+class DateNotInPastValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value
+
+    if in_past?(value)
+      record.errors.add(
+        attribute,
+        I18n.t("activerecord.errors.models.#{record.class.name.downcase}.attributes.#{attribute}.not_in_past")
+      )
+    end
+  end
+
+  def in_past?(date)
+    Time.zone.today >= date
+  end
+end

--- a/app/views/staff/shared/submissions/_table.html.haml
+++ b/app/views/staff/shared/submissions/_table.html.haml
@@ -9,15 +9,22 @@
         %th.govuk-table__header
           =t("table.header.submission.fund")
         %th.govuk-table__header
+          =t("table.header.submission.deadline")
+        %th.govuk-table__header
           = t("table.header.submission.organisation")
         %th.govuk-table__header
           =t("table.header.submission.state")
+        %th.govuk-table__header
 
     %tbody.govuk-table__body
       - submissions.each do |submission|
         %tr.govuk-table__row{id: submission.id}
           %td.govuk-table__cell= submission.description
           %td.govuk-table__cell= submission.fund.title
+          %td.govuk-table__cell= submission.deadline
           %td.govuk-table__cell= submission.organisation.name
           %td.govuk-table__cell= submission.state
+          %td.govuk-table__cell
+            - if policy(:submission).edit?
+              = link_to I18n.t("default.link.edit"), edit_submission_path(submission), class: "govuk-link"
 

--- a/app/views/staff/submissions/_form.html.haml
+++ b/app/views/staff/submissions/_form.html.haml
@@ -1,0 +1,5 @@
+= f.govuk_error_summary
+= f.govuk_text_field :description
+= f.govuk_date_field :deadline, legend: {  size: "s" }
+
+= f.govuk_submit t("default.button.submit")

--- a/app/views/staff/submissions/edit.html.haml
+++ b/app/views/staff/submissions/edit.html.haml
@@ -1,0 +1,10 @@
+=content_for :page_title_prefix, t("page_title.submission.edit")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.submission.edit")
+
+      = form_with model: @submission, url: submission_path(@submission) do |f|
+        = render partial: "form", locals: { f: f }

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -14,6 +14,7 @@ en:
     submission:
      state:
        inactive: Inactive
+       active: Active
   form:
     label:
       submission:

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -42,3 +42,5 @@ en:
               blank: Reporting period can't be bank
             fund:
               level: Activity must be a fund-level Activity
+            deadline:
+              not_in_past: The deadline must be a date in the future

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -7,15 +7,38 @@ en:
         description: Reporting period
         organisation: Organisation
         fund: Level A
+        deadline: Deadline
   page_content:
     submissions: Submissions
   label:
     submission:
      state:
        inactive: Inactive
-  errors:
-    models:
+  form:
+    label:
       submission:
-        attributes:
-          fund: must be a fund-level Activity
-
+        description: Reporting period
+        fund: Level A
+        organisation: Organisation
+        state: State
+        deadline: Deadline
+    legend:
+      submission:
+        description: Reporting period
+        deadline: Deadline
+  page_title:
+    submission:
+      edit: Edit submission
+  action:
+    submission:
+      update:
+        success: Submission successfully updated
+  activerecord:
+    errors:
+      models:
+        submission:
+          attributes:
+            description:
+              blank: Reporting period can't be bank
+            fund:
+              level: Activity must be a fund-level Activity

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -45,3 +45,4 @@ en:
               level: Activity must be a fund-level Activity
             deadline:
               not_in_past: The deadline must be a date in the future
+              between: Date must be between %{min} years ago and %{max} years in the future

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
         get "children" => "activity_children#show"
       end
     end
+    resources :submissions
 
     concern :transactionable do
       resources :transactions, only: [:new, :create, :show, :edit, :update]

--- a/db/migrate/20200722081543_add_deadline_field_to_submissions.rb
+++ b/db/migrate/20200722081543_add_deadline_field_to_submissions.rb
@@ -1,0 +1,9 @@
+class AddDeadlineFieldToSubmissions < ActiveRecord::Migration[6.0]
+  def up
+    add_column :submissions, :deadline, :date
+  end
+
+  def down
+    remove_column :submissions, :deadline, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_130243) do
+ActiveRecord::Schema.define(version: 2020_07_22_081543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_130243) do
     t.uuid "organisation_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "deadline"
     t.index ["fund_id"], name: "index_submissions_on_fund_id"
     t.index ["organisation_id"], name: "index_submissions_on_organisation_id"
   end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :submission do
     description { Faker::Lorem.paragraph }
     state { :inactive }
+    deadline { Date.today }
 
     association :fund, factory: :fund_activity
     association :organisation

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :submission do
     description { Faker::Lorem.paragraph }
     state { :inactive }
-    deadline { Date.today }
+    deadline { Date.tomorrow }
 
     association :fund, factory: :fund_activity
     association :organisation

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -2,9 +2,13 @@ FactoryBot.define do
   factory :submission do
     description { Faker::Lorem.paragraph }
     state { :inactive }
-    deadline { Date.tomorrow }
 
     association :fund, factory: :fund_activity
     association :organisation
+
+    trait :active do
+      state { :active }
+      deadline { 1.year.from_now }
+    end
   end
 end

--- a/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.feature "BEIS users can edit a submission" do
+  let(:delivery_partner_user) { create(:delivery_partner_user) }
+  let!(:submission) { create(:submission, organisation: delivery_partner_user.organisation, deadline: nil, description: "Legacy Submission") }
+
+  context "Logged in as a BEIS user" do
+    scenario "they can edit a Submission to set the deadline" do
+      PublicActivity.with_tracking do
+        user = create(:beis_user)
+        authenticate!(user: user)
+
+        visit organisation_path(user.organisation)
+
+        within "##{submission.id}" do
+          click_on I18n.t("default.link.edit")
+        end
+
+        fill_in "submission[deadline(3i)]", with: "31"
+        fill_in "submission[deadline(2i)]", with: "1"
+        fill_in "submission[deadline(1i)]", with: "2021"
+
+        click_on I18n.t("default.button.submit")
+
+        expect(page).to have_content I18n.t("action.submission.update.success")
+        within "##{submission.id}" do
+          expect(page).to have_content("31 Jan 2021")
+        end
+        auditable_events = PublicActivity::Activity.where(trackable_id: submission.id)
+        expect(auditable_events.map(&:key)).to include "submission.update"
+        expect(auditable_events.first.owner_id).to eq user.id
+      end
+    end
+
+    scenario "they can edit a Submission to change the description (Reporting Period)" do
+      user = create(:beis_user)
+      authenticate!(user: user)
+
+      visit organisation_path(user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.edit")
+      end
+
+      fill_in "submission[description]", with: "Quarter 4 2020"
+
+      click_on I18n.t("default.button.submit")
+
+      expect(page).to have_content I18n.t("action.submission.update.success")
+      within "##{submission.id}" do
+        expect(page).to have_content("Quarter 4 2020")
+      end
+    end
+
+    scenario "the description (Reporting Period) cannot be blank" do
+      user = create(:beis_user)
+      authenticate!(user: user)
+
+      visit organisation_path(user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.edit")
+      end
+
+      fill_in "submission[description]", with: ""
+
+      click_on I18n.t("default.button.submit")
+
+      expect(page).to_not have_content I18n.t("action.submission.update.success")
+      expect(page).to have_content I18n.t("activerecord.errors.models.submission.attributes.description.blank")
+    end
+  end
+
+  context "Logged in as a Delivery Partner user" do
+    scenario "they cannot edit a Submission" do
+      authenticate!(user: delivery_partner_user)
+
+      visit organisation_path(delivery_partner_user.organisation)
+
+      within "##{submission.id}" do
+        expect(page).to_not have_content(I18n.t("default.link.edit"))
+      end
+    end
+  end
+end

--- a/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
@@ -32,6 +32,26 @@ RSpec.feature "BEIS users can edit a submission" do
       end
     end
 
+    scenario "the deadline cannot be in the past" do
+      user = create(:beis_user)
+      authenticate!(user: user)
+
+      visit organisation_path(user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.edit")
+      end
+
+      fill_in "submission[deadline(3i)]", with: "31"
+      fill_in "submission[deadline(2i)]", with: "1"
+      fill_in "submission[deadline(1i)]", with: "2001"
+
+      click_on I18n.t("default.button.submit")
+
+      expect(page).to_not have_content I18n.t("action.submission.update.success")
+      expect(page).to have_content I18n.t("activerecord.errors.models.submission.attributes.deadline.not_in_past")
+    end
+
     scenario "they can edit a Submission to change the description (Reporting Period)" do
       user = create(:beis_user)
       authenticate!(user: user)

--- a/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
@@ -70,6 +70,26 @@ RSpec.feature "BEIS users can edit a submission" do
       expect(page).to have_content I18n.t("activerecord.errors.models.submission.attributes.deadline.not_in_past")
     end
 
+    scenario "the deadline cannot be very far in the future" do
+      user = create(:beis_user)
+      authenticate!(user: user)
+
+      visit organisation_path(user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.edit")
+      end
+
+      fill_in "submission[deadline(3i)]", with: "31"
+      fill_in "submission[deadline(2i)]", with: "1"
+      fill_in "submission[deadline(1i)]", with: "200020"
+
+      click_on I18n.t("default.button.submit")
+
+      expect(page).to_not have_content I18n.t("action.submission.update.success")
+      expect(page).to have_content I18n.t("activerecord.errors.models.submission.attributes.deadline.between", min: 10, max: 25)
+    end
+
     scenario "setting a Submission's deadline changes its state to 'active'" do
       user = create(:beis_user)
       authenticate!(user: user)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Submission, type: :model do
     programme = create(:programme_activity)
     submission = build(:submission, fund: programme)
     expect(submission).not_to be_valid
-    expect(submission.errors[:fund]).to include I18n.t("errors.models.submission.attributes.fund")
+    expect(submission.errors[:fund]).to include I18n.t("activerecord.errors.models.submission.attributes.fund.level")
   end
 
   it "does not allow more than one Submission for the same Fund and Organisation combination" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe Submission, type: :model do
     new_submission = build(:submission, organisation: organisation, fund: fund)
     expect(new_submission).not_to be_valid
   end
+
+  it "does not allow a Deadline which is in the past" do
+    submission = build(:submission, deadline: Date.yesterday)
+    expect(submission).not_to be_valid
+  end
 end

--- a/spec/presenters/submission_presenter_spec.rb
+++ b/spec/presenters/submission_presenter_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe SubmissionPresenter do
       expect(result).to eql("Inactive")
     end
   end
+
+  describe "#deadline" do
+    it "returns the formatted date for the deadline" do
+      submission = build(:submission, deadline: Date.today)
+      result = described_class.new(submission).deadline
+      expect(result).to eql I18n.l(Date.today)
+    end
+  end
 end

--- a/spec/validators/date_not_in_past_validator_spec.rb
+++ b/spec/validators/date_not_in_past_validator_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe DateNotInPastValidator do
+  subject do
+    Class.new {
+      include ActiveModel::Validations
+      attr_accessor :deadline
+      validates :deadline, date_not_in_past: true
+
+      def self.name
+        "Submission"
+      end
+    }.new
+  end
+
+  describe "#valid?" do
+    context "when date is nil" do
+      it "is valid" do
+        subject.deadline = nil
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context "when date is today" do
+      it "is not valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.deadline = Date.new(2004, 11, 24)
+        expect(subject.valid?).to be false
+
+        travel_back
+      end
+    end
+
+    context "when date is in the future" do
+      it "is valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.deadline = Date.new(2005, 1, 1)
+        expect(subject.valid?).to be true
+
+        travel_back
+      end
+    end
+
+    context "when date is in the past" do
+      it "is not valid" do
+        travel_to Time.zone.local(2004, 11, 24)
+
+        subject.deadline = Date.new(2003, 1, 1)
+        expect(subject.valid?).to be false
+
+        travel_back
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/QfCsh56Z/793-a-beis-user-can-edit-submissions-to-set-or-change-a-deadline

A Deadline date attributes has been added to the Submission model. This attribute is not required but when set, it can only be set to a future date. 

Setting a deadline to a future date moves the Submission from the "Inactive" state to "Active"

Only BEIS users can edit Submissions, Delivery Partner users do not see the Edit link against their submissions.

## Screenshots of UI changes

### After

<img width="1239" alt="Screenshot 2020-07-22 at 15 19 13" src="https://user-images.githubusercontent.com/1089521/88188330-9c896280-cc2f-11ea-871e-3c4fb5588202.png">

<img width="1163" alt="Screenshot 2020-07-22 at 15 19 24" src="https://user-images.githubusercontent.com/1089521/88187828-ede52200-cc2e-11ea-8ddc-7a6325ddf31a.png">

<img width="1120" alt="Screenshot 2020-07-22 at 15 19 34" src="https://user-images.githubusercontent.com/1089521/88187839-f0e01280-cc2e-11ea-8aa8-8f94b6867fc1.png">

<img width="1193" alt="Screenshot 2020-07-22 at 15 26 07" src="https://user-images.githubusercontent.com/1089521/88188389-b165f600-cc2f-11ea-8815-954b222ca24f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
