### PR TITLE
Address a flaky test with Submissions

### DIFF
--- a/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_submission_spec.rb
@@ -131,9 +131,9 @@ RSpec.feature "BEIS users can edit a submission" do
 
         click_on I18n.t("default.button.submit")
 
-        auditable_event = PublicActivity::Activity.find_by(trackable_id: submission.id)
-        expect(auditable_event.key).to eq "submission.activate"
-        expect(auditable_event.owner_id).to eq user.id
+        auditable_events = PublicActivity::Activity.where(trackable_id: submission.id)
+        expect(auditable_events.map(&:key)).to eq ["submission.update", "submission.activate"]
+        expect(auditable_events.map(&:owner_id).uniq).to eq [user.id]
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

When activating a Submission, a PublicActivity record with the string
`submission.activate` is created. This test is checking for the existence of
this record. However, as part of the test setup, another PublicActivity with the
string `submission.update` is created. Sometimes, when using `.find_by` to
retrieve the PublicActivity records associated with the Submission, the `activate`
record appears first, other times the `update` record appears first and causes
the test to fail.

This change makes the test consistent by retrieving both PublicActivity records
and testing for the existence of the `submission.activate` records in them, not
just relying on the one returned first.

