### PR TITLE
(875) The CSV download contains aggregated forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,8 @@
 - Scope the total transaction value for an Activity to a Report and that Report's date
   range, and call the result `actual_total_for_report_financial_quarter`. Add this
   value to the Report CSV.
+- Calculate the total of all Planned Disbursements in a Report's date range as 
+  `forecasted_total_for_report_financial_quarter` and output the value to the Report CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,9 @@
   Mapping `programme_status` to `IATI_status` included. Schema migration to replace
   `form_state` at `status` step for `programme_status` step
 - `programme status` form step is not shown for level A activities
+- Scope the total transaction value for an Activity to a Report and that Report's date
+  range, and call the result `actual_total_for_report_financial_quarter`. Add this
+  value to the Report CSV.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -86,12 +86,12 @@ class Staff::ReportsController < Staff::BaseController
   def send_csv
     response.headers["Content-Type"] = "text/csv"
     response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
-    response.stream.write ExportActivityToCsv.new.headers(report: @report)
+    response.stream.write ExportActivityToCsv.new(activity: nil, report: @report).headers
     @projects.each do |project|
-      response.stream.write ExportActivityToCsv.new(activity: project).call
+      response.stream.write ExportActivityToCsv.new(activity: project, report: @report).call
     end
     @third_party_projects.each do |project|
-      response.stream.write ExportActivityToCsv.new(activity: project).call
+      response.stream.write ExportActivityToCsv.new(activity: project, report: @report).call
     end
     response.stream.close
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -153,4 +153,8 @@ class Activity < ApplicationRecord
   def transactions_total
     transactions.sum(:value)
   end
+
+  def actual_total_for_report_financial_quarter(report:)
+    transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -157,4 +157,8 @@ class Activity < ApplicationRecord
   def actual_total_for_report_financial_quarter(report:)
     transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end
+
+  def forecasted_total_for_report_financial_quarter(report:)
+    planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -150,10 +150,6 @@ class Activity < ApplicationRecord
     }.push(identifier).join("-")
   end
 
-  def transactions_total
-    transactions.sum(:value)
-  end
-
   def actual_total_for_report_financial_quarter(report:)
     transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -85,4 +85,9 @@ class ActivityPresenter < SimpleDelegator
     return if super.blank?
     "%.2f" % super
   end
+
+  def actual_total_for_report_financial_quarter(report:)
+    return if super.blank?
+    "%.2f" % super
+  end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -90,4 +90,9 @@ class ActivityPresenter < SimpleDelegator
     return if super.blank?
     "%.2f" % super
   end
+
+  def forecasted_total_for_report_financial_quarter(report:)
+    return if super.blank?
+    "%.2f" % super
+  end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -81,11 +81,6 @@ class ActivityPresenter < SimpleDelegator
     Rails.application.routes.url_helpers.organisation_activity_details_url(organisation, self, host: ENV["DOMAIN"]).to_s
   end
 
-  def transactions_total
-    return if super.blank?
-    "%.2f" % super
-  end
-
   def actual_total_for_report_financial_quarter(report:)
     return if super.blank?
     "%.2f" % super

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -26,6 +26,7 @@ class ExportActivityToCsv
       activity_presenter.aid_type,
       activity_presenter.level,
       activity_presenter.actual_total_for_report_financial_quarter(report: report),
+      activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
       activity_presenter.link_to_roda,
     ].to_csv
   end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -1,10 +1,11 @@
 require "csv"
 
 class ExportActivityToCsv
-  attr_accessor :activity
+  attr_accessor :activity, :report
 
-  def initialize(activity: nil)
+  def initialize(activity: nil, report: nil)
     @activity = activity
+    @report = report
   end
 
   def call
@@ -24,12 +25,12 @@ class ExportActivityToCsv
       activity_presenter.recipient_country,
       activity_presenter.aid_type,
       activity_presenter.level,
-      activity_presenter.transactions_total,
+      activity_presenter.actual_total_for_report_financial_quarter(report: report),
       activity_presenter.link_to_roda,
     ].to_csv
   end
 
-  def headers(report:)
+  def headers
     report_financial_quarter = ReportPresenter.new(report).financial_quarter_and_year
     [
       "Identifier",
@@ -47,6 +48,7 @@ class ExportActivityToCsv
       "Aid type",
       "Level",
       report_financial_quarter ? report_financial_quarter + " actuals" : "Actuals",
+      report_financial_quarter ? report_financial_quarter + " forecast" : "Forecast",
       "Link to activity in RODA",
     ].to_csv
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -633,16 +633,6 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#transactions_total" do
-    it "returns the total of all the activity's transactions" do
-      project = create(:project_activity)
-      create(:transaction, parent_activity: project, value: 100.20)
-      create(:transaction, parent_activity: project, value: 210)
-
-      expect(project.transactions_total).to eq(310.20)
-    end
-  end
-
   describe "#actual_total_for_report_financial_quarter" do
     it "returns the total of all the activity's transactions scoped to a report" do
       project = create(:project_activity, :with_report)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -674,4 +674,31 @@ RSpec.describe Activity, type: :model do
       expect(project.actual_total_for_report_financial_quarter(report: report)).to eq(100.20)
     end
   end
+
+  describe "#forecasted_total_for_report_financial_quarter" do
+    it "returns the total of all the activity's planned disbursements scoped to a report's financial quarter only" do
+      quarter_one_date = Date.parse("1 April 2019")
+      quarter_two_date = Date.parse("1 July 2019")
+
+      project = create(:project_activity)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: quarter_one_date)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: quarter_one_date)
+
+      create(:planned_disbursement, parent_activity: project, value: 2000.00, period_start_date: quarter_two_date)
+      create(:planned_disbursement, parent_activity: project, value: 2000.00, period_start_date: quarter_two_date)
+
+      report = create(:report, fund: project.associated_fund)
+      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(0)
+
+      travel_to(quarter_one_date) do
+        report = create(:report, fund: project.associated_fund)
+        expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(2000.00)
+      end
+
+      travel_to(quarter_two_date) do
+        report = create(:report, fund: project.associated_fund)
+        expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(4000.00)
+      end
+    end
+  end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Report, type: :model do
       end
     end
 
-    context "when in the fouth quarter of the 2020-2021 financial year" do
+    context "when in the fourth quarter of the 2020-2021 financial year" do
       it "sets the financial year to 2020" do
         travel_to(Date.parse("1 February 2021")) do
           report = Report.new

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -272,13 +272,25 @@ RSpec.describe ActivityPresenter do
   end
 
   describe "#transactions_total" do
-    it "returns the transaction total as a formatted number with currency symbol" do
+    it "returns the transaction total as a formatted number" do
       project = create(:project_activity)
       _transaction_1 = create(:transaction, parent_activity: project, value: 100.20)
       _transaction_2 = create(:transaction, parent_activity: project, value: 300)
 
       expect(described_class.new(project).transactions_total)
         .to eq "400.20"
+    end
+  end
+
+  describe "#actual_total_for_report_financial_quarter" do
+    it "returns the transaction total scoped to report as a formatted number" do
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      _transaction_in_report_scope = create(:transaction, parent_activity: project, report: report, value: 100.20, date: Date.today)
+      _transaction_outside_report_scope = create(:transaction, parent_activity: project, report: report, value: 300, date: Date.today - 4.months)
+
+      expect(described_class.new(project).actual_total_for_report_financial_quarter(report: report))
+        .to eq "100.20"
     end
   end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -271,17 +271,6 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#transactions_total" do
-    it "returns the transaction total as a formatted number" do
-      project = create(:project_activity)
-      _transaction_1 = create(:transaction, parent_activity: project, value: 100.20)
-      _transaction_2 = create(:transaction, parent_activity: project, value: 300)
-
-      expect(described_class.new(project).transactions_total)
-        .to eq "400.20"
-    end
-  end
-
   describe "#actual_total_for_report_financial_quarter" do
     it "returns the transaction total scoped to report as a formatted number" do
       project = create(:project_activity, :with_report)

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -293,4 +293,16 @@ RSpec.describe ActivityPresenter do
         .to eq "100.20"
     end
   end
+
+  describe "#forecasted_total_for_report_financial_quarter" do
+    it "returns the planned disbursement total per report as a formatted number" do
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, report: report, value: 200.20, period_start_date: Date.today)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500.00)
+
+      expect(described_class.new(project).forecasted_total_for_report_financial_quarter(report: report))
+        .to eq "200.20"
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -26,19 +26,30 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.aid_type,
         activity_presenter.level,
         activity_presenter.actual_total_for_report_financial_quarter(report: report),
+        activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
         activity_presenter.link_to_roda,
       ].to_csv)
     end
   end
 
   describe "#headers" do
-    it "uses the current report financial quarter to generate the actuals total column " do
+    it "uses the current report financial quarter to generate the actuals total column" do
       travel_to(Date.parse("1 April 2020")) do
         report = Report.new
 
         headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
         expect(headers).to include "Q1 2020-2021 actuals"
+      end
+    end
+
+    it "uses the current report financial quarter to generate the forecast total column" do
+      travel_to(Date.parse("1 April 2020")) do
+        report = Report.new
+
+        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+
+        expect(headers).to include "Q1 2020-2021 forecast"
       end
     end
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe ExportActivityToCsv do
-  let(:project) { create(:project_activity) }
+  let(:project) { create(:project_activity, :with_report) }
+  let(:report) { Report.find_by(fund: project.associated_fund, organisation: project.organisation) }
 
   describe "#call" do
     it "creates a CSV line representation of the Activity" do
       activity_presenter = ActivityPresenter.new(project)
-      result = ExportActivityToCsv.new(activity: project).call
+      result = ExportActivityToCsv.new(activity: project, report: report).call
 
       expect(result).to eq([
         activity_presenter.identifier,
@@ -24,7 +25,7 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.recipient_country,
         activity_presenter.aid_type,
         activity_presenter.level,
-        activity_presenter.transactions_total,
+        activity_presenter.actual_total_for_report_financial_quarter(report: report),
         activity_presenter.link_to_roda,
       ].to_csv)
     end
@@ -35,7 +36,7 @@ RSpec.describe ExportActivityToCsv do
       travel_to(Date.parse("1 April 2020")) do
         report = Report.new
 
-        headers = ExportActivityToCsv.new.headers(report: report)
+        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
         expect(headers).to include "Q1 2020-2021 actuals"
       end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/n3371hcO/875-aggregated-forecasts-planned-disbursements-are-included-in-the-csv-download

The Report CSV will always contain all Activities associated with a Fund/Organisation pair, whether they had transactions or planned disbursements in the report period or not. But the transaction/planned disburement totals must be scoped to a single Report and its date range, not be the totals for that Activity for all time.
    
1) Scope the `transactions_total` to a Report & that Report's date range
    
The new method is called `actual_total_for_report_financial_quarter` for clarity

2) Calculate the total of all Planned Disbursements in a Report's date range
    
Planned Disbursements scoped to a single Report and that Report's date range are summed and returned in `forecasted_total_for_report_financial_quarter`
    
3) Remove `Activity#transactions_total` and its test as it is no longer used

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
