### PR TITLE
(895) Programme status form step removed for Funds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@
 - `programme status` field added to activity form in exchange for old IATI status.
   Mapping `programme_status` to `IATI_status` included. Schema migration to replace
   `form_state` at `status` step for `programme_status` step
+- `programme status` form step is not shown for level A activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...HEAD
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -34,6 +34,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step if @activity.fund?
     when :blank
       skip_step
+    when :programme_status
+      skip_step if @activity.fund?
     when :region
       skip_step if @activity.recipient_country?
     when :country

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -3,6 +3,8 @@ class Staff::ActivityFormsController < Staff::BaseController
   include DateHelper
   include ActivityHelper
 
+  DEFAULT_PROGRAMME_STATUS_FOR_FUNDS = "07"
+
   FORM_STEPS = [
     :blank,
     :level,
@@ -45,6 +47,11 @@ class Staff::ActivityFormsController < Staff::BaseController
     @page_title = t("page_title.activity_form.show.#{step}")
     @activity = Activity.find(activity_id)
     authorize @activity
+
+    if @activity.fund?
+      iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(DEFAULT_PROGRAMME_STATUS_FOR_FUNDS)
+      @activity.assign_attributes(programme_status: DEFAULT_PROGRAMME_STATUS_FOR_FUNDS, status: iati_status)
+    end
 
     case step
     when :level

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -67,14 +67,15 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("summary.label.activity.sector"))
 
-  .govuk-summary-list__row.programme_status
-    %dt.govuk-summary-list__key
-      = t("summary.label.activity.programme_status")
-    %dd.govuk-summary-list__value
-      = activity_presenter.programme_status
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :programme_status)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:programme_status)}"), activity_step_path(activity_presenter, :programme_status), t("summary.label.activity.programme_status"))
+  - unless activity_presenter.fund?
+    .govuk-summary-list__row.programme_status
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.programme_status")
+      %dd.govuk-summary-list__value
+        = activity_presenter.programme_status
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :programme_status)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:programme_status)}"), activity_step_path(activity_presenter, :programme_status), t("summary.label.activity.programme_status"))
 
   .govuk-summary-list__row.planned_start_date
     %dt.govuk-summary-list__key

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -19,6 +19,24 @@ RSpec.feature "Users can create a fund level activity" do
       expect(page).to have_content I18n.t("action.fund.create.success")
     end
 
+    scenario "a default value of 'Spend in progress' for programme status gets set" do
+      identifier = "a-fund-with-default-programme-status-of-spend-in-progress"
+      visit activities_path
+      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      fill_in_activity_form(identifier: identifier, level: "fund")
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.programme_status).to eq("07")
+    end
+
+    scenario "the iati status gets set based on the default programme status value" do
+      identifier = "a-fund-with-default-iati-status-of-implementation"
+      visit activities_path
+      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      fill_in_activity_form(identifier: identifier, level: "fund")
+      activity = Activity.find_by(identifier: identifier)
+      expect(activity.status).to eq("2")
+    end
+
     scenario "the activity form has some defaults" do
       activity = create(:fund_activity, organisation: user.organisation)
       activity_presenter = ActivityPresenter.new(activity)

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -380,14 +380,16 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(I18n.t("default.link.back"))
   click_on I18n.t("tabs.activity.details")
 
-  within(".programme_status") do
-    click_on(I18n.t("default.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :programme_status)
-    )
+  unless activity.fund?
+    within(".programme_status") do
+      click_on(I18n.t("default.link.edit"))
+      expect(page).to have_current_path(
+        activity_step_path(activity, :programme_status)
+      )
+    end
+    click_on(I18n.t("default.link.back"))
+    click_on I18n.t("tabs.activity.details")
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
 
   within(".planned_start_date") do
     click_on(I18n.t("default.link.edit"))

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -25,8 +25,10 @@ module ActivityHelpers
     expect(page).to have_content I18n.t("summary.label.activity.sector", level: activity_presenter.level)
     expect(page).to have_content activity_presenter.sector
 
-    expect(page).to have_content I18n.t("summary.label.activity.programme_status")
-    expect(page).to have_content activity_presenter.programme_status
+    unless activity_presenter.fund?
+      expect(page).to have_content I18n.t("summary.label.activity.programme_status")
+      expect(page).to have_content activity_presenter.programme_status
+    end
 
     expect(page).to have_content I18n.t("summary.label.activity.planned_start_date")
     expect(page).to have_content activity_presenter.planned_start_date

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -65,21 +65,23 @@ module FormHelpers
     choose sector
     click_button I18n.t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.programme_status")
-    expect(page).to have_content "Delivery"
-    expect(page).to have_content "Planned"
-    expect(page).to have_content "Agreement in place"
-    expect(page).to have_content "Call/Activity open"
-    expect(page).to have_content "Review"
-    expect(page).to have_content "Decided"
-    expect(page).to have_content "Spend in progress"
-    expect(page).to have_content "Finalisation"
-    expect(page).to have_content "Completed"
-    expect(page).to have_content "Stopped"
-    expect(page).to have_content "Cancelled"
+    unless level == "fund"
+      expect(page).to have_content I18n.t("form.legend.activity.programme_status")
+      expect(page).to have_content "Delivery"
+      expect(page).to have_content "Planned"
+      expect(page).to have_content "Agreement in place"
+      expect(page).to have_content "Call/Activity open"
+      expect(page).to have_content "Review"
+      expect(page).to have_content "Decided"
+      expect(page).to have_content "Spend in progress"
+      expect(page).to have_content "Finalisation"
+      expect(page).to have_content "Completed"
+      expect(page).to have_content "Stopped"
+      expect(page).to have_content "Cancelled"
 
-    choose("activity[programme_status]", option: programme_status)
-    click_button I18n.t("form.button.activity.submit")
+      choose("activity[programme_status]", option: programme_status)
+      click_button I18n.t("form.button.activity.submit")
+    end
 
     expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: activity_level(level))
 
@@ -127,7 +129,11 @@ module FormHelpers
     expect(page).to have_content title
     expect(page).to have_content description
     expect(page).to have_content sector
-    expect(page).to have_content I18n.t("activity.programme_status.#{programme_status}")
+    if level == "fund"
+      expect(page).not_to have_content I18n.t("activity.programme_status.#{programme_status}")
+    else
+      expect(page).to have_content I18n.t("activity.programme_status.#{programme_status}")
+    end
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
     expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")


### PR DESCRIPTION
Trello: https://trello.com/c/vHswa3bj

## Changes in this PR

Now that `programme status` field has been added to the create activity form, the next step was to remove this form step when users create a level A activity (Fund). Users are only required to add a programme status for levels B, C and D. However, despite not asking the user for a `programme status` on Funds we are still setting a default value of `Spend in progress` in the background, as agreed with the client. This will help us avoid potential errors with validations. As a result, the old IATI `status` also gets set in the background, but the user will not see any of those as they are not relevant for them when handling Funds.

To improve the user experience, only for Funds we have removed the `programme status` step form, the field in the view of activity details and the possibility to edit this field. 

## Screenshots of UI changes

### After

<img width="1440" alt="Screenshot 2020-08-18 at 16 56 35" src="https://user-images.githubusercontent.com/48016017/90536342-d63c8300-e173-11ea-85a7-fe17ccbaba06.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
