### PR TITLE
(Fix) `p` statement removed from spec file

### DIFF
--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe ActivityPresenter do
       it "returns the locale value for this option" do
         activity = build(:project_activity, call_present: "true")
         result = described_class.new(activity)
-        p result.call_present
         expect(result.call_present).to eq("Yes")
       end
     end


### PR DESCRIPTION
There was a `p result.call_present` on one of the test files that was accidentally
left on the file. This was printing `Yes` when running the tests. This commit
removes the printing line.

