### PR TITLE
(914) Enable a BEIS user to mark a submitted report as "in review"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,8 @@
   to the Report CSV as "Variance"
 - Find the next four financial quarters after this report's financial quarter. Find the 
   forecasted totals (planned disbursement totals) for those four future quarters and output
-  them to the report CSV  
+  them to the report CSV
+- Submitted reports can be moved into the review state    
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -10,6 +10,7 @@ class Staff::ReportsController < Staff::BaseController
     inactive_reports if current_user.service_owner?
     current_user.service_owner? ? active_reports_with_organisations : active_reports
     current_user.service_owner? ? submitted_reports_with_organisations : submitted_reports
+    current_user.service_owner? ? in_review_reports_with_organisations : in_review_reports
   end
 
   def show
@@ -86,6 +87,18 @@ class Staff::ReportsController < Staff::BaseController
     submitted_reports = policy_scope(Report.where(state: :submitted)).includes(:fund)
     authorize submitted_reports
     @submitted_report_presenters = submitted_reports.map { |report| ReportPresenter.new(report) }
+  end
+
+  def in_review_reports_with_organisations
+    in_review_reports = policy_scope(Report.where(state: :in_review)).includes([:fund, :organisation])
+    authorize in_review_reports
+    @in_review_report_presenters = in_review_reports.map { |report| ReportPresenter.new(report) }
+  end
+
+  def in_review_reports
+    in_review_reports = policy_scope(Report.where(state: :in_review)).includes(:fund)
+    authorize in_review_reports
+    @in_review_report_presenters = in_review_reports.map { |report| ReportPresenter.new(report) }
   end
 
   def send_csv

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -4,12 +4,13 @@ class Staff::ReportsStateController < Staff::BaseController
   include Secured
 
   def edit
-    report = Report.find(params[:report_id])
     case report.state
     when "inactive"
       confirm_activation
     when "active"
       confirm_submission
+    when "submitted"
+      confirm_in_review
     else
       authorize report
       redirect_to report_path(report)
@@ -17,12 +18,13 @@ class Staff::ReportsStateController < Staff::BaseController
   end
 
   def update
-    report = Report.find(params[:report_id])
     case report.state
     when "inactive"
       change_report_state_to_active
     when "active"
       change_report_state_to_submitted
+    when "submitted"
+      change_report_state_to_in_review
     else
       authorize report
       redirect_to report_path(report)
@@ -30,14 +32,12 @@ class Staff::ReportsStateController < Staff::BaseController
   end
 
   private def confirm_activation
-    report = Report.find(params[:report_id])
     authorize report, :activate?
     @report_presenter = ReportPresenter.new(report)
     render "staff/reports_state/activate/confirm"
   end
 
   private def change_report_state_to_active
-    report = Report.find(params[:report_id])
     authorize report, :activate?
     report.update!(state: :active)
     report.create_activity key: "report.activated", owner: current_user
@@ -46,18 +46,34 @@ class Staff::ReportsStateController < Staff::BaseController
   end
 
   private def confirm_submission
-    report = Report.find(params[:report_id])
     authorize report, :submit?
     @report_presenter = ReportPresenter.new(report)
     render "staff/reports_state/submit/confirm"
   end
 
   private def change_report_state_to_submitted
-    report = Report.find(params[:report_id])
     authorize report, :submit?
     report.update!(state: :submitted)
     report.create_activity key: "report.submitted", owner: current_user
     @report_presenter = ReportPresenter.new(report)
     render "staff/reports_state/submit/complete"
+  end
+
+  private def confirm_in_review
+    authorize report, :review?
+    @report_presenter = ReportPresenter.new(report)
+    render "staff/reports_state/review/confirm"
+  end
+
+  private def change_report_state_to_in_review
+    authorize report, :review?
+    report.update!(state: :in_review)
+    report.create_activity key: "report.in_review", owner: current_user
+    @report_presenter = ReportPresenter.new(report)
+    render "staff/reports_state/review/complete"
+  end
+
+  private def report
+    @report ||= Report.find(params[:report_id])
   end
 end

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -28,4 +28,11 @@
 
       = render partial: "staff/shared/reports/table_submitted", locals: { reports: @submitted_report_presenters }
 
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("table.title.report.in_review")
+
+      = render partial: "staff/shared/reports/table_in_review", locals: { reports: @in_review_report_presenters }
+
 

--- a/app/views/staff/reports/show.html.haml
+++ b/app/views/staff/reports/show.html.haml
@@ -14,5 +14,8 @@
         - if policy(@report_presenter).activate?
           = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
+        - if policy(@report_presenter).review?
+          = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
         - if policy(@report_presenter).submit?
           = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports_state/review/complete.html.haml
+++ b/app/views/staff/reports_state/review/complete.html.haml
@@ -1,0 +1,17 @@
+= content_for :page_title_prefix, t("page_title.report.in_review.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          = t("action.report.in_review.complete.title")
+
+        .govuk-panel__body
+          = t("action.report.activate.complete.body", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %h2.govuk-heading-m
+        What happens next
+
+      %p.govuk-body
+        This report is now in review

--- a/app/views/staff/reports_state/review/confirm.html.haml
+++ b/app/views/staff/reports_state/review/confirm.html.haml
@@ -1,0 +1,16 @@
+= content_for :page_title_prefix, t("page_title.report.in_review.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.in_review.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %p.govuk-body
+        Once you mark this report as in review:
+
+      %ul.govuk-list.govuk-list--bullet
+        %li
+
+      = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = f.govuk_submit t("action.report.in_review.confirm.button")

--- a/app/views/staff/shared/reports/_table_in_review.html.haml
+++ b/app/views/staff/shared/reports/_table_in_review.html.haml
@@ -1,0 +1,27 @@
+- unless reports.empty?
+  %table.govuk-table.reports
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.reports.title")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.report.financial_quarter")
+        - if current_user.service_owner?
+          %th.govuk-table__header
+            = t("table.header.report.organisation")
+        %th.govuk-table__header
+          = t("table.header.report.description")
+        %th.govuk-table__header
+          = t("table.header.report.fund")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - reports.each do |report|
+        %tr.govuk-table__row{id: report.id}
+          %td.govuk-table__cell= report.financial_quarter_and_year
+          - if current_user.service_owner?
+            %td.govuk-table__cell= report.organisation.name
+          %td.govuk-table__cell= report.description
+          %td.govuk-table__cell= report.fund.title
+          %td.govuk-table__cell
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -6,6 +6,7 @@ en:
         active: Active reports
         inactive: Inactive reports
         submitted: Submitted reports
+        in_review: Reports in review
     header:
       report:
         financial_quarter: Financial quarter
@@ -19,6 +20,7 @@ en:
         action:
           edit: Edit
           activate: Activate
+          in_review: Mark as in review
   page_content:
     reports:
       title: Reports
@@ -53,6 +55,9 @@ en:
       submit:
         confirm: Confirm submission of %{report_financial_quarter} %{report_description}
         complete: Submission complete
+      in_review:
+        confirm: Confirm you want to move %{report_financial_quarter} %{report_description} into review
+        complete: The report is now in review
   action:
     report:
       activate:
@@ -73,6 +78,12 @@ en:
           button: Confirm submission
       download:
         button: Download report as CSV file
+      in_review:
+        confirm:
+          button: Move into review
+        complete:
+          title: This report is now in review
+        button: Mark as in review
   activerecord:
     errors:
       models:

--- a/spec/features/staff/users_can_mark_a_report_in_review_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_in_review_spec.rb
@@ -1,0 +1,50 @@
+RSpec.feature "Users can move reports into review" do
+  context "signed in as a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before do
+      authenticate!(user: beis_user)
+    end
+
+    scenario "they can mark a report as in review" do
+      report = create(:report, state: :submitted)
+
+      visit report_path(report)
+      click_link t("table.body.report.action.in_review")
+      click_button t("action.report.in_review.confirm.button")
+
+      expect(page).to have_content "in review"
+      expect(report.reload.state).to eql "in_review"
+    end
+
+    context "when the report is already in_review" do
+      scenario "it cannot be set in review" do
+        report = create(:report, state: :in_review)
+
+        visit report_path(report)
+
+        expect(page).not_to have_link t("table.body.report.action.in_review")
+      end
+    end
+  end
+
+  context "signed in as a Delivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    before do
+      authenticate!(user: delivery_partner_user)
+    end
+
+    scenario "they cannot mark a report as in review" do
+      report = create(:report, state: :submitted)
+
+      visit report_path(report)
+
+      expect(page).not_to have_link t("table.body.report.action.in_review")
+
+      visit edit_report_state_path(report)
+
+      expect(page.status_code).to eql 401
+    end
+  end
+end


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/K6tgKNZv/914-a-beis-user-can-mark-a-report-as-in-review

This is a basic first pass at moving Reports from "submitted" to "in review"

When a Delivery Partner submits a report, it appears on the BEIS user's
dashboard. The BEIS user can then mark as it being "in review" to indicate to
other BEIS users that the report is being looked at.

The UI is very basic and will be iterated upon.

## Screenshots of UI changes

<img width="1111" alt="Screenshot 2020-08-25 at 16 24 50" src="https://user-images.githubusercontent.com/1089521/91194192-d7c7f700-e6ef-11ea-84e0-b2365786cc09.png">

<img width="1120" alt="Screenshot 2020-08-25 at 16 25 01" src="https://user-images.githubusercontent.com/1089521/91194215-dc8cab00-e6ef-11ea-8249-53374e0e8796.png">

<img width="1107" alt="Screenshot 2020-08-25 at 16 25 11" src="https://user-images.githubusercontent.com/1089521/91194236-df879b80-e6ef-11ea-8923-6a0039f49ace.png">

<img width="1122" alt="Screenshot 2020-08-25 at 16 25 18" src="https://user-images.githubusercontent.com/1089521/91194250-e31b2280-e6ef-11ea-8216-297191468c7f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
