### PR TITLE
(864) Transaction actuals totals are included in the CSV download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@
 - rename Submission to Report
 - reports can be managed in the reports section of the application
 - remove submission from the organisation page
+- Add `transactions_total` to Activity and add it to the Submission CSV per Activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -139,4 +139,8 @@ class Activity < ApplicationRecord
       parent_identifiers << parent.identifier
     }.push(identifier).join("-")
   end
+
+  def transactions_total
+    transactions.sum(:value)
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@ class Activity < ApplicationRecord
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
-  CSV_HEADERS = ["Identifier", "Transparency identifier", "Sector", "Title", "Description", "Status", "Planned start date", "Actual start date", "Planned end date", "Actual end date", "Recipient region", "Recipient country", "Aid type", "Level", "Link to activity in RODA"]
+  CSV_HEADERS = ["Identifier", "Transparency identifier", "Sector", "Title", "Description", "Status", "Planned start date", "Actual start date", "Planned end date", "Actual end date", "Recipient region", "Recipient country", "Aid type", "Level", "Actual", "Link to activity in RODA"]
 
   VALIDATION_STEPS = [
     :level_step,

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -80,4 +80,9 @@ class ActivityPresenter < SimpleDelegator
   def link_to_roda
     Rails.application.routes.url_helpers.organisation_activity_details_url(organisation, self, host: ENV["DOMAIN"]).to_s
   end
+
+  def transactions_total
+    return if super.blank?
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -24,6 +24,7 @@ class ExportActivityToCsv
       activity_presenter.recipient_country,
       activity_presenter.aid_type,
       activity_presenter.level,
+      activity_presenter.transactions_total,
       activity_presenter.link_to_roda,
     ].to_csv
   end

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature "BEIS users can edit a report" do
         click_on I18n.t("default.button.submit")
 
         auditable_events = PublicActivity::Activity.where(trackable_id: report.id)
-        expect(auditable_events.map(&:key)).to eq ["report.update", "report.activate"]
+        expect(auditable_events.map(&:key)).to match_array ["report.update", "report.activate"]
         expect(auditable_events.map(&:owner_id).uniq).to eq [beis_user.id]
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -602,4 +602,14 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  describe "#transactions_total" do
+    it "returns the total of all the activity's transactions" do
+      project = create(:project_activity)
+      _transaction_1 = create(:transaction, parent_activity: project, value: 100.20)
+      _transaction_2 = create(:transaction, parent_activity: project, value: 210)
+
+      expect(project.transactions_total).to eq(310.20)
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -270,4 +270,15 @@ RSpec.describe ActivityPresenter do
       expect(described_class.new(project).link_to_roda).to eq "http://test.local/organisations/#{project.organisation.id}/activities/#{project.id}/details"
     end
   end
+
+  describe "#transactions_total" do
+    it "returns the transaction total as a formatted number with currency symbol" do
+      project = create(:project_activity)
+      _transaction_1 = create(:transaction, parent_activity: project, value: 100.20)
+      _transaction_2 = create(:transaction, parent_activity: project, value: 300)
+
+      expect(described_class.new(project).transactions_total)
+        .to eq "£400.20"
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.recipient_country,
         activity_presenter.aid_type,
         activity_presenter.level,
+        activity_presenter.transactions_total,
         activity_presenter.link_to_roda,
       ].to_csv)
     end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/fp8pacDC/864-transaction-actuals-totals-are-included-in-the-csv-download

Add a `transactions_total` method to the Activity model to calculate the sum of all transactions associated to that Activity (thank you @mec for the spike)

Style the total using the ActivityPresenter.

Add the total to the Submission CSV download per Activity line.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
