### PR TITLE
(873) Prevent tests connecting to Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,11 @@ jobs:
       set -eu
       docker network create test
       docker run -d --name pg --network test -p 5432:5432 postgres:11.6
-      docker run -d --name redis --network test -p 6379:6379 redis:4.0.14
       docker run \
         --network test \
         -e RAILS_ENV=test \
         -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
         -e DATABASE_URL=postgres://postgres@pg:5432/roda_test \
-        -e REDIS_URL=redis://redis:6379 \
         -e TRAVIS="$TRAVIS" \
         -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" \
         -e TRAVIS_BRANCH="$TRAVIS_BRANCH" \

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "faker"
-  gem "mock_redis"
   gem "i18n-tasks", "~> 0.9.31"
   gem "rspec-rails"
   gem "standard"
@@ -70,6 +69,7 @@ group :test do
   gem "climate_control"
   gem "coveralls", require: false
   gem "database_cleaner"
+  gem "fakeredis", require: false
   gem "launchy"
   gem "pundit-matchers", "~> 1.6.0"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
       railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
+    fakeredis (0.8.0)
+      redis (~> 4.1)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.0)
@@ -201,7 +203,6 @@ GEM
     mini_racer (0.3.1)
       libv8 (~> 8.4.255)
     minitest (5.14.1)
-    mock_redis (0.25.0)
     monetize (1.9.4)
       money (~> 6.12)
     money (6.13.7)
@@ -449,6 +450,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  fakeredis
   govuk_design_system_formbuilder (~> 1.2.6)
   haml-rails
   high_voltage
@@ -461,7 +463,6 @@ DEPENDENCIES
   lograge
   mail-notify
   mini_racer
-  mock_redis
   monetize
   omniauth-auth0 (~> 2.3)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,12 +1,8 @@
 require "connection_pool"
 
-REDIS = if Rails.env.test?
-  Redis::Namespace.new(:test, redis: MockRedis.new)
-else
-  ConnectionPool.new(size: 5, timeout: 5) do
-    Redis::Namespace.new(
-      :roda,
-      redis: Redis.new(url: ENV["REDIS_URL"])
-    )
-  end
-end
+REDIS = ConnectionPool.new(size: 5, timeout: 5) {
+  Redis::Namespace.new(
+    :roda,
+    redis: Redis.new(url: ENV["REDIS_URL"])
+  )
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
-require "mock_redis"
+require "fakeredis/rspec"
 
 # Testing for public_activity gem
 require "public_activity/testing"


### PR DESCRIPTION
In the past we set up `mock_redis` to stand in for Redis in the test environment. Unfortunately, when we added the JavaScript tests, Redis gets used once more because the headless browser uses the session store that is connecting to Redis directly, skipping the mocked version.

Because the Redis session store only accepts a list of servers, rather than already-instantiated Redis instances, we can't use `mock_redis` here.

I've replaced `mock_redis` with `fakeredis` gem.  When required in `rails_helper.rb` it replaces `Redis.new` with a fake version, so this works everywhere including the session store.

**To test locally: stop Redis on your local development environment, and the test suite will continue to pass**