### PR TITLE
(912) User can activate reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,7 @@
 - Reports can be submitted
 - Submitted reports are shown to users
 - Reports can be activated explicitly
+- Inactive reports are shown in their own table on the reports page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,7 @@
 - Submitted reports are shown to users
 - Reports can be activated explicitly
 - Inactive reports are shown in their own table on the reports page
+- Reports are no longer activated when the deadline is set
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,7 @@
 ## [unreleased]
 - Reports can be submitted
 - Submitted reports are shown to users
+- Reports can be activated explicitly
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -41,7 +41,6 @@ class Staff::ReportsController < Staff::BaseController
     if @report.valid?
       @report.save!
       @report.create_activity key: "report.update", owner: current_user
-      activate!
       flash[:notice] = I18n.t("action.report.update.success")
       redirect_to reports_path
     else
@@ -57,14 +56,6 @@ class Staff::ReportsController < Staff::BaseController
 
   def report_params
     params.require(:report).permit(:deadline, :description)
-  end
-
-  def activate!
-    if @report.deadline.present? && @report.deadline > Date.today
-      @report.state = :active
-      @report.save!
-      @report.create_activity key: "report.activate", owner: current_user
-    end
   end
 
   def inactive_reports

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -12,7 +12,7 @@
         %h2.govuk-heading-m
           = t("table.title.report.inactive")
 
-        = render partial: "staff/shared/reports/table", locals: { reports: @inactive_report_presenters }
+        = render partial: "staff/shared/reports/table_inactive", locals: { reports: @inactive_report_presenters }
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full

--- a/app/views/staff/reports/show.html.haml
+++ b/app/views/staff/reports/show.html.haml
@@ -11,5 +11,8 @@
         - if policy(@report_presenter).download?
           = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
+        - if policy(@report_presenter).activate?
+          = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
         - if policy(@report_presenter).submit?
           = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports_state/activate/complete.html.haml
+++ b/app/views/staff/reports_state/activate/complete.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("page_title.report.activate.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          = t("action.report.activate.complete.title")
+
+        .govuk-panel__body
+          = t("action.report.activate.complete.body", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %h2.govuk-heading-m
+        What happens next
+
+      %p.govuk-body
+        This report is now active
+
+

--- a/app/views/staff/reports_state/activate/confirm.html.haml
+++ b/app/views/staff/reports_state/activate/confirm.html.haml
@@ -1,0 +1,16 @@
+= content_for :page_title_prefix, t("page_title.report.activate.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.activate.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %p.govuk-body
+        Once you activate this report:
+
+      %ul.govuk-list.govuk-list--bullet
+        %li
+
+      = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = f.govuk_submit t("action.report.activate.confirm.button")

--- a/app/views/staff/reports_state/submit/complete.html.haml
+++ b/app/views/staff/reports_state/submit/complete.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title_prefix, t("page_title.report.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+= content_for :page_title_prefix, t("page_title.report.submit.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
@@ -14,10 +14,10 @@
         What happens next
 
       %p.govuk-body
-        Your submission is now complete
+        Your report submission is now complete
 
       %p.govuk-body
-        The RODA support team will check your submission and assure it within two weeks. You will be the contact for any queries.
+        The RODA support team will check your report and assure it within two weeks. You will be the contact for any queries.
 
       %p.govuk-body
         You can still use RODA to:

--- a/app/views/staff/reports_state/submit/confirm.html.haml
+++ b/app/views/staff/reports_state/submit/confirm.html.haml
@@ -1,10 +1,10 @@
-= content_for :page_title_prefix, t("page_title.report.submit", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+= content_for :page_title_prefix, t("page_title.report.submit.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.report.submit", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+        = t("page_title.report.submit.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
       %p.govuk-body
         Once you submit your report:
@@ -20,6 +20,6 @@
           You will be the contact for any freedom of information requests about this data once it has been published
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
-        = f.govuk_submit t("action.report.confirm.button")
+        = f.govuk_submit t("action.report.submit.confirm.button")
 
   = render partial: "shared/help_and_support"

--- a/app/views/staff/shared/reports/_table_inactive.html.haml
+++ b/app/views/staff/shared/reports/_table_inactive.html.haml
@@ -1,0 +1,31 @@
+- unless reports.empty?
+  %table.govuk-table.reports
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.reports.title")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("table.header.report.financial_quarter")
+        - if current_user.service_owner?
+          %th.govuk-table__header
+            = t("table.header.report.organisation")
+        %th.govuk-table__header
+          =t("table.header.report.description")
+        %th.govuk-table__header
+          =t("table.header.report.fund")
+        %th.govuk-table__header
+          =t("table.header.report.deadline")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - reports.each do |report|
+        %tr.govuk-table__row{id: report.id}
+          %td.govuk-table__cell= report.financial_quarter_and_year
+          - if current_user.service_owner?
+            %td.govuk-table__cell= report.organisation.name
+          %td.govuk-table__cell= report.description
+          %td.govuk-table__cell= report.fund.title
+          %td.govuk-table__cell= report.deadline
+          %td.govuk-table__cell
+            = link_to I18n.t("table.body.report.action.edit"), edit_report_path(report), class: "govuk-link govuk-!-margin-left-2"
+            = link_to I18n.t("table.body.report.action.activate"), edit_report_state_path(report), class: "govuk-link govuk-!-margin-left-2"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -14,6 +14,11 @@ en:
         organisation: Organisation
         fund: Level A
         deadline: Deadline
+    body:
+      report:
+        action:
+          edit: Edit
+          activate: Activate
   page_content:
     reports:
       title: Reports

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -39,24 +39,33 @@ en:
       index: Reports
   page_title:
     report:
+      activate:
+        confirm: Confirm activation of %{report_financial_quarter} %{report_description}
+        complete: Report activation complete
       index: Reports
       edit: Edit report
       show: "%{report_financial_quarter} %{report_description}"
-      submit: Confirm submission of %{report_financial_quarter} %{report_description}
-      complete: Submission complete
+      submit:
+        confirm: Confirm submission of %{report_financial_quarter} %{report_description}
+        complete: Submission complete
   action:
     report:
+      activate:
+        button: Activate report
+        confirm:
+          button: Confirm report activation
+        complete:
+          title: Report activation complete
+          body: "%{report_financial_quarter} %{report_description}"
       update:
         success: Report successfully updated
       submit:
         button: Submit report
-        failure: Report could not be submitted
-        success: Report submitted successfully
         complete:
           title: Submission complete
           body: "%{report_financial_quarter} %{report_description}"
-      confirm:
-        button: Confirm submission
+        confirm:
+          button: Confirm submission
       download:
         button: Download report as CSV file
   activerecord:

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -90,26 +90,6 @@ RSpec.feature "BEIS users can edit a report" do
       expect(page).to have_content I18n.t("activerecord.errors.models.report.attributes.deadline.between", min: 10, max: 25)
     end
 
-    scenario "setting a Report's deadline changes its state to 'active'" do
-      authenticate!(user: beis_user)
-      report = create(:report)
-
-      visit reports_path
-
-      within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
-      end
-
-      fill_in "report[deadline(3i)]", with: "31"
-      fill_in "report[deadline(2i)]", with: "1"
-      fill_in "report[deadline(1i)]", with: "2021"
-
-      click_on I18n.t("default.button.submit")
-
-      expect(page).to have_content I18n.t("action.report.update.success")
-      expect(report.reload.state).to eq "active"
-    end
-
     scenario "setting a Report's deadline logs an activity in PublicActivity" do
       PublicActivity.with_tracking do
         authenticate!(user: beis_user)
@@ -128,7 +108,7 @@ RSpec.feature "BEIS users can edit a report" do
         click_on I18n.t("default.button.submit")
 
         auditable_events = PublicActivity::Activity.where(trackable_id: report.id)
-        expect(auditable_events.map(&:key)).to match_array ["report.update", "report.activate"]
+        expect(auditable_events.map(&:key)).to match_array ["report.update"]
         expect(auditable_events.map(&:owner_id).uniq).to eq [beis_user.id]
       end
     end

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -1,0 +1,54 @@
+RSpec.feature "Users can activate reports" do
+  context "signed in as a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before do
+      authenticate!(user: beis_user)
+    end
+
+    scenario "they can activate a report" do
+      report = create(:report, state: :inactive)
+
+      visit report_path(report)
+      click_link I18n.t("action.report.activate.button")
+      click_button I18n.t("action.report.activate.confirm.button")
+
+      expect(page).to have_content "complete"
+      expect(report.reload.state).to eql "active"
+    end
+
+    context "when the report is already active" do
+      scenario "it cannot be activated agian" do
+        report = create(:report, state: :active)
+
+        visit report_path(report)
+
+        expect(page).not_to have_link "Activate report"
+
+        visit edit_report_state_path(report)
+
+        expect(page.status_code).to eql 401
+      end
+    end
+  end
+
+  context "signed in as a Delivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    before do
+      authenticate!(user: delivery_partner_user)
+    end
+
+    scenario "they cannot activate a report" do
+      report = create(:report, state: :inactive)
+
+      visit report_path(report)
+
+      expect(page).not_to have_link "Activate report"
+
+      visit edit_report_state_path(report)
+
+      expect(page.status_code).to eql 401
+    end
+  end
+end

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Users can submit a report" do
           click_on I18n.t("default.link.view")
         end
         click_link I18n.t("action.report.submit.button")
-        click_button I18n.t("action.report.confirm.button")
+        click_button I18n.t("action.report.submit.confirm.button")
 
         auditable_events = PublicActivity::Activity.all
         expect(auditable_events.last.key).to include("report.submitted")


### PR DESCRIPTION
## Changes in this PR
Previously BEIS users had to fill in the deadline and the application would activate a report, although nice, it was felt we needed a more explicit approach.

This works follow the take action > confirm action > complete action pattern to activate a report and uses the new `reportsStateController` to do so.

As an inactive report can only become active we simply add that case to the controller and update the report, we have the Report policy to manage for who and when this is allowed.

We haven't come up with our first go at the content for this flow yet so none is included beyond the basics - this is by desgin.

If we want to get the content into this PR on there is a mockup of this flow here:

https://miro.com/app/board/o9J_kpe1v2k=/?moveToWidget=3074457348997454374&cot=6

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/480578/90910737-bbfee100-e3cf-11ea-9ca0-7483b6aa3e00.png)
![image](https://user-images.githubusercontent.com/480578/90910235-e56b3d00-e3ce-11ea-851f-276f6e4e4eec.png)
![image](https://user-images.githubusercontent.com/480578/90910159-d08ea980-e3ce-11ea-95dc-17851b7e2e64.png)
![image](https://user-images.githubusercontent.com/480578/90910190-d84e4e00-e3ce-11ea-8b87-55437423886d.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
