### PR TITLE
(927) Show the actual vs forecast variance on the report show page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@
   `Add activity` now.
 - RODA Identifiers can be added to activities on creation and when updating
 - Reports in 'awaiting changes' can be submitted.
+ - Forecasted and actual spend and variance is shown on the report show page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14
@@ -288,5 +289,3 @@
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6
 [release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5
 [release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4
-[release-3]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-2...release-3
-[release-2]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-1...release-2

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -17,14 +17,13 @@ class Staff::ReportsController < Staff::BaseController
   def show
     @report = Report.find(id)
     authorize @report
+
     @report_presenter = ReportPresenter.new(@report)
+    @report_activities = level_c_and_d_activities_for_report(report: @report)
 
     respond_to do |format|
       format.html
       format.csv do
-        fund = @report.fund
-        @projects = Activity.project.where(organisation: @report.organisation).select { |activity| activity.associated_fund == fund }
-        @third_party_projects = Activity.third_party_project.where(organisation: @report.organisation).select { |activity| activity.associated_fund == fund }
         send_csv
       end
     end
@@ -147,12 +146,14 @@ class Staff::ReportsController < Staff::BaseController
     response.headers["Content-Type"] = "text/csv"
     response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
     response.stream.write ExportActivityToCsv.new(report: @report).headers
-    @projects.each do |project|
-      response.stream.write ExportActivityToCsv.new(activity: project, report: @report).call
-    end
-    @third_party_projects.each do |project|
-      response.stream.write ExportActivityToCsv.new(activity: project, report: @report).call
+    @report_activities.each do |activity|
+      response.stream.write ExportActivityToCsv.new(activity: activity, report: @report).call
     end
     response.stream.close
+  end
+
+  def level_c_and_d_activities_for_report(report:)
+    return [] if report.nil?
+    Activity.where(level: :project).or(Activity.where(level: :third_party_project)).where(organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
   end
 end

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -22,7 +22,9 @@ class Staff::ReportsController < Staff::BaseController
     @report_activities = level_c_and_d_activities_for_report(report: @report)
 
     respond_to do |format|
-      format.html
+      format.html do
+        @activities = @report_activities.map { |activity| ActivityPresenter.new(activity) }
+      end
       format.csv do
         send_csv
       end
@@ -153,7 +155,7 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def level_c_and_d_activities_for_report(report:)
-    return [] if report.nil?
-    Activity.where(level: :project).or(Activity.where(level: :third_party_project)).where(organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
+    return Activity.none if report.nil?
+    Activity.where(level: [:project, :third_party_project], organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
   end
 end

--- a/app/views/staff/reports/show.html.haml
+++ b/app/views/staff/reports/show.html.haml
@@ -6,22 +6,27 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
-    .govuk-grid-row
-      .govuk-grid-column-full.page-actions
-        - if policy(@report_presenter).download?
-          = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+  .govuk-grid-row
+    .govuk-grid-column-full.page-actions
+      - if policy(@report_presenter).download?
+        = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
-        - if policy(@report_presenter).activate?
-          = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+      - if policy(@report_presenter).activate?
+        = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
-        - if policy(@report_presenter).review?
-          = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+      - if policy(@report_presenter).review?
+        = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
-        - if policy(@report_presenter).request_changes?
-          = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
+      - if policy(@report_presenter).request_changes?
+        = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
 
-        - if policy(@report_presenter).approve?
-          = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
-        - if policy(@report_presenter).submit?
-          = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+      - if policy(@report_presenter).approve?
+        = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+      - if policy(@report_presenter).submit?
+        = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render partial: "staff/shared/reports/table_variance", locals: { activities: @activities }

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -1,0 +1,23 @@
+%table.govuk-table.variance
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        = t("table.header.activity.identifier")
+      %th.govuk-table__header
+        = t("table.header.activity.forecasted_spend_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+      %th.govuk-table__header
+        = t("table.header.activity.actual_spend_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+      %th.govuk-table__header
+        = t("table.header.activity.variance_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+      %th.govuk-table__header
+
+  %tbody.govuk-table__body
+    - activities.each do |activity|
+      %tr.govuk-table__row{id: activity.id}
+        %td.govuk-table__cell= activity.delivery_partner_identifier
+        %td.govuk-table__cell= activity.forecasted_total_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell= activity.actual_total_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell= activity.variance_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell
+          = a11y_action_link(t('default.link.view'), organisation_activity_path(activity.organisation, activity), activity.delivery_partner_identifier)
+

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -127,6 +127,9 @@ en:
         identifier: Identifier
         title: Name
         level: Level
+        actual_spend_for_quarter: "%{financial_quarter_and_year} actual spend"
+        forecasted_spend_for_quarter: "%{financial_quarter_and_year} forecasted spend"
+        variance_for_quarter: "%{financial_quarter_and_year} variance"
     body:
       activity:
         level:


### PR DESCRIPTION
## Changes in this PR
As a first step towards showing all the changes made in a report in the application itself (rather than just the csv download) we want to show the total forecasted and actual spend and the variance for the reporting financial quarter.

This is also the place where we will allow users to add comments at the activity level in future work.

As we already calculate all the values for the csv this is a small change.

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/480578/91866872-e459cb80-ec6a-11ea-9584-c380e5febd76.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
