### PR TITLE
Rename Activity#identifier to `delivery_partner_identifier`

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -17,7 +17,7 @@ class Auth0Controller < ApplicationController
     else
       render "pages/errors/not_authorised",
         status: 401,
-        locals: {error_message: I18n.t("page_content.errors.not_authorised.explanation")}
+        locals: {error_message: t("page_content.errors.not_authorised.explanation")}
     end
   end
 

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -72,7 +72,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       when :third_party_project then UpdateActivityAsThirdPartyProject.new(activity: @activity, parent_id: parent_id).call
       end
     when :identifier
-      @activity.assign_attributes(identifier: identifier)
+      @activity.assign_attributes(delivery_partner_identifier: delivery_partner_identifier)
       add_transparency_identifier
     when :purpose
       @activity.assign_attributes(title: title, description: description)
@@ -131,8 +131,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     params.require(:activity).permit(:parent).fetch("parent", nil)
   end
 
-  def identifier
-    params.require(:activity).permit(:identifier).fetch("identifier", nil)
+  def delivery_partner_identifier
+    params.require(:activity).permit(:delivery_partner_identifier).fetch("delivery_partner_identifier", nil)
   end
 
   def sector_category

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -210,7 +210,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def finish_wizard_path
-    flash[:notice] ||= I18n.t("action.#{@activity.level}.create.success")
+    flash[:notice] ||= t("action.#{@activity.level}.create.success")
     @activity.update(form_state: "complete")
     organisation_activity_details_path(@activity.organisation, @activity)
   end
@@ -219,7 +219,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     return if @activity.invalid?
 
     if @activity.form_steps_completed?
-      flash[:notice] ||= I18n.t("action.#{@activity.level}.update.success")
+      flash[:notice] ||= t("action.#{@activity.level}.update.success")
       jump_to Wicked::FINISH_STEP
     else
       @activity.form_state = step

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -18,7 +18,7 @@ class Staff::BudgetsController < Staff::BaseController
 
     if result.success?
       @budget.create_activity key: "budget.create", owner: current_user
-      flash[:notice] = I18n.t("action.budget.create.success")
+      flash[:notice] = t("action.budget.create.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :new
@@ -42,7 +42,7 @@ class Staff::BudgetsController < Staff::BaseController
 
     if result.success?
       @budget.create_activity key: "budget.update", owner: current_user
-      flash[:notice] = I18n.t("action.budget.update.success")
+      flash[:notice] = t("action.budget.update.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/controllers/staff/extending_organisations_controller.rb
+++ b/app/controllers/staff/extending_organisations_controller.rb
@@ -15,7 +15,7 @@ class Staff::ExtendingOrganisationsController < Staff::BaseController
     if @activity.valid?(:update_extending_organisation)
       set_implementing_organisation
       @activity.save
-      flash[:notice] = I18n.t("action.#{@activity.level}.update.success")
+      flash[:notice] = t("action.#{@activity.level}.update.success")
       redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/controllers/staff/implementing_organisations_controller.rb
+++ b/app/controllers/staff/implementing_organisations_controller.rb
@@ -20,7 +20,7 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
 
     if @implementing_organisation.valid?
       @implementing_organisation.save
-      flash[:notice] = I18n.t("action.implementing_organisation.create.success")
+      flash[:notice] = t("action.implementing_organisation.create.success")
       redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :new
@@ -36,7 +36,7 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
 
     if @implementing_organisation.valid?
       @implementing_organisation.save!
-      flash[:notice] = I18n.t("action.implementing_organisation.update.success")
+      flash[:notice] = t("action.implementing_organisation.update.success")
       redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -46,7 +46,7 @@ class Staff::OrganisationsController < Staff::BaseController
     if @organisation.valid?
       @organisation.save
       @organisation.create_activity key: "organisation.create", owner: current_user
-      flash[:notice] = I18n.t("action.organisation.create.success")
+      flash[:notice] = t("action.organisation.create.success")
       redirect_to organisation_path(@organisation)
     else
       render :new
@@ -67,7 +67,7 @@ class Staff::OrganisationsController < Staff::BaseController
     if @organisation.valid?
       @organisation.save
       @organisation.create_activity key: "organisation.update", owner: current_user
-      flash[:notice] = I18n.t("action.organisation.update.success")
+      flash[:notice] = t("action.organisation.update.success")
       redirect_to organisation_path(@organisation)
     else
       render :edit

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -19,7 +19,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
 
     if result.success?
       @planned_disbursement.create_activity key: "planned_disbursement.create", owner: current_user
-      flash[:notice] = I18n.t("action.planned_disbursement.create.success")
+      flash[:notice] = t("action.planned_disbursement.create.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :new
@@ -43,7 +43,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
 
     if result.success?
       @planned_disbursement.create_activity key: "planned_disbursement.update", owner: current_user
-      flash[:notice] = I18n.t("action.planned_disbursement.update.success")
+      flash[:notice] = t("action.planned_disbursement.update.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -41,7 +41,7 @@ class Staff::ReportsController < Staff::BaseController
     if @report.valid?
       @report.save!
       @report.create_activity key: "report.update", owner: current_user
-      flash[:notice] = I18n.t("action.report.update.success")
+      flash[:notice] = t("action.report.update.success")
       redirect_to reports_path
     else
       render :edit

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -22,7 +22,7 @@ class Staff::TransactionsController < Staff::BaseController
 
     if result.success?
       @transaction.create_activity key: "transaction.create", owner: current_user
-      flash[:notice] = I18n.t("action.transaction.create.success")
+      flash[:notice] = t("action.transaction.create.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :new
@@ -46,7 +46,7 @@ class Staff::TransactionsController < Staff::BaseController
 
     if result.success?
       @transaction.create_activity key: "transaction.update", owner: current_user
-      flash[:notice] = I18n.t("action.transaction.update.success")
+      flash[:notice] = t("action.transaction.update.success")
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -25,10 +25,10 @@ class Staff::UsersController < Staff::BaseController
       result = CreateUser.new(user: @user, organisation: organisation).call
       if result.success?
         @user.create_activity key: "user.create", owner: current_user
-        flash.now[:notice] = I18n.t("action.user.create.success")
+        flash.now[:notice] = t("action.user.create.success")
         redirect_to user_path(@user.reload.id)
       else
-        flash.now[:error] = I18n.t("action.user.create.failed", error: result.error_message)
+        flash.now[:error] = t("action.user.create.failed", error: result.error_message)
         render :new
       end
     else
@@ -55,10 +55,10 @@ class Staff::UsersController < Staff::BaseController
 
       if result.success?
         @user.create_activity key: "user.update", owner: current_user
-        flash.now[:notice] = I18n.t("action.user.update.success")
+        flash.now[:notice] = t("action.user.update.success")
         redirect_to user_path(@user)
       else
-        flash.now[:error] = I18n.t("action.user.update.failed")
+        flash.now[:error] = t("action.user.update.failed")
         render :edit
       end
     else

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -10,13 +10,13 @@ module FormHelper
 
   def list_of_user_roles
     @list_of_user_roles ||= begin
-      User.roles.map { |id, name| OpenStruct.new(id: id, name: I18n.t("activerecord.attributes.user.roles.#{name}")) }
+      User.roles.map { |id, name| OpenStruct.new(id: id, name: t("activerecord.attributes.user.roles.#{name}")) }
     end
   end
 
   def list_of_budget_types
     @list_of_budget_types ||= begin
-      Budget::BUDGET_TYPES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("form.label.budget.budget_type_options.#{name}")) }
+      Budget::BUDGET_TYPES.map { |id, name| OpenStruct.new(id: id, name: t("form.label.budget.budget_type_options.#{name}")) }
     end
   end
 
@@ -25,8 +25,8 @@ module FormHelper
       PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.map do |id, name|
         OpenStruct.new(
           id: id,
-          name: I18n.t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.name"),
-          description: I18n.t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.description")
+          name: t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.name"),
+          description: t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.description")
         )
       end
     end
@@ -34,7 +34,7 @@ module FormHelper
 
   def list_of_budget_statuses
     @list_of_budget_statuses ||= begin
-      Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: I18n.t("form.label.budget.status_options.#{name}")) }
+      Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: t("form.label.budget.status_options.#{name}")) }
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -22,11 +22,11 @@ class Activity < ApplicationRecord
     :aid_type,
   ]
 
-  strip_attributes only: [:identifier]
+  strip_attributes only: [:delivery_partner_identifier]
 
   validates :level, presence: true, on: :level_step
   validates :parent, presence: true, on: :parent_step, unless: proc { |activity| activity.fund? }
-  validates :identifier, presence: true, on: :identifier_step
+  validates :delivery_partner_identifier, presence: true, on: :identifier_step
   validates :title, :description, presence: true, on: :purpose_step
   validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
@@ -38,7 +38,7 @@ class Activity < ApplicationRecord
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
 
-  validates :identifier, uniqueness: {scope: :parent_id}, allow_nil: true
+  validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :planned_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.actual_start_date.present? }
   validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
@@ -151,8 +151,8 @@ class Activity < ApplicationRecord
 
   def iati_identifier
     parent_activities.each_with_object([reporting_organisation.iati_reference]) { |parent, parent_identifiers|
-      parent_identifiers << parent.identifier
-    }.push(identifier).join("-")
+      parent_identifiers << parent.delivery_partner_identifier
+    }.push(delivery_partner_identifier).join("-")
   end
 
   def actual_total_for_report_financial_quarter(report:)

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -10,7 +10,7 @@ class ExportActivityToCsv
 
   def call
     [
-      activity_presenter.identifier,
+      activity_presenter.delivery_partner_identifier,
       activity_presenter.transparency_identifier,
       activity_presenter.sector,
       activity_presenter.title,

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -20,7 +20,8 @@ class IngestIatiActivities
 
     legacy_activity_nodes.each do |legacy_activity_node|
       legacy_activity = LegacyActivity.new(activity_node_set: legacy_activity_node, delivery_partner: delivery_partner)
-      existing_activity = Activity.find_by(previous_identifier: legacy_activity.identifier)
+      legacy_identifier = legacy_activity.identifier
+      existing_activity = Activity.find_by(previous_identifier: legacy_identifier)
 
       next if existing_activity&.ingested?
 
@@ -28,7 +29,7 @@ class IngestIatiActivities
         roda_activity = if existing_activity.present?
           existing_activity
         else
-          new_activity = Activity.new(identifier: legacy_activity.identifier, organisation: delivery_partner)
+          new_activity = Activity.new(delivery_partner_identifier: legacy_identifier, organisation: delivery_partner)
           add_identifiers(legacy_activity: legacy_activity, new_activity: new_activity)
           add_participating_organisation(delivery_partner: delivery_partner, new_activity: new_activity, legacy_activity: legacy_activity)
           add_title(legacy_activity: legacy_activity, new_activity: new_activity)
@@ -291,7 +292,7 @@ class IngestIatiActivities
 
   private def add_identifiers(legacy_activity:, new_activity:)
     new_activity.previous_identifier = legacy_activity.elements.detect { |element| element.name.eql?("iati-identifier") }.children.text
-    new_activity.identifier = legacy_activity.infer_internal_identifier
+    new_activity.delivery_partner_identifier = legacy_activity.infer_internal_identifier
   end
 
   private def service_owner_organisation

--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,3 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :aid_type
-  = f.govuk_collection_radio_buttons :aid_type, aid_type_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.aid_type") }, hint_text: I18n.t("form.hint.activity.aid_type").html_safe
+  = f.govuk_collection_radio_buttons :aid_type, aid_type_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.aid_type") }, hint_text: t("form.hint.activity.aid_type").html_safe

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl' }, hint_text: I18n.t("form.hint.activity.flow").html_safe
+  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl' }, hint_text: t("form.hint.activity.flow").html_safe

--- a/app/views/staff/activity_forms/identifier.html.haml
+++ b/app/views/staff/activity_forms/identifier.html.haml
@@ -1,2 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_text_field :identifier, label: { tag: 'h1', size: 'xl' }
+  = f.govuk_text_field :delivery_partner_identifier, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/activity_forms/level.html.haml
+++ b/app/views/staff/activity_forms/level.html.haml
@@ -5,5 +5,5 @@
     :level,
     :name,
     :description,
-    legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.level") },
-    hint_text: I18n.t("form.hint.activity.level")
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.level") },
+    hint_text: t("form.hint.activity.level")

--- a/app/views/staff/activity_forms/parent.html.haml
+++ b/app/views/staff/activity_forms/parent.html.haml
@@ -5,7 +5,7 @@
     scoped_parent_activities,
     :id,
     ->(activity){ ActivityPresenter.new(activity).display_title },
-    legend: { tag: 'h1', size: 'xl', text: I18n.t("form.legend.activity.parent", parent_level: f.object.parent_level, level: f.object.level) },
-    hint_text: I18n.t("form.hint.activity.parent",
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.parent", parent_level: f.object.parent_level, level: f.object.level) },
+    hint_text: t("form.hint.activity.parent",
       parent_level: f.object.parent_level,
       level: I18n.t("page_content.activity.level.#{f.object.level}"))

--- a/app/views/staff/activity_forms/sector.html.haml
+++ b/app/views/staff/activity_forms/sector.html.haml
@@ -5,4 +5,4 @@
     sector_radio_options(category: f.object.sector_category),
     :code,
     :name,
-    legend: { tag: 'h1', size: 'xl', text:  I18n.t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{f.object.sector_category}"), level: t("page_content.activity.level.#{f.object.level}")) }
+    legend: { tag: 'h1', size: 'xl', text:  t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{f.object.sector_category}"), level: t("page_content.activity.level.#{f.object.level}")) }

--- a/app/views/staff/activity_redactions/edit.html.haml
+++ b/app/views/staff/activity_redactions/edit.html.haml
@@ -7,10 +7,10 @@
       = form_for @activity, url: activity_redaction_path(@activity) do |f|
 
         = f.govuk_collection_radio_buttons :publish_to_iati,
-          [OpenStruct.new(id: true, name: I18n.t("summary.label.activity.publish_to_iati.true")),
-            OpenStruct.new(id: false, name: I18n.t("summary.label.activity.publish_to_iati.false"))],
+          [OpenStruct.new(id: true, name: t("summary.label.activity.publish_to_iati.true")),
+            OpenStruct.new(id: false, name: t("summary.label.activity.publish_to_iati.false"))],
           :id,
           :name,
-          legend: { text: I18n.t("form.label.activity.publish_to_iati") }
+          legend: { text: t("form.label.activity.publish_to_iati") }
 
         = f.govuk_submit t("form.button.activity.submit")

--- a/app/views/staff/organisations/index.html.haml
+++ b/app/views/staff/organisations/index.html.haml
@@ -7,7 +7,7 @@
         = t("page_title.organisation.index")
 
       - if policy(Organisation).new?
-        = link_to(I18n.t("page_content.organisations.button.create"), new_organisation_path, class: "govuk-button")
+        = link_to(t("page_content.organisations.button.create"), new_organisation_path, class: "govuk-button")
 
       - if @organisations
         = render partial: "staff/organisations/table", locals: { organisations: @organisations }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -27,9 +27,9 @@
 
   .govuk-summary-list__row.identifier
     %dt.govuk-summary-list__key
-      = t("summary.label.activity.identifier")
+      = t("summary.label.activity.delivery_partner_identifier")
     %dd.govuk-summary-list__value
-      = activity_presenter.identifier
+      = activity_presenter.delivery_partner_identifier
     %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.transparency-identifier

--- a/app/views/staff/shared/activities/_budgets.html.haml
+++ b/app/views/staff/shared/activities/_budgets.html.haml
@@ -4,5 +4,5 @@
       = t("page_content.activity.budgets")
 
     - if policy(activity).create?
-      = link_to(I18n.t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
+      = link_to(t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/budgets/table', locals: { budgets: budget_presenters }

--- a/app/views/staff/shared/activities/_extending_organisation.html.haml
+++ b/app/views/staff/shared/activities/_extending_organisation.html.haml
@@ -9,4 +9,4 @@
       %p.govuk-body
         = activity.extending_organisation.name
 
-    = link_to(I18n.t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisations_path(activity), class: "govuk-button")
+    = link_to(t("page_content.activity.extending_organisation.button.edit"), edit_activity_extending_organisations_path(activity), class: "govuk-button")

--- a/app/views/staff/shared/activities/_planned_disbursements.html.haml
+++ b/app/views/staff/shared/activities/_planned_disbursements.html.haml
@@ -3,5 +3,5 @@
     %h2.govuk-heading-m
       = t("page_content.activity.planned_disbursements")
     - if policy(activity).create?
-      = link_to(I18n.t("page_content.planned_disbursements.button.create"), new_activity_planned_disbursement_path(activity), class: "govuk-button")
+      = link_to(t("page_content.planned_disbursements.button.create"), new_activity_planned_disbursement_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/planned_disbursements/table', locals: { planned_disbursements: planned_disbursements }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -14,7 +14,7 @@
       - activities.each do |activity|
         %tr.govuk-table__row{ id: activity.id }
           %td.govuk-table__cell= activity.display_title
-          %td.govuk-table__cell= activity.identifier
+          %td.govuk-table__cell= activity.delivery_partner_identifier
           %td.govuk-table__cell= activity.level
           %td.govuk-table__cell
             = a11y_action_link t("table.body.activity.view_activity"),

--- a/app/views/staff/shared/activities/_transactions.html.haml
+++ b/app/views/staff/shared/activities/_transactions.html.haml
@@ -3,5 +3,5 @@
     %h2.govuk-heading-m
       = t("page_content.activity.transactions")
     - if policy(activity).create?
-      = link_to(I18n.t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
+      = link_to(t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/transactions/table', locals: { transactions: transaction_presenters }

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -27,4 +27,4 @@
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).create?
-              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("table.body.budget.edit_noun"))
+              = a11y_action_link(t('default.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("table.body.budget.edit_noun"))

--- a/app/views/staff/shared/planned_disbursements/_table.html.haml
+++ b/app/views/staff/shared/planned_disbursements/_table.html.haml
@@ -31,4 +31,4 @@
           %td.govuk-table__cell= planned_disbursement.receiving_organisation_name
           - if policy(planned_disbursement.parent_activity).edit?
             %td.govuk-table__cell
-              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_planned_disbursement_path(planned_disbursement.parent_activity, planned_disbursement), t("table.body.planned_disbursement.edit_noun"))
+              = a11y_action_link(t('default.link.edit'), edit_activity_planned_disbursement_path(planned_disbursement.parent_activity, planned_disbursement), t("table.body.planned_disbursement.edit_noun"))

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -16,7 +16,7 @@
     - programmes.each do |programme|
       %tr.govuk-table__row{id: programme.id}
         %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
-        %td.govuk-table__cell= programme.identifier
+        %td.govuk-table__cell= programme.delivery_partner_identifier
         %td.govuk-table__cell= programme.parent_title
         %td.govuk-table__cell
           - if programme.form_steps_completed?

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -20,7 +20,7 @@
       - projects.each do |project|
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
-          %td.govuk-table__cell= project.identifier
+          %td.govuk-table__cell= project.delivery_partner_identifier
           %td.govuk-table__cell= project.parent_title
           %td.govuk-table__cell
             - if project.form_steps_completed?

--- a/app/views/staff/shared/reports/_table.html.haml
+++ b/app/views/staff/shared/reports/_table.html.haml
@@ -28,5 +28,5 @@
           %td.govuk-table__cell= report.deadline
           %td.govuk-table__cell
             - if policy(:report).edit?
-              = link_to I18n.t("default.link.edit"), edit_report_path(report), class: "govuk-link"
-            = link_to I18n.t("default.link.view"), report_path(report), class: "govuk-link"
+              = link_to t("default.link.edit"), edit_report_path(report), class: "govuk-link"
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link"

--- a/app/views/staff/shared/reports/_table_inactive.html.haml
+++ b/app/views/staff/shared/reports/_table_inactive.html.haml
@@ -27,5 +27,5 @@
           %td.govuk-table__cell= report.fund.title
           %td.govuk-table__cell= report.deadline
           %td.govuk-table__cell
-            = link_to I18n.t("table.body.report.action.edit"), edit_report_path(report), class: "govuk-link govuk-!-margin-left-2"
-            = link_to I18n.t("table.body.report.action.activate"), edit_report_state_path(report), class: "govuk-link govuk-!-margin-left-2"
+            = link_to t("table.body.report.action.edit"), edit_report_path(report), class: "govuk-link govuk-!-margin-left-2"
+            = link_to t("table.body.report.action.activate"), edit_report_state_path(report), class: "govuk-link govuk-!-margin-left-2"

--- a/app/views/staff/shared/reports/_table_submitted.html.haml
+++ b/app/views/staff/shared/reports/_table_submitted.html.haml
@@ -24,4 +24,4 @@
           %td.govuk-table__cell= report.description
           %td.govuk-table__cell= report.fund.title
           %td.govuk-table__cell
-            = link_to I18n.t("default.link.view"), report_path(report), class: "govuk-link"
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link"

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -20,7 +20,7 @@
       - third_party_projects.each do |project|
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
-          %td.govuk-table__cell= project.identifier
+          %td.govuk-table__cell= project.delivery_partner_identifier
           %td.govuk-table__cell= project.parent_title
           %td.govuk-table__cell
             - if project.form_steps_completed?

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -30,4 +30,4 @@
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(transaction).create?
-              = a11y_action_link(I18n.t('default.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))
+              = a11y_action_link(t('default.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -23,4 +23,4 @@
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = a11y_action_link(t("default.link.show"), user_path(user), user.name)
-          = a11y_action_link(I18n.t("default.link.edit"), edit_user_path(user), user.name)
+          = a11y_action_link(t("default.link.edit"), edit_user_path(user), user.name)

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -53,4 +53,4 @@
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }
   - if activity.project?
     - activity.parent_activities.each do |parent_activity|
-      %related-activity{"ref" => parent_activity.identifier, "type" => 1}
+      %related-activity{"ref" => parent_activity.delivery_partner_identifier, "type" => 1}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Set a css_compressor so sassc-rails does not overwrite the compressor
   # See https://github.com/DFE-Digital/dfe-teachers-payment-service/commit/74ec587cfbe9aa6d0df01a72e99d70ffe9024748

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -25,7 +25,7 @@ en:
         geography_options:
           recipient_region: Region
           recipient_country: Country
-        identifier: Enter your unique identifier
+        delivery_partner_identifier: Enter your unique identifier
         region: Recipient region
         actual_end_date: Actual end date
         actual_start_date: Actual start date
@@ -64,7 +64,7 @@ en:
         call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
-        identifier: This could be the reference you use in your internal systems. This value cannot be edited once it is set
+        delivery_partner_identifier: This could be the reference you use in your internal systems. This value cannot be edited once it is set
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
         sector_category: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
@@ -96,7 +96,7 @@ en:
           incomplete: Incomplete
         flow: Flow type
         geography: Benefitting recipient geography
-        identifier: Identifier
+        delivery_partner_identifier: Identifier
         level: Level
         organisation: Organisation
         parent: Parent activity
@@ -192,7 +192,7 @@ en:
         dates: What are the start and end dates for the %{level}?
         flow: Flow
         geography: Will the benefitting recipient be a region or country?
-        identifier: Enter your unique identifier
+        delivery_partner_identifier: Enter your unique identifier
         level: Hierarchy level
         parent: Select the parent
         programme_status: A description of the status of the activity
@@ -225,7 +225,7 @@ en:
               blank: Select the activity type
             parent:
               blank: Select a parent activity
-            identifier:
+            delivery_partner_identifier:
               blank: Enter a unique identifier
             title:
               blank: Enter a title

--- a/db/migrate/20200821155008_rename_identifier_to_delivery_partner_identifier.rb
+++ b/db/migrate/20200821155008_rename_identifier_to_delivery_partner_identifier.rb
@@ -1,0 +1,5 @@
+class RenameIdentifierToDeliveryPartnerIdentifier < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :activities, :identifier, :delivery_partner_identifier
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_131932) do
+ActiveRecord::Schema.define(version: 2020_08_21_155008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_131932) do
     t.uuid "organisation_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "identifier"
+    t.string "delivery_partner_identifier"
     t.string "sector"
     t.string "title"
     t.text "description"

--- a/lib/legacy_activity.rb
+++ b/lib/legacy_activity.rb
@@ -34,7 +34,7 @@ class LegacyActivity
 
   def find_parent
     parent_identifier = activity_to_parent_mapping.fetch(identifier)
-    Activity.find_by!(identifier: parent_identifier)
+    Activity.find_by!(delivery_partner_identifier: parent_identifier)
   rescue ActiveRecord::RecordNotFound, KeyError
     raise ParentNotFoundForActivity.new(identifier)
   end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :activity do
     title { Faker::Lorem.sentence }
-    identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
+    delivery_partner_identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }
@@ -105,7 +105,7 @@ FactoryBot.define do
   end
 
   trait :at_identifier_step do
-    identifier { nil }
+    delivery_partner_identifier { nil }
     form_state { "identifier" }
     title { nil }
     description { nil }
@@ -185,7 +185,7 @@ FactoryBot.define do
   trait :level_form_state do
     form_state { "level" }
     level { nil }
-    identifier { nil }
+    delivery_partner_identifier { nil }
     title { nil }
     description { nil }
     sector { nil }
@@ -207,7 +207,7 @@ FactoryBot.define do
   trait :parent_form_state do
     form_state { "parent" }
     level { "programme" }
-    identifier { nil }
+    delivery_partner_identifier { nil }
     title { nil }
     description { nil }
     sector { nil }
@@ -227,8 +227,8 @@ FactoryBot.define do
 
   trait :with_transparency_identifier do
     after(:create) do |activity|
-      parent_identifier = activity.parent.present? ? "#{activity.parent.identifier}-" : ""
-      activity.transparency_identifier = "#{parent_identifier}#{activity.identifier}"
+      parent_identifier = activity.parent.present? ? "#{activity.parent.delivery_partner_identifier}-" : ""
+      activity.transparency_identifier = "#{parent_identifier}#{activity.delivery_partner_identifier}"
       activity.save
     end
   end

--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -1,7 +1,7 @@
 feature "Home page" do
   scenario "visit the home page" do
     visit root_path
-    expect(page).to have_content(I18n.t("app.title"))
+    expect(page).to have_content(t("app.title"))
   end
 
   context "when signed in as a BEIS user" do
@@ -30,7 +30,7 @@ feature "Home page" do
 
     scenario "they are shown the start page" do
       visit root_path
-      expect(page).to have_button(I18n.t("header.link.sign_in"))
+      expect(page).to have_button(t("header.link.sign_in"))
     end
   end
 end

--- a/spec/features/public/visitors/user_can_view_privacy_policy_spec.rb
+++ b/spec/features/public/visitors/user_can_view_privacy_policy_spec.rb
@@ -5,14 +5,14 @@ RSpec.feature "Users can view the privacy policy" do
     visit root_path
 
     within("footer") do
-      expect(page).to have_link I18n.t("footer.link.privacy_policy")
+      expect(page).to have_link t("footer.link.privacy_policy")
     end
   end
 
   scenario "the linked privacy policy page can be viewed" do
     visit root_path
-    click_on I18n.t("footer.link.privacy_policy")
+    click_on t("footer.link.privacy_policy")
 
-    expect(page).to have_content I18n.t("page_title.privacy_policy")
+    expect(page).to have_content t("page_title.privacy_policy")
   end
 end

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -14,31 +14,31 @@ RSpec.feature "BEIS users can create organisations" do
 
     scenario "successfully creating an organisation" do
       visit organisation_path(user.organisation)
-      click_link I18n.t("page_title.organisation.index")
-      click_link I18n.t("page_content.organisations.button.create")
+      click_link t("page_title.organisation.index")
+      click_link t("page_content.organisations.button.create")
 
-      expect(page).to have_content(I18n.t("page_title.organisation.new"))
+      expect(page).to have_content(t("page_title.organisation.new"))
       fill_in "organisation[name]", with: "My New Organisation"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
-      click_button I18n.t("default.button.submit")
+      click_button t("default.button.submit")
     end
 
     scenario "organisation creation is tracked with public_activity" do
       PublicActivity.with_tracking do
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_title.organisation.index")
-        click_link I18n.t("page_content.organisations.button.create")
+        click_link t("page_title.organisation.index")
+        click_link t("page_content.organisations.button.create")
 
-        expect(page).to have_content(I18n.t("page_title.organisation.new"))
+        expect(page).to have_content(t("page_title.organisation.new"))
         fill_in "organisation[name]", with: "My New Organisation"
         fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
         select "Government", from: "organisation[organisation_type]"
         select "Swedish", from: "organisation[language_code]"
         select "US Dollar", from: "organisation[default_currency]"
-        click_button I18n.t("default.button.submit")
+        click_button t("default.button.submit")
 
         organisation = Organisation.find_by(name: "My New Organisation")
         auditable_event = PublicActivity::Activity.find_by(trackable_id: organisation.id)
@@ -50,15 +50,15 @@ RSpec.feature "BEIS users can create organisations" do
 
     scenario "presence validation works as expected" do
       visit organisation_path(user.organisation)
-      click_link I18n.t("page_title.organisation.index")
-      click_link I18n.t("page_content.organisations.button.create")
+      click_link t("page_title.organisation.index")
+      click_link t("page_content.organisations.button.create")
 
-      expect(page).to have_content(I18n.t("page_title.organisation.new"))
+      expect(page).to have_content(t("page_title.organisation.new"))
       fill_in "organisation[name]", with: "My New Organisation"
 
-      click_button I18n.t("default.button.submit")
-      expect(page).to_not have_content I18n.t("action.organisation.create.success")
-      expect(page).to have_content I18n.t("activerecord.errors.models.organisation.attributes.organisation_type.blank")
+      click_button t("default.button.submit")
+      expect(page).to_not have_content t("action.organisation.create.success")
+      expect(page).to have_content t("activerecord.errors.models.organisation.attributes.organisation_type.blank")
     end
 
     context "when the user does not belongs to BEIS" do
@@ -66,7 +66,7 @@ RSpec.feature "BEIS users can create organisations" do
 
       it "does not show them the manage user button" do
         visit organisation_path(user.organisation)
-        expect(page).not_to have_content(I18n.t("page_title.organisation.index"))
+        expect(page).not_to have_content(t("page_title.organisation.index"))
       end
     end
   end

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "BEIS users can create organisations" do
 
       it "does not show them the manage user button" do
         visit organisation_path(user.organisation)
-        expect(page).not_to have_content(I18n.t("page_content.dashboard.button.manage_organisations"))
+        expect(page).not_to have_content(I18n.t("page_title.organisation.index"))
       end
     end
   end

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -12,16 +12,16 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "2021"
 
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to have_content I18n.t("action.report.update.success")
+      expect(page).to have_content t("action.report.update.success")
       within "##{report.id}" do
         expect(page).to have_content("31 Jan 2021")
       end
@@ -35,14 +35,14 @@ RSpec.feature "BEIS users can edit a report" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on I18n.t("default.link.edit")
+          click_on t("default.link.edit")
         end
 
         fill_in "report[deadline(3i)]", with: "31"
         fill_in "report[deadline(2i)]", with: "1"
         fill_in "report[deadline(1i)]", with: "2021"
 
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         auditable_events = PublicActivity::Activity.where(trackable_id: report.id)
         expect(auditable_events.map(&:key)).to include "report.update"
@@ -57,17 +57,17 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "2001"
 
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to_not have_content I18n.t("action.report.update.success")
-      expect(page).to have_content I18n.t("activerecord.errors.models.report.attributes.deadline.not_in_past")
+      expect(page).to_not have_content t("action.report.update.success")
+      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.not_in_past")
     end
 
     scenario "the deadline cannot be very far in the future" do
@@ -77,17 +77,17 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "200020"
 
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to_not have_content I18n.t("action.report.update.success")
-      expect(page).to have_content I18n.t("activerecord.errors.models.report.attributes.deadline.between", min: 10, max: 25)
+      expect(page).to_not have_content t("action.report.update.success")
+      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 10, max: 25)
     end
 
     scenario "setting a Report's deadline logs an activity in PublicActivity" do
@@ -98,14 +98,14 @@ RSpec.feature "BEIS users can edit a report" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on I18n.t("default.link.edit")
+          click_on t("default.link.edit")
         end
 
         fill_in "report[deadline(3i)]", with: "31"
         fill_in "report[deadline(2i)]", with: "1"
         fill_in "report[deadline(1i)]", with: "2021"
 
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         auditable_events = PublicActivity::Activity.where(trackable_id: report.id)
         expect(auditable_events.map(&:key)).to match_array ["report.update"]
@@ -120,14 +120,14 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "report[description]", with: "Quarter 4 2020"
 
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to have_content I18n.t("action.report.update.success")
+      expect(page).to have_content t("action.report.update.success")
 
       within "##{report.id}" do
         expect(page).to have_content("Quarter 4 2020")
@@ -141,15 +141,15 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "report[description]", with: ""
 
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to_not have_content I18n.t("action.report.update.success")
-      expect(page).to have_content I18n.t("activerecord.errors.models.report.attributes.description.blank")
+      expect(page).to_not have_content t("action.report.update.success")
+      expect(page).to have_content t("activerecord.errors.models.report.attributes.description.blank")
     end
   end
 
@@ -164,7 +164,7 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        expect(page).to_not have_content(I18n.t("default.link.edit"))
+        expect(page).to_not have_content(t("default.link.edit"))
       end
     end
   end

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -25,10 +25,10 @@ RSpec.feature "BEIS users can editing other users" do
     # Navigate from the landing page
     visit organisation_path(user.organisation)
 
-    click_on(I18n.t("page_title.users.index"))
+    click_on(t("page_title.users.index"))
 
     # Navigate to the users page
-    expect(page).to have_content(I18n.t("page_title.users.index"))
+    expect(page).to have_content(t("page_title.users.index"))
 
     # Find the target user and click on edit button
 
@@ -39,7 +39,7 @@ RSpec.feature "BEIS users can editing other users" do
     fill_in "user[email]", with: updated_email
 
     # Submit the form
-    click_button I18n.t("form.button.user.submit")
+    click_button t("form.button.user.submit")
 
     # Verify the user was updated
     expect(page).to have_content(updated_name)
@@ -51,7 +51,7 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on I18n.t("page_title.users.index")
+    click_on t("page_title.users.index")
 
     expect(page).to have_content(user.name)
 
@@ -68,11 +68,11 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on I18n.t("page_title.users.index")
+    click_on t("page_title.users.index")
     find("tr", text: user.name).click_link("Edit")
 
-    choose I18n.t("form.user.active.inactive")
-    click_on I18n.t("default.button.submit")
+    choose t("form.user.active.inactive")
+    click_on t("default.button.submit")
 
     expect(user.reload.active).to be false
   end
@@ -83,11 +83,11 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on I18n.t("page_title.users.index")
+    click_on t("page_title.users.index")
     find("tr", text: user.name).click_link("Edit")
 
-    choose I18n.t("form.user.active.active")
-    click_on I18n.t("default.button.submit")
+    choose t("form.user.active.active")
+    click_on t("default.button.submit")
 
     expect(user.reload.active).to be true
   end
@@ -109,14 +109,14 @@ RSpec.feature "BEIS users can editing other users" do
     PublicActivity.with_tracking do
       visit organisation_path(user.organisation)
 
-      click_on(I18n.t("page_title.users.index"))
+      click_on(t("page_title.users.index"))
 
       find("tr", text: target_user.name).click_link("Edit")
 
       fill_in "user[name]", with: updated_name
       fill_in "user[email]", with: updated_email
 
-      click_button I18n.t("form.button.user.submit")
+      click_button t("form.button.user.submit")
 
       auditable_event = PublicActivity::Activity.find_by(trackable_id: target_user.id)
       expect(auditable_event.key).to eq "user.update"

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
             click_button I18n.t("default.button.submit")
 
             expect(page).to have_content("Email is invalid")
-            expect(page).not_to have_content(I18n.t("form.user.create.failed"))
+            expect(page).not_to have_content(I18n.t("action.user.create.failed"))
           end
         end
       end
@@ -121,7 +121,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       it "does not show them the manage user button" do
         visit organisation_path(user.organisation)
-        expect(page).not_to have_content(I18n.t("page_content.dashboard.button.manage_users"))
+        expect(page).not_to have_content(I18n.t("page_title.users.index"))
       end
     end
   end

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -62,14 +62,14 @@ RSpec.feature "BEIS users can invite new users to the service" do
         it "shows the user validation errors instead" do
           visit new_user_path
 
-          expect(page).to have_content(I18n.t("page_title.users.new"))
+          expect(page).to have_content(t("page_title.users.new"))
           fill_in "user[name]", with: "" # deliberately omit a value
           fill_in "user[email]", with: "" # deliberately omit a value
 
-          click_button I18n.t("default.button.submit")
+          click_button t("default.button.submit")
 
-          expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.name.blank"))
-          expect(page).to have_content(I18n.t("activerecord.errors.models.user.attributes.email.blank"))
+          expect(page).to have_content(t("activerecord.errors.models.user.attributes.name.blank"))
+          expect(page).to have_content(t("activerecord.errors.models.user.attributes.email.blank"))
         end
       end
 
@@ -83,16 +83,16 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
             visit new_user_path
 
-            expect(page).to have_content(I18n.t("page_title.users.new"))
+            expect(page).to have_content(t("page_title.users.new"))
             fill_in "user[name]", with: "foo"
             fill_in "user[email]", with: new_email
             choose organisation.name
 
             expect {
-              click_button I18n.t("default.button.submit")
+              click_button t("default.button.submit")
             }.not_to change { User.count }
 
-            expect(page).to have_content(I18n.t("action.user.create.failed", error: "The user already exists."))
+            expect(page).to have_content(t("action.user.create.failed", error: "The user already exists."))
           end
         end
 
@@ -107,10 +107,10 @@ RSpec.feature "BEIS users can invite new users to the service" do
             fill_in "user[email]", with: "tom"
             choose organisation.name
 
-            click_button I18n.t("default.button.submit")
+            click_button t("default.button.submit")
 
             expect(page).to have_content("Email is invalid")
-            expect(page).not_to have_content(I18n.t("action.user.create.failed"))
+            expect(page).not_to have_content(t("action.user.create.failed"))
           end
         end
       end
@@ -121,7 +121,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       it "does not show them the manage user button" do
         visit organisation_path(user.organisation)
-        expect(page).not_to have_content(I18n.t("page_title.users.index"))
+        expect(page).not_to have_content(t("page_title.users.index"))
       end
     end
   end
@@ -129,21 +129,21 @@ RSpec.feature "BEIS users can invite new users to the service" do
   def create_user(organisation, new_user_name, new_user_email)
     # Navigate from the landing page
     visit organisation_path(organisation)
-    click_on(I18n.t("page_title.users.index"))
+    click_on(t("page_title.users.index"))
 
     # Navigate to the users page
-    expect(page).to have_content(I18n.t("page_title.users.index"))
+    expect(page).to have_content(t("page_title.users.index"))
 
     # Create a new user
-    click_on(I18n.t("page_content.users.button.create"))
+    click_on(t("page_content.users.button.create"))
 
     # Fill out the form
-    expect(page).to have_content(I18n.t("page_title.users.new"))
+    expect(page).to have_content(t("page_title.users.new"))
     fill_in "user[name]", with: new_user_name
     fill_in "user[email]", with: new_user_email
     choose organisation.name
 
     # Submit the form
-    click_button I18n.t("default.button.submit")
+    click_button t("default.button.submit")
   end
 end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
       visit organisations_path
 
-      expect(page).to have_content(I18n.t("page_title.organisation.index"))
+      expect(page).to have_content(t("page_title.organisation.index"))
       expect(page).to have_content(user.organisation.name)
       expect(page).to have_content(another_organisation.name)
     end

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -20,21 +20,21 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(I18n.t("page_title.users.index"))
+      click_on(t("page_title.users.index"))
 
       # Navigate to the users page
-      expect(page).to have_content(I18n.t("page_title.users.index"))
+      expect(page).to have_content(t("page_title.users.index"))
       expect(page).to have_content(another_user.name)
       expect(page).to have_content(another_user.email)
       expect(page).to have_content(another_user.organisation.name)
-      expect(page).to have_content(I18n.t("form.user.active.true"))
+      expect(page).to have_content(t("form.user.active.true"))
 
       # Navigate to the individual user page
       within(".users") do
-        find("tr", text: another_user.name).click_link(I18n.t("default.link.show"))
+        find("tr", text: another_user.name).click_link(t("default.link.show"))
       end
 
-      expect(page).to have_content(I18n.t("page_title.users.show"))
+      expect(page).to have_content(t("page_title.users.show"))
       expect(page).to have_content(another_user.name)
       expect(page).to have_content(another_user.email)
     end
@@ -50,7 +50,7 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(I18n.t("page_title.users.index"))
+      click_on(t("page_title.users.index"))
 
       expected_array = [
         a1_user.organisation.name,
@@ -68,17 +68,17 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(I18n.t("page_title.users.index"))
+      click_on(t("page_title.users.index"))
 
       # The details include whether the user is active
-      expect(page).to have_content(I18n.t("form.user.active.false"))
+      expect(page).to have_content(t("form.user.active.false"))
 
       # Navigate to the individual user page
       within(".users") do
-        find("tr", text: another_user.name).click_link(I18n.t("default.link.show"))
+        find("tr", text: another_user.name).click_link(t("default.link.show"))
       end
 
-      expect(page).to have_content(I18n.t("form.user.active.false"))
+      expect(page).to have_content(t("form.user.active.false"))
     end
   end
 end

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -18,7 +18,7 @@ feature "Organisation show page" do
       scenario "they see a edit details button" do
         visit organisation_path(beis_user.organisation)
 
-        expect(page).to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
+        expect(page).to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
       end
 
       context "when viewing a delivery partners organisation" do
@@ -28,7 +28,7 @@ feature "Organisation show page" do
 
           visit organisation_path(delivery_partner_organisation)
 
-          expect(page).to have_link I18n.t("page_content.organisation.download.title"),
+          expect(page).to have_link t("page_content.organisation.download.title"),
             href: organisation_path(delivery_partner_organisation, format: :xml, level: :project)
         end
 
@@ -38,7 +38,7 @@ feature "Organisation show page" do
 
           visit organisation_path(delivery_partner_organisation)
 
-          expect(page).to have_link I18n.t("page_content.organisation.download.title"),
+          expect(page).to have_link t("page_content.organisation.download.title"),
             href: organisation_path(delivery_partner_organisation, format: :xml, level: :third_party_project)
         end
       end
@@ -53,7 +53,7 @@ feature "Organisation show page" do
     scenario "they do not see the edit detials button" do
       visit organisation_path(delivery_partner_user.organisation)
 
-      expect(page).not_to have_link I18n.t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)
+      expect(page).not_to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)
     end
   end
 end

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Users can activate reports" do
       report = create(:report, state: :inactive)
 
       visit report_path(report)
-      click_link I18n.t("action.report.activate.button")
-      click_button I18n.t("action.report.activate.confirm.button")
+      click_link t("action.report.activate.button")
+      click_button t("action.report.activate.confirm.button")
 
       expect(page).to have_content "complete"
       expect(report.reload.state).to eql "active"

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -9,30 +9,30 @@ RSpec.feature "Users can choose a recipient country" do
     before do
       visit activity_step_path(activity, :geography)
       choose "Country"
-      click_button I18n.t("form.button.activity.submit")
+      click_button t("form.button.activity.submit")
     end
 
     context "with JavaScript disabled" do
       scenario "countries are choosen from a select box" do
-        expect(page).to have_select(I18n.t("form.label.activity.recipient_country"))
+        expect(page).to have_select(t("form.label.activity.recipient_country"))
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do
         select "Botswana"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         expect(activity.reload.recipient_region).to eq("289") # South of Sahara
       end
     end
 
     context "with JavaScript enabled", js: true do
       scenario "countries are choosen from an autocomplete" do
-        expect(page).not_to have_select(I18n.t("form.label.activity.recipient_country"))
-        expect(page).to have_field(I18n.t("form.label.activity.recipient_country"))
+        expect(page).not_to have_select(t("form.label.activity.recipient_country"))
+        expect(page).to have_field(t("form.label.activity.recipient_country"))
         expect(page).to have_css("input.autocomplete__input")
       end
 
       scenario "typing a partial match displays all the matching countries" do
-        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
+        fill_in t("form.label.activity.recipient_country"), with: "saint"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Lucia", visible: true
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Vincent and the Grenadines", visible: true
@@ -50,23 +50,23 @@ RSpec.feature "Users can choose a recipient country" do
       end
 
       scenario "typing a known country displays that country in the list of countries" do
-        fill_in I18n.t("form.label.activity.recipient_country"), with: "afghanistan"
+        fill_in t("form.label.activity.recipient_country"), with: "afghanistan"
 
         expect(page).to have_selector "li.autocomplete__option", text: "Afghanistan", visible: true
       end
 
       scenario "typing a partial match, clicking on the complete match and clicking continue saves the country " do
-        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
+        fill_in t("form.label.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
-        click_button I18n.t("form.button.activity.submit")
-        click_link I18n.t("default.link.back")
+        click_button t("form.button.activity.submit")
+        click_link t("default.link.back")
         expect(page).to have_content "Saint Lucia"
       end
 
       scenario "choosing a recipient country sets a recipient region associated to that country" do
-        fill_in I18n.t("form.label.activity.recipient_country"), with: "saint"
+        fill_in t("form.label.activity.recipient_country"), with: "saint"
         find("li.autocomplete__option", text: "Saint Lucia").click
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         expect(activity.reload.recipient_region).to eq("380") # West Indies
       end
     end

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "Users can create a budget" do
         visit activities_path
         click_on(fund_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+        click_on(t("page_content.budgets.button.create"))
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(I18n.t("action.budget.create.success"))
+        expect(page).to have_content(t("action.budget.create.success"))
       end
 
       scenario "budget creation is tracked with public_activity" do
@@ -25,7 +25,7 @@ RSpec.describe "Users can create a budget" do
           visit activities_path
           click_on(fund_activity.title)
 
-          click_on(I18n.t("page_content.budgets.button.create"))
+          click_on(t("page_content.budgets.button.create"))
 
           fill_in_and_submit_budget_form
 
@@ -45,14 +45,14 @@ RSpec.describe "Users can create a budget" do
 
         visit activities_path
         click_on(programme_activity.parent.title)
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_on(programme_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+        click_on(t("page_content.budgets.button.create"))
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(I18n.t("action.budget.create.success"))
+        expect(page).to have_content(t("action.budget.create.success"))
       end
 
       scenario "sees validation errors for missing attributes" do
@@ -62,19 +62,19 @@ RSpec.describe "Users can create a budget" do
         visit activities_path
 
         click_on(programme_activity.parent.title)
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_on(programme_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+        click_on(t("page_content.budgets.button.create"))
 
-        click_button I18n.t("default.button.submit")
+        click_button t("default.button.submit")
 
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.budget_type.blank"))
-        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.status.blank"))
-        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
-        expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_end_date.blank"))
-        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.other_than")
+        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.budget_type.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.status.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.period_end_date.blank"))
+        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.other_than")
       end
 
       scenario "sees validation error when the value is more than allowed" do
@@ -84,12 +84,12 @@ RSpec.describe "Users can create a budget" do
         visit activities_path
 
         click_on(programme_activity.parent.title)
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_on(programme_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+        click_on(t("page_content.budgets.button.create"))
 
-        click_button I18n.t("default.button.submit")
+        click_button t("default.button.submit")
 
         choose("budget[budget_type]", option: "1")
         choose("budget[status]", option: "1")
@@ -101,9 +101,9 @@ RSpec.describe "Users can create a budget" do
         fill_in "budget[period_end_date(1i)]", with: "2020"
         select "Pound Sterling", from: "budget[currency]"
         fill_in "budget[value]", with: "10000000000000.00"
-        click_button I18n.t("default.button.submit")
+        click_button t("default.button.submit")
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.budget.attributes.value.less_than_or_equal_to")
+        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.less_than_or_equal_to")
       end
     end
   end
@@ -120,8 +120,8 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(user.organisation, programme_activity)
 
-        expect(page).to have_content(I18n.t("page_content.activity.budgets"))
-        expect(page).not_to have_content(I18n.t("page_content.budgets.button.create"))
+        expect(page).to have_content(t("page_content.activity.budgets"))
+        expect(page).not_to have_content(t("page_content.budgets.button.create"))
       end
     end
 
@@ -139,11 +139,11 @@ RSpec.describe "Users can create a budget" do
 
         click_on(project_activity.title)
 
-        click_on(I18n.t("page_content.budgets.button.create"))
+        click_on(t("page_content.budgets.button.create"))
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(I18n.t("action.budget.create.success"))
+        expect(page).to have_content(t("action.budget.create.success"))
       end
     end
   end
@@ -159,6 +159,6 @@ RSpec.describe "Users can create a budget" do
     fill_in "budget[period_end_date(1i)]", with: "2020"
     select "Pound Sterling", from: "budget[currency]"
     fill_in "budget[value]", with: "1000.00"
-    click_button I18n.t("default.button.submit")
+    click_button t("default.button.submit")
   end
 end

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund-with-default-programme-status-of-spend-in-progress"
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
-      fill_in_activity_form(identifier: identifier, level: "fund")
-      activity = Activity.find_by(identifier: identifier)
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.programme_status).to eq("07")
     end
 
@@ -32,8 +32,8 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund-with-default-iati-status-of-implementation"
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
-      fill_in_activity_form(identifier: identifier, level: "fund")
-      activity = Activity.find_by(identifier: identifier)
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.status).to eq("2")
     end
 
@@ -57,9 +57,9 @@ RSpec.feature "Users can create a fund level activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "fund")
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
 
-      activity = Activity.find_by(identifier: identifier)
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.funding_organisation_name).to eq("HM Treasury")
       expect(activity.funding_organisation_reference).to eq("GB-GOV-2")
       expect(activity.funding_organisation_type).to eq("10")
@@ -71,9 +71,9 @@ RSpec.feature "Users can create a fund level activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "fund")
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
 
-      activity = Activity.find_by(identifier: identifier)
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
       expect(activity.accountable_organisation_reference).to eq("GB-GOV-13")
       expect(activity.accountable_organisation_type).to eq("10")
@@ -85,9 +85,9 @@ RSpec.feature "Users can create a fund level activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "fund")
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
 
-      activity = Activity.find_by(identifier: identifier)
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.extending_organisation).to eql(user.organisation)
     end
 
@@ -97,10 +97,10 @@ RSpec.feature "Users can create a fund level activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "fund")
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
 
-      activity = Activity.find_by(identifier: identifier)
-      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{activity.identifier}")
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
+      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{activity.delivery_partner_identifier}")
     end
 
     context "when there is an existing activity with a nil identifier" do
@@ -120,12 +120,12 @@ RSpec.feature "Users can create a fund level activity" do
     context "when there is an existing activity with the same identifier" do
       scenario "cannot use the duplicate identifier" do
         identifier = "A-non-unique-identifier"
-        _another_activity = create(:activity, identifier: identifier)
+        _another_activity = create(:activity, delivery_partner_identifier: identifier)
         new_activity = create(:activity, :blank_form_state, organisation: user.organisation)
 
         visit activity_step_path(new_activity, :identifier)
 
-        fill_in "activity[identifier]", with: identifier
+        fill_in "activity[delivery_partner_identifier]", with: identifier
         click_button t("form.button.activity.submit")
 
         expect(page).to have_content "has already been taken"
@@ -154,13 +154,13 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose parent.title
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("form.label.activity.identifier")
+        expect(page).to have_content t("form.label.activity.delivery_partner_identifier")
 
         # Don't provide an identifier
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.identifier.blank")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.delivery_partner_identifier.blank")
 
-        fill_in "activity[identifier]", with: identifier
+        fill_in "activity[delivery_partner_identifier]", with: identifier
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.purpose", level: "programme")
         expect(page).to have_content t("form.hint.activity.title", level: "programme")
@@ -247,7 +247,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose("activity[aid_type]", option: "A01")
         click_button t("form.button.activity.submit")
-        expect(page).to have_content Activity.find_by(identifier: identifier).title
+        expect(page).to have_content Activity.find_by(delivery_partner_identifier: identifier).title
       end
     end
 
@@ -256,9 +256,9 @@ RSpec.feature "Users can create a fund level activity" do
         visit activities_path
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(level: "fund", identifier: "my-unique-identifier")
+        fill_in_activity_form(level: "fund", delivery_partner_identifier: "my-unique-identifier")
 
-        fund = Activity.find_by(identifier: "my-unique-identifier")
+        fund = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
         auditable_events = PublicActivity::Activity.where(trackable_id: fund.id)
         expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
         expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -12,17 +12,17 @@ RSpec.feature "Users can create a fund level activity" do
 
     scenario "successfully create a activity" do
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(level: "fund")
 
-      expect(page).to have_content I18n.t("action.fund.create.success")
+      expect(page).to have_content t("action.fund.create.success")
     end
 
     scenario "a default value of 'Spend in progress' for programme status gets set" do
       identifier = "a-fund-with-default-programme-status-of-spend-in-progress"
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
       fill_in_activity_form(identifier: identifier, level: "fund")
       activity = Activity.find_by(identifier: identifier)
       expect(activity.programme_status).to eq("07")
@@ -31,7 +31,7 @@ RSpec.feature "Users can create a fund level activity" do
     scenario "the iati status gets set based on the default programme status value" do
       identifier = "a-fund-with-default-iati-status-of-implementation"
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
       fill_in_activity_form(identifier: identifier, level: "fund")
       activity = Activity.find_by(identifier: identifier)
       expect(activity.status).to eq("2")
@@ -42,7 +42,7 @@ RSpec.feature "Users can create a fund level activity" do
       activity_presenter = ActivityPresenter.new(activity)
       visit activities_path
 
-      click_on I18n.t("page_content.organisation.button.create_activity")
+      click_on t("page_content.organisation.button.create_activity")
 
       visit activity_step_path(activity, :region)
       expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.recipient_region
@@ -55,7 +55,7 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund-has-a-funding-organisation"
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "fund")
 
@@ -69,7 +69,7 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund-has-an-accountable-organisation"
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "fund")
 
@@ -83,7 +83,7 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund-has-an-extending-organisation"
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "fund")
 
@@ -95,7 +95,7 @@ RSpec.feature "Users can create a fund level activity" do
       identifier = "a-fund"
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "fund")
 
@@ -106,14 +106,14 @@ RSpec.feature "Users can create a fund level activity" do
     context "when there is an existing activity with a nil identifier" do
       scenario "successfully create a activity" do
         visit activities_path
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         visit activities_path
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(level: "fund")
 
-        expect(page).to have_content I18n.t("action.fund.create.success")
+        expect(page).to have_content t("action.fund.create.success")
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.feature "Users can create a fund level activity" do
         visit activity_step_path(new_activity, :identifier)
 
         fill_in "activity[identifier]", with: identifier
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_content "has already been taken"
       end
@@ -138,71 +138,71 @@ RSpec.feature "Users can create a fund level activity" do
         identifier = "foo"
 
         visit activities_path
-        click_on I18n.t("page_content.organisation.button.create_activity")
+        click_on t("page_content.organisation.button.create_activity")
 
         # Don't provide a level
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.level.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.level.blank")
 
         choose "Programme"
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.parent")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.parent")
 
         # Don't provide a parent
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.parent.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.parent.blank")
 
         choose parent.title
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.label.activity.identifier")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.label.activity.identifier")
 
         # Don't provide an identifier
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.identifier.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.identifier.blank")
 
         fill_in "activity[identifier]", with: identifier
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.purpose", level: "programme")
-        expect(page).to have_content I18n.t("form.hint.activity.title", level: "programme")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.purpose", level: "programme")
+        expect(page).to have_content t("form.hint.activity.title", level: "programme")
 
         # Don't provide a title and description
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.title.blank")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.description.blank")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.title.blank")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.description.blank")
 
         fill_in "activity[title]", with: Faker::Lorem.word
         fill_in "activity[description]", with: Faker::Lorem.paragraph
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.legend.activity.sector_category", level: "programme")
+        expect(page).to have_content t("form.legend.activity.sector_category", level: "programme")
 
         # Don't provide a sector category
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.sector_category.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.sector_category.blank")
 
         choose "Basic Education"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: "Basic Education", level: "programme")
+        expect(page).to have_content t("form.legend.activity.sector", sector_category: "Basic Education", level: "programme")
         # Don't provide a sector
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.sector.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.sector.blank")
 
         choose "Primary education"
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.programme_status", level: "programme")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.programme_status", level: "programme")
 
         # Don't provide a programme status
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         expect(page).to have_content "can't be blank"
 
         choose("activity[programme_status]", option: "07")
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: "programme")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("page_title.activity_form.show.dates", level: "programme")
 
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.dates")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.dates")
 
         # Dates cannot contain only a zero
         fill_in "activity[planned_start_date(3i)]", with: 1
@@ -211,9 +211,9 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[planned_end_date(3i)]", with: 0
         fill_in "activity[planned_end_date(2i)]", with: 12
         fill_in "activity[planned_end_date(1i)]", with: 2010
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.dates")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.dates")
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12
@@ -221,32 +221,32 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[planned_end_date(3i)]", with: 1
         fill_in "activity[planned_end_date(2i)]", with: 12
         fill_in "activity[planned_end_date(1i)]", with: 2010
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.geography")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.geography")
 
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.geography.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.geography.blank")
 
         choose "Region"
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.label.activity.recipient_region")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.label.activity.recipient_region")
 
         # region has the default value already selected
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.flow")
+        expect(page).to have_content t("form.label.activity.flow")
 
         # Flow has a default and can't be set to blank so we skip
         select "ODA", from: "activity[flow]"
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("form.legend.activity.aid_type")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.aid_type")
 
         # Don't select an aid type
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.aid_type.blank")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.aid_type.blank")
 
         choose("activity[aid_type]", option: "A01")
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         expect(page).to have_content Activity.find_by(identifier: identifier).title
       end
     end
@@ -254,7 +254,7 @@ RSpec.feature "Users can create a fund level activity" do
     scenario "fund creation is tracked with public_activity" do
       PublicActivity.with_tracking do
         visit activities_path
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(level: "fund", identifier: "my-unique-identifier")
 
@@ -281,7 +281,7 @@ RSpec.feature "Users can create a fund level activity" do
 
     it "does not let them create a fund level activity" do
       visit organisation_path(user.organisation)
-      expect(page).not_to have_button(I18n.t("page_content.organisation.button.create_activity"))
+      expect(page).not_to have_button(t("page_content.organisation.button.create_activity"))
     end
   end
 end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "Users can create a planned disbursement" do
       visit activities_path
       click_on project.title
 
-      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+      expect(page).to have_content t("page_content.activity.planned_disbursements")
 
-      click_on I18n.t("page_content.planned_disbursements.button.create")
+      click_on t("page_content.planned_disbursements.button.create")
 
-      expect(page).to have_content I18n.t("page_title.planned_disbursement.new")
+      expect(page).to have_content t("page_title.planned_disbursement.new")
 
-      choose I18n.t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
+      choose t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
       fill_in "planned_disbursement[period_start_date(3i)]", with: "01"
       fill_in "planned_disbursement[period_start_date(2i)]", with: "01"
       fill_in "planned_disbursement[period_start_date(1i)]", with: "2020"
@@ -28,10 +28,10 @@ RSpec.describe "Users can create a planned disbursement" do
       select "Government", from: "planned_disbursement[providing_organisation_type]"
       fill_in "planned_disbursement[receiving_organisation_name]", with: "another org"
       select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
-      click_button I18n.t("default.button.submit")
+      click_button t("default.button.submit")
 
       expect(page).to have_current_path organisation_activity_financials_path(user.organisation, project)
-      expect(page).to have_content I18n.t("action.planned_disbursement.create.success")
+      expect(page).to have_content t("action.planned_disbursement.create.success")
     end
 
     scenario "the action is recorded with public_activity" do
@@ -42,7 +42,7 @@ RSpec.describe "Users can create a planned disbursement" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.planned_disbursements.button.create"))
+        click_on(t("page_content.planned_disbursements.button.create"))
 
         fill_in_planned_disbursement_form
 
@@ -63,7 +63,7 @@ RSpec.describe "Users can create a planned disbursement" do
       visit activities_path
 
       click_on(project.title)
-      click_on(I18n.t("page_content.planned_disbursements.button.create"))
+      click_on(t("page_content.planned_disbursements.button.create"))
 
       fill_in_planned_disbursement_form
 
@@ -81,11 +81,11 @@ RSpec.describe "Users can create a planned disbursement" do
 
           visit activities_path
           click_on project.title
-          click_on I18n.t("page_content.planned_disbursements.button.create")
+          click_on t("page_content.planned_disbursements.button.create")
 
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
         end
       end
 
@@ -97,11 +97,11 @@ RSpec.describe "Users can create a planned disbursement" do
           project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
 
           visit organisation_activity_path(user.organisation, project)
-          click_on I18n.t("page_content.planned_disbursements.button.create")
+          click_on t("page_content.planned_disbursements.button.create")
 
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
         end
       end
     end
@@ -116,11 +116,11 @@ RSpec.describe "Users can create a planned disbursement" do
 
           visit activities_path
           click_on project.title
-          click_on I18n.t("page_content.planned_disbursements.button.create")
+          click_on t("page_content.planned_disbursements.button.create")
 
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
         end
       end
       context "and the activity is a third-party project" do
@@ -130,11 +130,11 @@ RSpec.describe "Users can create a planned disbursement" do
           project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
 
           visit organisation_activity_path(user.organisation, project)
-          click_on I18n.t("page_content.planned_disbursements.button.create")
+          click_on t("page_content.planned_disbursements.button.create")
 
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_name"), with: non_government_devlivery_partner.name)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_type"), with: non_government_devlivery_partner.organisation_type)
-          expect(page).to have_field(I18n.t("form.label.planned_disbursement.providing_organisation_reference"), with: non_government_devlivery_partner.iati_reference)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: non_government_devlivery_partner.name)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: non_government_devlivery_partner.organisation_type)
+          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: non_government_devlivery_partner.iati_reference)
         end
       end
     end
@@ -151,16 +151,16 @@ RSpec.describe "Users can create a planned disbursement" do
 
       visit activities_path
       within "##{programme.id}" do
-        click_on I18n.t("table.body.activity.view_activity")
+        click_on t("table.body.activity.view_activity")
       end
-      click_on I18n.t("tabs.activity.children")
+      click_on t("tabs.activity.children")
       click_on project.title
 
-      expect(page).not_to have_link I18n.t("page_content.planned_disbursements.button.create"), href: new_activity_planned_disbursement_path(project)
+      expect(page).not_to have_link t("page_content.planned_disbursements.button.create"), href: new_activity_planned_disbursement_path(project)
 
       visit new_activity_planned_disbursement_path(project)
 
-      expect(page).to have_content I18n.t("page_title.errors.not_authorised")
+      expect(page).to have_content t("page_title.errors.not_authorised")
     end
   end
 end

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -10,11 +10,11 @@ RSpec.feature "Users can create a programme activity" do
       fund = create(:fund_activity, organisation: user.organisation)
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(level: "programme", parent: fund)
 
-      expect(page).to have_content I18n.t("action.programme.create.success")
+      expect(page).to have_content t("action.programme.create.success")
     end
 
     scenario "the activity has the appropriate funding organisation defaults" do
@@ -23,8 +23,8 @@ RSpec.feature "Users can create a programme activity" do
 
       visit activities_path
       click_on fund.title
-      click_on I18n.t("tabs.activity.children")
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on t("tabs.activity.children")
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
 
@@ -40,8 +40,8 @@ RSpec.feature "Users can create a programme activity" do
 
       visit activities_path
       click_on fund.title
-      click_on I18n.t("tabs.activity.children")
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on t("tabs.activity.children")
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
 
@@ -56,7 +56,7 @@ RSpec.feature "Users can create a programme activity" do
       identifier = "a-programme"
 
       visit activities_path
-      click_on(I18n.t("page_content.organisation.button.create_activity"))
+      click_on(t("page_content.organisation.button.create_activity"))
 
       fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
 
@@ -70,8 +70,8 @@ RSpec.feature "Users can create a programme activity" do
       PublicActivity.with_tracking do
         visit activities_path
         click_on fund.title
-        click_on I18n.t("tabs.activity.children")
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on t("tabs.activity.children")
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(identifier: "my-unique-identifier", level: "programme", parent: fund)
 

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -26,9 +26,9 @@ RSpec.feature "Users can create a programme activity" do
       click_on t("tabs.activity.children")
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "programme", parent: fund)
 
-      activity = Activity.find_by(identifier: identifier)
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
       expect(activity.funding_organisation_reference).to eq("GB-GOV-13")
       expect(activity.funding_organisation_type).to eq("10")
@@ -43,9 +43,9 @@ RSpec.feature "Users can create a programme activity" do
       click_on t("tabs.activity.children")
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "programme", parent: fund)
 
-      activity = Activity.find_by(identifier: identifier)
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
       expect(activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
       expect(activity.accountable_organisation_reference).to eq("GB-GOV-13")
       expect(activity.accountable_organisation_type).to eq("10")
@@ -58,10 +58,10 @@ RSpec.feature "Users can create a programme activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(identifier: identifier, level: "programme", parent: fund)
+      fill_in_activity_form(delivery_partner_identifier: identifier, level: "programme", parent: fund)
 
-      activity = Activity.find_by(identifier: identifier)
-      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{fund.identifier}-#{activity.identifier}")
+      activity = Activity.find_by(delivery_partner_identifier: identifier)
+      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
     end
 
     scenario "programme creation is tracked with public_activity" do
@@ -73,9 +73,9 @@ RSpec.feature "Users can create a programme activity" do
         click_on t("tabs.activity.children")
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(identifier: "my-unique-identifier", level: "programme", parent: fund)
+        fill_in_activity_form(delivery_partner_identifier: "my-unique-identifier", level: "programme", parent: fund)
 
-        programme = Activity.find_by(identifier: "my-unique-identifier")
+        programme = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
         auditable_events = PublicActivity::Activity.where(trackable_id: programme.id)
         expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
         expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -11,11 +11,11 @@ RSpec.feature "Users can create a project" do
 
         visit organisation_activity_children_path(programme.organisation, programme)
 
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(level: "project", parent: programme)
 
-        expect(page).to have_content I18n.t("action.project.create.success")
+        expect(page).to have_content t("action.project.create.success")
         expect(programme.child_activities.count).to eq 1
 
         project = programme.child_activities.last
@@ -28,7 +28,7 @@ RSpec.feature "Users can create a project" do
         identifier = "a-project"
 
         visit activities_path
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(identifier: identifier, level: "project", parent: programme)
 
@@ -41,7 +41,7 @@ RSpec.feature "Users can create a project" do
 
         PublicActivity.with_tracking do
           visit organisation_activity_children_path(programme.organisation, programme)
-          click_on(I18n.t("page_content.organisation.button.create_activity"))
+          click_on(t("page_content.organisation.button.create_activity"))
 
           fill_in_activity_form(level: "project", identifier: "my-unique-identifier", parent: programme)
 

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -30,10 +30,10 @@ RSpec.feature "Users can create a project" do
         visit activities_path
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(identifier: identifier, level: "project", parent: programme)
+        fill_in_activity_form(delivery_partner_identifier: identifier, level: "project", parent: programme)
 
-        activity = Activity.find_by(identifier: identifier)
-        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{programme.parent.identifier}-#{programme.identifier}-#{activity.identifier}")
+        activity = Activity.find_by(delivery_partner_identifier: identifier)
+        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{programme.parent.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
       end
 
       scenario "project creation is tracked with public_activity" do
@@ -43,9 +43,9 @@ RSpec.feature "Users can create a project" do
           visit organisation_activity_children_path(programme.organisation, programme)
           click_on(t("page_content.organisation.button.create_activity"))
 
-          fill_in_activity_form(level: "project", identifier: "my-unique-identifier", parent: programme)
+          fill_in_activity_form(level: "project", delivery_partner_identifier: "my-unique-identifier", parent: programme)
 
-          project = Activity.find_by(identifier: "my-unique-identifier")
+          project = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
           auditable_events = PublicActivity::Activity.where(trackable_id: project.id)
           expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
           expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -35,10 +35,10 @@ RSpec.feature "Users can create a project" do
 
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(level: "third_party_project", identifier: identifier, parent: project)
+        fill_in_activity_form(level: "third_party_project", delivery_partner_identifier: identifier, parent: project)
 
-        activity = Activity.find_by(identifier: identifier)
-        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{project.parent.parent.identifier}-#{project.parent.identifier}-#{project.identifier}-#{activity.identifier}")
+        activity = Activity.find_by(delivery_partner_identifier: identifier)
+        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{project.parent.parent.delivery_partner_identifier}-#{project.parent.delivery_partner_identifier}-#{project.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
       end
 
       scenario "third party project creation is tracked with public_activity" do
@@ -52,9 +52,9 @@ RSpec.feature "Users can create a project" do
 
           click_on(t("page_content.organisation.button.create_activity"))
 
-          fill_in_activity_form(level: "third_party_project", identifier: "my-unique-identifier", parent: project)
+          fill_in_activity_form(level: "third_party_project", delivery_partner_identifier: "my-unique-identifier", parent: project)
 
-          third_party_project = Activity.find_by(identifier: "my-unique-identifier")
+          third_party_project = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
           auditable_events = PublicActivity::Activity.where(trackable_id: third_party_project.id)
           expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
           expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -10,13 +10,13 @@ RSpec.feature "Users can create a project" do
         visit activities_path
 
         click_on(project.title)
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
 
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(level: "third_party_project", parent: project)
 
-        expect(page).to have_content I18n.t("action.third_party_project.create.success")
+        expect(page).to have_content t("action.third_party_project.create.success")
         expect(project.child_activities.count).to eq 1
 
         third_party_project = project.child_activities.last
@@ -31,9 +31,9 @@ RSpec.feature "Users can create a project" do
         visit activities_path
 
         click_on(project.title)
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
 
-        click_on(I18n.t("page_content.organisation.button.create_activity"))
+        click_on(t("page_content.organisation.button.create_activity"))
 
         fill_in_activity_form(level: "third_party_project", identifier: identifier, parent: project)
 
@@ -48,9 +48,9 @@ RSpec.feature "Users can create a project" do
           visit activities_path
 
           click_on(project.title)
-          click_on I18n.t("tabs.activity.children")
+          click_on t("tabs.activity.children")
 
-          click_on(I18n.t("page_content.organisation.button.create_activity"))
+          click_on(t("page_content.organisation.button.create_activity"))
 
           fill_in_activity_form(level: "third_party_project", identifier: "my-unique-identifier", parent: project)
 

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -18,11 +18,11 @@ RSpec.feature "Users can create a transaction" do
 
       click_on(activity.title)
 
-      click_on(I18n.t("page_content.transactions.button.create"))
+      click_on(t("page_content.transactions.button.create"))
 
       fill_in_transaction_form
 
-      expect(page).to have_content(I18n.t("action.transaction.create.success"))
+      expect(page).to have_content(t("action.transaction.create.success"))
     end
 
     scenario "transaction creation is tracked with public_activity" do
@@ -33,7 +33,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form
 
@@ -52,16 +52,16 @@ RSpec.feature "Users can create a transaction" do
 
       click_on(activity.title)
 
-      click_on(I18n.t("page_content.transactions.button.create"))
-      click_on(I18n.t("default.button.submit"))
+      click_on(t("page_content.transactions.button.create"))
+      click_on(t("default.button.submit"))
 
-      expect(page).to_not have_content(I18n.t("action.transaction.create.success"))
-      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.description.blank"))
-      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
-      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.date.blank"))
-      expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.other_than")
-      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
-      expect(page).to have_content(I18n.t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
+      expect(page).to_not have_content(t("action.transaction.create.success"))
+      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.description.blank"))
+      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
+      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
+      expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.other_than")
+      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
     end
 
     scenario "disbursement channel is optional" do
@@ -71,9 +71,9 @@ RSpec.feature "Users can create a transaction" do
 
       click_on(activity.title)
 
-      click_on(I18n.t("page_content.transactions.button.create"))
+      click_on(t("page_content.transactions.button.create"))
       expect(page).to have_content("Disbursement channel (optional)")
-      click_on(I18n.t("default.button.submit"))
+      click_on(t("default.button.submit"))
 
       expect(page).to_not have_content("Disbursement channel can't be blank")
     end
@@ -86,7 +86,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[description]", with: "This money will be purchasing a new school roof"
         select "Outgoing Pledge", from: "transaction[transaction_type]"
@@ -96,9 +96,9 @@ RSpec.feature "Users can create a transaction" do
         fill_in "transaction[value]", with: "100000000000"
         select "Money is disbursed through central Ministry of Finance or Treasury", from: "transaction[disbursement_channel]"
         select "Pound Sterling", from: "transaction[currency]"
-        click_on(I18n.t("default.button.submit"))
+        click_on(t("default.button.submit"))
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.less_than_or_equal_to")
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.less_than_or_equal_to")
       end
 
       scenario "Value cannot be 0" do
@@ -108,7 +108,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[description]", with: "This money will be purchasing a new school roof"
         select "Outgoing Pledge", from: "transaction[transaction_type]"
@@ -118,9 +118,9 @@ RSpec.feature "Users can create a transaction" do
         fill_in "transaction[value]", with: "0"
         select "Money is disbursed through central Ministry of Finance or Treasury", from: "transaction[disbursement_channel]"
         select "Pound Sterling", from: "transaction[currency]"
-        click_on(I18n.t("default.button.submit"))
+        click_on(t("default.button.submit"))
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.value.other_than")
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.other_than")
       end
 
       scenario "Value can be negative" do
@@ -130,7 +130,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[description]", with: "This money will be purchasing a new school roof"
         select "Outgoing Pledge", from: "transaction[transaction_type]"
@@ -142,9 +142,9 @@ RSpec.feature "Users can create a transaction" do
         select "Pound Sterling", from: "transaction[currency]"
         fill_in "transaction[receiving_organisation_name]", with: "Company"
         select "Government", from: "transaction[receiving_organisation_type]"
-        click_on(I18n.t("default.button.submit"))
+        click_on(t("default.button.submit"))
 
-        expect(page).to have_content I18n.t("action.transaction.create.success")
+        expect(page).to have_content t("action.transaction.create.success")
       end
 
       scenario "When the value includes a pound sign" do
@@ -154,7 +154,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(value: "£123", expectations: false)
 
@@ -168,7 +168,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(value: "abc123def", expectations: false)
 
@@ -182,7 +182,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(value: "100.12", expectations: false)
 
@@ -196,7 +196,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(value: "123,000,000", expectations: false)
 
@@ -212,7 +212,7 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2100, expectations: false)
 
@@ -226,12 +226,12 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2.years.ago, expectations: false)
 
         expect(page).to_not have_content "Date must not be in the future"
-        expect(page).to have_content I18n.t("action.transaction.create.success")
+        expect(page).to have_content t("action.transaction.create.success")
       end
 
       scenario "When the date is nil" do
@@ -241,11 +241,11 @@ RSpec.feature "Users can create a transaction" do
 
         click_on(activity.title)
 
-        click_on(I18n.t("page_content.transactions.button.create"))
+        click_on(t("page_content.transactions.button.create"))
 
         fill_in_transaction_form(date_day: "", date_month: "", date_year: "", expectations: false)
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.transaction.attributes.date.blank")
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.date.blank")
       end
     end
   end
@@ -263,8 +263,8 @@ RSpec.feature "Users can create a transaction" do
 
       visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-      expect(page).not_to have_content(I18n.t("page_content.activity.transactions"))
-      expect(page).not_to have_content(I18n.t("page_content.transactions.button.create"))
+      expect(page).not_to have_content(t("page_content.activity.transactions"))
+      expect(page).not_to have_content(t("page_content.transactions.button.create"))
     end
 
     context "and the activity is a third-party project" do
@@ -276,9 +276,9 @@ RSpec.feature "Users can create a transaction" do
         visit organisation_activity_path(user.organisation, third_party_project)
         click_on "Add a transaction"
 
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_name"), with: beis.name
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_type"), with: beis.organisation_type
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_reference"), with: beis.iati_reference
+        expect(page).to have_field t("form.label.transaction.providing_organisation_name"), with: beis.name
+        expect(page).to have_field t("form.label.transaction.providing_organisation_type"), with: beis.organisation_type
+        expect(page).to have_field t("form.label.transaction.providing_organisation_reference"), with: beis.iati_reference
       end
 
       scenario "the transaction is associated with the currently active report" do
@@ -311,9 +311,9 @@ RSpec.feature "Users can create a transaction" do
         visit organisation_activity_path(user.organisation, third_party_project)
         click_on "Add a transaction"
 
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_name"), with: non_government_organisation.name
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_type"), with: non_government_organisation.organisation_type
-        expect(page).to have_field I18n.t("form.label.transaction.providing_organisation_reference"), with: non_government_organisation.iati_reference
+        expect(page).to have_field t("form.label.transaction.providing_organisation_name"), with: non_government_organisation.name
+        expect(page).to have_field t("form.label.transaction.providing_organisation_type"), with: non_government_organisation.organisation_type
+        expect(page).to have_field t("form.label.transaction.providing_organisation_reference"), with: non_government_organisation.iati_reference
       end
     end
   end

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "budget[value]", with: "20"
       choose("budget[budget_type]", option: "2")
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to have_content(I18n.t("action.budget.update.success"))
+      expect(page).to have_content(t("action.budget.update.success"))
       expect(page).to have_content("20.00")
       expect(page).to have_content("Updated")
     end
@@ -32,14 +32,14 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "budget[value]", with: "20"
       choose("budget[budget_type]", option: "2")
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
-      expect(page).to have_content(I18n.t("action.budget.update.success"))
+      expect(page).to have_content(t("action.budget.update.success"))
       expect(page).to have_content("20.00")
       expect(page).to have_content("Updated")
     end
@@ -51,12 +51,12 @@ RSpec.describe "Users can edit a budget" do
       PublicActivity.with_tracking do
         visit organisation_activity_path(user.organisation, activity)
         within("##{budget.id}") do
-          click_on I18n.t("default.link.edit")
+          click_on t("default.link.edit")
         end
 
         fill_in "budget[value]", with: "20"
         choose("budget[budget_type]", option: "2")
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         budget = Budget.last
         auditable_event = PublicActivity::Activity.find_by(trackable_id: budget.id)
@@ -71,17 +71,17 @@ RSpec.describe "Users can edit a budget" do
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on I18n.t("default.link.edit")
+        click_on t("default.link.edit")
       end
 
       fill_in "budget[value]", with: ""
       fill_in "budget[period_start_date(3i)]", with: ""
       fill_in "budget[period_start_date(2i)]", with: ""
       fill_in "budget[period_start_date(1i)]", with: ""
-      click_on I18n.t("default.button.submit")
+      click_on t("default.button.submit")
 
       expect(page).to have_content("There is a problem")
-      expect(page).to have_content(I18n.t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
+      expect(page).to have_content(t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
     end
   end
 end

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can edit a transaction" do
       expect(page).to have_content(transaction.value)
 
       within("##{transaction.id}") do
-        click_on(I18n.t("default.link.edit"))
+        click_on(t("default.link.edit"))
       end
 
       fill_in_transaction_form(
@@ -35,7 +35,7 @@ RSpec.feature "Users can edit a transaction" do
         currency: "US Dollar"
       )
 
-      expect(page).to have_content(I18n.t("action.transaction.update.success"))
+      expect(page).to have_content(t("action.transaction.update.success"))
     end
 
     scenario "transaction update is tracked with public_activity" do
@@ -47,7 +47,7 @@ RSpec.feature "Users can edit a transaction" do
         expect(page).to have_content(transaction.value)
 
         within("##{transaction.id}") do
-          click_on(I18n.t("default.link.edit"))
+          click_on(t("default.link.edit"))
         end
 
         fill_in_transaction_form(

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_details_path(activity.organisation, activity)
 
-        expect(page).not_to have_content(I18n.t("summary.activity.parent"))
+        expect(page).not_to have_content(I18n.t("summary.label.activity.parent"))
       end
 
       it "does not show the Publish to Iati field" do

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -9,27 +9,27 @@ RSpec.feature "Users can edit an activity" do
       activity = create(:third_party_project_activity, organisation: user.organisation)
 
       visit organisation_activity_path(activity.organisation, activity)
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
-      expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+      expect(page).to have_content(t("summary.label.activity.publish_to_iati.label"))
     end
 
     it "allows the user to redact the activity from Iati" do
       activity = create(:third_party_project_activity, organisation: user.organisation)
 
       visit organisation_activity_path(activity.organisation, activity)
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
       within ".publish_to_iati" do
-        click_on(I18n.t("default.link.edit"))
+        click_on(t("default.link.edit"))
       end
 
-      choose I18n.t("summary.label.activity.publish_to_iati.false")
-      click_button I18n.t("form.button.activity.submit")
+      choose t("summary.label.activity.publish_to_iati.false")
+      click_button t("form.button.activity.submit")
 
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
       within ".publish_to_iati" do
-        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
     end
 
@@ -38,26 +38,26 @@ RSpec.feature "Users can edit an activity" do
       third_party_project_activity = create(:third_party_project_activity, parent: project_activity, organisation: user.organisation)
 
       visit organisation_activity_path(project_activity.organisation, project_activity)
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
       within ".publish_to_iati" do
-        click_on(I18n.t("default.link.edit"))
+        click_on(t("default.link.edit"))
       end
 
-      choose I18n.t("summary.label.activity.publish_to_iati.false")
-      click_button I18n.t("form.button.activity.submit")
+      choose t("summary.label.activity.publish_to_iati.false")
+      click_button t("form.button.activity.submit")
 
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
       within ".publish_to_iati" do
-        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
 
       visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
       within ".publish_to_iati" do
-        expect(page).to have_content(I18n.t("summary.label.activity.publish_to_iati.false"))
+        expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
     end
 
@@ -68,11 +68,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".level") do
-          expect(page).to have_content(I18n.t("default.link.add"))
+          expect(page).to have_content(t("default.link.add"))
         end
 
         within(".parent") do
-          expect(page).not_to have_content(I18n.t("default.link.add"))
+          expect(page).not_to have_content(t("default.link.add"))
         end
       end
     end
@@ -83,7 +83,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_details_path(activity.organisation, activity)
 
-        expect(page).not_to have_content(I18n.t("summary.label.activity.parent"))
+        expect(page).not_to have_content(t("summary.label.activity.parent"))
       end
 
       it "does not show the Publish to Iati field" do
@@ -91,7 +91,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+        expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
 
       context "when a title attribute is present" do
@@ -102,7 +102,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".title") do
-            expect(page).to have_content(I18n.t("default.link.edit"))
+            expect(page).to have_content(t("default.link.edit"))
           end
         end
       end
@@ -114,7 +114,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".title") do
-            expect(page).to have_content(I18n.t("default.link.add"))
+            expect(page).to have_content(t("default.link.add"))
           end
         end
       end
@@ -126,13 +126,13 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".title") do
-            click_on(I18n.t("default.link.edit"))
+            click_on(t("default.link.edit"))
           end
 
           fill_in "activity[title]", with: new_title
-          click_button I18n.t("form.button.activity.submit")
+          click_button t("form.button.activity.submit")
 
-          expect(page).to have_content I18n.t("action.fund.update.success")
+          expect(page).to have_content t("action.fund.update.success")
           expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
         end
 
@@ -150,7 +150,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".identifier") do
-            expect(page).to_not have_content I18n.t("default.link.edit")
+            expect(page).to_not have_content t("default.link.edit")
           end
         end
 
@@ -160,7 +160,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".transparency-identifier") do
-            expect(page).to_not have_content I18n.t("default.link.edit")
+            expect(page).to_not have_content t("default.link.edit")
           end
         end
 
@@ -171,11 +171,11 @@ RSpec.feature "Users can edit an activity" do
             visit organisation_activity_details_path(activity.organisation, activity)
 
             within(".title") do
-              click_on(I18n.t("default.link.edit"))
+              click_on(t("default.link.edit"))
             end
 
             fill_in "activity[title]", with: new_title
-            click_button I18n.t("form.button.activity.submit")
+            click_button t("form.button.activity.submit")
 
             # grab the most recently created auditable_event
             auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
@@ -194,14 +194,14 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".recipient_region") do
-            click_on(I18n.t("default.link.edit"))
+            click_on(t("default.link.edit"))
           end
           choose "Region"
-          click_button I18n.t("form.button.activity.submit")
+          click_button t("form.button.activity.submit")
           select recipient_region, from: "activity[recipient_region]"
-          click_button I18n.t("form.button.activity.submit")
+          click_button t("form.button.activity.submit")
 
-          expect(page).to have_content I18n.t("form.label.activity.flow")
+          expect(page).to have_content t("form.label.activity.flow")
           expect(page).not_to have_content activity.title
         end
 
@@ -213,15 +213,15 @@ RSpec.feature "Users can edit an activity" do
 
             # Click the first edit link that opens the form on step 1
             within(".identifier") do
-              expect(page).to_not have_content(I18n.t("default.link.edit"))
+              expect(page).to_not have_content(t("default.link.edit"))
             end
 
             within(".title") do
-              expect(page).to have_content(I18n.t("default.link.add"))
+              expect(page).to have_content(t("default.link.add"))
             end
 
             within(".sector") do
-              expect(page).to_not have_content(I18n.t("default.link.add"))
+              expect(page).to_not have_content(t("default.link.add"))
             end
           end
         end
@@ -235,11 +235,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("default.link.edit"))
+          click_on(t("default.link.edit"))
         end
 
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content(I18n.t("action.programme.update.success"))
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content(t("action.programme.update.success"))
       end
 
       it "does not show the Publish to Iati field" do
@@ -247,7 +247,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+        expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
 
       context "when the activity was left at the parent step" do
@@ -256,10 +256,10 @@ RSpec.feature "Users can edit an activity" do
 
           visit organisation_activity_details_path(activity.organisation, activity)
           within(".parent") do
-            expect(page).to have_content(I18n.t("default.link.add"))
+            expect(page).to have_content(t("default.link.add"))
           end
           within(".identifier") do
-            expect(page).not_to have_content(I18n.t("default.link.add"))
+            expect(page).not_to have_content(t("default.link.add"))
           end
         end
       end
@@ -274,11 +274,11 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".level") do
-            expect(page).not_to have_content(I18n.t("default.link.add"))
+            expect(page).not_to have_content(t("default.link.add"))
           end
 
           within(".parent") do
-            expect(page).not_to have_content(I18n.t("default.link.add"))
+            expect(page).not_to have_content(t("default.link.add"))
           end
         end
       end
@@ -304,7 +304,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+        expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
     end
 
@@ -315,11 +315,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("default.link.edit"))
+          click_on(t("default.link.edit"))
         end
 
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content(I18n.t("action.project.update.success"))
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content(t("action.project.update.success"))
       end
 
       it "does not show the Publish to Iati field" do
@@ -327,7 +327,7 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).to_not have_content(I18n.t("summary.label.activity.publish_to_iati.label"))
+        expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
     end
 
@@ -338,11 +338,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(I18n.t("default.link.edit"))
+          click_on(t("default.link.edit"))
         end
 
-        click_button I18n.t("form.button.activity.submit")
-        expect(page).to have_content(I18n.t("action.third_party_project.update.success"))
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content(t("action.third_party_project.update.success"))
       end
     end
   end
@@ -350,107 +350,107 @@ end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   within(".identifier") do
-    expect(page).to_not have_content I18n.t("default.link.edit")
+    expect(page).to_not have_content t("default.link.edit")
   end
 
   within(".sector") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :sector_category)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".title") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :purpose)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".description") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :purpose)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   unless activity.fund?
     within(".programme_status") do
-      click_on(I18n.t("default.link.edit"))
+      click_on(t("default.link.edit"))
       expect(page).to have_current_path(
         activity_step_path(activity, :programme_status)
       )
     end
-    click_on(I18n.t("default.link.back"))
-    click_on I18n.t("tabs.activity.details")
+    click_on(t("default.link.back"))
+    click_on t("tabs.activity.details")
   end
 
   within(".planned_start_date") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".planned_end_date") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".actual_start_date") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".actual_end_date") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :dates)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".recipient_region") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :geography)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".flow") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :flow)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 
   within(".aid_type") do
-    click_on(I18n.t("default.link.edit"))
+    click_on(t("default.link.edit"))
     expect(page).to have_current_path(
       activity_step_path(activity, :aid_type)
     )
   end
-  click_on(I18n.t("default.link.back"))
-  click_on I18n.t("tabs.activity.details")
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 end

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Users can edit organisations" do
     fill_in "organisation[name]", with: ""
 
     click_button I18n.t("default.button.submit")
-    expect(page).to_not have_content I18n.t("organisation.action.update.success")
+    expect(page).to_not have_content I18n.t("action.organisation.update.success")
     expect(page).to have_content I18n.t("activerecord.errors.models.organisation.attributes.name.blank")
   end
 

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -33,35 +33,35 @@ RSpec.feature "Users can edit organisations" do
     authenticate!(user: create(:administrator, organisation: beis_organisation))
 
     visit organisation_path(beis_organisation)
-    click_link I18n.t("page_title.organisation.index")
+    click_link t("page_title.organisation.index")
     within("##{another_organisation.id}") do
-      click_link I18n.t("default.link.edit")
+      click_link t("default.link.edit")
     end
 
-    expect(page).to have_content(I18n.t("page_title.organisation.edit"))
+    expect(page).to have_content(t("page_title.organisation.edit"))
     fill_in "organisation[name]", with: ""
 
-    click_button I18n.t("default.button.submit")
-    expect(page).to_not have_content I18n.t("action.organisation.update.success")
-    expect(page).to have_content I18n.t("activerecord.errors.models.organisation.attributes.name.blank")
+    click_button t("default.button.submit")
+    expect(page).to_not have_content t("action.organisation.update.success")
+    expect(page).to have_content t("activerecord.errors.models.organisation.attributes.name.blank")
   end
 
   def successfully_edit_an_organisation(organisation_name: "My New Organisation")
     visit organisation_path(beis_organisation)
 
-    click_link I18n.t("page_title.organisation.index")
+    click_link t("page_title.organisation.index")
 
     within("##{another_organisation.id}") do
-      click_link I18n.t("default.link.edit")
+      click_link t("default.link.edit")
     end
 
-    expect(page).to have_content(I18n.t("page_title.organisation.edit"))
+    expect(page).to have_content(t("page_title.organisation.edit"))
     fill_in "organisation[name]", with: organisation_name
     fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
     select "Government", from: "organisation[organisation_type]"
     select "Czech", from: "organisation[language_code]"
     select "Zloty", from: "organisation[default_currency]"
-    click_button I18n.t("default.button.submit")
-    expect(page).to have_content I18n.t("action.organisation.update.success")
+    click_button t("default.button.submit")
+    expect(page).to have_content t("action.organisation.update.success")
   end
 end

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Users can edit a planned disbursement" do
       fill_in "Receiving organisation", with: "An Organisation"
       click_button "Submit"
 
-      expect(page).to have_content I18n.t("action.planned_disbursement.update.success")
+      expect(page).to have_content t("action.planned_disbursement.update.success")
       expect(page).to have_content "An Organisation"
     end
 
@@ -31,7 +31,7 @@ RSpec.describe "Users can edit a planned disbursement" do
         visit activities_path
         click_on(project.title)
         within("##{planned_disbursement.id}") do
-          click_on(I18n.t("default.link.edit"))
+          click_on(t("default.link.edit"))
         end
 
         fill_in_planned_disbursement_form(value: "2000.51")

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -21,13 +21,13 @@ RSpec.feature "Users can filter activities" do
       visit activities_path
 
       expect(page).to have_content programme.title
-      expect(page).to have_content programme.identifier
+      expect(page).to have_content programme.delivery_partner_identifier
 
       select delivery_partner_organisation.name, from: "organisation_id"
       click_on t("filters.activity.submit")
 
       expect(page).to have_content project.title
-      expect(page).to have_content project.identifier
+      expect(page).to have_content project.delivery_partner_identifier
     end
   end
 

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can filter activities" do
         click_on "Activities"
       end
 
-      expect(page).to have_content I18n.t("filters.activity.title")
+      expect(page).to have_content t("filters.activity.title")
       expect(page).to have_select "organisation_id"
     end
 
@@ -24,7 +24,7 @@ RSpec.feature "Users can filter activities" do
       expect(page).to have_content programme.identifier
 
       select delivery_partner_organisation.name, from: "organisation_id"
-      click_on I18n.t("filters.activity.submit")
+      click_on t("filters.activity.submit")
 
       expect(page).to have_content project.title
       expect(page).to have_content project.identifier
@@ -41,7 +41,7 @@ RSpec.feature "Users can filter activities" do
         click_on "Activities"
       end
 
-      expect(page).not_to have_content I18n.t("filters.activity.title")
+      expect(page).not_to have_content t("filters.activity.title")
       expect(page).not_to have_select "organisation_id"
     end
   end

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -6,36 +6,36 @@ RSpec.feature "Users can provide the geography for an activity" do
 
     scenario "they are asked to choose the geography" do
       visit activity_step_path(activity, :geography)
-      expect(page).to have_content I18n.t("form.legend.activity.geography")
-      expect(page).to have_button I18n.t("form.button.activity.submit")
+      expect(page).to have_content t("form.legend.activity.geography")
+      expect(page).to have_button t("form.button.activity.submit")
     end
 
     context "when they choose country geography" do
       scenario "they skip the region step and go straight to the country step" do
         visit activity_step_path(activity, :geography)
         choose "Country"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.recipient_country")
+        expect(page).to have_content t("form.label.activity.recipient_country")
         expect(page).to have_current_path(activity_step_path(activity, :country))
 
         select "Uganda"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.flow")
+        expect(page).to have_content t("form.label.activity.flow")
         expect(page).to have_current_path(activity_step_path(activity, :flow))
       end
 
       scenario "the region gets set in the background according to the selected country" do
         visit activity_step_path(activity, :geography)
         choose "Country"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.recipient_country")
+        expect(page).to have_content t("form.label.activity.recipient_country")
         expect(page).to have_current_path(activity_step_path(activity, :country))
 
         select "Uganda"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(activity.reload.recipient_region).to eq("289") # South of Sahara
       end
@@ -45,14 +45,14 @@ RSpec.feature "Users can provide the geography for an activity" do
       scenario "they go to the region step and skip the country step" do
         visit activity_step_path(activity, :geography)
         choose "Region"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.recipient_region")
+        expect(page).to have_content t("form.label.activity.recipient_region")
 
         select "Developing countries, unspecified", from: "activity[recipient_region]"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
-        expect(page).to have_content I18n.t("form.label.activity.flow")
+        expect(page).to have_content t("form.label.activity.flow")
         expect(page).to have_current_path(activity_step_path(activity, :flow))
       end
     end
@@ -70,16 +70,16 @@ RSpec.feature "Users can provide the geography for an activity" do
           click_on "Edit"
         end
 
-        expect(page).to have_content I18n.t("form.legend.activity.geography")
+        expect(page).to have_content t("form.legend.activity.geography")
 
         choose "Country"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         select "Uganda", from: "activity[recipient_country]"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_current_path(activity_path)
-        expect(page).not_to have_content I18n.t("summary.label.activity.recipient_region")
+        expect(page).not_to have_content t("summary.label.activity.recipient_region")
         within(".recipient_country") do
           expect(page).to have_content "Uganda"
         end
@@ -98,15 +98,15 @@ RSpec.feature "Users can provide the geography for an activity" do
           click_on "Edit"
         end
 
-        expect(page).to have_content I18n.t("form.legend.activity.geography")
+        expect(page).to have_content t("form.legend.activity.geography")
 
         choose "Region"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         select "Developing countries, unspecified", from: "activity[recipient_region]"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_current_path(activity_path)
-        expect(page).not_to have_content I18n.t("summary.label.activity.recipient_country")
+        expect(page).not_to have_content t("summary.label.activity.recipient_country")
         within(".recipient_region") do
           expect(page).to have_content "Developing countries, unspecified"
         end

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -8,10 +8,10 @@ RSpec.feature "Users can manage Sectors" do
         activity = create(:activity, :at_identifier_step, identifier: "GCRF", organisation: user.organisation)
         visit activity_step_path(activity, :sector_category)
         choose "Basic Education"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_current_path(activity_step_path(activity, :sector))
-        expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: I18n.t("activity.sector_category.#{activity.reload.sector_category}"), level: activity.level)
+        expect(page).to have_content t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{activity.reload.sector_category}"), level: activity.level)
       end
     end
 
@@ -27,9 +27,9 @@ RSpec.feature "Users can manage Sectors" do
         expect(page).to have_current_path(activity_step_path(activity, :sector_category))
 
         choose "Basic Education"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
         choose "Early childhood education"
-        click_button I18n.t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_current_path(organisation_activity_details_path(user.organisation, activity))
         within ".sector" do

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can manage Sectors" do
 
     context "with a new activity" do
       scenario "they can provide the sector category" do
-        activity = create(:activity, :at_identifier_step, identifier: "GCRF", organisation: user.organisation)
+        activity = create(:activity, :at_identifier_step, delivery_partner_identifier: "GCRF", organisation: user.organisation)
         visit activity_step_path(activity, :sector_category)
         choose "Basic Education"
         click_button t("form.button.activity.submit")

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -10,10 +10,10 @@ RSpec.feature "Users can manage the extending organisation" do
       scenario "they can set the extending organisation" do
         delivery_partner = create(:delivery_partner_organisation)
         visit organisation_activity_path(programme.organisation, programme)
-        click_on I18n.t("tabs.activity.details")
-        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
         choose delivery_partner.name
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         expect(page).to have_content("success")
         expect(page).to have_content delivery_partner.name
@@ -22,10 +22,10 @@ RSpec.feature "Users can manage the extending organisation" do
       scenario "when the extending organisation is set, the same organisation is set as the implementing organisation" do
         delivery_partner = create(:delivery_partner_organisation)
         visit organisation_activity_path(programme.organisation, programme)
-        click_on I18n.t("tabs.activity.details")
-        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
         choose delivery_partner.name
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         implementing_organisation = programme.reload.implementing_organisations.first
         expect(implementing_organisation.name).to eq(delivery_partner.name)
@@ -39,13 +39,13 @@ RSpec.feature "Users can manage the extending organisation" do
         another_delivery_partner = create(:delivery_partner_organisation)
 
         visit organisation_activity_path(programme.organisation, programme)
-        click_on I18n.t("tabs.activity.details")
-        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
 
         expect(page).to have_checked_field delivery_partner.name
 
         choose another_delivery_partner.name
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         expect(page).to have_content("success")
         expect(page).to have_content another_delivery_partner.name
@@ -57,13 +57,13 @@ RSpec.feature "Users can manage the extending organisation" do
         another_delivery_partner = create(:delivery_partner_organisation)
 
         visit organisation_activity_path(programme.organisation, programme)
-        click_on I18n.t("tabs.activity.details")
-        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
 
         expect(page).to have_checked_field delivery_partner.name
 
         choose another_delivery_partner.name
-        click_on I18n.t("default.button.submit")
+        click_on t("default.button.submit")
 
         implementing_organisation = programme.reload.implementing_organisations.first
         expect(implementing_organisation.name).to eq(another_delivery_partner.name)
@@ -73,11 +73,11 @@ RSpec.feature "Users can manage the extending organisation" do
 
       scenario "not selecting an extending organisation results in an error" do
         visit organisation_activity_path(programme.organisation, programme)
-        click_on I18n.t("tabs.activity.details")
-        click_on I18n.t("page_content.activity.extending_organisation.button.edit")
-        click_on I18n.t("default.button.submit")
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
+        click_on t("default.button.submit")
 
-        expect(page).to have_content I18n.t("activerecord.errors.models.activity.attributes.extending_organisation_id.blank")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.extending_organisation_id.blank")
       end
     end
   end
@@ -92,7 +92,7 @@ RSpec.feature "Users can manage the extending organisation" do
 
       visit organisation_activity_path(programme.organisation, programme)
 
-      expect(page).not_to have_content(I18n.t("page_content.activity.extending_organisation.button.edit"))
+      expect(page).not_to have_content(t("page_content.activity.extending_organisation.button.edit"))
     end
   end
 end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -10,20 +10,20 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       visit organisation_activity_details_path(project.organisation, project)
 
-      expect(page).to have_content I18n.t("page_content.activity.implementing_organisation.button.new")
-      click_on I18n.t("page_content.activity.implementing_organisation.button.new")
+      expect(page).to have_content t("page_content.activity.implementing_organisation.button.new")
+      click_on t("page_content.activity.implementing_organisation.button.new")
 
-      expect(page).to have_field I18n.t("form.label.implementing_organisation.name")
-      expect(page).to have_select I18n.t("form.label.implementing_organisation.organisation_type")
-      expect(page).to have_field I18n.t("form.label.implementing_organisation.reference")
+      expect(page).to have_field t("form.label.implementing_organisation.name")
+      expect(page).to have_select t("form.label.implementing_organisation.organisation_type")
+      expect(page).to have_field t("form.label.implementing_organisation.reference")
 
-      fill_in I18n.t("form.label.implementing_organisation.name"), with: other_public_sector_organisation.name
-      select("Other Public Sector", from: I18n.t("form.label.implementing_organisation.organisation_type"))
-      fill_in I18n.t("form.label.implementing_organisation.reference"), with: other_public_sector_organisation.reference
-      click_on I18n.t("default.button.submit")
+      fill_in t("form.label.implementing_organisation.name"), with: other_public_sector_organisation.name
+      select("Other Public Sector", from: t("form.label.implementing_organisation.organisation_type"))
+      fill_in t("form.label.implementing_organisation.reference"), with: other_public_sector_organisation.reference
+      click_on t("default.button.submit")
 
       expect(current_path).to eq organisation_activity_details_path(project.organisation, project)
-      expect(page).to have_content I18n.t("action.implementing_organisation.create.success")
+      expect(page).to have_content t("action.implementing_organisation.create.success")
 
       expect(page).to have_content other_public_sector_organisation.name
       expect(page).to have_content other_public_sector_organisation.reference
@@ -42,12 +42,12 @@ RSpec.feature "Users can manage the implementing organisations" do
         click_on "Edit"
       end
 
-      expect(find_field(I18n.t("form.label.implementing_organisation.name")).value).to eq other_public_sector_organisation.name
+      expect(find_field(t("form.label.implementing_organisation.name")).value).to eq other_public_sector_organisation.name
 
-      fill_in I18n.t("form.label.implementing_organisation.name"), with: "It is a charity"
-      click_on I18n.t("default.button.submit")
+      fill_in t("form.label.implementing_organisation.name"), with: "It is a charity"
+      click_on t("default.button.submit")
 
-      expect(page).to have_content I18n.t("action.implementing_organisation.update.success")
+      expect(page).to have_content t("action.implementing_organisation.update.success")
       expect(page).to have_content "It is a charity"
     end
   end
@@ -74,13 +74,13 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_link I18n.t("default.link.edit"), href: edit_activity_implementing_organisation_path(project, other_public_sector_organisation)
+      expect(page).not_to have_link t("default.link.edit"), href: edit_activity_implementing_organisation_path(project, other_public_sector_organisation)
     end
 
     scenario "they cannot add implementing organisations" do
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_button I18n.t("page_content.activity.implementing_organisation.button.new")
+      expect(page).not_to have_button t("page_content.activity.implementing_organisation.button.new")
     end
   end
 end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -8,13 +8,13 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(I18n.t("start_page.title"))
+    expect(page).to have_content(t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("header.link.sign_in"))
-    click_on I18n.t("header.link.sign_in")
+    expect(page).to have_content(t("header.link.sign_in"))
+    click_on t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
-    expect(page).to have_content(I18n.t("header.link.sign_out"))
+    expect(page).to have_content(t("header.link.sign_out"))
   end
 
   scenario "successful sign in via button link" do
@@ -24,13 +24,13 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit dashboard_path
-    expect(page).to have_content(I18n.t("start_page.title"))
+    expect(page).to have_content(t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("header.link.sign_in"))
-    click_on I18n.t("header.link.sign_in")
+    expect(page).to have_content(t("header.link.sign_in"))
+    click_on t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
-    expect(page).to have_content(I18n.t("header.link.sign_out"))
+    expect(page).to have_content(t("header.link.sign_out"))
   end
 
   scenario "any user lands on their organisation page" do
@@ -41,10 +41,10 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(I18n.t("start_page.title"))
+    expect(page).to have_content(t("start_page.title"))
 
-    expect(page).to have_content(I18n.t("header.link.sign_in"))
-    click_on I18n.t("header.link.sign_in")
+    expect(page).to have_content(t("header.link.sign_in"))
+    click_on t("header.link.sign_in")
 
     expect(page).to have_content(user.organisation.name)
   end
@@ -52,7 +52,7 @@ RSpec.feature "Users can sign in with Auth0" do
   scenario "protected pages cannot be visited unless signed in" do
     visit dashboard_path
 
-    expect(page).to have_content(I18n.t("start_page.title"))
+    expect(page).to have_content(t("start_page.title"))
   end
 
   context "when the Auth0 identifier does not match a user record" do
@@ -64,11 +64,11 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("header.link.sign_in"))
-      click_on I18n.t("header.link.sign_in")
+      expect(page).to have_content(t("header.link.sign_in"))
+      click_on t("header.link.sign_in")
 
-      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
-      expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content(t("page_title.errors.not_authorised"))
+      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
     end
   end
 
@@ -80,12 +80,12 @@ RSpec.feature "Users can sign in with Auth0" do
     it "displays the error message so they can try to correct the problem themselves" do
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("header.link.sign_in"))
-      click_on I18n.t("header.link.sign_in")
+      expect(page).to have_content(t("header.link.sign_in"))
+      click_on t("header.link.sign_in")
 
-      expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.explanation"))
-      expect(page).to have_content(I18n.t("page_content.errors.auth0.error_messages.invalid_credentials"))
-      expect(page).to have_content(I18n.t("page_content.errors.auth0.failed.prompt"))
+      expect(page).to have_content(t("page_content.errors.auth0.failed.explanation"))
+      expect(page).to have_content(t("page_content.errors.auth0.error_messages.invalid_credentials"))
+      expect(page).to have_content(t("page_content.errors.auth0.failed.prompt"))
     end
   end
 
@@ -99,10 +99,10 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit root_path
 
-      click_button I18n.t("header.link.sign_in")
+      click_button t("header.link.sign_in")
 
       expect(page).not_to have_content("unknown_failure")
-      expect(page).to have_content(I18n.t("page_content.errors.auth0.error_messages.generic"))
+      expect(page).to have_content(t("page_content.errors.auth0.error_messages.generic"))
       expect(Rollbar).to have_received(:log).with(:info, "Unknown response from Auth0", "unknown_failure")
     end
   end
@@ -116,11 +116,11 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit dashboard_path
 
-      expect(page).to have_content(I18n.t("header.link.sign_in"))
-      click_on I18n.t("header.link.sign_in")
+      expect(page).to have_content(t("header.link.sign_in"))
+      click_on t("header.link.sign_in")
 
-      expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
-      expect(page).to have_content(I18n.t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content(t("page_title.errors.not_authorised"))
+      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
     end
   end
 end

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -11,12 +11,12 @@ RSpec.feature "Users can submit a report" do
       report_presenter = ReportPresenter.new(report)
 
       visit report_path(report)
-      click_link I18n.t("action.report.submit.button")
+      click_link t("action.report.submit.button")
 
       click_button "Confirm submission"
 
-      expect(page).to have_content I18n.t("action.report.submit.complete.title")
-      expect(page).to have_content I18n.t("action.report.submit.complete.title",
+      expect(page).to have_content t("action.report.submit.complete.title")
+      expect(page).to have_content t("action.report.submit.complete.title",
         report_description: report_presenter.description,
         report_financial_quater_and_year: report_presenter.financial_quarter_and_year)
       expect(report.reload.state).to eql "submitted"
@@ -27,10 +27,10 @@ RSpec.feature "Users can submit a report" do
       PublicActivity.with_tracking do
         visit reports_path
         within "##{report.id}" do
-          click_on I18n.t("default.link.view")
+          click_on t("default.link.view")
         end
-        click_link I18n.t("action.report.submit.button")
-        click_button I18n.t("action.report.submit.confirm.button")
+        click_link t("action.report.submit.button")
+        click_button t("action.report.submit.confirm.button")
 
         auditable_events = PublicActivity::Activity.all
         expect(auditable_events.last.key).to include("report.submitted")
@@ -44,7 +44,7 @@ RSpec.feature "Users can submit a report" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link I18n.t("action.report.submit.button"), href: edit_report_state_path(report)
+      expect(page).not_to have_link t("action.report.submit.button"), href: edit_report_state_path(report)
 
       visit edit_report_state_path(report)
 
@@ -64,7 +64,7 @@ RSpec.feature "Users can submit a report" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link I18n.t("action.report.submit.button"), href: edit_report_state_path(report)
+      expect(page).not_to have_link t("action.report.submit.button"), href: edit_report_state_path(report)
 
       visit edit_report_state_path(report)
 

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Users can view a project" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to_not have_content I18n.t("default.button.download_as_xml")
+      expect(page).to_not have_content t("default.button.download_as_xml")
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.feature "Users can view a project" do
       visit organisation_activity_path(project.organisation, project)
 
       expect(page).to have_content project.title
-      expect(page).to_not have_content I18n.t("page_content.organisation.button.create_activity")
+      expect(page).to_not have_content t("page_content.organisation.button.create_activity")
     end
 
     scenario "can download a project as XML" do
@@ -73,9 +73,9 @@ RSpec.feature "Users can view a project" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to have_content I18n.t("default.button.download_as_xml")
+      expect(page).to have_content t("default.button.download_as_xml")
 
-      click_on I18n.t("default.button.download_as_xml")
+      click_on t("default.button.download_as_xml")
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -21,9 +21,9 @@ RSpec.feature "Users can view activities" do
       first_activity = activities.first
       last_activity = activities.last
 
-      expect(page).to have_content first_activity.identifier
-      expect(page).to have_content last_activity.identifier
-      expect(page).not_to have_content another_activity.identifier
+      expect(page).to have_content first_activity.delivery_partner_identifier
+      expect(page).to have_content last_activity.delivery_partner_identifier
+      expect(page).not_to have_content another_activity.delivery_partner_identifier
     end
 
     scenario "they can view another organisations activities" do
@@ -32,7 +32,7 @@ RSpec.feature "Users can view activities" do
 
       visit activities_path(organisation_id: activity.organisation)
 
-      expect(page).to have_content activity.identifier
+      expect(page).to have_content activity.delivery_partner_identifier
     end
 
     context "when an organisation id query parameter is not supplied" do
@@ -41,7 +41,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: "")
 
-        expect(page).to have_content activity.identifier
+        expect(page).to have_content activity.delivery_partner_identifier
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: delivery_partner.id)
 
-        expect(page).to have_content activity.identifier
+        expect(page).to have_content activity.delivery_partner_identifier
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: "this-is-no-a-know-organisation")
 
-        expect(page).to have_content activity.identifier
+        expect(page).to have_content activity.delivery_partner_identifier
       end
     end
   end
@@ -78,7 +78,7 @@ RSpec.feature "Users can view activities" do
 
       within("##{project.id}") do
         expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
-        expect(page).to have_content project.identifier
+        expect(page).to have_content project.delivery_partner_identifier
       end
     end
 
@@ -144,9 +144,9 @@ RSpec.feature "Users can view activities" do
       first_activity = activities.first
       last_activity = activities.last
 
-      expect(page).to have_content first_activity.identifier
+      expect(page).to have_content first_activity.delivery_partner_identifier
 
-      expect(page).to have_content last_activity.identifier
+      expect(page).to have_content last_activity.delivery_partner_identifier
     end
 
     scenario "an activity can be viewed" do
@@ -162,7 +162,7 @@ RSpec.feature "Users can view activities" do
 
       activity_presenter = ActivityPresenter.new(activity)
 
-      expect(page).to have_content activity_presenter.identifier
+      expect(page).to have_content activity_presenter.delivery_partner_identifier
       expect(page).to have_content activity_presenter.sector
       expect(page).to have_content activity_presenter.title
       expect(page).to have_content activity_presenter.description
@@ -179,7 +179,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: another_delivery_partner.id)
 
-        expect(page).to have_content activity.identifier
+        expect(page).to have_content activity.delivery_partner_identifier
       end
     end
 

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Users can view activities" do
       another_activity = create(:project_activity)
 
       visit activities_path(organisation_id: user.organisation)
-      expect(page).to have_content I18n.t("page_title.activity.index")
+      expect(page).to have_content t("page_title.activity.index")
 
       first_activity = activities.first
       last_activity = activities.last
@@ -98,14 +98,14 @@ RSpec.feature "Users can view activities" do
 
       visit activities_path
       click_on project.title
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
       click_on programme.title
-      click_on I18n.t("tabs.activity.children")
+      click_on t("tabs.activity.children")
 
-      expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+      expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
 
       within("##{project.id}") do
-        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
+        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.feature "Users can view activities" do
         expect(page).to have_content "Details"
       end
       expect(page).to have_content activity.title
-      expect(page).to have_link I18n.t("page_content.activity.implementing_organisation.button.new")
+      expect(page).to have_link t("page_content.activity.implementing_organisation.button.new")
     end
 
     scenario "all activities can be viewed" do
@@ -139,7 +139,7 @@ RSpec.feature "Users can view activities" do
 
       visit activities_path(organisation_id: user.organisation)
 
-      expect(page).to have_content I18n.t("page_title.activity.index")
+      expect(page).to have_content t("page_title.activity.index")
 
       first_activity = activities.first
       last_activity = activities.last
@@ -156,9 +156,9 @@ RSpec.feature "Users can view activities" do
       visit activities_path
 
       click_on(programme.title)
-      click_on I18n.t("tabs.activity.children")
+      click_on t("tabs.activity.children")
       click_on activity.title
-      click_on I18n.t("tabs.activity.details")
+      click_on t("tabs.activity.details")
 
       activity_presenter = ActivityPresenter.new(activity)
 
@@ -191,7 +191,7 @@ RSpec.feature "Users can view activities" do
                                              actual_end_date: Date.new(2020, 1, 29))
 
         visit organisation_activity_path(user.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
+        click_on t("tabs.activity.details")
 
         within(".planned_start_date") do
           expect(page).to have_content("3 Feb 2020")

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Users can view activities" do
       expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
 
       within("##{project.id}") do
-        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
       end
     end
 

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) {
           create(:fund_activity,
             organisation: organisation,
-            identifier: "IND-ENT-IFIER",
+            delivery_partner_identifier: "IND-ENT-IFIER",
             previous_identifier: "PREV-IND-ENT-IFIER",
             transparency_identifier: "GB-GOV-13-IND-ENT-IFIER")
         }
@@ -36,7 +36,7 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) {
           create(:fund_activity,
             organisation: organisation,
-            identifier: "IND-ENT-IFIER",
+            delivery_partner_identifier: "IND-ENT-IFIER",
             geography: :recipient_region,
             recipient_region: "489")
         }
@@ -60,7 +60,7 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) {
           create(:fund_activity,
             organisation: organisation,
-            identifier: "IND-ENT-IFIER",
+            delivery_partner_identifier: "IND-ENT-IFIER",
             geography: :recipient_country,
             recipient_country: "CV")
         }
@@ -83,7 +83,7 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) {
           create(:fund_activity,
             organisation: organisation,
-            identifier: "IND-ENT-IFIER",
+            delivery_partner_identifier: "IND-ENT-IFIER",
             geography: :recipient_country,
             recipient_country: "CL",
             recipient_region: "489")
@@ -102,7 +102,7 @@ RSpec.feature "Users can view an activity as XML" do
         let(:activity) {
           create(:fund_activity,
             organisation: organisation,
-            identifier: "IND-ENT-IFIER",
+            delivery_partner_identifier: "IND-ENT-IFIER",
             actual_start_date: nil,
             actual_end_date: nil)
         }
@@ -119,14 +119,14 @@ RSpec.feature "Users can view an activity as XML" do
       end
 
       context "when the activity is a fund activity" do
-        let(:activity) { create(:fund_activity, :with_transparency_identifier, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:activity) { create(:fund_activity, :with_transparency_identifier, organisation: organisation, delivery_partner_identifier: "IND-ENT-IFIER") }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
       end
 
       context "when the activity is a programme activity" do
-        let(:activity) { create(:programme_activity, :with_transparency_identifier, organisation: organisation, identifier: "IND-ENT-IFIER") }
+        let(:activity) { create(:programme_activity, :with_transparency_identifier, organisation: organisation, delivery_partner_identifier: "IND-ENT-IFIER") }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(fund.organisation, fund)
 
         expect(page).to have_content programme.title
-        expect(page).to have_content programme.identifier
+        expect(page).to have_content programme.delivery_partner_identifier
       end
 
       scenario "the child programme activities are ordered by created_at (oldest first)" do
@@ -75,13 +75,13 @@ RSpec.feature "Users can view an activity" do
 
         within("##{project.id}") do
           expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
-          expect(page).to have_content project.identifier
+          expect(page).to have_content project.delivery_partner_identifier
           expect(page).to have_content project.parent.title
         end
 
         within("##{another_project.id}") do
           expect(page).to have_link another_project.title, href: organisation_activity_path(another_project.organisation, another_project)
-          expect(page).to have_content another_project.identifier
+          expect(page).to have_content another_project.delivery_partner_identifier
           expect(page).to have_content another_project.parent.title
         end
       end
@@ -124,7 +124,7 @@ RSpec.feature "Users can view an activity" do
 
         within("##{third_party_project.id}") do
           expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
-          expect(page).to have_content third_party_project.identifier
+          expect(page).to have_content third_party_project.delivery_partner_identifier
           expect(page).to have_content third_party_project.parent.title
         end
       end
@@ -190,7 +190,7 @@ RSpec.feature "Users can view an activity" do
       end
       activity_presenter = ActivityPresenter.new(activity)
 
-      expect(page).to have_content activity_presenter.identifier
+      expect(page).to have_content activity_presenter.delivery_partner_identifier
       expect(page).to have_content activity_presenter.sector
       expect(page).to have_content activity_presenter.title
       expect(page).to have_content activity_presenter.description

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Users can view an activity" do
 
         within("##{incomplete_programme.id}") do
           expect(page).to have_link incomplete_programme.title
-          expect(page).to have_content I18n.t("summary.label.activity.form_state.incomplete")
+          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
         end
       end
 
@@ -55,11 +55,11 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(fund.organisation, fund)
 
         within(".programmes") do
-          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+          expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
         end
 
         within("##{programme.id}") do
-          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
+          expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
         end
       end
     end
@@ -94,7 +94,7 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(programme.organisation, programme)
         within("##{incomplete_project.id}") do
           expect(page).to have_link incomplete_project.title
-          expect(page).to have_content I18n.t("summary.label.activity.form_state.incomplete")
+          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(programme.organisation, programme)
 
         within(".projects") do
-          expect(page).to have_content I18n.t("summary.label.activity.publish_to_iati.label")
+          expect(page).to have_content t("summary.label.activity.publish_to_iati.label")
         end
 
         within("##{project.id}") do
@@ -137,7 +137,7 @@ RSpec.feature "Users can view an activity" do
 
         within("##{incomplete_third_party_project.id}") do
           expect(page).to have_link incomplete_third_party_project.title
-          expect(page).to have_content I18n.t("summary.label.activity.form_state.incomplete")
+          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
         end
       end
 
@@ -147,7 +147,7 @@ RSpec.feature "Users can view an activity" do
 
         visit organisation_activity_children_path(project.organisation, project)
 
-        expect(page).to have_content I18n.t("summary.label.activity.publish_to_iati.label")
+        expect(page).to have_content t("summary.label.activity.publish_to_iati.label")
 
         within("##{third_party_project.id}") do
           expect(page).to have_content "Yes"
@@ -177,7 +177,7 @@ RSpec.feature "Users can view an activity" do
         expect(page).to have_content "Child activities"
       end
       expect(page).to have_content activity.title
-      expect(page).to have_button I18n.t("page_content.organisation.button.create_activity")
+      expect(page).to have_button t("page_content.organisation.button.create_activity")
     end
 
     scenario "the activity details tab can be viewed" do
@@ -217,7 +217,7 @@ RSpec.feature "Users can view an activity" do
                                      actual_end_date: Date.new(2020, 1, 29))
 
         visit organisation_activity_path(user.organisation, activity)
-        click_on I18n.t("tabs.activity.details")
+        click_on t("tabs.activity.details")
 
         within(".planned_start_date") do
           expect(page).to have_content("3 Feb 2020")
@@ -258,10 +258,10 @@ RSpec.feature "Users can view an activity" do
 
       visit organisation_activity_children_path(project.organisation, project)
 
-      expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
+      expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
 
       within("##{third_party_project.id}") do
-        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
+        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Users can view an activity" do
         end
 
         within("##{programme.id}") do
-          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+          expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
         end
       end
     end
@@ -261,7 +261,7 @@ RSpec.feature "Users can view an activity" do
       expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.label")
 
       within("##{third_party_project.id}") do
-        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.yes")
+        expect(page).to_not have_content I18n.t("summary.label.activity.publish_to_iati.true")
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can view an organisation as XML" do
         visit organisation_path(beis)
 
         expect(page).to have_content(beis.name)
-        expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
+        expect(page).to_not have_content(t("default.button.download_as_xml"))
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to have_content(I18n.t("default.button.download_as_xml"))
+          expect(page).to have_content(t("default.button.download_as_xml"))
         end
 
         scenario "the XML file contains an `iati-activity` element for the project activities in the organisation" do
@@ -33,7 +33,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-projects" do
-            click_link I18n.t("default.button.download_as_xml")
+            click_link t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -46,7 +46,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-projects" do
-            click_link I18n.t("default.button.download_as_xml")
+            click_link t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -61,7 +61,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to have_content(I18n.t("default.button.download_as_xml"))
+          expect(page).to have_content(t("default.button.download_as_xml"))
         end
 
         scenario "the XML file contains an `iati-activity` element for the third-party project activity in the organisation" do
@@ -70,7 +70,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-third-party-projects" do
-            click_link I18n.t("default.button.download_as_xml")
+            click_link t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -84,7 +84,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
           visit organisation_path(organisation)
           within ".download-third-party-projects" do
-            click_link I18n.t("default.button.download_as_xml")
+            click_link t("default.button.download_as_xml")
           end
           xml = Nokogiri::XML::Document.parse(page.body)
 
@@ -97,7 +97,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
+          expect(page).to_not have_content(t("default.button.download_as_xml"))
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation)
 
           expect(page).to have_content(organisation.name)
-          expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
+          expect(page).to_not have_content(t("default.button.download_as_xml"))
         end
       end
 
@@ -126,7 +126,7 @@ RSpec.feature "Users can view an organisation as XML" do
         _transaction = create(:transaction, parent_activity: project, value: 100)
 
         visit organisation_path(organisation)
-        click_link I18n.t("default.button.download_as_xml")
+        click_link t("default.button.download_as_xml")
         xml = Nokogiri::XML::Document.parse(page.body)
 
         expect(xml.xpath("/iati-activities/iati-activity/budget/value").text).to eq "2000.0"
@@ -136,7 +136,7 @@ RSpec.feature "Users can view an organisation as XML" do
       scenario "the XML file does not contain incomplete activities" do
         _project = create(:project_activity, :at_purpose_step, organisation: organisation)
         visit organisation_path(organisation)
-        click_link I18n.t("default.button.download_as_xml")
+        click_link t("default.button.download_as_xml")
         xml = Nokogiri::XML::Document.parse(page.body)
 
         expect(xml.xpath("/iati-activities/iati-activity").count).to eq(0)
@@ -158,7 +158,7 @@ RSpec.feature "Users can view an organisation as XML" do
         visit organisation_path(organisation)
 
         expect(page).to have_content(organisation.name)
-        expect(page).to_not have_content(I18n.t("default.button.download_as_xml"))
+        expect(page).to_not have_content(t("default.button.download_as_xml"))
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.feature "Users can view an organisation as XML" do
       scenario "they cannot download the XML of the organisation" do
         visit organisation_path(organisation, format: :xml)
 
-        expect(page).to have_content(I18n.t("page_title.errors.not_authorised"))
+        expect(page).to have_content(t("page_title.errors.not_authorised"))
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Users can view an organisation" do
       scenario "does not see a back link on their organisation page" do
         visit organisation_path(user.organisation)
 
-        expect(page).to_not have_content(I18n.t("default.link.back"))
+        expect(page).to_not have_content(t("default.link.back"))
       end
     end
 
@@ -32,9 +32,9 @@ RSpec.feature "Users can view an organisation" do
 
       scenario "can see the other organisation's page" do
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_title.organisation.index")
+        click_link t("page_title.organisation.index")
         within("##{other_organisation.id}") do
-          click_link I18n.t("default.link.show")
+          click_link t("default.link.show")
         end
         expect(page).to have_content(other_organisation.name)
       end
@@ -44,9 +44,9 @@ RSpec.feature "Users can view an organisation" do
         other_project = create(:project_activity, organisation: create(:organisation))
 
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_title.organisation.index")
+        click_link t("page_title.organisation.index")
         within("##{other_organisation.id}") do
-          click_link I18n.t("default.link.show")
+          click_link t("default.link.show")
         end
 
         expect(page).to_not have_content(other_programme.title)
@@ -55,13 +55,13 @@ RSpec.feature "Users can view an organisation" do
 
       scenario "can go back to the previous page" do
         visit organisation_path(user.organisation)
-        click_link I18n.t("page_title.organisation.index")
+        click_link t("page_title.organisation.index")
 
         within("##{other_organisation.id}") do
-          click_link I18n.t("default.link.show")
+          click_link t("default.link.show")
         end
         expect(page).to have_content(other_organisation.name)
-        click_on I18n.t("default.link.back")
+        click_on t("default.link.back")
 
         expect(page).to have_current_path(organisations_path)
       end
@@ -84,7 +84,7 @@ RSpec.feature "Users can view an organisation" do
     scenario "does not see a back link on their organisation home page" do
       visit organisation_path(organisation)
 
-      expect(page).to_not have_content(I18n.t("default.link.back"))
+      expect(page).to_not have_content(t("default.link.back"))
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link programme_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -65,9 +65,9 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -83,14 +83,14 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
-        expect(page).to_not have_content(I18n.t("page_content.budgets.button.create"))
+        expect(page).to_not have_content(t("page_content.budgets.button.create"))
         within("tr##{budget.id}") do
-          expect(page).not_to have_content(I18n.t("default.link.edit"))
+          expect(page).not_to have_content(t("default.link.edit"))
         end
       end
     end
@@ -108,9 +108,9 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit activities_path
         within "##{project_activity.id}" do
-          click_link I18n.t("table.body.activity.view_activity")
+          click_link t("table.body.activity.view_activity")
         end
-        click_link I18n.t("tabs.activity.details")
+        click_link t("tabs.activity.details")
         click_link programme_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -124,7 +124,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
         within "##{budget.id}" do
-          expect(page).to_not have_content I18n.t("default.link.edit")
+          expect(page).to_not have_content t("default.link.edit")
         end
       end
     end
@@ -140,7 +140,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -155,12 +155,12 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
-        expect(page).to have_content(I18n.t("page_content.budgets.button.create"))
+        expect(page).to have_content(t("page_content.budgets.button.create"))
         within("tr##{budget.id}") do
-          expect(page).to have_content(I18n.t("default.link.edit"))
+          expect(page).to have_content(t("default.link.edit"))
         end
       end
     end

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Users can view fund level activities" do
       visit organisation_activity_children_path(fund_activity.organisation, fund_activity)
 
       expect(page).to have_link activity_presenter.display_title
-      expect(page).to have_button I18n.t("page_content.organisation.button.create_activity")
+      expect(page).to have_button t("page_content.organisation.button.create_activity")
     end
 
     context "when the activity is partially complete and doesn't have a title" do

--- a/spec/features/staff/users_can_view_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_view_planned_disbursements_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Users can view planned disbursements" do
 
       visit organisation_activity_path(user.organisation, project)
 
-      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+      expect(page).to have_content t("page_content.activity.planned_disbursements")
       expect(page).to have_selector "##{planned_disbursement.id}"
     end
 
@@ -19,7 +19,7 @@ RSpec.describe "Users can view planned disbursements" do
 
       visit organisation_activity_path(user.organisation, third_party_project)
 
-      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+      expect(page).to have_content t("page_content.activity.planned_disbursements")
       expect(page).to have_selector "##{planned_disbursement.id}"
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe "Users can view planned disbursements" do
 
       visit organisation_activity_path(beis_user.organisation, project)
 
-      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+      expect(page).to have_content t("page_content.activity.planned_disbursements")
       expect(page).to have_selector "##{planned_disbursement.id}"
     end
 
@@ -44,7 +44,7 @@ RSpec.describe "Users can view planned disbursements" do
 
       visit organisation_activity_path(beis_user.organisation, third_party_project)
 
-      expect(page).to have_content I18n.t("page_content.activity.planned_disbursements")
+      expect(page).to have_content t("page_content.activity.planned_disbursements")
       expect(page).to have_selector "##{planned_disbursement.id}"
     end
   end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can view reports" do
 
       visit reports_path
 
-      expect(page).to have_content I18n.t("page_title.report.index")
+      expect(page).to have_content t("page_title.report.index")
       expect(page).to have_content first_report.description
       expect(page).to have_content second_report.description
     end
@@ -39,7 +39,7 @@ RSpec.feature "Users can view reports" do
       reports = create_list(:report, 2)
       visit reports_path
 
-      expect(page).to have_content I18n.t("page_title.report.index")
+      expect(page).to have_content t("page_title.report.index")
       expect(page).to have_content reports.first.description
       expect(page).to have_content reports.last.description
     end
@@ -58,7 +58,7 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.show")
+        click_on t("default.link.show")
       end
 
       expect(page).to have_content report.description
@@ -70,10 +70,10 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on I18n.t("default.link.show")
+        click_on t("default.link.show")
       end
 
-      click_on I18n.t("action.report.download.button")
+      click_on t("action.report.download.button")
 
       expect(page.response_headers["Content-Type"]).to include("text/csv")
       header = page.response_headers["Content-Disposition"]
@@ -95,7 +95,7 @@ RSpec.feature "Users can view reports" do
 
         visit reports_path
 
-        expect(page).to have_content I18n.t("page_title.report.index")
+        expect(page).to have_content t("page_title.report.index")
         expect(page).to have_content report.description
         expect(page).not_to have_content other_organisation_report.description
       end
@@ -106,7 +106,7 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on I18n.t("default.link.show")
+          click_on t("default.link.show")
         end
 
         expect(page).to have_content report.description
@@ -142,10 +142,10 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on I18n.t("default.link.show")
+          click_on t("default.link.show")
         end
 
-        click_on I18n.t("action.report.download.button")
+        click_on t("action.report.download.button")
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
 

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -18,10 +18,10 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link I18n.t("page_title.home"), href: organisation_path(user.organisation)
-      expect(page).to have_link I18n.t("page_title.report.index"), href: reports_path
-      expect(page).not_to have_link I18n.t("page_title.organisation.index"), href: organisations_path
-      expect(page).not_to have_link I18n.t("page_title.users.index"), href: users_path
+      expect(page).to have_link t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).to have_link t("page_title.report.index"), href: reports_path
+      expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path
+      expect(page).not_to have_link t("page_title.users.index"), href: users_path
     end
   end
 
@@ -33,10 +33,10 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link I18n.t("page_title.home"), href: organisation_path(user.organisation)
-      expect(page).to have_link I18n.t("page_title.report.index"), href: reports_path
-      expect(page).to have_link I18n.t("page_title.organisation.index"), href: organisations_path
-      expect(page).to have_link I18n.t("page_title.users.index"), href: users_path
+      expect(page).to have_link t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).to have_link t("page_title.report.index"), href: reports_path
+      expect(page).to have_link t("page_title.organisation.index"), href: organisations_path
+      expect(page).to have_link t("page_title.users.index"), href: users_path
     end
   end
 end

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view a third-party project" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to_not have_content I18n.t("default.button.download_as_xml")
+      expect(page).to_not have_content t("default.button.download_as_xml")
     end
 
     scenario "can view and add budgets and transactions on a third-party project" do
@@ -29,8 +29,8 @@ RSpec.feature "Users can view a third-party project" do
 
       expect(page).to have_content(budget.value)
       expect(page).to have_content(transaction.value)
-      expect(page).to have_content(I18n.t("page_content.budgets.button.create"))
-      expect(page).to have_content(I18n.t("page_content.transactions.button.create"))
+      expect(page).to have_content(t("page_content.budgets.button.create"))
+      expect(page).to have_content(t("page_content.transactions.button.create"))
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.feature "Users can view a third-party project" do
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
       expect(page).to have_content third_party_project.title
-      expect(page).to_not have_content I18n.t("page_content.organisation.button.create_activity")
+      expect(page).to_not have_content t("page_content.organisation.button.create_activity")
     end
 
     scenario "can download a third-party project as XML" do
@@ -52,9 +52,9 @@ RSpec.feature "Users can view a third-party project" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to have_content I18n.t("default.button.download_as_xml")
+      expect(page).to have_content t("default.button.download_as_xml")
 
-      click_on I18n.t("default.button.download_as_xml")
+      click_on t("default.button.download_as_xml")
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -65,9 +65,9 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit activities_path
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
         expect(page).to have_content(transaction_presenter.transaction_type)
@@ -85,14 +85,14 @@ RSpec.feature "Users can view transactions on an activity page" do
         visit activities_path
 
         click_link fund_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link programme_activity.title
-        click_on I18n.t("tabs.activity.children")
+        click_on t("tabs.activity.children")
         click_link project_activity.title
 
-        expect(page).to_not have_content(I18n.t("page_content.transactions.button.create"))
+        expect(page).to_not have_content(t("page_content.transactions.button.create"))
         within("tr##{transaction.id}") do
-          expect(page).not_to have_content(I18n.t("default.link.edit"))
+          expect(page).not_to have_content(t("default.link.edit"))
         end
       end
     end

--- a/spec/features/user_can_view_static_pages_spec.rb
+++ b/spec/features/user_can_view_static_pages_spec.rb
@@ -6,45 +6,45 @@ RSpec.feature "Users can view the static pages" do
       visit root_path
 
       within("footer") do
-        expect(page).to have_link I18n.t("footer.link.privacy_policy")
+        expect(page).to have_link t("footer.link.privacy_policy")
       end
     end
 
     scenario "the linked privacy policy page can be viewed" do
       visit root_path
-      click_on I18n.t("footer.link.privacy_policy")
+      click_on t("footer.link.privacy_policy")
 
-      expect(page).to have_content I18n.t("page_title.privacy_policy")
+      expect(page).to have_content t("page_title.privacy_policy")
     end
 
     scenario "the footer contains a link to the cookie statment" do
       visit root_path
 
       within("footer") do
-        expect(page).to have_link I18n.t("footer.link.cookie_statement")
+        expect(page).to have_link t("footer.link.cookie_statement")
       end
     end
 
     scenario "the linked cookie statement page can be viewed" do
       visit root_path
-      click_on I18n.t("footer.link.cookie_statement")
+      click_on t("footer.link.cookie_statement")
 
-      expect(page).to have_content I18n.t("cookie_statement.title")
+      expect(page).to have_content t("cookie_statement.title")
     end
 
     scenario "the footer contains a link to the accessibility statment" do
       visit root_path
 
       within("footer") do
-        expect(page).to have_link I18n.t("footer.link.accessibility_statement")
+        expect(page).to have_link t("footer.link.accessibility_statement")
       end
     end
 
     scenario "the linked accessibility statement page can be viewed" do
       visit root_path
-      click_on I18n.t("footer.link.accessibility_statement")
+      click_on t("footer.link.accessibility_statement")
 
-      expect(page).to have_content I18n.t("accessibility_statement.title")
+      expect(page).to have_content t("accessibility_statement.title")
     end
   end
 
@@ -54,15 +54,15 @@ RSpec.feature "Users can view the static pages" do
       authenticate!(user: user)
       visit privacy_policy_path
 
-      expect(page).to have_content I18n.t("page_title.privacy_policy")
+      expect(page).to have_content t("page_title.privacy_policy")
 
       visit cookie_statement_path
 
-      expect(page).to have_content I18n.t("cookie_statement.title")
+      expect(page).to have_content t("cookie_statement.title")
 
       visit accessibility_statement_path
 
-      expect(page).to have_content I18n.t("accessibility_statement.title")
+      expect(page).to have_content t("accessibility_statement.title")
     end
   end
 end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe CodelistHelper, type: :helper do
     describe "#country_select_options" do
       it "returns an array of country objects with '' as the first (default) option" do
         expect(helper.country_select_options.first)
-          .to eq(OpenStruct.new(name: I18n.t("page_content.activity.recipient_country.default_selection_value"), code: ""))
+          .to eq(OpenStruct.new(name: t("page_content.activity.recipient_country.default_selection_value"), code: ""))
       end
     end
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe FormHelper, type: :helper do
     it "builds a list of budget types for a planned disbursement" do
       budget_types = helper.list_of_planned_disbursement_budget_types
 
-      expect(budget_types[0].name).to eq I18n.t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
-      expect(budget_types[0].description).to eq I18n.t("form.label.planned_disbursement.planned_disbursement_type_options.original.description")
+      expect(budget_types[0].name).to eq t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
+      expect(budget_types[0].description).to eq t("form.label.planned_disbursement.planned_disbursement_type_options.original.description")
     end
   end
 
@@ -73,12 +73,12 @@ RSpec.describe FormHelper, type: :helper do
           OpenStruct.new(
             level: "fund",
             name: "Fund",
-            description: I18n.t("form.hint.activity.level_step.fund"),
+            description: t("form.hint.activity.level_step.fund"),
           ),
           OpenStruct.new(
             level: "programme",
             name: "Programme",
-            description: I18n.t("form.hint.activity.level_step.programme"),
+            description: t("form.hint.activity.level_step.programme"),
           ),
         ])
       end

--- a/spec/lib/legacy_activity_spec.rb
+++ b/spec/lib/legacy_activity_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe LegacyActivity do
   describe "#find_parent" do
     context "when the identifier matches to an activity" do
       it "returns the related activity" do
-        existing_programme = create(:programme_activity, identifier: "GCRF-INTPART")
+        existing_programme = create(:programme_activity, delivery_partner_identifier: "GCRF-INTPART")
 
         fake_mapping = CSV::Table.new([
           CSV::Row.new([:activity_id, :parent_id], ["activity_id", "parent_id"]),

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "sanitisation" do
-    it { should strip_attribute(:identifier) }
+    it { should strip_attribute(:delivery_partner_identifier) }
   end
 
   describe "validations" do
@@ -88,21 +88,21 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when identifier is blank" do
-      subject(:activity) { build(:activity, identifier: nil) }
+    context "when delivery_partner_identifier is blank" do
+      subject(:activity) { build(:activity, delivery_partner_identifier: nil) }
       it "should not be valid" do
         expect(activity.valid?(:identifier_step)).to be_falsey
       end
     end
 
-    describe "#identifier" do
-      context "when an activity exists with the same identifier" do
+    describe "#delivery_partner_identifier" do
+      context "when an activity exists with the same delivery_partner_identifier" do
         context "shares the same parent" do
           it "should be invalid" do
             fund = create(:fund_activity)
-            create(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+            create(:programme_activity, delivery_partner_identifier: "GB-GOV-13-001", parent: fund)
 
-            new_programme_activity = build(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+            new_programme_activity = build(:programme_activity, delivery_partner_identifier: "GB-GOV-13-001", parent: fund)
 
             expect(new_programme_activity).not_to be_valid
           end
@@ -111,11 +111,11 @@ RSpec.describe Activity, type: :model do
         context "does NOT share the same parent" do
           it "should be valid" do
             create(:fund_activity) do |fund|
-              create(:programme_activity, identifier: "GB-GOV-13-001", parent: fund)
+              create(:programme_activity, delivery_partner_identifier: "GB-GOV-13-001", parent: fund)
             end
 
             other_fund = create(:fund_activity)
-            new_programme_activity = build(:programme_activity, identifier: "GB-GOV-13-001", parent: other_fund)
+            new_programme_activity = build(:programme_activity, delivery_partner_identifier: "GB-GOV-13-001", parent: other_fund)
 
             expect(new_programme_activity).to be_valid
           end
@@ -607,42 +607,42 @@ RSpec.describe Activity, type: :model do
 
   describe "#iati_identifier" do
     context "when the activity is a fund" do
-      it "returns a composite identifier formed with the reporting organisation" do
-        fund = build(:fund_activity, identifier: "GCRF-1", reporting_organisation: create(:beis_organisation))
+      it "returns a composite delivery_partner_identifier formed with the reporting organisation" do
+        fund = build(:fund_activity, delivery_partner_identifier: "GCRF-1", reporting_organisation: create(:beis_organisation))
         expect(fund.iati_identifier).to eql("GB-GOV-13-GCRF-1")
       end
     end
 
     context "when the activity is a programme" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an identifier with the reporting organisation, fund and programme" do
+        it "returns an delivery_partner_identifier with the reporting organisation, fund and programme" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           programme = create(:programme_activity, organisation: government_organisation)
           fund = programme.parent
 
           expect(programme.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}")
+            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}")
         end
       end
     end
 
     context "when the activity is a project" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an identifier with the reporting organisation, fund, programme and project" do
+        it "returns an delivery_partner_identifier with the reporting organisation, fund, programme and project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           project = create(:project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
           programme = project.parent
           fund = programme.parent
 
           expect(project.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}")
+            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{project.delivery_partner_identifier}")
         end
       end
     end
 
     context "when the activity is a third-party project" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an identifier with the reporting organisation, fund, programme, project and third-party project" do
+        it "returns an delivery_partner_identifier with the reporting organisation, fund, programme, project and third-party project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           third_party_project = create(:third_party_project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
           project = third_party_project.parent
@@ -650,7 +650,7 @@ RSpec.describe Activity, type: :model do
           fund = programme.parent
 
           expect(third_party_project.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.identifier}-#{programme.identifier}-#{project.identifier}-#{third_party_project.identifier}")
+            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{project.delivery_partner_identifier}-#{third_party_project.delivery_partner_identifier}")
         end
       end
     end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Budget do
 
       budget.valid?
 
-      expect(budget.errors[:period_end_date]).not_to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+      expect(budget.errors[:period_end_date]).not_to include t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Budget do
 
       budget.valid?
 
-      expect(budget.errors[:period_end_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+      expect(budget.errors[:period_end_date]).to include t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Organisation, type: :model do
         organisation = build(:organisation, iati_reference: "1234")
         organisation.valid?
         expect(organisation.errors.messages[:iati_reference]).to include(
-          I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")
+          t("activerecord.errors.models.organisation.attributes.iati_reference.format")
         )
       end
     end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PlannedDisbursement, type: :model do
       it "displays the appropriate error message" do
         planned_disbursement = build(:planned_disbursement, planned_disbursement_type: nil)
         expect(planned_disbursement.valid?).to be_falsey
-        expect(planned_disbursement.errors[:planned_disbursement_type]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.blank")
+        expect(planned_disbursement.errors[:planned_disbursement_type]).to include t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.blank")
       end
     end
     context "when period_start_date is not blank" do
@@ -41,7 +41,7 @@ RSpec.describe PlannedDisbursement, type: :model do
       it "does not allow a period_start_date more than 10 years ago" do
         planned_disbursement = build(:planned_disbursement, period_start_date: 11.years.ago)
         expect(planned_disbursement.valid?).to be_falsey
-        expect(planned_disbursement.errors[:period_start_date]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.period_start_date.between", min: 10, max: 25)
+        expect(planned_disbursement.errors[:period_start_date]).to include t("activerecord.errors.models.planned_disbursement.attributes.period_start_date.between", min: 10, max: 25)
       end
 
       it "does not allow a period_start_date more than 25 years in the future" do
@@ -61,13 +61,13 @@ RSpec.describe PlannedDisbursement, type: :model do
       it "does not allow the period_end_date to be before the period_start_date" do
         planned_disbursement = build(:planned_disbursement, period_start_date: Date.today + 1.month, period_end_date: Date.today)
         expect(planned_disbursement.valid?).to be_falsey
-        expect(planned_disbursement.errors[:period_end_date]).to include I18n.t("activerecord.errors.validators.end_date_not_before_start_date")
+        expect(planned_disbursement.errors[:period_end_date]).to include t("activerecord.errors.validators.end_date_not_before_start_date")
       end
 
       it "does not allow a period_end_date more than 10 years ago" do
         planned_disbursement = build(:planned_disbursement, period_start_date: 12.years.ago, period_end_date: 11.years.ago)
         expect(planned_disbursement.valid?).to be_falsey
-        expect(planned_disbursement.errors[:period_end_date]).to include I18n.t("activerecord.errors.models.planned_disbursement.attributes.period_end_date.between", min: 10, max: 25)
+        expect(planned_disbursement.errors[:period_end_date]).to include t("activerecord.errors.models.planned_disbursement.attributes.period_end_date.between", min: 10, max: 25)
       end
 
       it "does not allow a period_end_date more than 25 years in the future" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Report, type: :model do
     programme = create(:programme_activity)
     report = build(:report, fund: programme)
     expect(report).not_to be_valid
-    expect(report.errors[:fund]).to include I18n.t("activerecord.errors.models.report.attributes.fund.level")
+    expect(report.errors[:fund]).to include t("activerecord.errors.models.report.attributes.fund.level")
   end
 
   it "does not allow more than one Report for the same Fund and Organisation combination" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe ActivityPresenter do
       it "returns the locale value for the code" do
         activity = build(:activity, recipient_country: "CL")
         result = described_class.new(activity).recipient_country
-        expect(result).to eq I18n.t("activity.recipient_country.#{activity.recipient_country}")
+        expect(result).to eq t("activity.recipient_country.#{activity.recipient_country}")
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include ActionView::Helpers::TranslationHelper
+
   config.include AuthenticationHelpers
   config.include Auth0Helpers
   config.include EmailHelpers

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe "the custom error pages" do
     get "/404"
 
     expect(response).to have_http_status(404)
-    expect(response.body).to include I18n.t("page_title.errors.not_found")
+    expect(response.body).to include t("page_title.errors.not_found")
   end
 
   it "responds with a custom 500 page" do
     get "/500"
 
     expect(response).to have_http_status(500)
-    expect(response.body).to include I18n.t("page_title.errors.internal_server_error")
+    expect(response.body).to include t("page_title.errors.internal_server_error")
   end
 
   it "responds with a custom 422 page" do
     get "/422"
 
     expect(response).to have_http_status(422)
-    expect(response.body).to include I18n.t("page_title.errors.unacceptable")
+    expect(response.body).to include t("page_title.errors.unacceptable")
   end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ExportActivityToCsv do
       next_four_quarter_totals = export_service.next_four_quarter_forecasts
 
       expect(result).to eq([
-        activity_presenter.identifier,
+        activity_presenter.delivery_partner_identifier,
         activity_presenter.transparency_identifier,
         activity_presenter.sector,
         activity_presenter.title,

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -3,7 +3,7 @@ require "nokogiri"
 
 RSpec.describe IngestIatiActivities do
   let(:beis) { create(:beis_organisation) }
-  let!(:existing_activity) { create(:programme_activity, identifier: "GCRF-INTPART", organisation: beis) }
+  let!(:existing_activity) { create(:programme_activity, delivery_partner_identifier: "GCRF-INTPART", organisation: beis) }
 
   describe "#call" do
     it "creates 35 new projects for UKSA" do
@@ -24,7 +24,7 @@ RSpec.describe IngestIatiActivities do
       described_class.new(delivery_partner: uksa, file_io: legacy_activities).call
 
       new_activity = Activity.find_by(previous_identifier: "GB-GOV-13-GCRF-UKSA_NS_UKSA-019")
-      expect(new_activity.identifier).to eq("UKSA_NS_UKSA-019")
+      expect(new_activity.delivery_partner_identifier).to eq("UKSA_NS_UKSA-019")
     end
 
     it "adds a new ingested flag to the activity so the team can distinguish old from new" do
@@ -81,8 +81,8 @@ RSpec.describe IngestIatiActivities do
 
       activity = Activity.find_by(previous_identifier: "GB-GOV-13-GCRF-UKSA_NS_UKSA-019")
 
-      expect(activity.identifier).not_to be nil
-      expect(activity.identifier).not_to eq(activity.previous_identifier)
+      expect(activity.delivery_partner_identifier).not_to be nil
+      expect(activity.delivery_partner_identifier).not_to eq(activity.previous_identifier)
       expect(activity.organisation).to eq(uksa)
       expect(activity.reporting_organisation).to eq(beis)
       expect(activity.funding_organisation_reference).to eq(beis.iati_reference)
@@ -155,7 +155,7 @@ RSpec.describe IngestIatiActivities do
 
     it "ignores activities with the wrong IATI hierarchy level" do
       rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
-      programme = create(:programme_activity, organisation: rs, identifier: "RS-Del-RS")
+      programme = create(:programme_activity, organisation: rs, delivery_partner_identifier: "RS-Del-RS")
       legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/rs/with_wrong_hierarchy_level.xml")
 
       described_class.new(delivery_partner: rs, file_io: legacy_activities).call
@@ -234,7 +234,7 @@ RSpec.describe IngestIatiActivities do
 
       it "allows negative budgets" do
         rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
-        create(:programme_activity, organisation: rs, identifier: "Brazil-Newton-Mob-RS")
+        create(:programme_activity, organisation: rs, delivery_partner_identifier: "Brazil-Newton-Mob-RS")
 
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/rs/with_negative_budget.xml")
 
@@ -338,7 +338,7 @@ RSpec.describe IngestIatiActivities do
     describe "default aid type" do
       it "leaves aid_type blank if there is no attribute" do
         rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
-        create(:programme_activity, organisation: rs, identifier: "South Africa-Newton-Adv-RS")
+        create(:programme_activity, organisation: rs, delivery_partner_identifier: "South Africa-Newton-Adv-RS")
 
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/rs/with_missing_default_aid_type.xml")
 

--- a/spec/services/update_activity_as_project_spec.rb
+++ b/spec/services/update_activity_as_project_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UpdateActivityAsProject do
       it "sets the parent to nil and does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
+        expect(result.errors.messages).to include(parent: [t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end

--- a/spec/services/update_activity_as_third_party_project_spec.rb
+++ b/spec/services/update_activity_as_third_party_project_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UpdateActivityAsThirdPartyProject do
       it "sets the parent to nil does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
+        expect(result.errors.messages).to include(parent: [t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end

--- a/spec/services/update_programme_activity_spec.rb
+++ b/spec/services/update_programme_activity_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UpdateActivityAsProgramme do
       it "sets the parent to nil does not save the record" do
         result = described_class.new(activity: activity, parent_id: "an-id-that-does-not-exist").call
         expect(result.parent).to eq(nil)
-        expect(result.errors.messages).to include(parent: [I18n.t("activerecord.errors.models.activity.attributes.parent.blank")])
+        expect(result.errors.messages).to include(parent: [t("activerecord.errors.models.activity.attributes.parent.blank")])
       end
     end
   end

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -1,54 +1,54 @@
 module ActivityHelpers
   def page_displays_an_activity(activity_presenter:)
-    click_on I18n.t("tabs.activity.details")
+    click_on t("tabs.activity.details")
 
-    expect(page).to have_content I18n.t("summary.label.activity.organisation")
+    expect(page).to have_content t("summary.label.activity.organisation")
     expect(page).to have_content activity_presenter.organisation.name
 
-    expect(page).to have_content I18n.t("summary.label.activity.level")
+    expect(page).to have_content t("summary.label.activity.level")
     expect(page).to have_content activity_presenter.level
 
     unless activity_presenter.fund?
-      expect(page).to have_content I18n.t("summary.label.activity.parent")
+      expect(page).to have_content t("summary.label.activity.parent")
       expect(page).to have_content activity_presenter.parent_title
     end
 
-    expect(page).to have_content I18n.t("summary.label.activity.identifier")
+    expect(page).to have_content t("summary.label.activity.identifier")
     expect(page).to have_content activity_presenter.identifier
 
-    expect(page).to have_content I18n.t("summary.label.activity.title", level: activity_presenter.level).capitalize
+    expect(page).to have_content t("summary.label.activity.title", level: activity_presenter.level).capitalize
     expect(page).to have_content activity_presenter.title
 
-    expect(page).to have_content I18n.t("summary.label.activity.description")
+    expect(page).to have_content t("summary.label.activity.description")
     expect(page).to have_content activity_presenter.description
 
-    expect(page).to have_content I18n.t("summary.label.activity.sector", level: activity_presenter.level)
+    expect(page).to have_content t("summary.label.activity.sector", level: activity_presenter.level)
     expect(page).to have_content activity_presenter.sector
 
     unless activity_presenter.fund?
-      expect(page).to have_content I18n.t("summary.label.activity.programme_status")
+      expect(page).to have_content t("summary.label.activity.programme_status")
       expect(page).to have_content activity_presenter.programme_status
     end
 
-    expect(page).to have_content I18n.t("summary.label.activity.planned_start_date")
+    expect(page).to have_content t("summary.label.activity.planned_start_date")
     expect(page).to have_content activity_presenter.planned_start_date
 
-    expect(page).to have_content I18n.t("summary.label.activity.planned_end_date")
+    expect(page).to have_content t("summary.label.activity.planned_end_date")
     expect(page).to have_content activity_presenter.planned_end_date
 
-    expect(page).to have_content I18n.t("summary.label.activity.actual_start_date")
+    expect(page).to have_content t("summary.label.activity.actual_start_date")
     expect(page).to have_content activity_presenter.actual_start_date
 
-    expect(page).to have_content I18n.t("summary.label.activity.actual_end_date")
+    expect(page).to have_content t("summary.label.activity.actual_end_date")
     expect(page).to have_content activity_presenter.actual_end_date
 
-    expect(page).to have_content I18n.t("summary.label.activity.recipient_region")
+    expect(page).to have_content t("summary.label.activity.recipient_region")
     expect(page).to have_content activity_presenter.recipient_region
 
-    expect(page).to have_content I18n.t("summary.label.activity.flow")
+    expect(page).to have_content t("summary.label.activity.flow")
     expect(page).to have_content activity_presenter.flow
 
-    expect(page).to have_content I18n.t("summary.label.activity.aid_type")
+    expect(page).to have_content t("summary.label.activity.aid_type")
     expect(page).to have_content activity_presenter.aid_type
   end
 end

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -13,8 +13,8 @@ module ActivityHelpers
       expect(page).to have_content activity_presenter.parent_title
     end
 
-    expect(page).to have_content t("summary.label.activity.identifier")
-    expect(page).to have_content activity_presenter.identifier
+    expect(page).to have_content t("summary.label.activity.delivery_partner_identifier")
+    expect(page).to have_content activity_presenter.delivery_partner_identifier
 
     expect(page).to have_content t("summary.label.activity.title", level: activity_presenter.level).capitalize
     expect(page).to have_content activity_presenter.title

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -25,6 +25,6 @@ module AuthenticationHelpers
   def stub_authenticated_session(uid: "123456789", name: "Alex", email: "alex@example.com")
     mock_successful_authentication(uid: uid, name: name, email: email)
     visit root_path
-    click_on I18n.t("header.link.sign_in")
+    click_on t("header.link.sign_in")
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -33,68 +33,68 @@ module FormHelpers
     parent: nil
   )
 
-    expect(page).to have_content I18n.t("form.legend.activity.level")
-    expect(page).to have_content I18n.t("form.hint.activity.level")
-    expect(page).to have_content I18n.t("form.hint.activity.level_step.#{level}")
-    choose I18n.t("page_content.activity.level.#{level}").capitalize
-    click_button I18n.t("form.button.activity.submit")
+    expect(page).to have_content t("form.legend.activity.level")
+    expect(page).to have_content t("form.hint.activity.level")
+    expect(page).to have_content t("form.hint.activity.level_step.#{level}")
+    choose t("page_content.activity.level.#{level}").capitalize
+    click_button t("form.button.activity.submit")
 
     if parent.present?
-      expect(page).to have_content I18n.t("form.legend.activity.parent", parent_level: parent.level, level: I18n.t("page_content.activity.level.#{level}"))
-      expect(page).to have_content I18n.t("form.hint.activity.parent", parent_level: parent.level, level: I18n.t("page_content.activity.level.#{level}"))
+      expect(page).to have_content t("form.legend.activity.parent", parent_level: parent.level, level: t("page_content.activity.level.#{level}"))
+      expect(page).to have_content t("form.hint.activity.parent", parent_level: parent.level, level: t("page_content.activity.level.#{level}"))
       choose parent.title
-      click_button I18n.t("form.button.activity.submit")
+      click_button t("form.button.activity.submit")
     end
 
-    expect(page).to have_content I18n.t("form.label.activity.identifier")
-    expect(page).to have_content I18n.t("form.hint.activity.identifier")
+    expect(page).to have_content t("form.label.activity.identifier")
+    expect(page).to have_content t("form.hint.activity.identifier")
     fill_in "activity[identifier]", with: identifier
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.purpose", level: activity_level(level))
-    expect(page).to have_content I18n.t("form.label.activity.title", level: activity_level(level).humanize)
-    expect(page).to have_content I18n.t("form.label.activity.description")
+    expect(page).to have_content t("form.legend.activity.purpose", level: activity_level(level))
+    expect(page).to have_content t("form.label.activity.title", level: activity_level(level).humanize)
+    expect(page).to have_content t("form.label.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.sector_category", level: activity_level(level))
+    expect(page).to have_content t("form.legend.activity.sector_category", level: activity_level(level))
     expect(page).to have_content(
       ActionView::Base.full_sanitizer.sanitize(
-        I18n.t("form.legend.activity.sector_category", level: I18n.t("page_content.activity.level.#{level}"))
+        t("form.legend.activity.sector_category", level: t("page_content.activity.level.#{level}"))
       )
     )
     choose sector_category
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.sector", sector_category: sector_category, level: activity_level(level))
+    expect(page).to have_content t("form.legend.activity.sector", sector_category: sector_category, level: activity_level(level))
 
     choose sector
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
     if level == "project" || level == "third_party_project"
-      expect(page).to have_content I18n.t("form.legend.activity.call_present", level: activity_level(level))
+      expect(page).to have_content t("form.legend.activity.call_present", level: activity_level(level))
       choose "Yes"
-      click_button I18n.t("form.button.activity.submit")
-      expect(page).to have_content I18n.t("page_title.activity_form.show.call_dates", level: activity_level(level))
+      click_button t("form.button.activity.submit")
+      expect(page).to have_content t("page_title.activity_form.show.call_dates", level: activity_level(level))
 
-      expect(page).to have_content I18n.t("form.legend.activity.call_open_date")
+      expect(page).to have_content t("form.legend.activity.call_open_date")
       fill_in "activity[call_open_date(3i)]", with: call_open_date_day
       fill_in "activity[call_open_date(2i)]", with: call_open_date_month
       fill_in "activity[call_open_date(1i)]", with: call_open_date_year
 
-      expect(page).to have_content I18n.t("form.legend.activity.call_close_date")
+      expect(page).to have_content t("form.legend.activity.call_close_date")
       fill_in "activity[call_close_date(3i)]", with: call_close_date_day
       fill_in "activity[call_close_date(2i)]", with: call_close_date_month
       fill_in "activity[call_close_date(1i)]", with: call_close_date_year
 
-      click_button I18n.t("form.button.activity.submit")
+      click_button t("form.button.activity.submit")
     else
       call_present = nil
     end
 
     unless level == "fund"
-      expect(page).to have_content I18n.t("form.legend.activity.programme_status")
+      expect(page).to have_content t("form.legend.activity.programme_status")
       expect(page).to have_content "Delivery"
       expect(page).to have_content "Planned"
       expect(page).to have_content "Agreement in place"
@@ -108,66 +108,66 @@ module FormHelpers
       expect(page).to have_content "Cancelled"
 
       choose("activity[programme_status]", option: programme_status)
-      click_button I18n.t("form.button.activity.submit")
+      click_button t("form.button.activity.submit")
     end
 
-    expect(page).to have_content I18n.t("page_title.activity_form.show.dates", level: activity_level(level))
+    expect(page).to have_content t("page_title.activity_form.show.dates", level: activity_level(level))
 
-    expect(page).to have_content I18n.t("form.legend.activity.planned_start_date")
+    expect(page).to have_content t("form.legend.activity.planned_start_date")
     fill_in "activity[planned_start_date(3i)]", with: planned_start_date_day
     fill_in "activity[planned_start_date(2i)]", with: planned_start_date_month
     fill_in "activity[planned_start_date(1i)]", with: planned_start_date_year
 
-    expect(page).to have_content I18n.t("form.legend.activity.planned_end_date")
+    expect(page).to have_content t("form.legend.activity.planned_end_date")
     fill_in "activity[planned_end_date(3i)]", with: planned_end_date_day
     fill_in "activity[planned_end_date(2i)]", with: planned_end_date_month
     fill_in "activity[planned_end_date(1i)]", with: planned_end_date_year
 
-    expect(page).to have_content I18n.t("form.legend.activity.actual_start_date")
+    expect(page).to have_content t("form.legend.activity.actual_start_date")
     fill_in "activity[actual_start_date(3i)]", with: actual_start_date_day
     fill_in "activity[actual_start_date(2i)]", with: actual_start_date_month
     fill_in "activity[actual_start_date(1i)]", with: actual_start_date_year
 
-    expect(page).to have_content I18n.t("form.legend.activity.actual_end_date")
+    expect(page).to have_content t("form.legend.activity.actual_end_date")
     fill_in "activity[actual_end_date(3i)]", with: actual_end_date_day
     fill_in "activity[actual_end_date(2i)]", with: actual_end_date_month
     fill_in "activity[actual_end_date(1i)]", with: actual_end_date_year
 
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.geography")
+    expect(page).to have_content t("form.legend.activity.geography")
     choose "Region"
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.label.activity.recipient_region")
+    expect(page).to have_content t("form.label.activity.recipient_region")
     select recipient_region, from: "activity[recipient_region]"
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.label.activity.flow")
-    expect(page.html).to include I18n.t("form.hint.activity.flow")
+    expect(page).to have_content t("form.label.activity.flow")
+    expect(page.html).to include t("form.hint.activity.flow")
     select flow, from: "activity[flow]"
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
-    expect(page).to have_content I18n.t("form.legend.activity.aid_type")
+    expect(page).to have_content t("form.legend.activity.aid_type")
     expect(page).to have_content "A code for the vocabulary aid-type classifications. International Aid Transparency Initiative (IATI) descriptions can be found here (Opens in new window)"
     choose("activity[aid_type]", option: aid_type)
-    click_button I18n.t("form.button.activity.submit")
+    click_button t("form.button.activity.submit")
 
     expect(page).to have_content identifier
     expect(page).to have_content title
     expect(page).to have_content description
     expect(page).to have_content sector
     if call_present == "true"
-      expect(page).to have_content I18n.t("activity.call_present.#{call_present}")
+      expect(page).to have_content t("activity.call_present.#{call_present}")
     end
     if level == "fund"
-      expect(page).not_to have_content I18n.t("activity.programme_status.#{programme_status}")
+      expect(page).not_to have_content t("activity.programme_status.#{programme_status}")
     else
-      expect(page).to have_content I18n.t("activity.programme_status.#{programme_status}")
+      expect(page).to have_content t("activity.programme_status.#{programme_status}")
     end
     expect(page).to have_content recipient_region
     expect(page).to have_content flow
-    expect(page).to have_content I18n.t("activity.aid_type.#{aid_type.downcase}")
+    expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,
       month: planned_start_date_month,
@@ -225,7 +225,7 @@ module FormHelpers
     select receiving_organisation.type, from: "transaction[receiving_organisation_type]"
     fill_in "transaction[receiving_organisation_reference]", with: receiving_organisation.reference
 
-    click_on(I18n.t("default.button.submit"))
+    click_on(t("default.button.submit"))
 
     if expectations
       within ".transactions" do
@@ -271,7 +271,7 @@ module FormHelpers
     select receiving_organisation.type, from: "planned_disbursement[receiving_organisation_type]"
     fill_in "planned_disbursement[receiving_organisation_reference]", with: receiving_organisation.reference
 
-    click_on(I18n.t("default.button.submit"))
+    click_on(t("default.button.submit"))
   end
 
   def localise_date_from_input_fields(year:, month:, day:)
@@ -279,6 +279,6 @@ module FormHelpers
   end
 
   private def activity_level(level)
-    I18n.t("page_content.activity.level.#{level}")
+    t("page_content.activity.level.#{level}")
   end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,6 +1,6 @@
 module FormHelpers
   def fill_in_activity_form(
-    identifier: "A-Unique-Identifier",
+    delivery_partner_identifier: "A-Unique-Identifier",
     title: "My Aid Activity",
     description: Faker::Lorem.paragraph,
     sector_category: "Basic Education",
@@ -46,9 +46,9 @@ module FormHelpers
       click_button t("form.button.activity.submit")
     end
 
-    expect(page).to have_content t("form.label.activity.identifier")
-    expect(page).to have_content t("form.hint.activity.identifier")
-    fill_in "activity[identifier]", with: identifier
+    expect(page).to have_content t("form.label.activity.delivery_partner_identifier")
+    expect(page).to have_content t("form.hint.activity.delivery_partner_identifier")
+    fill_in "activity[delivery_partner_identifier]", with: delivery_partner_identifier
     click_button t("form.button.activity.submit")
 
     expect(page).to have_content t("form.legend.activity.purpose", level: activity_level(level))
@@ -153,7 +153,7 @@ module FormHelpers
     choose("activity[aid_type]", option: aid_type)
     click_button t("form.button.activity.submit")
 
-    expect(page).to have_content identifier
+    expect(page).to have_content delivery_partner_identifier
     expect(page).to have_content title
     expect(page).to have_content description
     expect(page).to have_content sector
@@ -191,7 +191,7 @@ module FormHelpers
       )
     end
 
-    my_activity = Activity.find_by(identifier: identifier)
+    my_activity = Activity.find_by(delivery_partner_identifier: delivery_partner_identifier)
     iati_status = ProgrammeToIatiStatus.new.programme_status_to_iati_status(programme_status)
     expect(my_activity.status).not_to be_nil
     expect(my_activity.status).to eq(iati_status)

--- a/spec/validators/budget_date_validator_spec.rb
+++ b/spec/validators/budget_date_validator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BudgetDatesValidator do
       subject.period_end_date = Date.today
 
       subject.valid?
-      expect(subject.errors.messages[:period_start_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_start_date.not_after_end_date")
+      expect(subject.errors.messages[:period_start_date]).to include t("activerecord.errors.models.budget.attributes.period_start_date.not_after_end_date")
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe BudgetDatesValidator do
       subject.period_end_date = subject.period_start_date + 366.days
 
       subject.valid?
-      expect(subject.errors.messages[:period_end_date]).to include I18n.t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
+      expect(subject.errors.messages[:period_end_date]).to include t("activerecord.errors.models.budget.attributes.period_end_date.within_365_days_of_start_date")
     end
   end
 

--- a/spec/validators/end_date_not_before_start_date_validator_spec.rb
+++ b/spec/validators/end_date_not_before_start_date_validator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe EndDateNotBeforeStartDateValidator do
       subject.period_end_date = Date.today
 
       subject.valid?
-      expect(subject.errors.messages[:period_end_date]).to include I18n.t("activerecord.errors.validators.end_date_not_before_start_date")
+      expect(subject.errors.messages[:period_end_date]).to include t("activerecord.errors.validators.end_date_not_before_start_date")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

This PR only renames the database column `activities.identifier` to `activities.delivery_partner_identifier`. The rationale for this is recorded in the commits. This is being done to support adding a new field to store the _RODA ID_ on activities, but I wanted to merge this on its own since it changes a lot of files and could be quite disruptive.

The main thing I'm worried about here is that I might not have caught all the users of `identifier` that need changing. I've made a best effort based on searching for this name, using the test suite, and the first commit here which will cause more tests to fail if there are missing translations. I may not have caught everything though and would appreciate a careful review to catch things I've missed.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
