### PR TITLE
(854) Ingest allows negative budgets

### DIFF
--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -176,8 +176,6 @@ class IngestIatiActivities
       value = budget_element.children.detect { |child| child.name.eql?("value") }.children.text
       currency = budget_element.children.detect { |child| child.name.eql?("value") }.attributes["currency"].value
 
-      value = "0.01" if value.to_f.negative?
-
       budget = Budget.new(
         status: status,
         budget_type: budget_type,

--- a/db/data/20200730095019_restore_negative_budget_value.rb
+++ b/db/data/20200730095019_restore_negative_budget_value.rb
@@ -1,0 +1,13 @@
+class RestoreNegativeBudgetValue < ActiveRecord::Migration[6.0]
+  def up
+    activity = Activity.find_by(previous_identifier: "GB-GOV-13-NEWT-RS_BRA_797")
+
+    Budget.find_by(parent_activity: activity, period_start_date: "2015-10-01", value: "0.01")&.update!(value: "-3920.71")
+  end
+
+  def down
+    activity = Activity.find_by(previous_identifier: "GB-GOV-13-NEWT-RS_BRA_797")
+
+    Budget.find_by(parent_activity: activity, period_start_date: "2015-10-01", value: "-3920.71")&.update!(value: "0.01")
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200727124151)
+DataMigrate::Data.define(version: 20200701162318)

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe IngestIatiActivities do
         expect(budgets.first.ingested).to be true
       end
 
-      it "sets negative budgets to a penny (0.01)" do
+      it "allows negative budgets" do
         rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
         create(:programme_activity, organisation: rs, identifier: "Brazil-Newton-Mob-RS")
 
@@ -179,7 +179,7 @@ RSpec.describe IngestIatiActivities do
         activity = Activity.find_by(previous_identifier: "GB-GOV-13-NEWT-RS_BRA_797")
         budgets = Budget.where(parent_activity: activity)
 
-        expect(budgets.first.value).to eq "0.01".to_f
+        expect(budgets.first.value).to eq "-3920.71".to_f
         expect(budgets.first.ingested).to be true
       end
     end


### PR DESCRIPTION
Previously, we decided to set these rare occurrences to a penny and then correct their values through the UI. Now we're permitting negative budget values, this is no longer necessary.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
