### PR TITLE
(843) Allow Budgets to have a negative value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,8 @@
 
 ## [unreleased]
 
+- Allow budgets to have a negative value (but not zero)
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...HEAD
 [release-12]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...release-12
 [release-11]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-10...release-11

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -9,7 +9,7 @@ class Budget < ApplicationRecord
     :period_end_date,
     :value,
     :currency
-  validates :value, inclusion: 0.01..99_999_999_999.00
+  validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :period_start_date, :period_end_date, date_within_boundaries: true
 
   validates_with BudgetDatesValidator, if: -> { period_start_date.present? && period_end_date.present? }

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -66,4 +66,5 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_after_end_date: The period start date cannot be after the period end date
             value:
-              inclusion: Value must be between 0.01 and 99,999,999,999.00
+              less_than_or_equal_to: Value must not be more than 99,999,999,999.00
+              other_than: Value must not be zero

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -74,7 +74,36 @@ RSpec.describe "Users can create a budget" do
         expect(page).to have_content("Status can't be blank")
         expect(page).to have_content("Period start date can't be blank")
         expect(page).to have_content("Period end date can't be blank")
-        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.inclusion")
+        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.other_than")
+      end
+
+      scenario "sees validation error when the value is more than allowed" do
+        fund_activity = create(:fund_activity, organisation: user.organisation)
+        programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
+
+        visit activities_path
+
+        click_on(programme_activity.parent.title)
+        click_on I18n.t("tabs.activity.children")
+        click_on(programme_activity.title)
+
+        click_on(I18n.t("page_content.budgets.button.create"))
+
+        click_button I18n.t("default.button.submit")
+
+        choose("budget[budget_type]", option: "1")
+        choose("budget[status]", option: "1")
+        fill_in "budget[period_start_date(3i)]", with: "01"
+        fill_in "budget[period_start_date(2i)]", with: "01"
+        fill_in "budget[period_start_date(1i)]", with: "2020"
+        fill_in "budget[period_end_date(3i)]", with: "31"
+        fill_in "budget[period_end_date(2i)]", with: "12"
+        fill_in "budget[period_end_date(1i)]", with: "2020"
+        select "Pound Sterling", from: "budget[currency]"
+        fill_in "budget[value]", with: "10000000000000.00"
+        click_button I18n.t("default.button.submit")
+
+        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.less_than_or_equal_to")
       end
     end
   end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -25,7 +25,12 @@ RSpec.describe Budget do
       expect(budget).to be_valid
     end
 
-    it "does not allow a value of less than 0.01" do
+    it "allows a value of less than 0" do
+      budget = build(:budget, value: -0.01)
+      expect(budget).to be_valid
+    end
+
+    it "does not allow a value of 0" do
       budget = build(:budget, value: 0)
       expect(budget).to_not be_valid
     end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/0OZq4dRU/843-users-can-report-negative-budget-values

BEIS have a requirement to allow negative budget values. This has occurred
due to multi-year budget splitting.

Allow Budgets to have a negative value, but NOT a value of zero.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
