### PR TITLE
(915) a BEIS user can mark a report as awaiting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,8 @@
 - Find the next four financial quarters after this report's financial quarter. Find the 
   forecasted totals (planned disbursement totals) for those four future quarters and output
   them to the report CSV
-- Submitted reports can be moved into the review state    
+- Submitted reports can be moved into the review state 
+- Reports in review can be moved into the awaiting changes state   
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -35,4 +35,11 @@
 
       = render partial: "staff/shared/reports/table_in_review", locals: { reports: @in_review_report_presenters }
 
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("table.title.report.awaiting_changes")
+
+      = render partial: "staff/shared/reports/table_awaiting_changes", locals: { reports: @awaiting_changes_report_presenters }
+
 

--- a/app/views/staff/reports/show.html.haml
+++ b/app/views/staff/reports/show.html.haml
@@ -17,5 +17,8 @@
         - if policy(@report_presenter).review?
           = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
+        - if policy(@report_presenter).request_changes?
+          = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
+
         - if policy(@report_presenter).submit?
           = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports_state/request_changes/complete.html.haml
+++ b/app/views/staff/reports_state/request_changes/complete.html.haml
@@ -1,0 +1,17 @@
+= content_for :page_title_prefix, t("page_title.report.request_changes.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          = t("action.report.request_changes.complete.title")
+
+        .govuk-panel__body
+          = t("action.report.activate.complete.body", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %h2.govuk-heading-m
+        What happens next
+
+      %p.govuk-body
+        This report has been passed back to the delivery partner for editing

--- a/app/views/staff/reports_state/request_changes/confirm.html.haml
+++ b/app/views/staff/reports_state/request_changes/confirm.html.haml
@@ -1,0 +1,17 @@
+= content_for :page_title_prefix, t("page_title.report.request_changes.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.request_changes.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %p.govuk-body
+        Once you request changes for this report:
+
+      %ul.govuk-list.govuk-list--bullet
+        %li
+
+      = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag "request_changes", "true"
+        = f.govuk_submit t("action.report.request_changes.confirm.button")

--- a/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
+++ b/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
@@ -1,0 +1,27 @@
+- unless reports.empty?
+  %table.govuk-table.reports
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.reports.title")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.report.financial_quarter")
+        - if current_user.service_owner?
+          %th.govuk-table__header
+            = t("table.header.report.organisation")
+        %th.govuk-table__header
+          = t("table.header.report.description")
+        %th.govuk-table__header
+          = t("table.header.report.fund")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - reports.each do |report|
+        %tr.govuk-table__row{id: report.id}
+          %td.govuk-table__cell= report.financial_quarter_and_year
+          - if current_user.service_owner?
+            %td.govuk-table__cell= report.organisation.name
+          %td.govuk-table__cell= report.description
+          %td.govuk-table__cell= report.fund.title
+          %td.govuk-table__cell
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -7,6 +7,7 @@ en:
         inactive: Inactive reports
         submitted: Submitted reports
         in_review: Reports in review
+        awaiting_changes: Reports awaiting changes
     header:
       report:
         financial_quarter: Financial quarter
@@ -58,6 +59,9 @@ en:
       in_review:
         confirm: Confirm you want to move %{report_financial_quarter} %{report_description} into review
         complete: The report is now in review
+      request_changes:
+        confirm: Confirm you want to request changes for %{report_financial_quarter} %{report_description}
+        complete: This report is now awaiting changes
   action:
     report:
       activate:
@@ -84,6 +88,12 @@ en:
         complete:
           title: This report is now in review
         button: Mark as in review
+      request_changes:
+        button: Request changes
+        confirm:
+          button: Confirm request
+        complete:
+          title: This report is now awaiting changes
   activerecord:
     errors:
       models:

--- a/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
@@ -1,0 +1,46 @@
+RSpec.feature "Users can move reports into awaiting changes & view reports awaiting changes" do
+  context "signed in as a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before do
+      authenticate!(user: beis_user)
+    end
+
+    scenario "they can mark a report as awaiting changes" do
+      report = create(:report, state: :in_review)
+
+      visit report_path(report)
+      click_link t("action.report.request_changes.button")
+      click_button t("action.report.request_changes.confirm.button")
+
+      expect(page).to have_content "awaiting changes"
+      expect(report.reload.state).to eql "awaiting_changes"
+    end
+
+    context "when the report is already awaiting changes" do
+      scenario "it cannot be set in review" do
+        report = create(:report, state: :awaiting_changes)
+
+        visit report_path(report)
+
+        expect(page).not_to have_link t("action.report.request_changes.button")
+      end
+    end
+  end
+
+  context "signed in as a Delivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    before do
+      authenticate!(user: delivery_partner_user)
+    end
+
+    scenario "they cannot mark a report as in awaiting changes" do
+      report = create(:report, state: :in_review, organisation: delivery_partner_user.organisation)
+
+      visit report_path(report)
+
+      expect(page).not_to have_link t("action.report.request_changes.button")
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -154,6 +154,17 @@ RSpec.feature "Users can view reports" do
         expect(header).to match(/Legacy%20Report/)
       end
     end
+
+    context "when there are reports awaiting changes" do
+      scenario "they see their own reports which are awaiting changes" do
+        report = create(:report, organisation: delivery_partner_user.organisation, state: :awaiting_changes)
+
+        visit reports_path
+
+        expect(page).to have_content t("table.title.report.awaiting_changes")
+        expect(page).to have_content report.description
+      end
+    end
   end
 
   context "when there are no active reports" do


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/cqMSIb5w/915-a-beis-user-can-mark-a-report-as-awaiting-changes

#601 Must be merged before this PR.

A BEIS user can move a report from "in review" to "awaiting changes". The DP
user will then see their reports awaiting changes on their dashboard.

Because a report can be moved from "in review" to either "awaiting changes" or
"approved", we have used a parameter in ReportsStateController to indicate
which state the report should be moved to.

The UI for this is still very basic and will be iterated upon.

## Screenshots of UI changes

<img width="1213" alt="Screenshot 2020-08-26 at 16 31 40" src="https://user-images.githubusercontent.com/1089521/91324226-bd5a5000-e7b9-11ea-8eb0-d27411ef43f6.png">
<img width="1085" alt="Screenshot 2020-08-26 at 16 31 50" src="https://user-images.githubusercontent.com/1089521/91324236-bfbcaa00-e7b9-11ea-8a7f-45e115427bda.png">
<img width="1082" alt="Screenshot 2020-08-26 at 16 31 58" src="https://user-images.githubusercontent.com/1089521/91324240-c0edd700-e7b9-11ea-8261-998193a6d312.png">
<img width="1074" alt="Screenshot 2020-08-26 at 16 32 05" src="https://user-images.githubusercontent.com/1089521/91324242-c1866d80-e7b9-11ea-834a-74fac72dddc1.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
