### PR TITLE
(795) Users can view individual submissions and download a skeleton of the Submission CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,7 @@
 
 - Allow budgets to have a negative value (but not zero)
 - Customise error messages according to the content review
+- Add a very basic Submission show page and CSV skeleton
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...HEAD
 [release-12]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...release-12

--- a/app/controllers/staff/submissions_controller.rb
+++ b/app/controllers/staff/submissions_controller.rb
@@ -3,6 +3,11 @@
 class Staff::SubmissionsController < Staff::BaseController
   include Secured
 
+  def show
+    @submission = Submission.find(id)
+    authorize @submission
+  end
+
   def edit
     @submission = Submission.find(id)
     authorize @submission

--- a/app/controllers/staff/submissions_controller.rb
+++ b/app/controllers/staff/submissions_controller.rb
@@ -6,6 +6,13 @@ class Staff::SubmissionsController < Staff::BaseController
   def show
     @submission = Submission.find(id)
     authorize @submission
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        response.headers["Content-Disposition"] = "attachment; filename=\"#{ERB::Util.url_encode(@submission.description)}.csv\""
+      end
+    end
   end
 
   def edit

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -29,7 +29,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-m
-        = t("page_content.submissions")
+        = t("page_content.submissions.title")
       = render partial: "staff/shared/submissions/table", locals: { submissions: @submissions }
 
 

--- a/app/views/staff/shared/submissions/_table.html.haml
+++ b/app/views/staff/shared/submissions/_table.html.haml
@@ -27,4 +27,4 @@
           %td.govuk-table__cell
             - if policy(:submission).edit?
               = link_to I18n.t("default.link.edit"), edit_submission_path(submission), class: "govuk-link"
-
+            = link_to I18n.t("default.link.show"), submission_path(submission), class: "govuk-link"

--- a/app/views/staff/submissions/show.csv.haml
+++ b/app/views/staff/submissions/show.csv.haml
@@ -1,0 +1,1 @@
+= "Level A,Organisation,Implementing organisations,Title,Identifier,Recipient region,Focus area,Description,Planned start date,Actual start date,Planned end date,Sector,Channel of delivery code,Type of flow,Type of finance,Aid type,Link to RODA"

--- a/app/views/staff/submissions/show.html.haml
+++ b/app/views/staff/submissions/show.html.haml
@@ -1,0 +1,8 @@
+=content_for :page_title_prefix, t("page_title.submission.show", submission_name: @submission.description)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = @submission.description
+

--- a/app/views/staff/submissions/show.html.haml
+++ b/app/views/staff/submissions/show.html.haml
@@ -6,3 +6,9 @@
       %h1.govuk-heading-xl
         = @submission.description
 
+  .govuk-grid-row
+    .govuk-grid-column-full.download-csv
+      %div.govuk-body
+        = t("page_content.submissions.download_as_csv")
+      = link_to t("default.button.download_as_csv"), submission_path(@submission, format: :csv), class: "govuk-button"
+

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -14,6 +14,7 @@ en:
       download_as_xml: Download as XML
       menu: Menu
       submit: Submit
+      download_as_csv: Download as CSV
     link:
       add: Add
       back: Back

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -9,7 +9,9 @@ en:
         fund: Level A
         deadline: Deadline
   page_content:
-    submissions: Submissions
+    submissions:
+      title: Submissions
+      download_as_csv: Download Submission as a CSV
   label:
     submission:
      state:

--- a/config/locales/models/submission.en.yml
+++ b/config/locales/models/submission.en.yml
@@ -30,6 +30,7 @@ en:
   page_title:
     submission:
       edit: Edit submission
+      show: View submission %{submission_name}
   action:
     submission:
       update:

--- a/spec/features/staff/users_can_view_a_submission_spec.rb
+++ b/spec/features/staff/users_can_view_a_submission_spec.rb
@@ -1,0 +1,61 @@
+RSpec.feature "Users can view a submission" do
+  let(:beis_user) { create(:beis_user) }
+  let(:delivery_partner_user) { create(:delivery_partner_user) }
+  let!(:submission) { create(:submission, organisation: delivery_partner_user.organisation, deadline: nil, description: "Legacy Submission") }
+
+  context "as a BEIS user" do
+    before do
+      authenticate!(user: beis_user)
+    end
+
+    scenario "can view a submission belonging to any delivery partner" do
+      visit organisation_path(beis_user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.show")
+      end
+
+      expect(page).to have_content submission.description
+    end
+
+    scenario "can download a CSV of the submission" do
+      visit organisation_path(beis_user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.show")
+      end
+
+      click_on I18n.t("default.button.download_as_csv")
+
+      expect(page.response_headers["Content-Type"]).to include("text/csv")
+
+      header = page.response_headers["Content-Disposition"]
+      expect(header).to match(/^attachment/)
+      expect(header).to match(/filename=\"#{ERB::Util.url_encode(submission.description)}.csv\"$/)
+    end
+  end
+
+  context "as a delivery partner user" do
+    scenario "can view their own submission" do
+      authenticate!(user: delivery_partner_user)
+
+      visit organisation_path(delivery_partner_user.organisation)
+
+      within "##{submission.id}" do
+        click_on I18n.t("default.link.show")
+      end
+
+      expect(page).to have_content submission.description
+    end
+
+    scenario "cannot view a submission belonging to another delivery partner" do
+      another_submission = create(:submission, organisation: create(:organisation))
+
+      authenticate!(user: delivery_partner_user)
+
+      visit organisation_path(delivery_partner_user.organisation)
+
+      expect(page).to_not have_content another_submission.description
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/Ad9Tp69Y/795-delivery-partners-can-view-individual-submissions-and-download-the-data-as-a-single-csv

This ticket was originally to fill the CSV with all the submission data, but we have split it up so that this PR contains the work to add a show page for the Submissions, and a downloadable skeleton of the CSV (headers only).

The next stage is to decide what data goes into the CSV and add that data (future ticket)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
