### PR TITLE
(920) Schema migration to backfill `programme_status`

### DIFF
--- a/db/migrate/20200819081212_add_programme_status_to_existing_funds.rb
+++ b/db/migrate/20200819081212_add_programme_status_to_existing_funds.rb
@@ -1,0 +1,5 @@
+class AddProgrammeStatusToExistingFunds < ActiveRecord::Migration[6.0]
+  def up
+    Activity.where(level: "fund", programme_status: nil).update_all(programme_status: "06")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_17_144853) do
+ActiveRecord::Schema.define(version: 2020_08_19_081212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Trello: https://trello.com/c/87YhiGTG

## Changes in this PR

Existing Funds will not have a `programme_status` value, as this field has been introduced just recently. To avoid potential errors, we have agreed to backfill this field on existing Funds to the value `Decided` (code `06`).

This PR contains the schema migration that changes the value from `nil` to `06` for existing Funds.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
