### PR TITLE
Update Organisation-related error messages according to content review

### DIFF
--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -69,3 +69,12 @@ en:
           attributes:
             iati_reference:
               format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
+              blank: Enter an IATI reference
+            default_currency:
+              blank: Enter a default currency
+            name:
+              blank: Enter an organisation name
+            language_code:
+              blank: Enter a language code
+            organisation_type:
+              blank: Enter an organisation type

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "BEIS users can create organisations" do
 
       click_button I18n.t("default.button.submit")
       expect(page).to_not have_content I18n.t("action.organisation.create.success")
-      expect(page).to have_content "can't be blank"
+      expect(page).to have_content I18n.t("activerecord.errors.models.organisation.attributes.organisation_type.blank")
     end
 
     context "when the user does not belongs to BEIS" do

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Users can edit organisations" do
 
     click_button I18n.t("default.button.submit")
     expect(page).to_not have_content I18n.t("organisation.action.update.success")
-    expect(page).to have_content "can't be blank"
+    expect(page).to have_content I18n.t("activerecord.errors.models.organisation.attributes.name.blank")
   end
 
   def successfully_edit_an_organisation(organisation_name: "My New Organisation")


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/JsC9J8lr/840-change-error-messages

Additional error messages related to the content review & missed in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/550

The Gov.uk style guide requires error messages to be in the format "Enter a(n) {attribute name}" instead of "{attribute name} can't be blank"

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
