### PR TITLE
(924) Store partner and RODA IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,11 +269,11 @@
 - Reports in review can be moved into the awaiting changes state   
 - Transactions & Planned Disbursements cannot be edited if they are associated with an approved Report
 - BEIS users can move a Report into the approved state
-
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`
 - `Create activity` buttons that were not changed on previous PR, are changed to
   `Add activity` now.
+- RODA Identifiers can be added to activities on creation and when updating
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -10,6 +10,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :level,
     :parent,
     :identifier,
+    :roda_identifier,
     :purpose,
     :sector_category,
     :sector,
@@ -74,6 +75,9 @@ class Staff::ActivityFormsController < Staff::BaseController
     when :identifier
       @activity.assign_attributes(delivery_partner_identifier: delivery_partner_identifier)
       add_transparency_identifier
+    when :roda_identifier
+      @activity.assign_attributes(roda_identifier_fragment: roda_identifier_fragment)
+      @activity.cache_roda_identifier!
     when :purpose
       @activity.assign_attributes(title: title, description: description)
     when :sector_category
@@ -133,6 +137,10 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def delivery_partner_identifier
     params.require(:activity).permit(:delivery_partner_identifier).fetch("delivery_partner_identifier", nil)
+  end
+
+  def roda_identifier_fragment
+    params.require(:activity).permit(:roda_identifier_fragment).fetch("roda_identifier_fragment", nil)
   end
 
   def sector_category

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -35,6 +35,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     case step
     when :parent
       skip_step if @activity.fund?
+    when :roda_identifier
+      skip_step unless @activity.can_set_roda_identifier?
     when :blank
       skip_step
     when :programme_status

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -119,7 +119,7 @@ class Activity < ApplicationRecord
   end
 
   def parent_activities
-    ancestors.reverse
+    @parent_activities ||= ancestors.reverse
   end
 
   def associated_fund
@@ -156,9 +156,13 @@ class Activity < ApplicationRecord
     }.push(delivery_partner_identifier).join("-")
   end
 
+  def can_set_roda_identifier?
+    identifier_fragments = roda_identifier_fragment_chain
+    identifier_fragments[0..-2].all?(&:present?) && identifier_fragments.last.blank?
+  end
+
   def cache_roda_identifier
-    activity_chain = parent_activities + [self]
-    identifier_fragments = activity_chain.map(&:roda_identifier_fragment)
+    identifier_fragments = roda_identifier_fragment_chain
     return false unless identifier_fragments.all?(&:present?)
 
     compound = identifier_fragments[0..2].join("-")
@@ -172,6 +176,11 @@ class Activity < ApplicationRecord
     unless cache_roda_identifier
       raise TypeError, "Attempted to generate a RODA ID but some parent identifiers are blank"
     end
+  end
+
+  private def roda_identifier_fragment_chain
+    activity_chain = parent_activities + [self]
+    activity_chain.map(&:roda_identifier_fragment)
   end
 
   def actual_total_for_report_financial_quarter(report:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -155,6 +155,24 @@ class Activity < ApplicationRecord
     }.push(delivery_partner_identifier).join("-")
   end
 
+  def cache_roda_identifier
+    activity_chain = parent_activities + [self]
+    identifier_fragments = activity_chain.map(&:roda_identifier_fragment)
+    return false unless identifier_fragments.all?(&:present?)
+
+    compound = identifier_fragments[0..2].join("-")
+    compound << identifier_fragments[3] if identifier_fragments.size == 4
+
+    self.roda_identifier_compound = compound
+    true
+  end
+
+  def cache_roda_identifier!
+    unless cache_roda_identifier
+      raise TypeError, "Attempted to generate a RODA ID but some parent identifiers are blank"
+    end
+  end
+
   def actual_total_for_report_financial_quarter(report:)
     @actual_total_for_report_financial_quarter ||= transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,6 +9,7 @@ class Activity < ApplicationRecord
     :level_step,
     :parent_step,
     :identifier_step,
+    :roda_identifier_step,
     :purpose_step,
     :sector_category_step,
     :sector_step,
@@ -22,7 +23,7 @@ class Activity < ApplicationRecord
     :aid_type,
   ]
 
-  strip_attributes only: [:delivery_partner_identifier]
+  strip_attributes only: [:delivery_partner_identifier, :roda_identifier_fragment]
 
   validates :level, presence: true, on: :level_step
   validates :parent, presence: true, on: :parent_step, unless: proc { |activity| activity.fund? }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -28,6 +28,7 @@ class Activity < ApplicationRecord
   validates :level, presence: true, on: :level_step
   validates :parent, presence: true, on: :parent_step, unless: proc { |activity| activity.fund? }
   validates :delivery_partner_identifier, presence: true, on: :identifier_step
+  validates_with RodaIdentifierValidator, on: :roda_identifier_step
   validates :title, :description, presence: true, on: :purpose_step
   validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
@@ -40,6 +41,7 @@ class Activity < ApplicationRecord
   validates :aid_type, presence: true, on: :aid_type_step
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
+  validates :roda_identifier_compound, uniqueness: true, allow_nil: true
   validates :planned_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.actual_start_date.present? }
   validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -180,6 +180,14 @@ class Activity < ApplicationRecord
     end
   end
 
+  def roda_identifier_compound=(roda_identifier)
+    if roda_identifier_compound.blank?
+      super
+    else
+      raise TypeError, "Activity #{id} already has a compound RODA identifier"
+    end
+  end
+
   private def roda_identifier_fragment_chain
     activity_chain = parent_activities + [self]
     activity_chain.map(&:roda_identifier_fragment)

--- a/app/validators/roda_identifier_validator.rb
+++ b/app/validators/roda_identifier_validator.rb
@@ -1,0 +1,50 @@
+class RodaIdentifierValidator < ActiveModel::Validator
+  VALILD_IDENTIFIER = /^[A-Za-z0-9\-\_\/\\]+$/
+
+  def validate(activity)
+    fragment = activity.roda_identifier_fragment
+    return if fragment.blank?
+
+    unless VALILD_IDENTIFIER.match?(fragment)
+      activity.errors.add(:roda_identifier_fragment,
+        I18n.t("activerecord.errors.models.activity.attributes.roda_identifier_fragment.invalid_characters"))
+    end
+
+    validate_for_fund(activity, fragment) if activity.fund?
+    validate_for_programme(activity, fragment) if activity.programme?
+    validate_for_project(activity, fragment) if activity.project?
+    validate_for_third_party_project(activity, fragment) if activity.third_party_project?
+  end
+
+  private
+
+  def validate_for_fund(activity, fragment)
+    limit = 16
+    check_size(activity, fragment, limit, :level_a_too_long)
+  end
+
+  def validate_for_programme(activity, fragment)
+    parent_fragment = activity.parent.roda_identifier_fragment
+    limit = 18 - parent_fragment.size - 1
+
+    check_size(activity, fragment, limit, :level_b_too_long)
+  end
+
+  def validate_for_project(activity, fragment)
+    limit = 20
+    check_size(activity, fragment, limit, :level_c_too_long)
+  end
+
+  def validate_for_third_party_project(activity, fragment)
+    parent_fragment = activity.parent.roda_identifier_fragment
+    limit = 21 - parent_fragment.size
+
+    check_size(activity, fragment, limit, :level_d_too_long)
+  end
+
+  def check_size(activity, fragment, limit, error_type)
+    if fragment.size > limit
+      activity.errors.add(:roda_identifier_fragment, error_type, limit: limit)
+    end
+  end
+end

--- a/app/views/staff/activity_forms/roda_identifier.html.haml
+++ b/app/views/staff/activity_forms/roda_identifier.html.haml
@@ -1,0 +1,2 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_text_field :roda_identifier_fragment, label: { tag: 'h1', size: 'xl' }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -32,6 +32,15 @@
       = activity_presenter.delivery_partner_identifier
     %dd.govuk-summary-list__actions
 
+  .govuk-summary-list__row.roda_identifier
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.roda_identifier")
+    %dd.govuk-summary-list__value
+      = activity_presenter.roda_identifier_compound
+    %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :roda_identifier) && activity_presenter.can_set_roda_identifier?
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:roda_identifier_fragment)}"), activity_step_path(activity_presenter, :roda_identifier), t("summary.label.activity.title"))
+
   .govuk-summary-list__row.transparency-identifier
     %dt.govuk-summary-list__key
       = t("summary.label.activity.transparency_identifier")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -232,7 +232,11 @@ en:
             delivery_partner_identifier:
               blank: Enter a unique identifier
             roda_identifier_fragment:
-              blank: Enter a unique identifier
+              invalid_characters: Must contain only letters, digits, dashes, underscores and slashes
+              level_a_too_long: Fund identifiers must be at most %{limit} characters long
+              level_b_too_long: This programme's identifier must be at most %{limit} characters long
+              level_c_too_long: This project's identifier must be at most %{limit} characters long
+              level_d_too_long: This third-party project's identifier must be at most %{limit} characters long
             title:
               blank: Enter a title
             description:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -26,6 +26,7 @@ en:
           recipient_region: Region
           recipient_country: Country
         delivery_partner_identifier: Enter your unique identifier
+        roda_identifier_fragment: Enter a unique identifier for RODA
         region: Recipient region
         actual_end_date: Actual end date
         actual_start_date: Actual start date
@@ -65,6 +66,7 @@ en:
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems. This value cannot be edited once it is set
+        roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
         sector_category: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
@@ -97,6 +99,7 @@ en:
         flow: Flow type
         geography: Benefitting recipient geography
         delivery_partner_identifier: Identifier
+        roda_identifier: RODA identifier
         level: Level
         organisation: Organisation
         parent: Parent activity
@@ -193,6 +196,7 @@ en:
         flow: Flow
         geography: Will the benefitting recipient be a region or country?
         delivery_partner_identifier: Enter your unique identifier
+        roda_identifier: Enter your unique RODA identifier
         level: Hierarchy level
         parent: Select the parent
         programme_status: A description of the status of the activity
@@ -226,6 +230,8 @@ en:
             parent:
               blank: Select a parent activity
             delivery_partner_identifier:
+              blank: Enter a unique identifier
+            roda_identifier_fragment:
               blank: Enter a unique identifier
             title:
               blank: Enter a title

--- a/db/migrate/20200826090103_add_roda_identifier.rb
+++ b/db/migrate/20200826090103_add_roda_identifier.rb
@@ -1,0 +1,10 @@
+class AddRodaIdentifier < ActiveRecord::Migration[6.0]
+  def change
+    change_table :activities do |t|
+      t.string :roda_identifier_fragment
+      t.string :roda_identifier_compound
+
+      t.index [:roda_identifier_compound]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_155008) do
+ActiveRecord::Schema.define(version: 2020_08_26_090103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -55,11 +55,14 @@ ActiveRecord::Schema.define(version: 2020_08_21_155008) do
     t.boolean "call_present"
     t.date "call_open_date"
     t.date "call_close_date"
+    t.string "roda_identifier_fragment"
+    t.string "roda_identifier_compound"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"
     t.index ["parent_id"], name: "index_activities_on_parent_id"
     t.index ["reporting_organisation_id"], name: "index_activities_on_reporting_organisation_id"
+    t.index ["roda_identifier_compound"], name: "index_activities_on_roda_identifier_compound"
   end
 
   create_table "auditable_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :activity do
     title { Faker::Lorem.sentence }
     delivery_partner_identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
+    roda_identifier_fragment { Faker::Alphanumeric.alpha(number: 5) }
+    roda_identifier_compound { nil }
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }
@@ -22,6 +24,10 @@ FactoryBot.define do
 
     association :organisation, factory: :organisation
     association :reporting_organisation, factory: :beis_organisation
+
+    before(:create) do |activity|
+      activity.cache_roda_identifier
+    end
 
     trait :with_report do
       after(:create) do |activity|
@@ -105,8 +111,29 @@ FactoryBot.define do
   end
 
   trait :at_identifier_step do
-    delivery_partner_identifier { nil }
     form_state { "identifier" }
+    delivery_partner_identifier { nil }
+    roda_identifier_fragment { nil }
+    title { nil }
+    description { nil }
+    sector_category { nil }
+    sector { nil }
+    call_present { nil }
+    programme_status { nil }
+    planned_start_date { nil }
+    planned_end_date { nil }
+    actual_start_date { nil }
+    actual_end_date { nil }
+    geography { nil }
+    recipient_region { nil }
+    recipient_country { nil }
+    flow { nil }
+    aid_type { nil }
+  end
+
+  trait :at_roda_identifier_step do
+    form_state { "roda_identifier" }
+    roda_identifier_fragment { nil }
     title { nil }
     description { nil }
     sector_category { nil }
@@ -125,7 +152,7 @@ FactoryBot.define do
   end
 
   trait :at_purpose_step do
-    form_state { "identifier" }
+    form_state { "purpose" }
     title { nil }
     description { nil }
     sector { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -162,6 +162,12 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[delivery_partner_identifier]", with: identifier
         click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.label.activity.roda_identifier_fragment", level: "programme")
+
+        # TODO: validation for RODA identifier
+
+        fill_in "activity[roda_identifier_fragment]", with: identifier
+        click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.purpose", level: "programme")
         expect(page).to have_content t("form.hint.activity.title", level: "programme")
 

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -164,7 +164,10 @@ RSpec.feature "Users can create a fund level activity" do
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.label.activity.roda_identifier_fragment", level: "programme")
 
-        # TODO: validation for RODA identifier
+        # Provide an invalid identifier
+        fill_in "activity[roda_identifier_fragment]", with: "!!!"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.roda_identifier_fragment.invalid_characters")
 
         fill_in "activity[roda_identifier_fragment]", with: identifier
         click_button t("form.button.activity.submit")

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -23,6 +23,20 @@ RSpec.feature "Users can create a project" do
         expect(project.organisation).to eq user.organisation
       end
 
+      scenario "a new project can be added when the program has no RODA identifier" do
+        programme = create(:programme_activity, extending_organisation: user.organisation, roda_identifier_fragment: nil)
+
+        visit organisation_activity_children_path(programme.organisation, programme)
+        click_on(t("page_content.organisation.button.create_activity"))
+        fill_in_activity_form(level: "project", parent: programme)
+
+        expect(page).to have_content t("action.project.create.success")
+
+        expect(programme.child_activities.count).to eq 1
+        project = programme.child_activities.last
+        expect(project.organisation).to eq user.organisation
+      end
+
       scenario "the activity saves its identifier as read-only `transparency_identifier`" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
         identifier = "a-project"

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -329,6 +329,53 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
+
+      context "when the project does not have a RODA identifier" do
+        let(:fund) { create(:fund_activity, roda_identifier_fragment: "AAA") }
+        let(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "BBB") }
+
+        scenario "a RODA identifier can be added" do
+          activity = create(:project_activity, organisation: user.organisation, parent: programme, roda_identifier_fragment: nil)
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".roda_identifier") { click_on(t("default.link.add")) }
+          fill_in "activity[roda_identifier_fragment]", with: "CCC"
+          click_button t("form.button.activity.submit")
+
+          expect(page).to have_content(t("action.project.update.success"))
+          expect(activity.reload.roda_identifier_compound).to eq("AAA-BBB-CCC")
+        end
+      end
+
+      context "when the project has a RODA identifier" do
+        let(:activity) { create(:project_activity, organisation: user.organisation, roda_identifier_fragment: "A-RODA-ID") }
+
+        scenario "the RODA identifier cannot be edited" do
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".roda_identifier") do
+            expect(page).not_to have_content(t("default.link.add"))
+            expect(page).not_to have_content(t("default.link.edit"))
+          end
+        end
+      end
+
+      context "when the project's parent does not have a RODA identifier" do
+        let(:activity) { create(:project_activity, organisation: user.organisation, roda_identifier_fragment: nil) }
+
+        before do
+          activity.parent.update!(roda_identifier_fragment: nil)
+        end
+
+        scenario "a RODA identifier cannot be added" do
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".roda_identifier") do
+            expect(page).not_to have_content(t("default.link.add"))
+            expect(page).not_to have_content(t("default.link.edit"))
+          end
+        end
+      end
     end
 
     context "when the activity is a third-party project" do

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActivityHelper, type: :helper do
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do
       it "returns true for the purpose fields" do
-        activity = build(:activity, :at_identifier_step)
+        activity = build(:activity, :at_roda_identifier_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "purpose")).to be(true)
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -854,6 +854,15 @@ RSpec.describe Activity, type: :model do
     let!(:project) { create(:project_activity, parent: programme, roda_identifier_fragment: "Level/C") }
     let!(:third_party_project) { create(:third_party_project_activity, parent: project, roda_identifier_fragment: "Level/D") }
 
+    before do
+      project.write_attribute(:roda_identifier_compound, nil)
+      third_party_project.write_attribute(:roda_identifier_compound, nil)
+    end
+
+    it "raises an exception if roda_identifier_compound is overwritten" do
+      expect { fund.cache_roda_identifier! }.to raise_error(TypeError, "Activity #{fund.id} already has a compound RODA identifier")
+    end
+
     it "caches the compound RODA identifier on a project" do
       project.cache_roda_identifier!
       expect(project.roda_identifier_compound).to eq("Level/A-Level/B-Level/C")

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -656,6 +656,42 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#can_set_roda_identifier?" do
+    let!(:fund) { create(:fund_activity, roda_identifier_fragment: "Level/A") }
+    let!(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "Level/B") }
+    let!(:project) { create(:project_activity, parent: programme, roda_identifier_fragment: nil) }
+
+    context "for a top-level (fund) activity" do
+      it "is true when the activity does not have a RODA identifier" do
+        fund.roda_identifier_fragment = nil
+        expect(fund.can_set_roda_identifier?).to be(true)
+      end
+
+      it "is false when the activity already has a RODA identifier" do
+        expect(fund.can_set_roda_identifier?).to be(false)
+      end
+    end
+
+    it "is true when all parent identifiers are present" do
+      expect(project.can_set_roda_identifier?).to be(true)
+    end
+
+    it "is false if the activity has a RODA identifier" do
+      project.update!(roda_identifier_fragment: "Level/C")
+      expect(project.can_set_roda_identifier?).to be(false)
+    end
+
+    it "is false if the parent identifier is missing" do
+      programme.update!(roda_identifier_fragment: nil)
+      expect(project.can_set_roda_identifier?).to be(false)
+    end
+
+    it "is false if the grandparent identifier is missing" do
+      fund.update!(roda_identifier_fragment: nil)
+      expect(project.can_set_roda_identifier?).to be(false)
+    end
+  end
+
   describe "#cache_roda_identifier!" do
     let!(:fund) { create(:fund_activity, roda_identifier_fragment: "Level/A") }
     let!(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "Level/B") }

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,6 +1,7 @@
 module FormHelpers
   def fill_in_activity_form(
     delivery_partner_identifier: "A-Unique-Identifier",
+    roda_identifier_fragment: "A-RODA-Identifier",
     title: "My Aid Activity",
     description: Faker::Lorem.paragraph,
     sector_category: "Basic Education",
@@ -49,6 +50,11 @@ module FormHelpers
     expect(page).to have_content t("form.label.activity.delivery_partner_identifier")
     expect(page).to have_content t("form.hint.activity.delivery_partner_identifier")
     fill_in "activity[delivery_partner_identifier]", with: delivery_partner_identifier
+    click_button t("form.button.activity.submit")
+
+    expect(page).to have_content t("form.label.activity.roda_identifier_fragment")
+    expect(page).to have_content t("form.hint.activity.roda_identifier_fragment")
+    fill_in "activity[roda_identifier_fragment]", with: roda_identifier_fragment
     click_button t("form.button.activity.submit")
 
     expect(page).to have_content t("form.legend.activity.purpose", level: activity_level(level))

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -52,10 +52,12 @@ module FormHelpers
     fill_in "activity[delivery_partner_identifier]", with: delivery_partner_identifier
     click_button t("form.button.activity.submit")
 
-    expect(page).to have_content t("form.label.activity.roda_identifier_fragment")
-    expect(page).to have_content t("form.hint.activity.roda_identifier_fragment")
-    fill_in "activity[roda_identifier_fragment]", with: roda_identifier_fragment
-    click_button t("form.button.activity.submit")
+    if parent.blank? || parent.roda_identifier_fragment.present?
+      expect(page).to have_content t("form.label.activity.roda_identifier_fragment")
+      expect(page).to have_content t("form.hint.activity.roda_identifier_fragment")
+      fill_in "activity[roda_identifier_fragment]", with: roda_identifier_fragment
+      click_button t("form.button.activity.submit")
+    end
 
     expect(page).to have_content t("form.legend.activity.purpose", level: activity_level(level))
     expect(page).to have_content t("form.label.activity.title", level: activity_level(level).humanize)

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,7 +1,7 @@
 module FormHelpers
   def fill_in_activity_form(
     delivery_partner_identifier: "A-Unique-Identifier",
-    roda_identifier_fragment: "A-RODA-Identifier",
+    roda_identifier_fragment: "RODA-ID",
     title: "My Aid Activity",
     description: Faker::Lorem.paragraph,
     sector_category: "Basic Education",


### PR DESCRIPTION
## Changes in this PR

This set of changes adds the ability to store RODA Identifiers for activities. RODA Identifiers are defined hierarchically, so the ID of a fund becomes a prefix for the IDs of its programmes, and so on down the tree. The complete RODA ID schema is:

    {A}-{B}-{C}{D}

where, `{A}`, `{B}`, `{C}`, and `{D}` are the Identifier _fragments_ belonging to level-A, B, C and D activities. These fragments may contain letters, digits, dashes, underscores, and slashes. The combined length of `{A}-{B}` is 18 characters maximum, and `{C}{D}` is at most 21 characters, giving a maximum total length of 40.

Users can add RODA IDs to activities starting with funds, then moving to programmes and so on down the tree. Since validation relies on the length of parent's ID fragment, we only allow an ID to be added once all the ancestors of an activity have an ID fragment.

## Screenshots of UI changes

To begin with, a fund has a blank Roda Identifier, with a link to add one.

<img width="1182" alt="Screenshot 2020-08-27 at 17 48 23" src="https://user-images.githubusercontent.com/9265/91471856-873ad000-e88e-11ea-81dd-cc66f40e1ee2.png">

A programme sitting under this fund does not yet have an 'Add' link, because its parent does not have a RODA ID.

<img width="1178" alt="Screenshot 2020-08-27 at 17 48 44" src="https://user-images.githubusercontent.com/9265/91471865-899d2a00-e88e-11ea-8109-935e5389cbd8.png">

On clicking the 'Add' button, the user sees a step for adding the RODA Identifier fragment. This step is also added to the creation journer, after the Delivery Partner ID step.

<img width="1181" alt="Screenshot 2020-08-27 at 17 49 03" src="https://user-images.githubusercontent.com/9265/91471870-8a35c080-e88e-11ea-8db6-d00adb64fb79.png">

The step validates that the ID fragment only contains acceptable characters.

<img width="1183" alt="Screenshot 2020-08-27 at 17 49 26" src="https://user-images.githubusercontent.com/9265/91471874-8ace5700-e88e-11ea-9a84-2aa5ca20ed8a.png">

A length validation appropriate to the activity's level is enforced.

<img width="1182" alt="Screenshot 2020-08-27 at 17 49 52" src="https://user-images.githubusercontent.com/9265/91471877-8b66ed80-e88e-11ea-8427-24e079570711.png">

On succfully saving the ID, we return to the fund's page and the RODA Identifier is displayed.

<img width="1179" alt="Screenshot 2020-08-27 at 17 50 13" src="https://user-images.githubusercontent.com/9265/91471879-8bff8400-e88e-11ea-922c-c8a3748bb5f3.png">

If we now look at the details for a programme under this fund, we have an 'Add' button for entering the RODA Identifier at this level.

<img width="1182" alt="Screenshot 2020-08-27 at 17 50 28" src="https://user-images.githubusercontent.com/9265/91471880-8bff8400-e88e-11ea-9e40-01ccf35707ca.png">

At this level, a length limit is enforced dynamically based on the length of the parent ID.

<img width="1183" alt="Screenshot 2020-08-27 at 17 50 54" src="https://user-images.githubusercontent.com/9265/91471882-8c981a80-e88e-11ea-85e5-b994d3d48fa3.png">

On saving the record, the full ("compound") RODA Identifier is displayed, and cannot be edited.

<img width="1181" alt="Screenshot 2020-08-27 at 17 51 39" src="https://user-images.githubusercontent.com/9265/91471884-8d30b100-e88e-11ea-9cfd-0fdb5b69035a.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
