### PR TITLE
(848) Add `call open` and `call close` dates to activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,9 @@
 - Inactive reports are shown in their own table on the reports page
 - Reports are no longer activated when the deadline is set
 
+- `Call open date` and `Call close date` added to the create activity form, for levels C and D.
+  This field is mandatory for new activities, but optional for activities marked as `ingested: true`
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14
 [release-13]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-12...release-13

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -13,6 +13,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     :purpose,
     :sector_category,
     :sector,
+    :call_present,
+    :call_dates,
     :programme_status,
     :dates,
     :geography,
@@ -36,6 +38,10 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step
     when :programme_status
       skip_step if @activity.fund?
+    when :call_present
+      skip_step unless @activity.requires_call_dates?
+    when :call_dates
+      skip_step unless @activity.call_present?
     when :region
       skip_step if @activity.recipient_country?
     when :country
@@ -74,6 +80,13 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(sector_category: sector_category, sector: nil)
     when :sector
       @activity.assign_attributes(sector: sector)
+    when :call_present
+      @activity.assign_attributes(call_present: call_present)
+    when :call_dates
+      @activity.assign_attributes(
+        call_open_date: format_date(call_open_date),
+        call_close_date: format_date(call_close_date),
+      )
     when :programme_status
       iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(programme_status)
       @activity.assign_attributes(programme_status: programme_status, status: iati_status)
@@ -136,6 +149,20 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def description
     params.require(:activity).permit(:description).fetch("description", nil)
+  end
+
+  def call_present
+    params.require(:activity).permit(:call_present).fetch("call_present", nil)
+  end
+
+  def call_open_date
+    call_open_date = params.require(:activity).permit(:call_open_date)
+    {day: call_open_date["call_open_date(3i)"], month: call_open_date["call_open_date(2i)"], year: call_open_date["call_open_date(1i)"]}
+  end
+
+  def call_close_date
+    call_close_date = params.require(:activity).permit(:call_close_date)
+    {day: call_close_date["call_close_date(3i)"], month: call_close_date["call_close_date(2i)"], year: call_close_date["call_close_date(1i)"]}
   end
 
   def programme_status

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,6 +12,8 @@ class Activity < ApplicationRecord
     :purpose_step,
     :sector_category_step,
     :sector_step,
+    :call_present_step,
+    :call_dates_step,
     :programme_status_step,
     :geography_step,
     :region_step,
@@ -28,6 +30,7 @@ class Activity < ApplicationRecord
   validates :title, :description, presence: true, on: :purpose_step
   validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
+  validates :call_present, inclusion: {in: [true, false]}, on: :call_present_step, if: :requires_call_dates?
   validates :programme_status, presence: true, on: :programme_status_step
   validates :geography, presence: true, on: :geography_step
   validates :recipient_region, presence: true, on: :region_step, if: :recipient_region?
@@ -41,6 +44,8 @@ class Activity < ApplicationRecord
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation
+  validates :call_open_date, presence: true, on: :call_dates_step, if: :call_present?
+  validates :call_close_date, presence: true, on: :call_dates_step, if: :call_present?
 
   acts_as_tree
   belongs_to :parent, optional: true, class_name: :Activity, foreign_key: "parent_id"
@@ -156,5 +161,9 @@ class Activity < ApplicationRecord
 
   def forecasted_total_for_report_financial_quarter(report:)
     planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+  end
+
+  def requires_call_dates?
+    !ingested? && (project? || third_party_project?)
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -13,6 +13,21 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.sector.#{super}")
   end
 
+  def call_present
+    return if super.nil?
+    I18n.t("activity.call_present.#{super}")
+  end
+
+  def call_open_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
+  def call_close_date
+    return if super.blank?
+    I18n.l(super)
+  end
+
   def programme_status
     return if super.blank?
     I18n.t("activity.programme_status.#{super}")

--- a/app/views/staff/activity_forms/call_dates.html.haml
+++ b/app/views/staff/activity_forms/call_dates.html.haml
@@ -1,0 +1,5 @@
+= render layout: "wrapper" do |f|
+  %h1.govuk-heading-xl= @page_title
+
+  = f.govuk_date_field :call_open_date
+  = f.govuk_date_field :call_close_date

--- a/app/views/staff/activity_forms/call_present.html.haml
+++ b/app/views/staff/activity_forms/call_present.html.haml
@@ -1,0 +1,5 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_radio_buttons_fieldset(:call_present, legend: { text: t("form.legend.activity.call_present", level: t("page_content.activity.level.#{f.object.level}")), size: "xl", tag: "h1" }) do
+    = f.hidden_field :call_present, value: nil
+    = f.govuk_radio_button :call_present, :true, label: { text: t("form.label.activity.call_present.true") }
+    = f.govuk_radio_button :call_present, :false, label: { text: t("form.label.activity.call_present.false") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -67,6 +67,36 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("summary.label.activity.sector"))
 
+
+  - if activity_presenter.requires_call_dates?
+    .govuk-summary-list__row.call_present
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.call_present")
+      %dd.govuk-summary-list__value
+        = activity_presenter.call_present
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :call_present)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:call_present)}"), activity_step_path(activity_presenter, :call_present), t("summary.label.activity.call_present"))
+
+  - if activity_presenter.call_present?
+    .govuk-summary-list__row.call_open_date
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.call_open_date")
+      %dd.govuk-summary-list__value
+        = activity_presenter.call_open_date
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :call_dates)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:call_open_date)}"), activity_step_path(activity_presenter, :call_dates), t("summary.label.activity.call_open_date"))
+
+    .govuk-summary-list__row.call_close_date
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.call_close_date")
+      %dd.govuk-summary-list__value
+        = activity_presenter.call_close_date
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :call_dates)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:call_close_date)}"), activity_step_path(activity_presenter, :call_dates), t("summary.label.activity.call_close_date"))
+
   - unless activity_presenter.fund?
     .govuk-summary-list__row.programme_status
       %dt.govuk-summary-list__key

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -17,6 +17,9 @@ en:
       g01: Administrative costs not included elsewhere
       h01: Development awareness
       h02: Refugees in donor countries
+    call_present:
+      'true': 'Yes'
+      'false': 'No'
     flow:
       '10': ODA
       '20': OOF

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -19,6 +19,9 @@ en:
     label:
       activity:
         flow: What is the flow type?
+        call_present:
+          'true': 'Yes'
+          'false': 'No'
         geography_options:
           recipient_region: Region
           recipient_country: Country
@@ -40,6 +43,9 @@ en:
         aid_type: Aid type
         actual_end_date: Actual end date (optional)
         actual_start_date: Actual start date (optional)
+        call_present: Is there a call for this %{level}?
+        call_open_date: Call open date
+        call_close_date: Call close date
         geography: Will the benefitting recipient be a region or country?
         level: Add new activity
         parent: Select the parent activity
@@ -55,6 +61,8 @@ en:
         actual_end_date: For example, 2 2 2020
         actual_start_date: For example, 11 1 2020
         aid_type: A code for the vocabulary aid-type classifications. <a href='http://reference.iatistandard.org/203/codelists/AidType/' target='_blank'>International Aid Transparency Initiative (IATI) descriptions can be found here (Opens in new window)</a>
+        call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
+        call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         identifier: This could be the reference you use in your internal systems. This value cannot be edited once it is set
         planned_end_date: For example, 28 11 2020
@@ -79,6 +87,9 @@ en:
         budgets: Budgets
         button:
           create: Add activity
+        call_present: Calls
+        call_open_date: Call open date
+        call_close_date: Call close date
         description: Description
         form_state:
           complete: Complete
@@ -175,6 +186,8 @@ en:
     activity_form:
       show:
         aid_type: Aid type
+        call_dates: What are the call open and close dates for this %{level}?
+        call_present: Is there a call for this %{level}?
         country: What country will benefit from this activity?
         dates: What are the start and end dates for the %{level}?
         flow: Flow

--- a/db/migrate/20200819131932_add_call_dates_to_activities.rb
+++ b/db/migrate/20200819131932_add_call_dates_to_activities.rb
@@ -1,0 +1,7 @@
+class AddCallDatesToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :call_present, :boolean
+    add_column :activities, :call_open_date, :date
+    add_column :activities, :call_close_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_081212) do
+ActiveRecord::Schema.define(version: 2020_08_19_131932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -52,6 +52,9 @@ ActiveRecord::Schema.define(version: 2020_08_19_081212) do
     t.uuid "parent_id"
     t.string "transparency_identifier"
     t.string "programme_status"
+    t.boolean "call_present"
+    t.date "call_open_date"
+    t.date "call_close_date"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -62,6 +62,9 @@ FactoryBot.define do
     factory :project_activity do
       parent factory: :programme_activity
       level { :project }
+      call_present { "true" }
+      call_open_date { Date.yesterday }
+      call_close_date { Date.tomorrow }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
@@ -86,6 +89,9 @@ FactoryBot.define do
     factory :third_party_project_activity do
       parent factory: :project_activity
       level { :third_party_project }
+      call_present { "true" }
+      call_open_date { Date.yesterday }
+      call_close_date { Date.tomorrow }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
@@ -105,6 +111,7 @@ FactoryBot.define do
     description { nil }
     sector_category { nil }
     sector { nil }
+    call_present { nil }
     programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
@@ -122,6 +129,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
+    call_present { nil }
     programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
@@ -158,6 +166,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
+    call_present { nil }
     programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }
@@ -180,6 +189,7 @@ FactoryBot.define do
     title { nil }
     description { nil }
     sector { nil }
+    call_present { nil }
     programme_status { nil }
     planned_start_date { nil }
     planned_end_date { nil }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -296,6 +296,29 @@ RSpec.describe Activity, type: :model do
         expect(blank_activity.valid?).to eq(true)
       end
     end
+
+    context "when the activity is neither a fund nor a programme" do
+      context "when call_present is blank" do
+        subject(:activity) { build(:project_activity, call_present: nil) }
+        it "should not be valid" do
+          expect(activity.valid?(:call_present_step)).to be_falsey
+        end
+      end
+
+      context "when there is a call but any of the call dates are blank" do
+        subject(:activity) { build(:project_activity, call_present: true, call_open_date: Date.today, call_close_date: nil) }
+        it "should not be valid" do
+          expect(activity.valid?(:call_dates_step)).to be_falsey
+        end
+      end
+
+      context "when the activity is 'ingested:true'" do
+        subject(:activity) { build(:project_activity, ingested: true, call_present: nil) }
+        it "should not require the presence of 'call_present'" do
+          expect(activity.valid?(:call_present_step)).to be_truthy
+        end
+      end
+    end
   end
 
   describe "associations" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -45,6 +45,61 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#call_present" do
+    context "when there is a call" do
+      it "returns the locale value for this option" do
+        activity = build(:project_activity, call_present: "true")
+        result = described_class.new(activity)
+        p result.call_present
+        expect(result.call_present).to eq("Yes")
+      end
+    end
+
+    context "when there is not a call" do
+      it "returns the locale value for this option" do
+        activity = build(:project_activity, call_present: "false")
+        result = described_class.new(activity)
+        expect(result.call_present).to eq("No")
+      end
+    end
+  end
+
+  describe "#call_open_date" do
+    context "when the call open date exists" do
+      it "returns a human readable date" do
+        activity = build(:project_activity, call_open_date: "2020-02-20")
+        result = described_class.new(activity).call_open_date
+        expect(result).to eq("20 Feb 2020")
+      end
+    end
+
+    context "when the planned start date does not exist" do
+      it "returns nil" do
+        activity = build(:project_activity, call_open_date: nil)
+        result = described_class.new(activity)
+        expect(result.call_open_date).to be_nil
+      end
+    end
+  end
+
+  describe "#call_close_date" do
+    context "when the call close date exists" do
+      it "returns a human readable date" do
+        activity = build(:project_activity, call_close_date: "2020-06-23")
+        result = described_class.new(activity).call_close_date
+        expect(result).to eq("23 Jun 2020")
+      end
+    end
+
+    context "when the planned close date does not exist" do
+      it "returns nil" do
+        activity = build(:project_activity, call_close_date: nil)
+        result = described_class.new(activity)
+        expect(result.call_close_date).to be_nil
+      end
+    end
+  end
+
   describe "#programme_status" do
     context "when the programme status exists" do
       it "returns the locale value for the code" do

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe IngestIatiActivities do
       end
 
       it "sets the level to third-party project when its parent is a project" do
-        existing_activity.update!(level: :project)
+        existing_activity.update!(level: :project, call_present: false)
 
         described_class.new(delivery_partner: uksa, file_io: legacy_activities_xml).call
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -5,6 +5,13 @@ module FormHelpers
     description: Faker::Lorem.paragraph,
     sector_category: "Basic Education",
     sector: "Primary education",
+    call_present: "true",
+    call_open_date_day: "1",
+    call_open_date_month: "10",
+    call_open_date_year: "2019",
+    call_close_date_day: "31",
+    call_close_date_month: "12",
+    call_close_date_year: "2019",
     programme_status: "07",
     planned_start_date_day: "1",
     planned_start_date_month: "1",
@@ -64,6 +71,27 @@ module FormHelpers
 
     choose sector
     click_button I18n.t("form.button.activity.submit")
+
+    if level == "project" || level == "third_party_project"
+      expect(page).to have_content I18n.t("form.legend.activity.call_present", level: activity_level(level))
+      choose "Yes"
+      click_button I18n.t("form.button.activity.submit")
+      expect(page).to have_content I18n.t("page_title.activity_form.show.call_dates", level: activity_level(level))
+
+      expect(page).to have_content I18n.t("form.legend.activity.call_open_date")
+      fill_in "activity[call_open_date(3i)]", with: call_open_date_day
+      fill_in "activity[call_open_date(2i)]", with: call_open_date_month
+      fill_in "activity[call_open_date(1i)]", with: call_open_date_year
+
+      expect(page).to have_content I18n.t("form.legend.activity.call_close_date")
+      fill_in "activity[call_close_date(3i)]", with: call_close_date_day
+      fill_in "activity[call_close_date(2i)]", with: call_close_date_month
+      fill_in "activity[call_close_date(1i)]", with: call_close_date_year
+
+      click_button I18n.t("form.button.activity.submit")
+    else
+      call_present = nil
+    end
 
     unless level == "fund"
       expect(page).to have_content I18n.t("form.legend.activity.programme_status")
@@ -129,6 +157,9 @@ module FormHelpers
     expect(page).to have_content title
     expect(page).to have_content description
     expect(page).to have_content sector
+    if call_present == "true"
+      expect(page).to have_content I18n.t("activity.call_present.#{call_present}")
+    end
     if level == "fund"
       expect(page).not_to have_content I18n.t("activity.programme_status.#{programme_status}")
     else
@@ -147,6 +178,18 @@ module FormHelpers
       month: planned_end_date_month,
       day: planned_end_date_day
     )
+    if call_present == "true"
+      expect(page).to have_content localise_date_from_input_fields(
+        year: call_open_date_year,
+        month: call_open_date_month,
+        day: call_open_date_day
+      )
+      expect(page).to have_content localise_date_from_input_fields(
+        year: call_close_date_year,
+        month: call_close_date_month,
+        day: call_close_date_day
+      )
+    end
 
     my_activity = Activity.find_by(identifier: identifier)
     iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(programme_status)


### PR DESCRIPTION
Trello: https://trello.com/c/AQTkUKy7

## Changes in this PR

As part of the additional fields needed in RODA, and having identified this one as a priority for the users, we have now added `call open date` and `call close date` to the service. These dates are only present in level C and D activities,
and they relate to the timeline to apply for grants (note that they are not the same as IATI activity dates). As requested by the client, this new field comes in two different steps. On a first step, the DP user will select whether an activity has any calls. If they do have calls, then the second step will be displayed on the form, in which the DP can add both `call open date` and `call close date`. If there are no calls for that activity, the second step will be ignored and the form will move on to the next step.

This field will be mandatory for all level C and D activities created through RODA, but optional for those `ingested: true`. For this, I have added some validations in the model and some examples on the specs.

During the developing of this feature, and as a result of introducing the new validations for this field, I encountered a failing test related to the ingest of IATI activities. I modified the test to incorporate the new logic (see separate commit message for more information).

## Screenshots of UI changes

### After

<img width="1440" alt="Screenshot 2020-08-21 at 14 52 04" src="https://user-images.githubusercontent.com/48016017/90905513-34fa3a80-e3c8-11ea-8e03-3ee1c8a3976a.png">


<img width="1440" alt="Screenshot 2020-08-21 at 14 52 35" src="https://user-images.githubusercontent.com/48016017/90905534-3c214880-e3c8-11ea-8d1d-1a3735938a0f.png">


<img width="1440" alt="Screenshot 2020-08-21 at 14 54 00" src="https://user-images.githubusercontent.com/48016017/90905563-45aab080-e3c8-11ea-9c6a-ecb0a28adbc8.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
