### PR TITLE
(890) Reports store their financial quarter and financial year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,7 @@
 - Add `transactions_total` to Activity and add it to the Submission CSV per Activity
 - Migrate AMS GCRF activities from Level C to Level B and update identifiers
 - Ingest creates new activities at a level below its parent
+- Reports store the relevant financial quarter
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -86,7 +86,7 @@ class Staff::ReportsController < Staff::BaseController
   def send_csv
     response.headers["Content-Type"] = "text/csv"
     response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
-    response.stream.write ExportActivityToCsv.new.headers
+    response.stream.write ExportActivityToCsv.new.headers(report: @report)
     @projects.each do |project|
       response.stream.write ExportActivityToCsv.new(activity: project).call
     end

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -86,7 +86,7 @@ class Staff::ReportsController < Staff::BaseController
   def send_csv
     response.headers["Content-Type"] = "text/csv"
     response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
-    response.stream.write Activity::CSV_HEADERS.to_csv
+    response.stream.write ExportActivityToCsv.new.headers
     @projects.each do |project|
       response.stream.write ExportActivityToCsv.new(activity: project).call
     end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,6 @@ class Activity < ApplicationRecord
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
-  CSV_HEADERS = ["Identifier", "Transparency identifier", "Sector", "Title", "Description", "Status", "Planned start date", "Actual start date", "Planned end date", "Actual end date", "Recipient region", "Recipient country", "Aid type", "Level", "Actual", "Link to activity in RODA"]
 
   VALIDATION_STEPS = [
     :level_step,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,8 @@
 class Report < ApplicationRecord
   include PublicActivity::Common
 
+  attr_readonly :financial_quarter, :financial_year
+
   validates_presence_of :description
   validates_presence_of :state
 
@@ -14,10 +16,35 @@ class Report < ApplicationRecord
 
   enum state: [:inactive, :active]
 
+  def initialize(attributes = nil)
+    super(attributes)
+    self.financial_quarter = current_financial_quarter
+    self.financial_year = current_financial_year
+  end
+
   def activity_must_be_a_fund
     return unless fund.present?
     unless fund.fund?
       errors.add(:fund, I18n.t("activerecord.errors.models.report.attributes.fund.level"))
     end
+  end
+
+  private def current_financial_quarter
+    case Date.today.month
+    when 4, 5, 6
+      1
+    when 7, 8, 9
+      2
+    when 10, 11, 12
+      3
+    when 1, 2, 3
+      4
+    end
+  end
+
+  private def current_financial_year
+    year = Date.today.year
+    return year - 1 if current_financial_quarter == 4
+    year
   end
 end

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -10,4 +10,9 @@ class ReportPresenter < SimpleDelegator
     return if super.blank?
     I18n.l(super)
   end
+
+  def financial_quarter_and_year
+    return nil if financial_quarter.nil? || financial_year.nil?
+    "Q#{financial_quarter} #{financial_year}-#{financial_year + 1}"
+  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -3,7 +3,7 @@ require "csv"
 class ExportActivityToCsv
   attr_accessor :activity
 
-  def initialize(activity:)
+  def initialize(activity: nil)
     @activity = activity
   end
 
@@ -29,7 +29,8 @@ class ExportActivityToCsv
     ].to_csv
   end
 
-  def headers
+  def headers(report:)
+    report_financial_quarter = ReportPresenter.new(report).financial_quarter_and_year
     [
       "Identifier",
       "Transparency identifier",
@@ -45,7 +46,7 @@ class ExportActivityToCsv
       "Recipient country",
       "Aid type",
       "Level",
-      "Actuals",
+      report_financial_quarter ? report_financial_quarter + " actuals" : "Actuals",
       "Link to activity in RODA",
     ].to_csv
   end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -28,4 +28,25 @@ class ExportActivityToCsv
       activity_presenter.link_to_roda,
     ].to_csv
   end
+
+  def headers
+    [
+      "Identifier",
+      "Transparency identifier",
+      "Sector",
+      "Title",
+      "Description",
+      "Status",
+      "Planned start date",
+      "Actual start date",
+      "Planned end date",
+      "Actual end date",
+      "Recipient region",
+      "Recipient country",
+      "Aid type",
+      "Level",
+      "Actuals",
+      "Link to activity in RODA",
+    ].to_csv
+  end
 end

--- a/app/views/staff/shared/reports/_table.html.haml
+++ b/app/views/staff/shared/reports/_table.html.haml
@@ -4,6 +4,8 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header
             = t("table.header.report.organisation")
@@ -18,6 +20,7 @@
     %tbody.govuk-table__body
       - reports.each do |report|
         %tr.govuk-table__row{id: report.id}
+          %td.govuk-table__cell= report.financial_quarter_and_year
           - if current_user.service_owner?
             %td.govuk-table__cell= report.organisation.name
           %td.govuk-table__cell= report.description

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -7,8 +7,9 @@ en:
         inactive: Inactive reports
     header:
       report:
+        financial_quarter: Financial quarter
         state: State
-        description: Reporting period
+        description: Description
         organisation: Organisation
         fund: Level A
         deadline: Deadline

--- a/db/migrate/20200813102824_add_financial_quarter_and_financial_year_to_reports.rb
+++ b/db/migrate/20200813102824_add_financial_quarter_and_financial_year_to_reports.rb
@@ -1,0 +1,6 @@
+class AddFinancialQuarterAndFinancialYearToReports < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reports, :financial_quarter, :integer
+    add_column :reports, :financial_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_121536) do
+ActiveRecord::Schema.define(version: 2020_08_13_102824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -141,6 +141,8 @@ ActiveRecord::Schema.define(version: 2020_08_05_121536) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.date "deadline"
+    t.integer "financial_quarter"
+    t.integer "financial_year"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"
   end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -25,6 +25,16 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content report.organisation.name
     end
 
+    scenario "they see the financial quarter the of the report" do
+      travel_to(Date.parse("1 Jan 2020")) do
+        _report = create(:report, :active)
+
+        visit reports_path
+
+        expect(page).to have_content "Q4 2019-2020"
+      end
+    end
+
     scenario "they can view all inactive reports for all organisations" do
       reports = create_list(:report, 2)
       visit reports_path

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -4,11 +4,21 @@ RSpec.describe Report, type: :model do
   describe "validations" do
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:state) }
+    it { should have_readonly_attribute(:financial_quarter) }
+    it { should have_readonly_attribute(:financial_year) }
   end
 
   describe "associations" do
     it { should belong_to(:fund).class_name("Activity") }
     it { should belong_to(:organisation) }
+  end
+
+  it "sets the financial_quarter and financial_year when created" do
+    travel_to(Date.parse("01-04-2020")) do
+      report = Report.new
+
+      expect(report.financial_quarter).to eql 1
+    end
   end
 
   it "does not allow an association to an Activity that is not level = fund" do
@@ -30,5 +40,81 @@ RSpec.describe Report, type: :model do
   it "does not allow a Deadline which is in the past" do
     report = build(:report, deadline: Date.yesterday)
     expect(report).not_to be_valid
+  end
+
+  describe "#financial_quarter" do
+    context "when in the first quarter of the financial year - April to March" do
+      it "sets the financial quarter to 1" do
+        ["1 April 2020", "30 June 2020"].each do |date|
+          travel_to(Date.parse(date)) do
+            report = Report.new
+            expect(report.financial_quarter).to eql 1
+          end
+        end
+      end
+    end
+
+    context "when in the second quarter of the financial year - May to July" do
+      it "sets the financial quarter to 2" do
+        ["1 July 2020", "30 September 2020"].each do |date|
+          travel_to(Date.parse(date)) do
+            report = Report.new
+            expect(report.financial_quarter).to eql 2
+          end
+        end
+      end
+    end
+
+    context "when in the third quarter of the financial year - October to December" do
+      it "sets the financial quarter to 3" do
+        ["1 October 2020", "31 December 2020"].each do |date|
+          travel_to(Date.parse(date)) do
+            report = Report.new
+            expect(report.financial_quarter).to eql 3
+          end
+        end
+      end
+    end
+
+    context "when in the fourth quarter of the financial year - January to March" do
+      it "sets the financial quarter to 4" do
+        ["1 January 2020", "31 March 2020"].each do |date|
+          travel_to(Date.parse(date)) do
+            report = Report.new
+            expect(report.financial_quarter).to eql 4
+          end
+        end
+      end
+    end
+  end
+
+  describe "#financial_year" do
+    context "when in the first, second or third quarter of the 2020-2021 financial year" do
+      it "sets the financial year to 2020" do
+        travel_to(Date.parse("1 May 2020")) do
+          report = Report.new
+          expect(report.financial_year).to eql 2020
+        end
+
+        travel_to(Date.parse("1 September 2020")) do
+          report = Report.new
+          expect(report.financial_year).to eql 2020
+        end
+
+        travel_to(Date.parse("1 November 2020")) do
+          report = Report.new
+          expect(report.financial_year).to eql 2020
+        end
+      end
+    end
+
+    context "when in the fouth quarter of the 2020-2021 financial year" do
+      it "sets the financial year to 2020" do
+        travel_to(Date.parse("1 February 2021")) do
+          report = Report.new
+          expect(report.financial_year).to eql 2020
+        end
+      end
+    end
   end
 end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe ReportPresenter do
       expect(result).to eql I18n.l(Date.today)
     end
   end
+
+  describe "#financial_quarter_and_year" do
+    it "returns the formatted financial quarter and year e.g. Q1 2020-2021" do
+      report = build(:report, financial_quarter: 1, financial_year: 2020)
+      result = described_class.new(report).financial_quarter_and_year
+
+      expect(result).to eql "Q1 2020-2021"
+    end
+
+    it "returns nil when the report has no financial quarter or year" do
+      report = build(:report, financial_quarter: nil, financial_year: nil)
+      result = described_class.new(report).financial_quarter_and_year
+
+      expect(result).to be_nil
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -29,4 +29,16 @@ RSpec.describe ExportActivityToCsv do
       ].to_csv)
     end
   end
+
+  describe "#headers" do
+    it "uses the current report financial quarter to generate the actuals total column " do
+      travel_to(Date.parse("1 April 2020")) do
+        report = Report.new
+
+        headers = ExportActivityToCsv.new.headers(report: report)
+
+        expect(headers).to include "Q1 2020-2021 actuals"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
I've found the resons for storing the financial quarter and year on a report really hard to articulate, and discussion have taken place to drive this work.

To try and summerise:

- In order to label the actuals column with the FQ for the report
- In order to show the relevent forecasts for the report (these will not have been recorded (associated) in the report as they are from the past)
- in order to show the relevent future forecasts we need to know from where to begin
- in order to display data in ways users find meaningful, users ❤️ financial quarters

We are in a odd place at the moment where we are backfilling data into RODA with many quarters worth of data  – I feel like we know this case is an exception and the fact that the 'current report' has no FQ is alright and something we can deal with.  I do believe we could do the work to slice the legacy data into quarters but am unconvinced the effort is worth it – happy to chat about this if folks feel different.

I wanted the Report to set its own FQ values are early as possible so we do not have to think about, I decided to do this in the intializer after considering other options. As the values are also set to read only, once the value is set and saved Rails will not expect it to change.

This work contains a refactor of where we store the column headers for the csv, as we now generate some of these dynamically having a constant in the Activity model felt awkward.

I wondered about creating a seperate service object for the headers but in the end, decided to keep a single object that can take an activity and give you a csv row or a report and give you the correct set of headers. I was a bit iffy about whether to guard against passing in nil to this service object - thoughts appreciated on that - it feels a little clunky as is.

I also wondered about how to store the values and settled on intgers as they feel low cost and can easily be compared to the relevent part of a Date object as needed.

I suspect we will be doing a lot of calcualting the quarter for a given date and may move that code out to it's own class or helper, but this didn't feel like the time to do that (I am a fan of letting need drive work rather than trying to pre think too much!)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
