### PR TITLE
(941) Fix AMS GCRF programmes hierarchy

### DIFF
--- a/db/data/20200827120801_update_ams_gcrf_programme_parents.rb
+++ b/db/data/20200827120801_update_ams_gcrf_programme_parents.rb
@@ -1,0 +1,19 @@
+class UpdateAmsGcrfProgrammeParents < ActiveRecord::Migration[6.0]
+  def up
+    fund = Activity.fund.find_by!(delivery_partner_identifier: "GCRF")
+
+    delivery_partner_identifiers = [
+      "AMS-GCRF-Coll-RF-FLAIR",
+      "AMS-GCRF-DEL",
+      "AMS-GCRF-Coll-RF-NG",
+      "AMS-GCRF-Core-Workshops",
+      "AMS-GCRF-Coll-RF-SF",
+    ]
+
+    Activity.programme.where(delivery_partner_identifier: delivery_partner_identifiers).update_all(parent_id: fund.id)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200814135953)
+DataMigrate::Data.define(version: 20200827120801)


### PR DESCRIPTION
During the previous data migration we moved activities from projects to programmes to reflect mapping changes.

Unfortunately, we didn't change the parent mappings, which lead to programmes being the parent of other programmes, which shouldn't be possible.

This data migration updates the affected activities to link them directly to the GCRF fund activity instead.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
