### PR TITLE
Make MigrateUksaGcrfMappings more tolerant of missing data

### DIFF
--- a/db/data/20200722154738_migrate_uksa_gcrf_mappings.rb
+++ b/db/data/20200722154738_migrate_uksa_gcrf_mappings.rb
@@ -8,7 +8,9 @@ class MigrateUksaGcrfMappings < ActiveRecord::Migration[6.0]
       csv.each do |row|
         activity = Activity.project.find_by!(identifier: row[:identifier])
         activity.level = :third_party_project
-        activity.parent = Activity.project.find_by!(identifier: row[:parent_identifier])
+        parent = Activity.project.find_by(identifier: row[:parent_identifier])
+        next unless parent
+        activity.parent = parent
         activity.save!
       end
     end


### PR DESCRIPTION
When running this migration on pentest & staging, we encountered issues where
if a programme is missing, the migration could not run. This is a problem
because we cannot expect each environment to contain exactly the same data.

This fix makes the migration more tolerant of missing programmes & therefore
less likely to break the build on staging.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
