### PR TITLE
(836) Associate Transactions to a Submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,8 @@
 
 ## [unreleased]
 
+- Associate Transactions to Submissions
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13
 [release-12]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-11...release-12

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -22,7 +22,6 @@ class Staff::TransactionsController < Staff::BaseController
 
     if result.success?
       @transaction.create_activity key: "transaction.create", owner: current_user
-      associate_transaction_to_submission
       flash[:notice] = I18n.t("action.transaction.create.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
@@ -84,13 +83,6 @@ class Staff::TransactionsController < Staff::BaseController
 
   def activity
     @activity ||= Activity.find(activity_id)
-  end
-
-  def associate_transaction_to_submission
-    organisation = activity.organisation
-    fund = activity.associated_fund
-    submission = Submission.active.find_by(organisation: organisation, fund: fund)
-    @transaction.update!(submission: submission) if submission
   end
 
   private def pre_fill_providing_organisation

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -116,6 +116,11 @@ class Activity < ApplicationRecord
     ancestors.reverse
   end
 
+  def associated_fund
+    return self if fund?
+    parent_activities.detect(&:fund?)
+  end
+
   def providing_organisation
     return organisation if third_party_project? && !organisation.is_government?
     Organisation.find_by(service_owner: true)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,6 +6,7 @@ class Submission < ApplicationRecord
 
   belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"
   belongs_to :organisation
+  has_many :transactions
 
   validates_uniqueness_of :fund, scope: :organisation
   validate :activity_must_be_a_fund

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,6 +4,8 @@ class Transaction < ApplicationRecord
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"
+  belongs_to :submission, optional: true
+
   validates_presence_of :description,
     :transaction_type,
     :date,

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,7 +4,7 @@ class Transaction < ApplicationRecord
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"
-  belongs_to :submission, optional: true
+  belongs_to :submission
 
   validates_presence_of :description,
     :transaction_type,

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -1,13 +1,22 @@
 class TransactionPolicy < ApplicationPolicy
   def create?
-    Pundit.policy!(user, record.parent_activity).create?
+    Pundit.policy!(user, record.parent_activity).create? && !!associated_submission&.active?
   end
 
   def update?
-    Pundit.policy!(user, record.parent_activity).update?
+    Pundit.policy!(user, record.parent_activity).update? && !!associated_submission&.active?
   end
 
   def destroy?
     Pundit.policy!(user, record.parent_activity).destroy?
+  end
+
+  private
+
+  def associated_submission
+    parent_activity = record.parent_activity
+    organisation = parent_activity.organisation
+    fund = parent_activity.associated_fund
+    Submission.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -10,6 +10,7 @@ class CreateTransaction
 
     transaction.parent_activity = activity
     transaction.assign_attributes(attributes)
+    transaction.submission = submission(activity: activity)
     transaction.value = sanitize_monetary_string(value: attributes[:value])
 
     result = if transaction.valid?
@@ -25,5 +26,11 @@ class CreateTransaction
 
   def sanitize_monetary_string(value:)
     Monetize.parse(value)
+  end
+
+  def submission(activity:)
+    organisation = activity.organisation
+    fund = activity.associated_fund
+    Submission.active.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -44,13 +44,13 @@ class IngestIatiActivities
           new_activity
         end
 
-        add_transactions(legacy_activity: legacy_activity, roda_activity: roda_activity)
-        add_budgets(legacy_activity: legacy_activity, roda_activity: roda_activity)
-        add_planned_disbursements(legacy_activity: legacy_activity, roda_activity: roda_activity)
-
         roda_activity.parent = legacy_activity.find_parent_programme
         roda_activity.legacy_iati_xml = legacy_activity.to_xml.squish
         roda_activity.ingested = true
+
+        add_transactions(legacy_activity: legacy_activity, roda_activity: roda_activity)
+        add_budgets(legacy_activity: legacy_activity, roda_activity: roda_activity)
+        add_planned_disbursements(legacy_activity: legacy_activity, roda_activity: roda_activity)
 
         roda_activity.save!
       end
@@ -145,6 +145,8 @@ class IngestIatiActivities
       receiving_organisation_reference = receiving_organisation.attributes["ref"].try(:value)
       receiving_organisation_type = receiving_organisation_type(attribute: receiving_organisation.attributes["type"], implementing_organisation: roda_activity.implementing_organisations.first)
 
+      submission = Submission.find_by(fund: roda_activity.associated_fund, organisation: roda_activity.organisation)
+
       transaction = Transaction.new(
         description: normalize_string(description),
         transaction_type: transaction_type,
@@ -159,7 +161,8 @@ class IngestIatiActivities
         receiving_organisation_name: receiving_organisation_name,
         receiving_organisation_type: receiving_organisation_type,
         receiving_organisation_reference: receiving_organisation_reference,
-        ingested: true
+        ingested: true,
+        submission: submission
       )
 
       transaction.save!

--- a/db/migrate/20200803141156_add_associations_between_transactions_and_submissions.rb
+++ b/db/migrate/20200803141156_add_associations_between_transactions_and_submissions.rb
@@ -1,0 +1,5 @@
+class AddAssociationsBetweenTransactionsAndSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :transactions, :submission, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_140110) do
+ActiveRecord::Schema.define(version: 2020_08_03_141156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -159,7 +159,9 @@ ActiveRecord::Schema.define(version: 2020_07_24_140110) do
     t.string "receiving_organisation_reference"
     t.uuid "parent_activity_id"
     t.boolean "ingested", default: false
+    t.uuid "submission_id"
     t.index ["parent_activity_id"], name: "index_transactions_on_parent_activity_id"
+    t.index ["submission_id"], name: "index_transactions_on_submission_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
       association :organisation, factory: :beis_organisation
       association :extending_organisation, factory: :beis_organisation
       association :reporting_organisation, factory: :beis_organisation
+
+      trait :with_submission do
+        after(:create) do |fund|
+          create(:submission, :active, fund: fund, organisation: fund.organisation)
+        end
+      end
     end
 
     factory :programme_activity do

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -18,5 +18,6 @@ FactoryBot.define do
     receiving_organisation_type { "70" }
 
     association :parent_activity, factory: :activity
+    association :submission
   end
 end

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -279,6 +279,21 @@ RSpec.feature "Users can create a transaction" do
         expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_type"), with: beis.organisation_type
         expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_reference"), with: beis.iati_reference
       end
+
+      scenario "the transaction is associated with the currently active submission" do
+        fund = create(:fund_activity)
+        programme = create(:programme_activity, parent: fund)
+        submission = create(:submission, :active, organisation: user.organisation, fund: fund)
+        project = create(:project_activity, organisation: user.organisation, parent: programme)
+
+        visit organisation_activity_path(user.organisation, project)
+        click_on "Add a transaction"
+
+        fill_in_transaction_form
+
+        transaction = Transaction.last
+        expect(transaction.submission).to eq(submission)
+      end
     end
   end
 

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can create a transaction" do
     let(:user) { create(:beis_user) }
 
     scenario "successfully creates a transaction on an activity" do
-      activity = create(:fund_activity, organisation: user.organisation)
+      activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
       visit activities_path
 
@@ -26,7 +26,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "transaction creation is tracked with public_activity" do
-      activity = create(:fund_activity, organisation: user.organisation)
+      activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
       PublicActivity.with_tracking do
         visit activities_path
@@ -46,7 +46,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "validations" do
-      activity = create(:fund_activity, organisation: user.organisation)
+      activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
       visit activities_path
 
@@ -65,7 +65,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "disbursement channel is optional" do
-      activity = create(:fund_activity, organisation: user.organisation)
+      activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
       visit activities_path
 
@@ -80,7 +80,7 @@ RSpec.feature "Users can create a transaction" do
 
     context "Value number validation" do
       scenario "Value must be maximum 99,999,999,999" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -102,7 +102,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "Value cannot be 0" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -124,7 +124,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "Value can be negative" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -148,7 +148,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes a pound sign" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -162,7 +162,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes alphabetical characters" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -176,7 +176,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes decimal places" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -190,7 +190,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes commas" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -206,7 +206,7 @@ RSpec.feature "Users can create a transaction" do
 
     context "Date validation" do
       scenario "When the date is in the future" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -220,7 +220,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the date is in the past" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -235,7 +235,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the date is nil" do
-        activity = create(:fund_activity, organisation: user.organisation)
+        activity = create(:fund_activity, :with_submission, organisation: user.organisation)
 
         visit activities_path
 
@@ -255,7 +255,7 @@ RSpec.feature "Users can create a transaction" do
     let(:user) { create(:delivery_partner_user) }
 
     scenario "they cannot create transactions on a programme" do
-      fund_activity = create(:fund_activity, organisation: user.organisation)
+      fund_activity = create(:fund_activity, :with_submission, organisation: user.organisation)
       programme_activity = create(:programme_activity,
         parent: fund_activity,
         organisation: user.organisation,
@@ -271,6 +271,7 @@ RSpec.feature "Users can create a transaction" do
       scenario "the providing organisation details are pre-filled with BEIS information" do
         beis = create(:beis_organisation)
         third_party_project = create(:third_party_project_activity, organisation: user.organisation)
+        _submission = create(:submission, :active, organisation: user.organisation, fund: third_party_project.associated_fund)
 
         visit organisation_activity_path(user.organisation, third_party_project)
         click_on "Add a transaction"
@@ -305,6 +306,7 @@ RSpec.feature "Users can create a transaction" do
     context "and the activity is a third-party project" do
       scenario "the providing organisation details are pre-filled with the delivery organisation information" do
         third_party_project = create(:third_party_project_activity, organisation: user.organisation)
+        _submission = create(:submission, :active, organisation: user.organisation, fund: third_party_project.associated_fund)
 
         visit organisation_activity_path(user.organisation, third_party_project)
         click_on "Add a transaction"

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "Users can edit a transaction" do
     before { authenticate!(user: user) }
     let(:user) { create(:beis_user) }
     let!(:activity) { create(:fund_activity, organisation: user.organisation) }
-    let!(:transaction) { create(:transaction, parent_activity: activity) }
+    let(:submission) { create(:submission, :active, organisation: user.organisation, fund: activity) }
+    let!(:transaction) { create(:transaction, parent_activity: activity, submission: submission) }
 
     scenario "editing a transaction on a fund" do
       visit activities_path

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -357,6 +357,45 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#associated_fund" do
+    context "when the activity is a fund" do
+      it "returns itself" do
+        fund = create(:fund_activity)
+        expect(fund.associated_fund).to eq(fund)
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns the parent fund" do
+        programme = create(:programme_activity)
+        fund = programme.parent
+
+        expect(programme.associated_fund).to eq(fund)
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns the ancestor fund" do
+        project = create(:project_activity)
+        programme = project.parent
+        fund = programme.parent
+
+        expect(project.associated_fund).to eq(fund)
+      end
+    end
+
+    context "when the activity is a third party project" do
+      it "returns the ancestor fund" do
+        third_party_project = create(:third_party_project_activity)
+        project = third_party_project.parent
+        programme = project.parent
+        fund = programme.parent
+
+        expect(third_party_project.associated_fund).to eq(fund)
+      end
+    end
+  end
+
   describe "#form_stpes_completed?" do
     it "is true when a user has completed all of the form steps" do
       activity = build(:activity, form_state: :complete)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Transaction, type: :model do
   end
 
   describe "associations" do
-    it { should belong_to(:submission).optional }
+    it { should belong_to(:submission) }
   end
 
   describe "sanitation" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Transaction, type: :model do
     it { should validate_presence_of(:receiving_organisation_type) }
   end
 
+  describe "associations" do
+    it { should belong_to(:submission).optional }
+  end
+
   describe "sanitation" do
     it { should strip_attribute(:providing_organisation_reference) }
     it { should strip_attribute(:receiving_organisation_reference) }

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -8,22 +8,37 @@ RSpec.describe TransactionPolicy do
   subject { described_class.new(user, transaction) }
 
   describe "#create?" do
-    context "when the user belongs to the authoring organisation" do
-      let(:transaction) { create(:transaction, parent_activity: activity) }
-      it { is_expected.to permit_action(:create) }
+    context "when there is no submission to attach this transaction to" do
+      context "when the user belongs to the authoring organisation" do
+        let(:transaction) { create(:transaction, parent_activity: activity) }
+        it { is_expected.to forbid_action(:create) }
+      end
     end
 
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      let(:transaction) { create(:transaction, parent_activity: activity) }
-      it { is_expected.to forbid_action(:create) }
+    context "when there is a submission to attach this transaction to" do
+      before do
+        _submission = create(:submission, :active, organisation: user.organisation, fund: activity)
+      end
+
+      context "when the user belongs to the authoring organisation" do
+        let(:transaction) { create(:transaction, parent_activity: activity) }
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context "when the user does NOT belong to the authoring organisation" do
+        let(:another_organisation) { create(:organisation) }
+        let(:activity) { create(:activity, organisation: another_organisation) }
+        let(:transaction) { create(:transaction, parent_activity: activity) }
+        it { is_expected.to forbid_action(:create) }
+      end
     end
   end
 
   describe "#update?" do
+    let(:submission) { create(:submission, :active, organisation: user.organisation, fund: activity) }
+
     context "when the user belongs to the authoring organisation" do
-      let(:transaction) { create(:transaction, parent_activity: activity) }
+      let(:transaction) { create(:transaction, parent_activity: activity, submission: submission) }
       it { is_expected.to permit_action(:update) }
     end
 
@@ -34,13 +49,8 @@ RSpec.describe TransactionPolicy do
       it { is_expected.to forbid_action(:update) }
     end
 
-    context "when the transaction is not associated to a submission" do
-      let(:transaction) { create(:transaction, parent_activity: activity, submission: nil) }
-      it { is_expected.to permit_action(:update) }
-    end
-
     context "when the transaction is associated to an active submission" do
-      let(:submission) { create(:submission, :active, organisation: activity.organisation) }
+      let(:submission) { create(:submission, :active, organisation: activity.organisation, fund: activity) }
       let(:transaction) { create(:transaction, parent_activity: activity, submission: submission) }
       it { is_expected.to permit_action(:update) }
     end

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe TransactionPolicy do
       let(:transaction) { create(:transaction, parent_activity: activity) }
       it { is_expected.to forbid_action(:update) }
     end
+
+    context "when the transaction is not associated to a submission" do
+      let(:transaction) { create(:transaction, parent_activity: activity, submission: nil) }
+      it { is_expected.to permit_action(:update) }
+    end
+
+    context "when the transaction is associated to an active submission" do
+      let(:submission) { create(:submission, :active, organisation: activity.organisation) }
+      let(:transaction) { create(:transaction, parent_activity: activity, submission: submission) }
+      it { is_expected.to permit_action(:update) }
+    end
+
+    context "when the transaction is associated to an inactive submission" do
+      let(:submission) { create(:submission, organisation: activity.organisation, fund: activity) }
+      let(:transaction) { create(:transaction, parent_activity: activity, submission: submission) }
+      it { is_expected.to forbid_action(:update) }
+    end
   end
 
   describe "#destroy?" do

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe IngestIatiActivities do
   describe "#call" do
     it "creates 35 new projects for UKSA" do
       uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+      _submission = create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund)
       legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/real_and_complete_legacy_file.xml")
 
       service_object = described_class.new(delivery_partner: uksa, file_io: legacy_activities)
@@ -104,11 +105,13 @@ RSpec.describe IngestIatiActivities do
 
     it "creates transactions and marks them as ingested" do
       uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+      _submission = create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund)
       legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_transactions.xml")
 
       described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
 
       activity = Activity.find_by(previous_identifier: "GB-GOV-13-GCRF-UKSA_TZ_UKSA-021")
+
       transactions = Transaction.where(parent_activity: activity)
 
       expect(transactions.count).to eql(5)
@@ -190,6 +193,7 @@ RSpec.describe IngestIatiActivities do
 
       let(:activity) { Activity.find_by(previous_identifier: "GB-GOV-13-GCRF-UKSA_NS_UKSA-029") }
       let(:planned_disbursements) { PlannedDisbursement.where(parent_activity: activity) }
+      let!(:submission) { create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund) }
 
       it "creates valid planned disbursement and marks it as ingested" do
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/real_and_complete_legacy_file.xml")
@@ -254,7 +258,6 @@ RSpec.describe IngestIatiActivities do
         end
 
         it "returns 0 if there is no attribute and the activity does not have an implementing organisation" do
-          uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
           existing_project = create(:project_activity,
             previous_identifier: "GB-GOV-13-GCRF-UKSA_TZ_UKSA-021",
             organisation: uksa)
@@ -319,6 +322,8 @@ RSpec.describe IngestIatiActivities do
     context "when a transaction has no description" do
       it "set a placeholder description" do
         uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        _submission = create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund)
+
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_missing_transaction_description.xml")
 
         described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
@@ -348,6 +353,7 @@ RSpec.describe IngestIatiActivities do
     context "when an activity with the IATI identifier already exists" do
       it "updates the activity rather then creating a new record" do
         uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        _submission = create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund)
         existing_project = create(:project_activity,
           previous_identifier: "GB-GOV-13-GCRF-UKSA_TZ_UKSA-021",
           organisation: uksa)
@@ -370,6 +376,8 @@ RSpec.describe IngestIatiActivities do
             :at_geography_step,
             previous_identifier: "GB-GOV-13-GCRF-UKSA_TZ_UKSA-021",
             organisation: uksa)
+          _submission = create(:submission, :active, organisation: uksa, fund: existing_programme.associated_fund)
+
           legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_transactions.xml")
 
           described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
@@ -417,6 +425,7 @@ RSpec.describe IngestIatiActivities do
       ams = create(:organisation, name: "Academy of Medical Sciences", iati_reference: "GB-COH-03520281")
       legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/ams/newt/fake_activity_with_dates.xml")
       programme = create(:programme_activity, organisation: ams)
+      _submission = create(:submission, :active, organisation: ams, fund: programme.associated_fund)
       # Temporary fix until we have the actual programme-project mappings
       allow_any_instance_of(LegacyActivity).to receive(:find_parent_programme).and_return(programme)
 


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/Lasw3YS4/836-associate-transactions-to-a-submission

Associate Transactions to Submissions. A Transaction can have one Submission; a Submission can have many Transactions.

When a Transaction is created, associate it with the current Submission for that Delivery Partner & Fund.

Do not allow Transactions to be created if there is no Submission in existence.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
