### PR TITLE
(refactor) Change the way Report state is stored

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,7 +14,7 @@ class Report < ApplicationRecord
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true, date_within_boundaries: true
 
-  enum state: [:inactive, :active]
+  enum state: {inactive: "inactive", active: "active"}
 
   def initialize(attributes = nil)
     super(attributes)

--- a/db/data/20200814135953_report_states_are_strings.rb
+++ b/db/data/20200814135953_report_states_are_strings.rb
@@ -1,0 +1,9 @@
+class ReportStatesAreStrings < ActiveRecord::Migration[6.0]
+  def up
+    Report.update_all state: "inactive"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200810141939)
+DataMigrate::Data.define(version: 20200814135953)

--- a/db/migrate/20200814134116_report_state_stored_as_string.rb
+++ b/db/migrate/20200814134116_report_state_stored_as_string.rb
@@ -1,0 +1,6 @@
+class ReportStateStoredAsString < ActiveRecord::Migration[6.0]
+  def change
+    change_column :reports, :state, :string, default: "inactive"
+    add_index :reports, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_102824) do
+ActiveRecord::Schema.define(version: 2020_08_14_134116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_102824) do
   end
 
   create_table "reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "state", default: 0, null: false
+    t.string "state", default: "inactive", null: false
     t.string "description"
     t.uuid "fund_id"
     t.uuid "organisation_id"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_102824) do
     t.integer "financial_year"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"
+    t.index ["state"], name: "index_reports_on_state"
   end
 
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Defining the enum as an array has two drawbacks:

1. the values in the DB have no context for developers as they are
   simply numbers
2. less flexibility to allow change as the order of the array matters

By switching to a hash we get around both these drawbacks.

This work also adds an index to state as it is likely the application
will need to sort and display Reports by their state.

We currently have reports in production but they are all 'inactive' so
this work contains a simple data migration to map the stored 0s to
"inactive". Doing this work any later would be far more difficult.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
