### PR TITLE
Reports that are awaiting changes can be submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,7 @@
 - `Create activity` buttons that were not changed on previous PR, are changed to
   `Add activity` now.
 - RODA Identifiers can be added to activities on creation and when updating
+- Reports in 'awaiting changes' can be submitted.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -13,6 +13,8 @@ class Staff::ReportsStateController < Staff::BaseController
       confirm_in_review
     when "in_review"
       params[:request_changes] ? confirm_request_changes : confirm_approve
+    when "awaiting_changes"
+      confirm_submission
     else
       authorize report
       redirect_to report_path(report)
@@ -29,6 +31,8 @@ class Staff::ReportsStateController < Staff::BaseController
       change_report_state_to_in_review
     when "in_review"
       params[:request_changes] ? change_report_state_to_awaiting_changes : change_report_state_to_approved
+    when "awaiting_changes"
+      change_report_state_to_submitted
     else
       authorize report
       redirect_to report_path(report)


### PR DESCRIPTION
## Changes in this PR

When we introduced the awaiting changes state we missed handling the
transition from `awaiting_changes` to `submitted` in the report state
controller.

Also removes a redundant expectation in the users can submit a
report spec.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
