### PR TITLE
Update the Report policy

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,7 +15,14 @@ class Report < ApplicationRecord
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true, date_within_boundaries: true
 
-  enum state: {inactive: "inactive", active: "active"}
+  enum state: {
+    inactive: "inactive",
+    active: "active",
+    submitted: "submitted",
+    in_review: "in_review",
+    awaiting_changes: "awaiting_changes",
+    approved: "approved",
+  }
 
   def initialize(attributes = nil)
     super(attributes)

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -7,24 +7,65 @@ class ReportPolicy < ApplicationPolicy
 
   def show?
     return true if beis_user?
-    record.organisation == user.organisation
+    return true if record.organisation == user.organisation && record.state != "inactive"
+    false
   end
 
   def create?
-    beis_user?
+    false
+  end
+
+  def edit?
+    update?
   end
 
   def update?
     beis_user?
   end
 
-  def download?
-    return true if beis_user?
-    record.organisation == user.organisation
-  end
-
   def destroy?
     false
+  end
+
+  def change_state?
+    case record.state
+    when "inactive"
+      beis_user?
+    when "active"
+      delivery_partner_user?
+    when "submitted"
+      beis_user?
+    when "in_review"
+      beis_user?
+    when "awaiting_changes"
+      delivery_partner_user?
+    when "approved"
+      false
+    end
+  end
+
+  def download?
+    show?
+  end
+
+  def activate?
+    return change_state? if record.state == "inactive"
+  end
+
+  def submit?
+    return change_state? if ["active", "awaiting_changes"].include? record.state
+  end
+
+  def review?
+    return change_state? if record.state == "submitted"
+  end
+
+  def request_changes?
+    return change_state? if record.state == "in_review"
+  end
+
+  def approve?
+    return change_state? if record.state == "in_review"
   end
 
   class Scope < Scope

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -1,58 +1,210 @@
 require "rails_helper"
 
 RSpec.describe ReportPolicy do
-  let(:organisation) { create(:delivery_partner_organisation) }
-  let(:another_organistion) { create(:delivery_partner_organisation) }
-  let!(:report) { create(:report, organisation: organisation) }
-  let!(:another_report) { create(:report, organisation: another_organistion) }
-
   subject { described_class.new(user, report) }
 
-  context "as a user that belongs to BEIS" do
+  context "as a BEIS user" do
     let(:user) { build_stubbed(:beis_user) }
-
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
-    it { is_expected.to permit_action(:download) }
+    let(:report) { create(:report) }
 
     it "includes all reports in the resolved scope" do
+      report = create(:report)
+      another_report = create(:report)
       resolved_scope = described_class::Scope.new(user, Report).resolve
+
       expect(resolved_scope).to include report, another_report
+    end
+
+    context "when the report is inactive" do
+      before { report.update(state: :inactive) }
+
+      it { is_expected.to permit_action(:update) }
+      it { is_expected.to permit_action(:index) }
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:download) }
+      it { is_expected.to permit_action(:change_state) }
+      it { is_expected.to permit_action(:activate) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:destroy) }
+
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:approve) }
+    end
+
+    context "when the report is active" do
+      before { report.update(state: :active) }
+
+      it { is_expected.to forbid_action(:change_state) }
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:approve) }
+    end
+
+    context "when the report is submitted" do
+      before { report.update(state: :submitted) }
+
+      it { is_expected.to permit_action(:change_state) }
+      it { is_expected.to permit_action(:review) }
+
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:approve) }
+    end
+
+    context "when the report is in review" do
+      before { report.update(state: :in_review) }
+
+      it { is_expected.to permit_action(:change_state) }
+      it { is_expected.to permit_action(:request_changes) }
+      it { is_expected.to permit_action(:approve) }
+
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:review) }
+    end
+
+    context "when the report is awaiting changes" do
+      before { report.update(state: :awaiting_changes) }
+
+      it { is_expected.to forbid_action(:change_state) }
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:approve) }
+    end
+
+    context "when the report is approved" do
+      before { report.update(state: :approved) }
+
+      it { is_expected.to forbid_action(:change_state) }
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:approve) }
     end
   end
 
-  context "as a user that does NOT belong to BEIS" do
-    let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
-
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_action(:destroy) }
-
-    context "when the report belongs to the user's organisation" do
-      let(:report) { create(:report, organisation: user.organisation) }
-      it { is_expected.to permit_action(:download) }
-      it { is_expected.to permit_action(:show) }
-    end
-
-    context "when the report does not belong to the user's organisation" do
-      let(:report) { create(:report, organisation: create(:organisation)) }
-      it { is_expected.to forbid_action(:download) }
-      it { is_expected.to forbid_action(:show) }
-    end
+  context "as a Delivery partner user" do
+    let(:user) { build_stubbed(:delivery_partner_user) }
 
     it "includes only reports that the users organisation is reporting in the resolved scope" do
+      report = create(:report, organisation: user.organisation)
+      _another_report = create(:report)
       resolved_scope = described_class::Scope.new(user, Report).resolve
+
       expect(resolved_scope).to contain_exactly report
     end
 
-    context "when the report does not belong to the delivery partner users organisation" do
-      let(:report) { create(:report, :active, organisation: another_organistion) }
+    context "when the report does not belong to the users organisation" do
+      let(:report) { create(:report) }
 
-      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:change_state) }
+      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:activate) }
+      it { is_expected.to forbid_action(:submit) }
+      it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:request_changes) }
+      it { is_expected.to forbid_action(:approve) }
+
+      it { is_expected.to permit_action(:index) }
+    end
+
+    context "when the report belongs to the users organisation" do
+      let(:report) { create(:report, organisation: user.organisation) }
+
+      context "when the report is inactive" do
+        before { report.update(state: :inactive) }
+
+        it { is_expected.to forbid_action(:show) }
+        it { is_expected.to forbid_action(:download) }
+        it { is_expected.to forbid_action(:change_state) }
+        it { is_expected.to forbid_action(:destroy) }
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:submit) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:approve) }
+      end
+
+      context "when the report is active" do
+        before { report.update(state: :active) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:download) }
+        it { is_expected.to permit_action(:change_state) }
+        it { is_expected.to permit_action(:submit) }
+
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:approve) }
+      end
+
+      context "when the report is submitted" do
+        before { report.update(state: :submitted) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:download) }
+
+        it { is_expected.to forbid_action(:change_state) }
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:submit) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:approve) }
+      end
+
+      context "when the report is in review" do
+        before { report.update(state: :in_review) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:download) }
+
+        it { is_expected.to forbid_action(:change_state) }
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:submit) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:approve) }
+      end
+
+      context "when the report is awaiting changes" do
+        before { report.update(state: :awaiting_changes) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:download) }
+        it { is_expected.to permit_action(:change_state) }
+        it { is_expected.to permit_action(:submit) }
+
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:approve) }
+      end
+
+      context "when the report is approved" do
+        before { report.update(state: :approved) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:download) }
+
+        it { is_expected.to forbid_action(:change_state) }
+        it { is_expected.to forbid_action(:activate) }
+        it { is_expected.to forbid_action(:submit) }
+        it { is_expected.to forbid_action(:request_changes) }
+        it { is_expected.to forbid_action(:review) }
+        it { is_expected.to forbid_action(:approve) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

We already have a good understanding of the what state transitions are
valid and which user can make them.

This work updates the report policy and related spec to make it possible
to enforce this understanding and support future work to allow users to
move a report though its state inside the application.

This Miro board speaks to how the state and permission works:

https://miro.com/app/board/o9J_knq_KVg=/

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
