### PR TITLE
Fix for `Add activity` buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,8 @@
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`
+- `Create activity` buttons that were not changed on previous PR, are changed to
+  `Add activity` now.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -41,7 +41,7 @@ en:
     organisation:
       button:
         choose_extending_organisation: Choose extending organisation
-        create_activity: Create activity
+        create_activity: Add activity
         edit: Edit organisation
         edit_details: Edit details
       details: Organisation details


### PR DESCRIPTION
Trello: https://trello.com/c/dm6oA18s

## Changes in this PR

On a previously merged PR we intended to replace all `Create activity` buttons for `Add activity` buttons, as recommended by the content review. Some of the buttons still appeared as `Create activity` due to an unchanged field on a yml
file. This PR is to fix that problem.



## Screenshots of UI changes

### After

<img width="1310" alt="Screenshot 2020-08-25 at 11 22 02" src="https://user-images.githubusercontent.com/48016017/91163363-5d827d00-e6c5-11ea-9ac3-8f7e5f42c264.png">


<img width="1310" alt="Screenshot 2020-08-25 at 11 21 46" src="https://user-images.githubusercontent.com/48016017/91163380-64a98b00-e6c5-11ea-9f00-20fd67389878.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
