### PR TITLE
Remove currency symbol from `ActivityPresenter#transactions_total`

### DIFF
--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -83,6 +83,6 @@ class ActivityPresenter < SimpleDelegator
 
   def transactions_total
     return if super.blank?
-    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+    "%.2f" % super
   end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe ActivityPresenter do
       _transaction_2 = create(:transaction, parent_activity: project, value: 300)
 
       expect(described_class.new(project).transactions_total)
-        .to eq "£400.20"
+        .to eq "400.20"
     end
   end
 end


### PR DESCRIPTION
##  Changes in this PR

Trello: https://trello.com/c/px9jVQ5v/897-report-csv-actuals-value-contains-odd-characters

The data in the CSV output should be as formatting-free as possible. Also the
£ symbol was not being interpreted correctly in all spreadsheet programmes.

Instead of using `number_to_currency`, use simple number formatting to show the
value to two decimal places

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
