### PR TITLE
(903) The next 4 quarters' forecast totals are included in a report's CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,9 +252,6 @@
 - Calculate the total of all Planned Disbursements in a Report's date range as
   `forecasted_total_for_report_financial_quarter` and output the value to the Report CSV
 - Ingest RAEng Newton fund data from IATI
-- Calculate the variance between an Activity's transactions total for a date range, and
-  that same Activity's planned disbursements total for a date range. Output this value
-  to the Report CSV as "Variance"
 
 ## [unreleased]
 - Reports can be submitted
@@ -262,6 +259,12 @@
 - Reports can be activated explicitly
 - Inactive reports are shown in their own table on the reports page
 - Reports are no longer activated when the deadline is set
+- Calculate the variance between an Activity's transactions total for a date range, and
+  that same Activity's planned disbursements total for a date range. Output this value
+  to the Report CSV as "Variance"
+- Find the next four financial quarters after this report's financial quarter. Find the 
+  forecasted totals (planned disbursement totals) for those four future quarters and output
+  them to the report CSV  
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -160,7 +160,7 @@ class Activity < ApplicationRecord
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    @forecasted_total_for_report_financial_quarter ||= planned_disbursements.where(period_start_date: report.created_at.all_quarter).sum(:value)
+    @forecasted_total_for_report_financial_quarter ||= forecasted_total_for_date_range(range: report.created_at.all_quarter)
   end
 
   def variance_for_report_financial_quarter(report:)
@@ -169,5 +169,9 @@ class Activity < ApplicationRecord
 
   def requires_call_dates?
     !ingested? && (project? || third_party_project?)
+  end
+
+  def forecasted_total_for_date_range(range:)
+    planned_disbursements.where(period_start_date: range).sum(:value)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -37,6 +37,19 @@ class Report < ApplicationRecord
     end
   end
 
+  def next_four_financial_quarters
+    case current_financial_quarter
+    when 1
+      ["Q2 #{current_financial_year}", "Q3 #{current_financial_year}", "Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}"]
+    when 2
+      ["Q3 #{current_financial_year}", "Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}"]
+    when 3
+      ["Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}", "Q3 #{current_financial_year + 1}"]
+    when 4
+      ["Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}", "Q3 #{current_financial_year + 1}", "Q4 #{current_financial_year + 1}"]
+    end
+  end
+
   private def current_financial_quarter
     case Date.today.month
     when 4, 5, 6

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -106,6 +106,11 @@ class ActivityPresenter < SimpleDelegator
     "%.2f" % super
   end
 
+  def forecasted_total_for_date_range(range:)
+    return if super.blank?
+    "%.2f" % super
+  end
+
   def variance_for_report_financial_quarter(report:)
     return if super.blank?
     "%.2f" % super

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -15,4 +15,23 @@ class ReportPresenter < SimpleDelegator
     return nil if financial_quarter.nil? || financial_year.nil?
     "Q#{financial_quarter} #{financial_year}-#{financial_year + 1}"
   end
+
+  def quarters_to_date_ranges
+    next_four_financial_quarters.map! do |quarter|
+      quarter = quarter.match(/(\d) (\d{4})/)
+      quarter_num, year = quarter[1].to_i, quarter[2].to_i
+      quarter_month = case quarter_num
+                      when 1
+                        "April"
+                      when 2
+                        "July"
+                      when 3
+                        "October"
+                      when 4
+                        "January"
+      end
+      year = quarter_num == 4 ? year + 1 : year
+      Date.parse("1 #{quarter_month} #{year}").all_quarter
+    end
+  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -34,6 +34,7 @@ class ExportActivityToCsv
 
   def headers
     report_financial_quarter = ReportPresenter.new(report).financial_quarter_and_year
+    next_four_quarters = report.next_four_financial_quarters
     [
       "Identifier",
       "Transparency identifier",
@@ -53,6 +54,6 @@ class ExportActivityToCsv
       report_financial_quarter ? report_financial_quarter + " forecast" : "Forecast",
       "Variance",
       "Link to activity in RODA",
-    ].to_csv
+    ].concat(next_four_quarters).to_csv
   end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -9,7 +9,6 @@ class ExportActivityToCsv
   end
 
   def call
-    activity_presenter = ActivityPresenter.new(activity)
     [
       activity_presenter.identifier,
       activity_presenter.transparency_identifier,
@@ -29,12 +28,11 @@ class ExportActivityToCsv
       activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
       activity_presenter.variance_for_report_financial_quarter(report: report),
       activity_presenter.link_to_roda,
-    ].to_csv
+    ].concat(next_four_quarter_forecasts).to_csv
   end
 
   def headers
     report_financial_quarter = ReportPresenter.new(report).financial_quarter_and_year
-    next_four_quarters = report.next_four_financial_quarters
     [
       "Identifier",
       "Transparency identifier",
@@ -54,6 +52,19 @@ class ExportActivityToCsv
       report_financial_quarter ? report_financial_quarter + " forecast" : "Forecast",
       "Variance",
       "Link to activity in RODA",
-    ].concat(next_four_quarters).to_csv
+    ].concat(report_presenter.next_four_financial_quarters).to_csv
+  end
+
+  def next_four_quarter_forecasts
+    quarter_date_ranges = report_presenter.quarters_to_date_ranges
+    quarter_date_ranges.map { |range| activity_presenter.forecasted_total_for_date_range(range: range) }
+  end
+
+  private def activity_presenter
+    @activity_presenter ||= ActivityPresenter.new(activity)
+  end
+
+  private def report_presenter
+    @report_presenter ||= ReportPresenter.new(report)
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -712,4 +712,15 @@ RSpec.describe Activity, type: :model do
       expect(project.variance_for_report_financial_quarter(report: report)).to eq(-1700)
     end
   end
+
+  describe "#forecasted_total_for_date_range" do
+    it "returns the total of all the activity's planned disbursements scoped to a date range" do
+      project = create(:project_activity, :with_report)
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200, period_start_date: Date.parse("13 April 2020"))
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1000, period_start_date: Date.parse("20 November 2020"))
+
+      expect(project.forecasted_total_for_date_range(range: Date.parse("1 April 2020")..Date.parse("30 June 2020"))).to eq 200
+      expect(project.forecasted_total_for_date_range(range: Date.parse("1 October 2020")..Date.parse("31 December 2020"))).to eq 1000
+    end
+  end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -117,4 +117,46 @@ RSpec.describe Report, type: :model do
       end
     end
   end
+
+  describe "#next_four_financial_quarters" do
+    context "when in Q1 2020" do
+      it "returns an array with the next four financial quarters" do
+        travel_to(Date.parse("1 April 2020")) do
+          report = create(:report)
+
+          expect(report.next_four_financial_quarters).to eq ["Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021"]
+        end
+      end
+    end
+
+    context "when in Q2 2020" do
+      it "returns an array with the next four financial quarters" do
+        travel_to(Date.parse("1 July 2020")) do
+          report = create(:report)
+
+          expect(report.next_four_financial_quarters).to eq ["Q3 2020", "Q4 2020", "Q1 2021", "Q2 2021"]
+        end
+      end
+    end
+
+    context "when in Q3 2020" do
+      it "returns an array with the next four financial quarters" do
+        travel_to(Date.parse("1 October 2020")) do
+          report = create(:report)
+
+          expect(report.next_four_financial_quarters).to eq ["Q4 2020", "Q1 2021", "Q2 2021", "Q3 2021"]
+        end
+      end
+    end
+
+    context "when in Q4 2020" do
+      it "returns an array with the next four financial quarters" do
+        travel_to(Date.parse("1 January 2021")) do
+          report = create(:report)
+
+          expect(report.next_four_financial_quarters).to eq ["Q1 2021", "Q2 2021", "Q3 2021", "Q4 2021"]
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -349,6 +349,21 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#forecasted_total_for_date_range" do
+    it "returns the planned disbursement total for a date range as a formatted number" do
+      project = create(:project_activity, :with_report)
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200.20, period_start_date: Date.today)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: 3.months.ago)
+
+      expect(described_class.new(project).forecasted_total_for_date_range(range: Date.today.all_quarter))
+        .to eq "200.20"
+      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.ago.all_quarter))
+        .to eq "1500.00"
+      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.from_now.all_quarter))
+        .to eq "0.00"
+    end
+  end
+
   describe "#variance_for_report_financial_quarter" do
     it "returns the variance per report as a formatted number" do
       project = create(:project_activity, :with_report)

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe ReportPresenter do
       expect(result).to be_nil
     end
   end
+
+  describe "#quarters_to_date_ranges" do
+    it "returns a date range for each quarter it is passed" do
+      travel_to(Date.parse("20 January 2021")) do
+        report = create(:report)
+        expect(described_class.new(report).quarters_to_date_ranges).to eq [
+          Date.parse("1 April 2021").all_quarter,
+          Date.parse("1 July 2021").all_quarter,
+          Date.parse("1 October 2021").all_quarter,
+          Date.parse("1 January 2022").all_quarter,
+        ]
+      end
+    end
+  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe ExportActivityToCsv do
   describe "#call" do
     it "creates a CSV line representation of the Activity" do
       activity_presenter = ActivityPresenter.new(project)
-      result = ExportActivityToCsv.new(activity: project, report: report).call
+      export_service = ExportActivityToCsv.new(activity: project, report: report)
+      result = export_service.call
+      next_four_quarter_totals = export_service.next_four_quarter_forecasts
 
       expect(result).to eq([
         activity_presenter.identifier,
@@ -29,7 +31,17 @@ RSpec.describe ExportActivityToCsv do
         activity_presenter.forecasted_total_for_report_financial_quarter(report: report),
         activity_presenter.variance_for_report_financial_quarter(report: report),
         activity_presenter.link_to_roda,
-      ].to_csv)
+      ].concat(next_four_quarter_totals).to_csv)
+    end
+  end
+
+  describe "#next_four_quarter_forecasts" do
+    it "gets the forecasted total for the date ranges of the next four quarters" do
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, period_start_date: 3.months.from_now, value: 1000)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, period_start_date: 9.months.from_now, value: 500)
+      totals = ExportActivityToCsv.new(activity: project, report: report).next_four_quarter_forecasts
+
+      expect(totals).to eq ["1000.00", "0.00", "500.00", "0.00"]
     end
   end
 

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -53,5 +53,15 @@ RSpec.describe ExportActivityToCsv do
         expect(headers).to include "Q1 2020-2021 forecast"
       end
     end
+
+    it "includes the next four financial quarters as headers" do
+      travel_to(Date.parse("1 April 2020")) do
+        report = Report.new
+
+        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+
+        expect(headers).to include ["Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021"].to_csv
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/Ee0f5VTG/903-a-number-of-future-aggregated-forecast-amounts-are-included-in-the-csv-file

A report has a financial quarter & year, e.g. Q1 2020.

Find the next 4 quarters after this report's quarter, e.g. Q2 2020, Q3 2020, Q4 2020 and Q1 2021

Calculate the forecast totals (planned disbursement totals) for those 4 quarters per Activity. Output these values to the report CSV as future forecast totals. 

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
