### PR TITLE
(910) a BEIS user can approve a report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@
   them to the report CSV
 - Submitted reports can be moved into the review state 
 - Reports in review can be moved into the awaiting changes state   
+- Transactions & Planned Disbursements cannot be edited if they are associated with an approved Report
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@
 - Submitted reports can be moved into the review state 
 - Reports in review can be moved into the awaiting changes state   
 - Transactions & Planned Disbursements cannot be edited if they are associated with an approved Report
+- BEIS users can move a Report into the approved state
 
 - `Call open date` and `Call close date` added to the create activity form, for levels C and D.
   This field is mandatory for new activities, but optional for activities marked as `ingested: true`

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -66,6 +66,7 @@ class Staff::ReportsController < Staff::BaseController
     submitted_reports_with_organisations
     in_review_reports_with_organisations
     awaiting_changes_reports_with_organisations
+    approved_reports_with_organisations
   end
 
   def reports_for_delivery_partner
@@ -73,6 +74,7 @@ class Staff::ReportsController < Staff::BaseController
     submitted_reports
     in_review_reports
     awaiting_changes_reports
+    approved_reports
   end
 
   def inactive_reports
@@ -127,6 +129,18 @@ class Staff::ReportsController < Staff::BaseController
     awaiting_changes_reports = policy_scope(Report.where(state: :awaiting_changes)).includes(:fund)
     authorize awaiting_changes_reports
     @awaiting_changes_report_presenters = awaiting_changes_reports.map { |report| ReportPresenter.new(report) }
+  end
+
+  def approved_reports_with_organisations
+    approved_reports = policy_scope(Report.where(state: :approved)).includes([:fund, :organisation])
+    authorize approved_reports
+    @approved_report_presenters = approved_reports.map { |report| ReportPresenter.new(report) }
+  end
+
+  def approved_reports
+    approved_reports = policy_scope(Report.where(state: :approved)).includes(:fund)
+    authorize approved_reports
+    @approved_report_presenters = approved_reports.map { |report| ReportPresenter.new(report) }
   end
 
   def send_csv

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -92,9 +92,17 @@ class Staff::ReportsStateController < Staff::BaseController
   end
 
   private def confirm_approve
+    authorize report, :approve?
+    @report_presenter = ReportPresenter.new(report)
+    render "staff/reports_state/approve/confirm"
   end
 
   private def change_report_state_to_approved
+    authorize report, :approve?
+    report.update!(state: :approved)
+    report.create_activity key: "report.approve", owner: current_user
+    @report_presenter = ReportPresenter.new(report)
+    render "staff/reports_state/approve/complete"
   end
 
   private def report

--- a/app/policies/planned_disbursement_policy.rb
+++ b/app/policies/planned_disbursement_policy.rb
@@ -6,6 +6,7 @@ class PlannedDisbursementPolicy < ApplicationPolicy
 
   def update?
     return false if record.parent_activity.fund? || record.parent_activity.programme?
+    return false if associated_report&.approved?
     Pundit.policy!(user, record.parent_activity).update? && !!associated_report&.active?
   end
 

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -4,6 +4,7 @@ class TransactionPolicy < ApplicationPolicy
   end
 
   def update?
+    return false if associated_report&.approved?
     Pundit.policy!(user, record.parent_activity).update? && !!associated_report&.active?
   end
 

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -42,4 +42,11 @@
 
       = render partial: "staff/shared/reports/table_awaiting_changes", locals: { reports: @awaiting_changes_report_presenters }
 
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("table.title.report.approved")
+
+      = render partial: "staff/shared/reports/table_approved", locals: { reports: @approved_report_presenters }
+
 

--- a/app/views/staff/reports/show.html.haml
+++ b/app/views/staff/reports/show.html.haml
@@ -20,5 +20,8 @@
         - if policy(@report_presenter).request_changes?
           = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
 
+        - if policy(@report_presenter).approve?
+          = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
         - if policy(@report_presenter).submit?
           = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports_state/approve/complete.html.haml
+++ b/app/views/staff/reports_state/approve/complete.html.haml
@@ -1,0 +1,17 @@
+= content_for :page_title_prefix, t("page_title.report.approve.complete", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          = t("action.report.approve.complete.title")
+
+        .govuk-panel__body
+          = t("action.report.activate.complete.body", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %h2.govuk-heading-m
+        What happens next
+
+      %p.govuk-body
+        This report has been approved. It can no longer be edited. Its associated transactions & planned disbursements can no longer be edited.

--- a/app/views/staff/reports_state/approve/confirm.html.haml
+++ b/app/views/staff/reports_state/approve/confirm.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("page_title.report.approve.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.approve.confirm", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %p.govuk-body
+        Once you approve  this report:
+
+      %ul.govuk-list.govuk-list--bullet
+        %li
+          The report will not be editable
+        %li
+          The associated transactions and planned disbursements will not be editable
+
+      = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = f.govuk_submit t("action.report.approve.confirm.button")

--- a/app/views/staff/shared/reports/_table_approved.html.haml
+++ b/app/views/staff/shared/reports/_table_approved.html.haml
@@ -1,0 +1,27 @@
+- unless reports.empty?
+  %table.govuk-table.reports
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t("page_content.reports.title")
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.report.financial_quarter")
+        - if current_user.service_owner?
+          %th.govuk-table__header
+            = t("table.header.report.organisation")
+        %th.govuk-table__header
+          = t("table.header.report.description")
+        %th.govuk-table__header
+          = t("table.header.report.fund")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - reports.each do |report|
+        %tr.govuk-table__row{id: report.id}
+          %td.govuk-table__cell= report.financial_quarter_and_year
+          - if current_user.service_owner?
+            %td.govuk-table__cell= report.organisation.name
+          %td.govuk-table__cell= report.description
+          %td.govuk-table__cell= report.fund.title
+          %td.govuk-table__cell
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -8,6 +8,7 @@ en:
         submitted: Submitted reports
         in_review: Reports in review
         awaiting_changes: Reports awaiting changes
+        approved: Approved reports
     header:
       report:
         financial_quarter: Financial quarter
@@ -62,6 +63,9 @@ en:
       request_changes:
         confirm: Confirm you want to request changes for %{report_financial_quarter} %{report_description}
         complete: This report is now awaiting changes
+      approve:
+        confirm: Confirm approval for %{report_financial_quarter} %{report_description}
+        complete: This report is approved
   action:
     report:
       activate:
@@ -94,6 +98,12 @@ en:
           button: Confirm request
         complete:
           title: This report is now awaiting changes
+      approve:
+        complete:
+          title: This report is now approved
+        button: Approve
+        confirm:
+          button: Confirm approval
   activerecord:
     errors:
       models:

--- a/spec/factories/report.rb
+++ b/spec/factories/report.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
       state { :active }
       deadline { 1.year.from_now }
     end
+
+    trait :approved do
+      state { :approved }
+      deadline { 1.day.from_now }
+    end
   end
 end

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -1,0 +1,50 @@
+RSpec.feature "Users can approve reports" do
+  context "signed in as a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before do
+      authenticate!(user: beis_user)
+    end
+
+    scenario "they can mark a report as approved" do
+      report = create(:report, state: :in_review)
+
+      visit report_path(report)
+      click_link t("action.report.approve.button")
+      click_button t("action.report.approve.confirm.button")
+
+      expect(page).to have_content "approved"
+      expect(report.reload.state).to eql "approved"
+    end
+
+    context "when the report is already approved" do
+      scenario "it cannot be approved" do
+        report = create(:report, state: :approved)
+
+        visit report_path(report)
+
+        expect(page).not_to have_link t("action.report.approve.button")
+      end
+    end
+  end
+
+  context "signed in as a Delivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    before do
+      authenticate!(user: delivery_partner_user)
+    end
+
+    scenario "they cannot mark a report as approved" do
+      report = create(:report, state: :in_review)
+
+      visit report_path(report)
+
+      expect(page).not_to have_link t("action.report.approve.button")
+
+      visit edit_report_state_path(report)
+
+      expect(page.status_code).to eql 401
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -165,6 +165,17 @@ RSpec.feature "Users can view reports" do
         expect(page).to have_content report.description
       end
     end
+
+    context "when there are approved reports" do
+      scenario "they see their own reports which are approved" do
+        report = create(:report, organisation: delivery_partner_user.organisation, state: :approved)
+
+        visit reports_path
+
+        expect(page).to have_content t("table.title.report.approved")
+        expect(page).to have_content report.description
+      end
+    end
   end
 
   context "when there are no active reports" do

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe PlannedDisbursementPolicy do
         it { is_expected.to forbid_action(:update) }
       end
     end
+
+    context "when the planned disbursement is associated to an approved report" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      let(:report) { create(:report, :approved, organisation: activity.organisation, fund: activity.associated_fund) }
+      let(:planned_disbursement) { create(:planned_disbursement, parent_activity: activity, report: report) }
+      it { is_expected.to forbid_action(:update) }
+    end
   end
 
   describe "#destroy?" do

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe TransactionPolicy do
       let(:transaction) { create(:transaction, parent_activity: activity, report: report) }
       it { is_expected.to forbid_action(:update) }
     end
+
+    context "when the transaction is associated to an approved report" do
+      let(:report) { create(:report, :approved, organisation: activity.organisation, fund: activity) }
+      let(:transaction) { create(:transaction, parent_activity: activity, report: report) }
+      it { is_expected.to forbid_action(:update) }
+    end
   end
 
   describe "#destroy?" do


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/ax4ldF7H/910-a-beis-user-can-approve-a-report

Note: #603 must be merged before this PR

A report in the `in_review` state can be moved into the `approved` state by
BEIS users. Delivery partners can see their approved reports but not edit them
or move them into the approved state.

Transactions and Planned Disbursements associated to an approved report cannot be edited. 

## Screenshots of UI changes

<img width="1077" alt="Screenshot 2020-08-28 at 10 12 31" src="https://user-images.githubusercontent.com/1089521/91546533-7fc10880-e91a-11ea-9d5d-94f7f9c2c353.png">
<img width="1079" alt="Screenshot 2020-08-28 at 10 12 53" src="https://user-images.githubusercontent.com/1089521/91546542-82236280-e91a-11ea-8345-e439d6c5a03b.png">
<img width="1107" alt="Screenshot 2020-08-28 at 10 12 44" src="https://user-images.githubusercontent.com/1089521/91546546-83548f80-e91a-11ea-9395-6cdbd98fd825.png">
<img width="1082" alt="Screenshot 2020-08-28 at 10 13 00" src="https://user-images.githubusercontent.com/1089521/91546547-83ed2600-e91a-11ea-8df0-6dada7f87872.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
