### PR TITLE
(859) The Report CSV contains Activity details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@
 ## [unreleased]
 
 - Associate Transactions to Submissions
+- Export Activity data in the Submission CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,6 +4,7 @@ class Activity < ApplicationRecord
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
+  CSV_HEADERS = ["Identifier", "Transparency identifier", "Sector", "Title", "Description", "Status", "Planned start date", "Actual start date", "Planned end date", "Actual end date", "Recipient region", "Recipient country", "Aid type", "Level", "Link to activity in RODA"]
 
   VALIDATION_STEPS = [
     :level_step,

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -1,4 +1,6 @@
 class SubmissionPolicy < ApplicationPolicy
+  attr_reader :user, :record
+
   def index?
     true
   end
@@ -13,6 +15,11 @@ class SubmissionPolicy < ApplicationPolicy
 
   def update?
     beis_user?
+  end
+
+  def download?
+    return true if beis_user?
+    record.organisation == user.organisation
   end
 
   def destroy?

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -6,7 +6,8 @@ class SubmissionPolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    return true if beis_user?
+    record.organisation == user.organisation
   end
 
   def create?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -76,4 +76,8 @@ class ActivityPresenter < SimpleDelegator
     return if super.blank?
     I18n.t("page_content.activity.level.#{super}").capitalize
   end
+
+  def link_to_roda
+    Rails.application.routes.url_helpers.organisation_activity_details_url(organisation, self, host: ENV["DOMAIN"]).to_s
+  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -1,0 +1,30 @@
+require "csv"
+
+class ExportActivityToCsv
+  attr_accessor :activity
+
+  def initialize(activity:)
+    @activity = activity
+  end
+
+  def call
+    activity_presenter = ActivityPresenter.new(activity)
+    [
+      activity_presenter.identifier,
+      activity_presenter.transparency_identifier,
+      activity_presenter.sector,
+      activity_presenter.title,
+      activity_presenter.description,
+      activity_presenter.status,
+      activity_presenter.planned_start_date,
+      activity_presenter.actual_start_date,
+      activity_presenter.planned_end_date,
+      activity_presenter.actual_end_date,
+      activity_presenter.recipient_region,
+      activity_presenter.recipient_country,
+      activity_presenter.aid_type,
+      activity_presenter.level,
+      "https://#{ENV["DOMAIN"]}#{Rails.application.routes.url_helpers.organisation_activity_details_path(activity_presenter.organisation, activity_presenter)}",
+    ].to_csv
+  end
+end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -24,7 +24,7 @@ class ExportActivityToCsv
       activity_presenter.recipient_country,
       activity_presenter.aid_type,
       activity_presenter.level,
-      "https://#{ENV["DOMAIN"]}#{Rails.application.routes.url_helpers.organisation_activity_details_path(activity_presenter.organisation, activity_presenter)}",
+      activity_presenter.link_to_roda,
     ].to_csv
   end
 end

--- a/app/views/staff/submissions/show.csv.haml
+++ b/app/views/staff/submissions/show.csv.haml
@@ -1,1 +1,0 @@
-= "Level A,Organisation,Implementing organisations,Title,Identifier,Recipient region,Focus area,Description,Planned start date,Actual start date,Planned end date,Sector,Channel of delivery code,Type of flow,Type of finance,Aid type,Link to RODA"

--- a/app/views/staff/submissions/show.html.haml
+++ b/app/views/staff/submissions/show.html.haml
@@ -6,9 +6,10 @@
       %h1.govuk-heading-xl
         = @submission.description
 
-  .govuk-grid-row
-    .govuk-grid-column-full.download-csv
-      %div.govuk-body
-        = t("page_content.submissions.download_as_csv")
-      = link_to t("default.button.download_as_csv"), submission_path(@submission, format: :csv), class: "govuk-button"
+  - if policy(@submission).download?
+    .govuk-grid-row
+      .govuk-grid-column-full.download-csv
+        %div.govuk-body
+          = t("page_content.submissions.download_as_csv")
+        = link_to t("default.button.download_as_csv"), submission_path(@submission, format: :csv), class: "govuk-button"
 

--- a/spec/features/staff/users_can_view_a_submission_spec.rb
+++ b/spec/features/staff/users_can_view_a_submission_spec.rb
@@ -30,8 +30,7 @@ RSpec.feature "Users can view a submission" do
       expect(page.response_headers["Content-Type"]).to include("text/csv")
 
       header = page.response_headers["Content-Disposition"]
-      expect(header).to match(/^attachment/)
-      expect(header).to match(/filename=\"#{ERB::Util.url_encode(submission.description)}.csv\"$/)
+      expect(header).to match(/#{submission.description}/)
     end
   end
 
@@ -70,8 +69,7 @@ RSpec.feature "Users can view a submission" do
       expect(page.response_headers["Content-Type"]).to include("text/csv")
 
       header = page.response_headers["Content-Disposition"]
-      expect(header).to match(/^attachment/)
-      expect(header).to match(/filename=\"#{ERB::Util.url_encode(submission.description)}.csv\"$/)
+      expect(header).to match(/#{submission.description}/)
     end
   end
 end

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SubmissionPolicy do
     let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
 
     it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_action(:destroy) }
@@ -35,11 +34,13 @@ RSpec.describe SubmissionPolicy do
     context "when the submission belongs to the user's organisation" do
       let(:submission) { create(:submission, organisation: user.organisation) }
       it { is_expected.to permit_action(:download) }
+      it { is_expected.to permit_action(:show) }
     end
 
     context "when the submission does not belong to the user's organisation" do
       let(:submission) { create(:submission, organisation: create(:organisation)) }
       it { is_expected.to forbid_action(:download) }
+      it { is_expected.to forbid_action(:show) }
     end
 
     it "includes only submissions that the users organisation is reporting in the resolved scope" do

--- a/spec/policies/submission_policy_spec.rb
+++ b/spec/policies/submission_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SubmissionPolicy do
   let(:submission) { create(:submission, organisation: organisation) }
   let(:another_submission) { create(:submission, organisation: create(:organisation)) }
 
-  subject { described_class.new(user, Submission) }
+  subject { described_class.new(user, submission) }
 
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
@@ -15,6 +15,7 @@ RSpec.describe SubmissionPolicy do
     it { is_expected.to permit_new_and_create_actions }
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to permit_action(:download) }
 
     it "includes all submissions in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Submission).resolve
@@ -30,6 +31,16 @@ RSpec.describe SubmissionPolicy do
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_new_and_create_actions }
     it { is_expected.to forbid_action(:destroy) }
+
+    context "when the submission belongs to the user's organisation" do
+      let(:submission) { create(:submission, organisation: user.organisation) }
+      it { is_expected.to permit_action(:download) }
+    end
+
+    context "when the submission does not belong to the user's organisation" do
+      let(:submission) { create(:submission, organisation: create(:organisation)) }
+      it { is_expected.to forbid_action(:download) }
+    end
 
     it "includes only submissions that the users organisation is reporting in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Submission).resolve

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -263,4 +263,11 @@ RSpec.describe ActivityPresenter do
       end
     end
   end
+
+  describe "#link_to_roda" do
+    it "returns the full URL to the activity in RODA" do
+      project = create(:project_activity)
+      expect(described_class.new(project).link_to_roda).to eq "http://test.local/organisations/#{project.organisation.id}/activities/#{project.id}/details"
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.recipient_country,
         activity_presenter.aid_type,
         activity_presenter.level,
-        "https://#{ENV["DOMAIN"]}#{Rails.application.routes.url_helpers.organisation_activity_details_path(activity_presenter.organisation, activity_presenter)}",
+        activity_presenter.link_to_roda,
       ].to_csv)
     end
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe ExportActivityToCsv do
+  let(:project) { create(:project_activity) }
+
+  describe "#call" do
+    it "creates a CSV line representation of the Activity" do
+      activity_presenter = ActivityPresenter.new(project)
+      result = ExportActivityToCsv.new(activity: project).call
+
+      expect(result).to eq([
+        activity_presenter.identifier,
+        activity_presenter.transparency_identifier,
+        activity_presenter.sector,
+        activity_presenter.title,
+        activity_presenter.description,
+        activity_presenter.status,
+        activity_presenter.planned_start_date,
+        activity_presenter.actual_start_date,
+        activity_presenter.planned_end_date,
+        activity_presenter.actual_end_date,
+        activity_presenter.recipient_region,
+        activity_presenter.recipient_country,
+        activity_presenter.aid_type,
+        activity_presenter.level,
+        "https://#{ENV["DOMAIN"]}#{Rails.application.routes.url_helpers.organisation_activity_details_path(activity_presenter.organisation, activity_presenter)}",
+      ].to_csv)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/QLknCpWs/859-the-report-csv-contains-activity-details

In a previous PR we added a basic CSV skeleton for the Submissions (Reports). This PR adds Activity data to this CSV download. Currently all level C & D activities in a Submission are included in the CSV. 

There is also a small refactor here, I have changed the CSV export from HAML to a CSV object sent with event streaming

Note that this should be merged after https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/555 and https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/559 because there is some overlap with functionality (`Activity#associated_fund`) and some changes of names will need to be refactored in.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
