### PR TITLE
(891) URL encode report CSV filename so it is not truncated

### DIFF
--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -85,7 +85,7 @@ class Staff::ReportsController < Staff::BaseController
 
   def send_csv
     response.headers["Content-Type"] = "text/csv"
-    response.headers["Content-Disposition"] = "attachment; filename=#{@report.description}.csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
     response.stream.write Activity::CSV_HEADERS.to_csv
     @projects.each do |project|
       response.stream.write ExportActivityToCsv.new(activity: project).call

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Users can view reports" do
     end
 
     scenario "can download a CSV of the report" do
-      report = create(:report, :active)
+      report = create(:report, :active, description: "Legacy Report")
 
       visit reports_path
 
@@ -59,7 +59,7 @@ RSpec.feature "Users can view reports" do
 
       expect(page.response_headers["Content-Type"]).to include("text/csv")
       header = page.response_headers["Content-Disposition"]
-      expect(header).to match(/#{report.description}/)
+      expect(header).to match(/Legacy%20Report/)
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.feature "Users can view reports" do
       end
 
       scenario "can download a CSV of their own report" do
-        report = create(:report, :active, organisation: delivery_partner_user.organisation)
+        report = create(:report, :active, organisation: delivery_partner_user.organisation, description: "Legacy Report")
 
         visit reports_path
 
@@ -125,7 +125,7 @@ RSpec.feature "Users can view reports" do
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
         header = page.response_headers["Content-Disposition"]
-        expect(header).to match(/#{report.description}/)
+        expect(header).to match(/Legacy%20Report/)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/PcSYrR3E/891-the-csv-attachment-filename-is-truncated

URL encode the CSV attachment filename so it does not get truncated. Tested on a Mac in Chrome, Safari & FF; hopefully this covers most bases.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
