### PR TITLE
(840) Customise validation error messages according to the content review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,7 @@
 ## [unreleased]
 
 - Allow budgets to have a negative value (but not zero)
+- Customise error messages according to the content review
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...HEAD
 [release-12]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...release-12

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -205,3 +205,25 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
             planned_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+            level:
+              blank: Select the activity type
+            parent:
+              blank: Select a parent activity
+            identifier:
+              blank: Enter a unique identifier
+            title:
+              blank: Enter a title
+            description:
+              blank: Enter a description
+            sector_category:
+              blank: Select a category
+            sector:
+              blank: Select a focus area
+            status:
+              blank: Select a status
+            geography:
+              blank: Select a benefitting region or country
+            aid_type:
+              blank: Select the aid type
+            extending_organisation_id:
+              blank: Select an extending organisation

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -62,9 +62,17 @@ en:
             period_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               within_365_days_of_start_date: The period end date must be no more than 365 days after the period start date
+              blank: Enter an end date
             period_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_after_end_date: The period start date cannot be after the period end date
+              blank: Enter a start date
             value:
               less_than_or_equal_to: Value must not be more than 99,999,999,999.00
               other_than: Value must not be zero
+              blank: Enter a budget amount
+            budget_type:
+              blank: Enter a budget type
+            status:
+              blank: Enter a budget status
+

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -65,6 +65,16 @@ en:
             date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Date must not be in the future
+              blank: Enter a date the transaction was made
             value:
               less_than_or_equal_to: Value must be less than or equal to 99,999,999,999.00
               other_than: Value must not be zero
+              blank: Enter a transaction amount
+            transaction_type:
+              blank: Select a transaction type
+            description:
+              blank: Enter a description
+            receiving_organisation_name:
+              blank: Enter a receiving organisation name
+            receiving_organisation_type:
+              blank: Select the organisation type

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -75,5 +75,9 @@ en:
       models:
         user:
           attributes:
-            organisation_ids:
-              blank: Select the organisation(s) this user belongs to
+            organisation:
+              required: Select the user's organisation
+            name:
+              blank: Enter a full name
+            email:
+              blank: Enter an email address

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -68,8 +68,8 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
           click_button I18n.t("default.button.submit")
 
-          expect(page).to have_content("Name can't be blank")
-          expect(page).to have_content("Email can't be blank")
+          expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.name.blank"))
+          expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
         end
       end
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe "Users can create a budget" do
         click_button I18n.t("default.button.submit")
 
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content("Budget type can't be blank")
-        expect(page).to have_content("Status can't be blank")
-        expect(page).to have_content("Period start date can't be blank")
-        expect(page).to have_content("Period end date can't be blank")
+        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.budget_type.blank"))
+        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.status.blank"))
+        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
+        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_end_date.blank"))
         expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.other_than")
       end
 

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a level
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.level.blank")
 
         choose "Programme"
         click_button I18n.t("form.button.activity.submit")
@@ -132,7 +132,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a parent
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.parent.blank")
 
         choose parent.title
         click_button I18n.t("form.button.activity.submit")
@@ -140,7 +140,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide an identifier
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.identifier.blank")
 
         fill_in "activity[identifier]", with: identifier
         click_button I18n.t("form.button.activity.submit")
@@ -150,8 +150,8 @@ RSpec.feature "Users can create a fund level activity" do
         # Don't provide a title and description
         click_button I18n.t("form.button.activity.submit")
 
-        expect(page).to have_content "Title can't be blank"
-        expect(page).to have_content "Description can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.title.blank")
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.description.blank")
 
         fill_in "activity[title]", with: Faker::Lorem.word
         fill_in "activity[description]", with: Faker::Lorem.paragraph
@@ -161,7 +161,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a sector category
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.sector_category.blank")
 
         choose "Basic Education"
         click_button I18n.t("form.button.activity.submit")
@@ -170,7 +170,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a sector
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.sector.blank")
 
         choose "Primary education"
         click_button I18n.t("form.button.activity.submit")
@@ -178,7 +178,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't provide a status
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "Status can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.status.blank")
 
         choose("activity[status]", option: "2")
         click_button I18n.t("form.button.activity.submit")
@@ -209,7 +209,7 @@ RSpec.feature "Users can create a fund level activity" do
         expect(page).to have_content I18n.t("form.legend.activity.geography")
 
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.geography.blank")
 
         choose "Region"
         click_button I18n.t("form.button.activity.submit")
@@ -227,7 +227,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         # Don't select an aid type
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content "Aid type can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.aid_type.blank")
 
         choose("activity[aid_type]", option: "A01")
         click_button I18n.t("form.button.activity.submit")

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -56,12 +56,12 @@ RSpec.feature "Users can create a transaction" do
       click_on(I18n.t("default.button.submit"))
 
       expect(page).to_not have_content(I18n.t("action.transaction.create.success"))
-      expect(page).to have_content("Description can't be blank")
-      expect(page).to have_content("Transaction type can't be blank")
-      expect(page).to have_content("Date can't be blank")
+      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.description.blank"))
+      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
+      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.date.blank"))
       expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.other_than")
-      expect(page).to have_content("Receiving organisation name can't be blank")
-      expect(page).to have_content("Receiving organisation type can't be blank")
+      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
     end
 
     scenario "disbursement channel is optional" do
@@ -245,7 +245,7 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(date_day: "", date_month: "", date_year: "", expectations: false)
 
-        expect(page).to have_content "Date can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.date.blank")
       end
     end
   end

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Users can edit a budget" do
       click_on I18n.t("default.button.submit")
 
       expect(page).to have_content("There is a problem")
-      expect(page).to have_content("can't be blank")
+      expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
     end
   end
 end

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Users can manage the extending organisation" do
         click_on I18n.t("page_content.activity.extending_organisation.button.edit")
         click_on I18n.t("default.button.submit")
 
-        expect(page).to have_content "Error: Extending organisation can't be blank"
+        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.extending_organisation_id.blank")
       end
     end
   end

--- a/spec/services/update_activity_as_project_spec.rb
+++ b/spec/services/update_activity_as_project_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UpdateActivityAsProject do
       it "sets the parent to nil and does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: ["Parent can't be blank"])
+        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end

--- a/spec/services/update_activity_as_third_party_project_spec.rb
+++ b/spec/services/update_activity_as_third_party_project_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UpdateActivityAsThirdPartyProject do
       it "sets the parent to nil does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: ["Parent can't be blank"])
+        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end

--- a/spec/services/update_programme_activity_spec.rb
+++ b/spec/services/update_programme_activity_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UpdateActivityAsProgramme do
       it "sets the parent to nil does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: ["Parent can't be blank"])
+        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/JsC9J8lr/840-change-error-messages

The content review required many of the standard ActiveRecord validation error messages to be changed. These required new keys to be added to the translation files. Some of the messages cannot be fully customised - for example, if an Activity title is blank, we say "Enter a title" instead of "Enter a fund/programme/project title" as these error messages are generic across Activity levels.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
