### PR TITLE
(869) Get Terraform to wait longer for app to boot

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -5,6 +5,7 @@ resource "cloudfoundry_app" "beis-roda-app" {
   space                      = cloudfoundry_space.space.id
   instances                  = 2
   disk_quota                 = 3072
+  timeout                    = 120
   docker_image               = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
   strategy                   = "blue-green-v2"
   health_check_http_endpoint = "/health_check"


### PR DESCRIPTION
During a recent production deploy, the app instances took too long to
spin up which resulting in the deploy being terminated.

The worker instance was already given 120 seconds to start, so let's do
the same for the app instances.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
