### PR TITLE
(877) Variance between the actual and forecasted totals is included in the CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,9 @@
 - Calculate the total of all Planned Disbursements in a Report's date range as
   `forecasted_total_for_report_financial_quarter` and output the value to the Report CSV
 - Ingest RAEng Newton fund data from IATI
+- Calculate the variance between an Activity's transactions total for a date range, and
+  that same Activity's planned disbursements total for a date range. Output this value
+  to the Report CSV as "Variance"
 
 ## [unreleased]
 - Reports can be submitted

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -156,11 +156,18 @@ class Activity < ApplicationRecord
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
+    @actual_total_for_report_financial_quarter ||= transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+    @forecasted_total_for_report_financial_quarter ||= {}
+    return @forecasted_total_for_report_financial_quarter[report] if @forecasted_total_for_report_financial_quarter.key?(report)
+
+    @forecasted_total_for_report_financial_quarter[report] = planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+  end
+
+  def variance_for_report_financial_quarter(report:)
+     actual_total_for_report_financial_quarter(report: report) - forecasted_total_for_report_financial_quarter(report: report)
   end
 
   def requires_call_dates?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -160,14 +160,11 @@ class Activity < ApplicationRecord
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    @forecasted_total_for_report_financial_quarter ||= {}
-    return @forecasted_total_for_report_financial_quarter[report] if @forecasted_total_for_report_financial_quarter.key?(report)
-
-    @forecasted_total_for_report_financial_quarter[report] = planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+    @forecasted_total_for_report_financial_quarter ||= planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
   end
 
   def variance_for_report_financial_quarter(report:)
-     actual_total_for_report_financial_quarter(report: report) - forecasted_total_for_report_financial_quarter(report: report)
+    @variance_for_report_financial_quarter ||= actual_total_for_report_financial_quarter(report: report) - forecasted_total_for_report_financial_quarter(report: report)
   end
 
   def requires_call_dates?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -105,4 +105,9 @@ class ActivityPresenter < SimpleDelegator
     return if super.blank?
     "%.2f" % super
   end
+
+  def variance_for_report_financial_quarter(report:)
+    return if super.blank?
+    "%.2f" % super
+  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -27,6 +27,7 @@ class ExportActivityToCsv
       activity_presenter.level,
       activity_presenter.actual_total_for_report_financial_quarter(report: report),
       activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
+      activity_presenter.variance_for_report_financial_quarter(report: report),
       activity_presenter.link_to_roda,
     ].to_csv
   end
@@ -50,6 +51,7 @@ class ExportActivityToCsv
       "Level",
       report_financial_quarter ? report_financial_quarter + " actuals" : "Actuals",
       report_financial_quarter ? report_financial_quarter + " forecast" : "Forecast",
+      "Variance",
       "Link to activity in RODA",
     ].to_csv
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -662,7 +662,7 @@ RSpec.describe Activity, type: :model do
       report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
       create(:transaction, parent_activity: project, value: 100.20, report: report, date: Date.today)
       create(:transaction, parent_activity: project, value: 50.00, report: report, date: Date.today)
-      create(:transaction, parent_activity: project, value: 210, report: report, date: Date.today - 4.months)
+      create(:transaction, parent_activity: project, value: 210, report: report, date: 4.months.ago)
 
       expect(project.actual_total_for_report_financial_quarter(report: report)).to eq(150.20)
     end
@@ -670,48 +670,33 @@ RSpec.describe Activity, type: :model do
     it "does not include the totals for any transactions outside the report's date range" do
       project = create(:project_activity, :with_report)
       report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
-      create(:transaction, parent_activity: project, value: 100.20, report: report, date: Date.today - 6.months)
-      create(:transaction, parent_activity: project, value: 210, report: report, date: Date.today - 4.months)
+      create(:transaction, parent_activity: project, value: 100.20, report: report, date: 6.months.ago)
+      create(:transaction, parent_activity: project, value: 210, report: report, date: 4.months.ago)
 
       expect(project.actual_total_for_report_financial_quarter(report: report)).to eq(0)
     end
   end
 
-  describe "#actual_total_for_report_financial_quarter" do
-    it "returns the total of all the activity's transactions scoped to a report" do
-      project = create(:project_activity, :with_report)
-      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
-      create(:transaction, parent_activity: project, value: 100.20, report: report, date: Date.today)
-      create(:transaction, parent_activity: project, value: 210)
-
-      expect(project.actual_total_for_report_financial_quarter(report: report)).to eq(100.20)
-    end
-  end
-
   describe "#forecasted_total_for_report_financial_quarter" do
     it "returns the total of all the activity's planned disbursements scoped to a report's financial quarter only" do
-      quarter_one_date = Date.parse("1 April 2019")
-      quarter_two_date = Date.parse("1 July 2019")
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
 
-      project = create(:project_activity)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: quarter_one_date)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: quarter_one_date)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
 
-      create(:planned_disbursement, parent_activity: project, value: 2000.00, period_start_date: quarter_two_date)
-      create(:planned_disbursement, parent_activity: project, value: 2000.00, period_start_date: quarter_two_date)
+      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(2000.00)
+    end
 
-      report = create(:report, fund: project.associated_fund)
+    it "does not include totals for any planned disbursements outside the report's date range" do
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 6.months.ago)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
+
       expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(0)
-
-      travel_to(quarter_one_date) do
-        report = create(:report, fund: project.associated_fund)
-        expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(2000.00)
-      end
-
-      travel_to(quarter_two_date) do
-        report = create(:report, fund: project.associated_fund)
-        expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(4000.00)
-      end
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -714,4 +714,17 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  describe "#variance_for_report_financial_quarter" do
+    it "returns the variance between #actual_total_for_report_financial_quarter and #forecasted_total_for_report_financial_quarter" do
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      create(:transaction, parent_activity: project, value: 100, report: report, date: Date.today)
+      create(:transaction, parent_activity: project, value: 200, report: report, date: Date.today)
+      create(:planned_disbursement, parent_activity: project, value: 1500, report: report, period_start_date: Date.today)
+      create(:planned_disbursement, parent_activity: project, value: 500, report: report, period_start_date: Date.today)
+
+      expect(project.variance_for_report_financial_quarter(report: report)).to eq(-1700)
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -348,4 +348,16 @@ RSpec.describe ActivityPresenter do
         .to eq "200.20"
     end
   end
+
+  describe "#variance_for_report_financial_quarter" do
+    it "returns the variance per report as a formatted number" do
+      project = create(:project_activity, :with_report)
+      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      _transaction = create(:transaction, parent_activity: project, report: report, value: 200, date: Date.today)
+      _disbursement = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: Date.today)
+
+      expect(described_class.new(project).variance_for_report_financial_quarter(report: report))
+        .to eq "-1300.00"
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.level,
         activity_presenter.actual_total_for_report_financial_quarter(report: report),
         activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
+        activity_presenter.variance_for_report_financial_quarter(report: report),
         activity_presenter.link_to_roda,
       ].to_csv)
     end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/1i9BekH8/877-variance-between-the-actual-and-forecasted-totals-is-included-in-the-csv

Calculate the variance between the actual total (transactions) for an Activity in a Report's date range, and the forecasted total (planned disbursements) for that same Activity in the Report's date range. The method is named `variance_for_report_financial_quarter`. Express this number in the CSV as "Variance".

I have attempted to memoize `variance_for_report_financial_quarter` for performance.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
