### PR TITLE
(845) Add `programme status` field to activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,7 +243,8 @@
 - Associate Planned Disbursements to Reports
 - Update extending organisation question content
 - `programme status` field added to activity form in exchange for old IATI status.
-  Mapping `programme_status` to `IATI_status` included
+  Mapping `programme_status` to `IATI_status` included. Schema migration to replace
+  `form_state` at `status` step for `programme_status` step
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,8 @@
 - Reports store the relevant financial quarter
 - Associate Planned Disbursements to Reports
 - Update extending organisation question content
+- `programme status` field added to activity form in exchange for old IATI status.
+  Mapping `programme_status` to `IATI_status` included
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -65,8 +65,9 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(sector_category: sector_category, sector: nil)
     when :sector
       @activity.assign_attributes(sector: sector)
-    when :status
-      @activity.assign_attributes(status: status)
+    when :programme_status
+      iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(programme_status)
+      @activity.assign_attributes(programme_status: programme_status, status: iati_status)
     when :dates
       @activity.assign_attributes(
         planned_start_date: format_date(planned_start_date),

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -11,7 +11,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :purpose,
     :sector_category,
     :sector,
-    :status,
+    :programme_status,
     :dates,
     :geography,
     :region,
@@ -128,8 +128,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     params.require(:activity).permit(:description).fetch("description", nil)
   end
 
-  def status
-    params.require(:activity).permit(:status).fetch("status", nil)
+  def programme_status
+    params.require(:activity).permit(:programme_status).fetch("programme_status", nil)
   end
 
   def planned_start_date

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,7 +12,7 @@ class Activity < ApplicationRecord
     :purpose_step,
     :sector_category_step,
     :sector_step,
-    :status_step,
+    :programme_status_step,
     :geography_step,
     :region_step,
     :country_step,
@@ -28,7 +28,7 @@ class Activity < ApplicationRecord
   validates :title, :description, presence: true, on: :purpose_step
   validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
-  validates :status, presence: true, on: :status_step
+  validates :programme_status, presence: true, on: :programme_status_step
   validates :geography, presence: true, on: :geography_step
   validates :recipient_region, presence: true, on: :region_step, if: :recipient_region?
   validates :recipient_country, presence: true, on: :country_step, if: :recipient_country?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -13,9 +13,9 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.sector.#{super}")
   end
 
-  def status
+  def programme_status
     return if super.blank?
-    I18n.t("activity.status.#{super}")
+    I18n.t("activity.programme_status.#{super}")
   end
 
   def planned_start_date

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -33,6 +33,7 @@ class IngestIatiActivities
           add_participating_organisation(delivery_partner: delivery_partner, new_activity: new_activity, legacy_activity: legacy_activity)
           add_title(legacy_activity: legacy_activity, new_activity: new_activity)
           add_description(legacy_activity: legacy_activity, new_activity: new_activity)
+          add_programme_status(legacy_activity: legacy_activity, new_activity: new_activity)
           add_status(legacy_activity: legacy_activity, new_activity: new_activity)
           add_sector(legacy_activity: legacy_activity, new_activity: new_activity)
           add_flow(legacy_activity: legacy_activity, new_activity: new_activity)
@@ -68,6 +69,11 @@ class IngestIatiActivities
   private def add_description(legacy_activity:, new_activity:)
     description = legacy_activity.elements[3].children.detect { |child| child.name.eql?("narrative") }.children.text if legacy_activity.elements[3].name.eql?("description")
     new_activity.description = normalize_string(description)
+  end
+
+  private def add_programme_status(legacy_activity:, new_activity:)
+    # This will need to be replaced once we have a bi-directional mapping between programme_status and IATI status
+    new_activity.programme_status = "Replace me"
   end
 
   private def add_status(legacy_activity:, new_activity:)

--- a/app/services/programme_to_iati_status.rb
+++ b/app/services/programme_to_iati_status.rb
@@ -1,0 +1,20 @@
+class ProgrammeToIatiStatus
+  STATUS_MAPPING = {
+    "01" => "2",
+    "02" => "1",
+    "03" => "1",
+    "04" => "1",
+    "05" => "1",
+    "06" => "1",
+    "07" => "2",
+    "08" => "3",
+    "09" => "4",
+    "10" => "5",
+    "11" => "5",
+  }.freeze
+
+  def programme_status_to_iati_status(programme_status)
+    return nil if programme_status.blank?
+    STATUS_MAPPING[programme_status]
+  end
+end

--- a/app/views/staff/activity_forms/programme_status.html.haml
+++ b/app/views/staff/activity_forms/programme_status.html.haml
@@ -1,0 +1,8 @@
+= render layout: "wrapper" do |f|
+  = f.hidden_field :programme_status, value: nil
+  = f.govuk_collection_radio_buttons :programme_status,
+    yaml_to_objects_with_description(entity: "activity", type: "programme_status"),
+    :code,
+    :name,
+    :description,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.programme_status", level: t("page_content.activity.level.#{f.object.level}")) }

--- a/app/views/staff/activity_forms/status.html.haml
+++ b/app/views/staff/activity_forms/status.html.haml
@@ -1,8 +1,0 @@
-= render layout: "wrapper" do |f|
-  = f.hidden_field :status, value: nil
-  = f.govuk_collection_radio_buttons :status,
-    yaml_to_objects_with_description(entity: "activity", type: "status"),
-    :code,
-    :name,
-    :description,
-    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.status", level: t("page_content.activity.level.#{f.object.level}")) }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -67,14 +67,14 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("summary.label.activity.sector"))
 
-  .govuk-summary-list__row.status
+  .govuk-summary-list__row.programme_status
     %dt.govuk-summary-list__key
-      = t("summary.label.activity.status")
+      = t("summary.label.activity.programme_status")
     %dd.govuk-summary-list__value
-      = activity_presenter.status
+      = activity_presenter.programme_status
     %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :status)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:status)}"), activity_step_path(activity_presenter, :status), t("summary.label.activity.status"))
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :programme_status)
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:programme_status)}"), activity_step_path(activity_presenter, :programme_status), t("summary.label.activity.programme_status"))
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -658,6 +658,18 @@ en:
       '920': SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
       '930': Refugees in Donor Countries
       '998': Unallocated / Unspecified
+    programme_status:
+      '01': Delivery
+      '02': Planned
+      '03': Agreement in place
+      '04': Call/Activity open
+      '05': Review
+      '06': Decided
+      '07': Spend in progress
+      '08': Finalisation
+      '09': Completed
+      '10': Stopped
+      '11': Cancelled
     status:
       '1': Pipeline/identification
       '2': Implementation

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -45,6 +45,7 @@ en:
         parent: Select the parent activity
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
         sector: Which %{sector_category} sector is the focus area for this %{level}?
         sector_category: What area of the economy or society is the %{level} helping?
@@ -91,6 +92,7 @@ en:
         planned_disbursements: Planned disbursements
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        programme_status: Activity status
         projects: Projects
         recipient_country: Recipient country
         recipient_region: Recipient region
@@ -180,6 +182,7 @@ en:
         identifier: Enter your unique identifier
         level: Hierarchy level
         parent: Select the parent
+        programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
         region: What region will benefit from this activity?
         sector: Which %{sector_category} sector is the focus area for this %{level}

--- a/db/migrate/20200803104010_add_programme_status_to_activities.rb
+++ b/db/migrate/20200803104010_add_programme_status_to_activities.rb
@@ -1,0 +1,5 @@
+class AddProgrammeStatusToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :programme_status, :string
+  end
+end

--- a/db/migrate/20200817144853_change_status_to_programme_status_on_form_state.rb
+++ b/db/migrate/20200817144853_change_status_to_programme_status_on_form_state.rb
@@ -1,0 +1,9 @@
+class ChangeStatusToProgrammeStatusOnFormState < ActiveRecord::Migration[6.0]
+  def up
+    Activity.where(form_state: "status").update_all(form_state: "programme_status")
+  end
+
+  def down
+    Activity.where(form_state: "programme_status").update_all(form_state: "status")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_134116) do
+ActiveRecord::Schema.define(version: 2020_08_17_144853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_134116) do
     t.boolean "publish_to_iati", default: true
     t.uuid "parent_id"
     t.string "transparency_identifier"
+    t.string "programme_status"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }
-    status { "2" }
+    programme_status { "07" }
     planned_start_date { Date.today }
     planned_end_date { Date.tomorrow }
     actual_start_date { Date.yesterday }
@@ -105,7 +105,7 @@ FactoryBot.define do
     description { nil }
     sector_category { nil }
     sector { nil }
-    status { nil }
+    programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
     actual_start_date { nil }
@@ -122,7 +122,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
-    status { nil }
+    programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
     actual_start_date { nil }
@@ -158,7 +158,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
-    status { nil }
+    programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
     actual_start_date { nil }
@@ -180,7 +180,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
-    status { nil }
+    programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
     actual_start_date { nil }
@@ -201,7 +201,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
-    status { nil }
+    programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
     actual_start_date { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -167,22 +167,20 @@ RSpec.feature "Users can create a fund level activity" do
         click_button I18n.t("form.button.activity.submit")
 
         expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: "Basic Education", level: "programme")
-
         # Don't provide a sector
         click_button I18n.t("form.button.activity.submit")
         expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.sector.blank")
 
         choose "Primary education"
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.status", level: "programme")
+        expect(page).to have_content I18n.t("form.legend.activity.programme_status", level: "programme")
 
-        # Don't provide a status
+        # Don't provide a programme status
         click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.status.blank")
+        expect(page).to have_content "can't be blank"
 
-        choose("activity[status]", option: "2")
+        choose("activity[programme_status]", option: "07")
         click_button I18n.t("form.button.activity.submit")
-
         expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: "programme")
 
         click_button I18n.t("form.button.activity.submit")

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -380,10 +380,10 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
   click_on I18n.t("tabs.activity.details")
 
-  within(".status") do
+  within(".programme_status") do
     click_on(I18n.t("default.link.edit"))
     expect(page).to have_current_path(
-      activity_step_path(activity, :status)
+      activity_step_path(activity, :programme_status)
     )
   end
   click_on(I18n.t("default.link.back"))

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ActivityHelper, type: :helper do
       it "returns false for the next fields following the purpose field" do
         activity = build(:activity, :at_identifier_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "sector")).to be(false)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "status")).to be(false)
+        expect(helper.step_is_complete_or_next?(activity: activity, step: "programme_status")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "dates")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "region")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(false)
@@ -27,7 +27,7 @@ RSpec.describe ActivityHelper, type: :helper do
         activity = build(:activity, :at_region_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "purpose")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "sector")).to be(true)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "status")).to be(true)
+        expect(helper.step_is_complete_or_next?(activity: activity, step: "programme_status")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "dates")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "region")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(true)

--- a/spec/lib/programme_to_iati_status_spec.rb
+++ b/spec/lib/programme_to_iati_status_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "#programme_status_to_iati_status" do
+  context "when the user sets the programme status for an activity" do
+    it "sets the correct IATI status automatically" do
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("01")
+      expect(status).to eq "2"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("02")
+      expect(status).to eq "1"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("03")
+      expect(status).to eq "1"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("04")
+      expect(status).to eq "1"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("05")
+      expect(status).to eq "1"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("06")
+      expect(status).to eq "1"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("07")
+      expect(status).to eq "2"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("08")
+      expect(status).to eq "3"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("09")
+      expect(status).to eq "4"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("10")
+      expect(status).to eq "5"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("11")
+      expect(status).to eq "5"
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -158,10 +158,10 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when status is blank" do
-      subject(:activity) { build(:activity, status: nil) }
+    context "when programme status is blank" do
+      subject(:activity) { build(:activity, programme_status: nil) }
       it "should not be valid" do
-        expect(activity.valid?(:status_step)).to be_falsey
+        expect(activity.valid?(:programme_status_step)).to be_falsey
       end
     end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -45,20 +45,20 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#status" do
-    context "when the status exists" do
+  describe "#programme_status" do
+    context "when the programme status exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, status: "2")
-        result = described_class.new(activity).status
-        expect(result).to eql("Implementation")
+        activity = build(:activity, programme_status: "07")
+        result = described_class.new(activity).programme_status
+        expect(result).to eql("Spend in progress")
       end
     end
 
-    context "when the activity does not have a status set" do
+    context "when the activity does not have a programme status set" do
       it "returns nil" do
-        activity = build(:activity, status: nil)
+        activity = build(:activity, programme_status: nil)
         result = described_class.new(activity)
-        expect(result.status).to be_nil
+        expect(result.programme_status).to be_nil
       end
     end
   end

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -25,8 +25,8 @@ module ActivityHelpers
     expect(page).to have_content I18n.t("summary.label.activity.sector", level: activity_presenter.level)
     expect(page).to have_content activity_presenter.sector
 
-    expect(page).to have_content I18n.t("summary.label.activity.status")
-    expect(page).to have_content activity_presenter.status
+    expect(page).to have_content I18n.t("summary.label.activity.programme_status")
+    expect(page).to have_content activity_presenter.programme_status
 
     expect(page).to have_content I18n.t("summary.label.activity.planned_start_date")
     expect(page).to have_content activity_presenter.planned_start_date

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -141,6 +141,11 @@ module FormHelpers
       month: planned_end_date_month,
       day: planned_end_date_day
     )
+
+    my_activity = Activity.find_by(identifier: identifier)
+    iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(programme_status)
+    expect(my_activity.status).not_to be_nil
+    expect(my_activity.status).to eq(iati_status)
   end
 
   def fill_in_transaction_form(expectations: true,

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -5,7 +5,7 @@ module FormHelpers
     description: Faker::Lorem.paragraph,
     sector_category: "Basic Education",
     sector: "Primary education",
-    status: "2",
+    programme_status: "07",
     planned_start_date_day: "1",
     planned_start_date_month: "1",
     planned_start_date_year: "2020",
@@ -65,15 +65,20 @@ module FormHelpers
     choose sector
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.status", level: activity_level(level))
-    expect(page).to have_content "The activity is being scoped or planned"
-    expect(page).to have_content "The activity is currently being implemented"
-    expect(page).to have_content "Physical activity is complete or the final disbursement has been made"
-    expect(page).to have_content "Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&E"
-    expect(page).to have_content "The activity has been cancelled"
-    expect(page).to have_content "The activity has been temporarily suspended"
+    expect(page).to have_content I18n.t("form.legend.activity.programme_status")
+    expect(page).to have_content "Delivery"
+    expect(page).to have_content "Planned"
+    expect(page).to have_content "Agreement in place"
+    expect(page).to have_content "Call/Activity open"
+    expect(page).to have_content "Review"
+    expect(page).to have_content "Decided"
+    expect(page).to have_content "Spend in progress"
+    expect(page).to have_content "Finalisation"
+    expect(page).to have_content "Completed"
+    expect(page).to have_content "Stopped"
+    expect(page).to have_content "Cancelled"
 
-    choose("activity[status]", option: status)
+    choose("activity[programme_status]", option: programme_status)
     click_button I18n.t("form.button.activity.submit")
 
     expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: activity_level(level))
@@ -122,7 +127,7 @@ module FormHelpers
     expect(page).to have_content title
     expect(page).to have_content description
     expect(page).to have_content sector
-    expect(page).to have_content status
+    expect(page).to have_content I18n.t("activity.programme_status.#{programme_status}")
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
     expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")

--- a/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
@@ -1,0 +1,43 @@
+---
+attributes:
+  category-codelist:
+  name: ProgrammeStatus
+  complete: '1'
+data:
+  - code: '01'
+    name: Delivery
+    description: Activities related to delivery of ODA activities only
+  - code: '02'
+    name: Planned
+    description: Scoping negotiations and/or workshops have begun but no formal commitment has been made between the UK Delivery Partner. Scoping activity. Financial allocation has been made
+  - code: '03'
+    name: Agreement in place
+    description: A formal agreement to fund the activity has been made, or is at outline stage. For activities in outline stage, please only progress to 'Call/Activity open' if a full call is initiated
+  - code: '04'
+    name: Call/Activity open
+    description: The call/activity is open for applications
+  - code: '05'
+    name: Review
+    description: The application period has ended and the activity is in the peer review stage. The panek neetubg has not yet happened
+  - code: '06'
+    name: Decided
+    description: Awards have been made (i.e. panel meeting has occurred) but have not begun
+  - code: '07'
+    name: Spend in progress
+    description: Awards/activity active, contracted and actual spend is occurring
+  - code: '08'
+    name: Finalisation
+    description: Physical activity is complete or the final disbursement has been made, but the activity remains open pending financia sign off or M&E
+  - code: '09'
+    name: Completed
+    description: All awards have completed and there is no more financial spend or forecast spend from UK. Can only be applied after ALL final payments on the activity, including final reconciliation, have been made
+  - code: '10'
+    name: Stopped
+    description: Activity has been cancelled or indefinitely postponed before an activity started
+  - code: '11'
+    name: Cancelled
+    description: Activity has been cancelled or indefinitely postponed after an activity has started
+metadata:
+  url: ''
+  name: Programme Status
+  description: A description of the status of the activity


### PR DESCRIPTION
Trello: https://trello.com/c/jj2Dju4x

## Changes in this PR

After a user research session, users feedback that they are missing some important fields in the activity form in RODA. It was then identified as a priority for them to have the field `programme status` added to the activity form so they can track the status of each activity. Users preferred this status to the previously used `IATI status`, as they are more familiar with the terminology of Programme status. Since IATI status is a requirement for IATI, we will still keep it in the background to ensure the reports follow the IATI standards and pass the IATI validator, but we will not ask the user to introduce an IATI status anymore when they create activities (the form step `status` has been removed and now they are asked for a `programme status` instead). As a result, we now need to map one programme status to a specific IATI status. The client provided us with a mapping chart for this. The mapping logic has been implemented as part of this PR.

This PR also introduces the new field in the form, alongside the mapping logic and a placeholder for future work on ingesting non-IATI data.

## Screenshots of UI changes

### Before

<img width="1440" alt="Screenshot 2020-08-13 at 12 11 40" src="https://user-images.githubusercontent.com/48016017/90134703-7c9a1a00-dd69-11ea-8c21-83326d73d09c.png">


### After

<img width="1440" alt="Screenshot 2020-08-13 at 10 59 26" src="https://user-images.githubusercontent.com/48016017/90134788-9d626f80-dd69-11ea-87bf-0478803c2ff8.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
