### PR TITLE
Changed "planned disbursement" to "forecasted spend"

### DIFF
--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -3,9 +3,9 @@ en:
   action:
     planned_disbursement:
       create:
-        success: Planned disbursement successfully created
+        success: Forecasted spend successfully created
       update:
-        success: Planned disbursement successfully updated
+        success: Forecasted spend successfully updated
   form:
     label:
       planned_disbursement:
@@ -24,7 +24,7 @@ en:
             name: Revised
         providing_organisation_reference: International Aid Transparency Initiative (IATI) Reference (optional)
         receiving_organisation_reference: IATI Reference (optional)
-        value: Value
+        value: Forecasted spend amount
     legend:
       planned_disbursement:
         period_end_date: End date
@@ -50,7 +50,7 @@ en:
         currency: Currency
         providing_organisation: Provider
         receiving_organisation: Receiver
-        value: Value
+        value: Forecasted spend amount
     body:
       planned_disbursement:
         planned_disbursement_type_options:
@@ -60,11 +60,11 @@ en:
   page_content:
     planned_disbursements:
       button:
-        create: Add planned disbursement
+        create: Add forecasted spend
   page_title:
     planned_disbursement:
-      edit: Edit planned disbursement
-      new: Add a planned disbursement
+      edit: Edit forecasted spend
+      new: Add forecasted spend
   activerecord:
     errors:
       models:


### PR DESCRIPTION
Updated all mentions of "planned disbursement" to "forecasted spend" based on the service language definitions doc

## Changes in this PR

Changed the following:
Title on financials tab
Button on financials tab
"Value" to "Forecasted spend amount" on the page and the financials tab
Both confirmation messages should say "Forecasted spend has been successfully xx"

I think all of these updates still make sense - happy to change if not. 

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
