### PR TITLE
(889) Associate PlannedDisbursements to Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@
 - Migrate AMS GCRF activities from Level C to Level B and update identifiers
 - Ingest creates new activities at a level below its parent
 - Reports store the relevant financial quarter
+- Associate Planned Disbursements to Reports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -5,6 +5,7 @@ class PlannedDisbursement < ApplicationRecord
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"
+  belongs_to :report
 
   validates_presence_of :planned_disbursement_type,
     :period_start_date,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -9,6 +9,7 @@ class Report < ApplicationRecord
   belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"
   belongs_to :organisation
   has_many :transactions
+  has_many :planned_disbursements
 
   validates_uniqueness_of :fund, scope: :organisation
   validate :activity_must_be_a_fund

--- a/app/policies/planned_disbursement_policy.rb
+++ b/app/policies/planned_disbursement_policy.rb
@@ -1,15 +1,24 @@
 class PlannedDisbursementPolicy < ApplicationPolicy
   def create?
     return false if record.parent_activity.fund? || record.parent_activity.programme?
-    Pundit.policy!(user, record.parent_activity).create?
+    Pundit.policy!(user, record.parent_activity).create? && !!associated_report&.active?
   end
 
   def update?
     return false if record.parent_activity.fund? || record.parent_activity.programme?
-    Pundit.policy!(user, record.parent_activity).update?
+    Pundit.policy!(user, record.parent_activity).update? && !!associated_report&.active?
   end
 
   def destroy?
     false
+  end
+
+  private
+
+  def associated_report
+    parent_activity = record.parent_activity
+    organisation = parent_activity.organisation
+    fund = parent_activity.associated_fund
+    Report.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -9,6 +9,7 @@ class CreatePlannedDisbursement
     planned_disbursement = PlannedDisbursement.new
 
     planned_disbursement.parent_activity = activity
+    planned_disbursement.report = report
     planned_disbursement.assign_attributes(attributes)
     planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
 
@@ -25,5 +26,11 @@ class CreatePlannedDisbursement
 
   def sanitize_monetary_string(value:)
     Monetize.parse(value)
+  end
+
+  def report
+    organisation = activity.organisation
+    fund = activity.associated_fund
+    Report.active.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -216,6 +216,8 @@ class IngestIatiActivities
       receiving_organisation_reference = receiving_organisation.attributes["ref"].try(:value)
       receiving_organisation_type = receiving_organisation_type(attribute: receiving_organisation.attributes["type"], implementing_organisation: roda_activity.implementing_organisations.first)
 
+      report = Report.find_by(fund: roda_activity.associated_fund, organisation: roda_activity.organisation)
+
       planned_disbursement = PlannedDisbursement.new(
         planned_disbursement_type: planned_disbursement_type,
         period_start_date: period_start_date,
@@ -229,6 +231,7 @@ class IngestIatiActivities
         receiving_organisation_name: receiving_organisation_name,
         receiving_organisation_type: receiving_organisation_type,
         receiving_organisation_reference: receiving_organisation_reference,
+        report: report,
         ingested: true
       )
       planned_disbursement.save!

--- a/db/migrate/20200812151612_add_association_between_report_and_planned_disbursements.rb
+++ b/db/migrate/20200812151612_add_association_between_report_and_planned_disbursements.rb
@@ -1,0 +1,5 @@
+class AddAssociationBetweenReportAndPlannedDisbursements < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :planned_disbursements, :report, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,7 +130,9 @@ ActiveRecord::Schema.define(version: 2020_08_14_134116) do
     t.uuid "parent_activity_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "report_id"
     t.index ["parent_activity_id"], name: "index_planned_disbursements_on_parent_activity_id"
+    t.index ["report_id"], name: "index_planned_disbursements_on_report_id"
   end
 
   create_table "reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -71,6 +71,13 @@ FactoryBot.define do
       association :extending_organisation, factory: :delivery_partner_organisation
       association :reporting_organisation, factory: :beis_organisation
 
+      trait :with_report do
+        after(:create) do |project|
+          fund = project.associated_fund
+          create(:report, :active, fund: fund, organisation: project.organisation)
+        end
+      end
+
       factory :project_activity_with_implementing_organisations do
         transient do
           implementing_organisations_count { 3 }

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -23,6 +23,13 @@ FactoryBot.define do
     association :organisation, factory: :organisation
     association :reporting_organisation, factory: :beis_organisation
 
+    trait :with_report do
+      after(:create) do |activity|
+        fund = activity.associated_fund
+        create(:report, :active, fund: fund, organisation: activity.organisation)
+      end
+    end
+
     factory :fund_activity do
       level { :fund }
       funding_organisation_name { "HM Treasury" }
@@ -35,12 +42,6 @@ FactoryBot.define do
       association :organisation, factory: :beis_organisation
       association :extending_organisation, factory: :beis_organisation
       association :reporting_organisation, factory: :beis_organisation
-
-      trait :with_report do
-        after(:create) do |fund|
-          create(:report, :active, fund: fund, organisation: fund.organisation)
-        end
-      end
     end
 
     factory :programme_activity do
@@ -70,13 +71,6 @@ FactoryBot.define do
 
       association :extending_organisation, factory: :delivery_partner_organisation
       association :reporting_organisation, factory: :beis_organisation
-
-      trait :with_report do
-        after(:create) do |project|
-          fund = project.associated_fund
-          create(:report, :active, fund: fund, organisation: project.organisation)
-        end
-      end
 
       factory :project_activity_with_implementing_organisations do
         transient do

--- a/spec/factories/planned_disbursement.rb
+++ b/spec/factories/planned_disbursement.rb
@@ -11,5 +11,7 @@ FactoryBot.define do
     receiving_organisation_name { Faker::Company.name }
     receiving_organisation_reference { "GB-COH-{#{Faker::Number.number(digits: 6)}}" }
     receiving_organisation_type { "70" }
+
+    association :report
   end
 end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe "Users can create a planned disbursement" do
       context "and the activity is a project" do
         it "pre fills the providing organisation details with those of BEIS" do
           beis = create(:beis_organisation)
-          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
-          user.update(organisation: government_devlivery_partner)
-          project = create(:project_activity, organisation: user.organisation)
+          government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
+          user.update(organisation: government_delivery_partner)
+          project = create(:project_activity, :with_report, organisation: user.organisation)
 
           visit activities_path
           click_on project.title
@@ -92,9 +92,9 @@ RSpec.describe "Users can create a planned disbursement" do
       context "and the activity is a third-party project" do
         it "pre fills the providing organisation details with those of BEIS" do
           beis = create(:beis_organisation)
-          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
-          user.update(organisation: government_devlivery_partner)
-          project = create(:third_party_project_activity, organisation: user.organisation)
+          government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
+          user.update(organisation: government_delivery_partner)
+          project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
 
           visit organisation_activity_path(user.organisation, project)
           click_on I18n.t("page_content.planned_disbursements.button.create")
@@ -112,7 +112,7 @@ RSpec.describe "Users can create a planned disbursement" do
           beis = create(:beis_organisation)
           government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
           user.update(organisation: government_devlivery_partner)
-          project = create(:project_activity, organisation: user.organisation)
+          project = create(:project_activity, :with_report, organisation: user.organisation)
 
           visit activities_path
           click_on project.title
@@ -124,10 +124,10 @@ RSpec.describe "Users can create a planned disbursement" do
         end
       end
       context "and the activity is a third-party project" do
-        it "pre fills the providing organisation detauls with those of the delivery partner" do
+        it "pre fills the providing organisation details with those of the delivery partner" do
           non_government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "22")
           user.update(organisation: non_government_devlivery_partner)
-          project = create(:third_party_project_activity, organisation: user.organisation)
+          project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
 
           visit organisation_activity_path(user.organisation, project)
           click_on I18n.t("page_content.planned_disbursements.button.create")

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -284,8 +284,7 @@ RSpec.feature "Users can create a transaction" do
       scenario "the transaction is associated with the currently active report" do
         fund = create(:fund_activity)
         programme = create(:programme_activity, parent: fund)
-        report = create(:report, :active, organisation: user.organisation, fund: fund)
-        project = create(:project_activity, organisation: user.organisation, parent: programme)
+        project = create(:project_activity, :with_report, organisation: user.organisation, parent: programme)
 
         visit organisation_activity_path(user.organisation, project)
         click_on "Add a transaction"
@@ -293,6 +292,7 @@ RSpec.feature "Users can create a transaction" do
         fill_in_transaction_form
 
         transaction = Transaction.last
+        report = Report.find_by(fund: fund, organisation: project.organisation)
         expect(transaction.report).to eq(report)
       end
     end

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Users can edit a planned disbursement" do
 
     scenario "they can edit a planned disbursement" do
       organisation = user.organisation
-      project = create(:project_activity, organisation: user.organisation)
+      project = create(:project_activity, :with_report, organisation: user.organisation)
       planned_disbursement = create(:planned_disbursement, parent_activity: project)
       visit organisation_activity_path(organisation, project)
 
@@ -25,7 +25,7 @@ RSpec.describe "Users can edit a planned disbursement" do
 
     scenario "the action is recorded with public_activity" do
       PublicActivity.with_tracking do
-        project = create(:project_activity, organisation: user.organisation)
+        project = create(:project_activity, :with_report, organisation: user.organisation)
         planned_disbursement = create(:planned_disbursement, parent_activity: project)
 
         visit activities_path

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe PlannedDisbursement, type: :model do
     end
   end
 
+  describe "associations" do
+    it { should belong_to(:report) }
+  end
+
   describe "sanitation" do
     it { should strip_attribute(:providing_organisation_reference) }
     it { should strip_attribute(:receiving_organisation_reference) }

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -2,76 +2,90 @@ require "rails_helper"
 
 RSpec.describe PlannedDisbursementPolicy do
   let(:user) { create(:beis_user) }
-  let(:activity) { create(:project_activity, organisation: user.organisation) }
+  let(:activity) { create(:project_activity, :with_report, organisation: user.organisation) }
   let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
 
   subject { described_class.new(user, planned_disbursement) }
 
   describe "#create?" do
-    context "when the parent is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
-      it { is_expected.to forbid_action(:create) }
-    end
-
-    context "when the parent is a programme" do
-      let(:activity) { create(:programme_activity, organisation: user.organisation) }
-      it { is_expected.to forbid_action(:create) }
-    end
-
-    context "when the parent is a project" do
+    context "when there is no active Report to attach this planned disbursement to" do
       let(:activity) { create(:project_activity, organisation: user.organisation) }
-      it { is_expected.to permit_action(:create) }
-    end
-
-    context "when the parent is a third_party_project" do
-      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
-      it { is_expected.to permit_action(:create) }
-    end
-
-    context "when the user belongs to the authoring organisation" do
-      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
-      it { is_expected.to permit_action(:create) }
-    end
-
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
       it { is_expected.to forbid_action(:create) }
+    end
+
+    context "when there is an active Report to attach this planned disbursement to" do
+      context "when the parent is a fund" do
+        let(:activity) { create(:fund_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to forbid_action(:create) }
+      end
+
+      context "when the parent is a programme" do
+        let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to forbid_action(:create) }
+      end
+
+      context "when the parent is a project" do
+        let(:activity) { create(:project_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context "when the parent is a third_party_project" do
+        let(:activity) { create(:third_party_project_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context "when the user belongs to the authoring organisation" do
+        let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+        it { is_expected.to permit_action(:create) }
+      end
+
+      context "when the user does NOT belong to the authoring organisation" do
+        let(:another_organisation) { create(:organisation) }
+        let(:activity) { create(:activity, organisation: another_organisation) }
+        let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+        it { is_expected.to forbid_action(:create) }
+      end
     end
   end
 
   describe "#update?" do
-    context "when the parent is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
-      it { is_expected.to forbid_action(:update) }
-    end
-
-    context "when the parent is a programme" do
-      let(:activity) { create(:programme_activity, organisation: user.organisation) }
-      it { is_expected.to forbid_action(:update) }
-    end
-
-    context "when the parent is a project" do
+    context "when there is no active Report to attach this planned disbursement to" do
       let(:activity) { create(:project_activity, organisation: user.organisation) }
-      it { is_expected.to permit_action(:update) }
-    end
-
-    context "when the parent is a third_party_project" do
-      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
-      it { is_expected.to permit_action(:update) }
-    end
-
-    context "when the user belongs to the authoring organisation" do
-      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
-      it { is_expected.to permit_action(:update) }
-    end
-
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
       it { is_expected.to forbid_action(:update) }
+    end
+
+    context "when there is an active Report to attach this planned disbursement to" do
+      context "when the parent is a fund" do
+        let(:activity) { create(:fund_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to forbid_action(:update) }
+      end
+
+      context "when the parent is a programme" do
+        let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to forbid_action(:update) }
+      end
+
+      context "when the parent is a project" do
+        let(:activity) { create(:project_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to permit_action(:update) }
+      end
+
+      context "when the parent is a third_party_project" do
+        let(:activity) { create(:third_party_project_activity, :with_report, organisation: user.organisation) }
+        it { is_expected.to permit_action(:update) }
+      end
+
+      context "when the user belongs to the authoring organisation" do
+        let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+        it { is_expected.to permit_action(:update) }
+      end
+
+      context "when the user does NOT belong to the authoring organisation" do
+        let(:another_organisation) { create(:organisation) }
+        let(:activity) { create(:activity, organisation: another_organisation) }
+        let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity) }
+        it { is_expected.to forbid_action(:update) }
+      end
     end
   end
 

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe IngestIatiActivities do
     context "ingesting budgets" do
       it "creates budgets and marks them as ingested" do
         uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        _report = create(:report, :active, organisation: uksa, fund: existing_activity.associated_fund)
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_budget.xml")
 
         described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
@@ -363,6 +364,7 @@ RSpec.describe IngestIatiActivities do
     context "when a description has escaped characters and extra whitespace" do
       it "normalizes the text" do
         uksa = create(:organisation, name: "UKSA", iati_reference: "GB-GOV-EA31")
+        _report = create(:report, :active, organisation: uksa, fund: existing_activity.associated_fund)
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/uksa/with_escaped_characters.xml")
 
         described_class.new(delivery_partner: uksa, file_io: legacy_activities).call


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/GiEQQVOZ/889-associate-planned-disbursements-to-reports

Create an association between Planned Disbursements and Reports, much like we did for Transactions and Reports in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/555

We assume an `active` Report always exists, in order to associate with Planned Disbursements on create and ingest. 

Add a `:with_report` trait to the `project_activity` factory, to create an associated Report after the Project Activity is created.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
