### PR TITLE
(924) Allow Delivery Partner Identifier to be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,8 @@
 - Ingest RS GCRF data from IATI
 - Ingest BA GCRF data from IATI
 - Ingest RAEng GCRF data from IATI
+- Transparency Identifiers are set based on RODA Identifiers
+- Delivery Partner Identifiers can be edited
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...HEAD
 [release-14]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-13...release-14

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -76,7 +76,6 @@ class Staff::ActivityFormsController < Staff::BaseController
       end
     when :identifier
       @activity.assign_attributes(delivery_partner_identifier: delivery_partner_identifier)
-      add_transparency_identifier
     when :roda_identifier
       @activity.assign_attributes(roda_identifier_fragment: roda_identifier_fragment)
       @activity.cache_roda_identifier!
@@ -244,9 +243,5 @@ class Staff::ActivityFormsController < Staff::BaseController
   def country_to_region_mapping
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/BEIS/country_to_region_mapping.yml"))
     yaml["data"]
-  end
-
-  def add_transparency_identifier
-    @activity.update(transparency_identifier: @activity.iati_identifier)
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -194,6 +194,14 @@ class Activity < ApplicationRecord
     activity_chain.map(&:roda_identifier_fragment)
   end
 
+  def iati_identifier
+    if previous_identifier.present?
+      previous_identifier
+    else
+      transparency_identifier
+    end
+  end
+
   def actual_total_for_report_financial_quarter(report:)
     @actual_total_for_report_financial_quarter ||= transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -153,12 +153,6 @@ class Activity < ApplicationRecord
     end
   end
 
-  def iati_identifier
-    parent_activities.each_with_object([reporting_organisation.iati_reference]) { |parent, parent_identifiers|
-      parent_identifiers << parent.delivery_partner_identifier
-    }.push(delivery_partner_identifier).join("-")
-  end
-
   def can_set_roda_identifier?
     identifier_fragments = roda_identifier_fragment_chain
     identifier_fragments[0..-2].all?(&:present?) && identifier_fragments.last.blank?
@@ -172,6 +166,12 @@ class Activity < ApplicationRecord
     compound << identifier_fragments[3] if identifier_fragments.size == 4
 
     self.roda_identifier_compound = compound
+
+    self.transparency_identifier ||= [
+      reporting_organisation.iati_reference,
+      compound.gsub(/[^a-z0-9-]+/i, "-"),
+    ].join("-")
+
     true
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -42,6 +42,7 @@ class Activity < ApplicationRecord
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :roda_identifier_compound, uniqueness: true, allow_nil: true
+  validates :transparency_identifier, uniqueness: true, allow_nil: true
   validates :planned_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.actual_start_date.present? }
   validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -31,6 +31,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.delivery_partner_identifier
     %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :identifier)
+        = a11y_action_link(t("default.link.edit"), activity_step_path(activity_presenter, :identifier), t("summary.label.activity.delivery_partner_identifier").downcase)
 
   .govuk-summary-list__row.roda_identifier
     %dt.govuk-summary-list__key

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -1,8 +1,5 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
-  - if activity.previous_identifier?
-    %iati-identifier= activity.previous_identifier
-  - else
-    %iati-identifier= activity.transparency_identifier
+  %iati-identifier= activity.iati_identifier
   %reporting-org{"type" => activity.reporting_organisation.organisation_type, "ref" => activity.reporting_organisation.iati_reference }
     %narrative= activity.reporting_organisation.name
   %title

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -65,7 +65,7 @@ en:
         call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
-        delivery_partner_identifier: This could be the reference you use in your internal systems. This value cannot be edited once it is set
+        delivery_partner_identifier: This could be the reference you use in your internal systems
         roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
@@ -98,7 +98,7 @@ en:
           incomplete: Incomplete
         flow: Flow type
         geography: Benefitting recipient geography
-        delivery_partner_identifier: Identifier
+        delivery_partner_identifier: Delivery partner identifier
         roda_identifier: RODA identifier
         level: Level
         organisation: Organisation

--- a/db/data/20200903140938_correct_transparency_identifiers.rb
+++ b/db/data/20200903140938_correct_transparency_identifiers.rb
@@ -1,0 +1,20 @@
+class CorrectTransparencyIdentifiers < ActiveRecord::Migration[6.0]
+  def up
+    Activity.transaction do
+      Activity.update_all(transparency_identifier: nil)
+
+      Activity.lock.where.not(roda_identifier_compound: nil).find_each do |activity|
+        activity.transparency_identifier = [
+          activity.reporting_organisation.iati_reference,
+          activity.roda_identifier_compound.gsub(/[^a-z0-9-]+/i, "-"),
+        ].join("-")
+
+        activity.save!
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200827120801)
+DataMigrate::Data.define(version: 20200903140938)

--- a/db/migrate/20200901150652_add_unique_index_on_transparency_identifier.rb
+++ b/db/migrate/20200901150652_add_unique_index_on_transparency_identifier.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexOnTransparencyIdentifier < ActiveRecord::Migration[6.0]
+  def change
+    change_table :activities do |t|
+      t.index [:transparency_identifier], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_090103) do
+ActiveRecord::Schema.define(version: 2020_09_01_150652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2020_08_26_090103) do
     t.index ["parent_id"], name: "index_activities_on_parent_id"
     t.index ["reporting_organisation_id"], name: "index_activities_on_reporting_organisation_id"
     t.index ["roda_identifier_compound"], name: "index_activities_on_roda_identifier_compound"
+    t.index ["transparency_identifier"], name: "index_activities_on_transparency_identifier", unique: true
   end
 
   create_table "auditable_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -97,10 +97,10 @@ RSpec.feature "Users can create a fund level activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
+      fill_in_activity_form(roda_identifier_fragment: identifier, level: "fund")
 
-      activity = Activity.find_by(delivery_partner_identifier: identifier)
-      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{activity.delivery_partner_identifier}")
+      activity = Activity.find_by(roda_identifier_fragment: identifier)
+      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{activity.roda_identifier_fragment}")
     end
 
     context "when there is an existing activity with a nil identifier" do

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -58,10 +58,10 @@ RSpec.feature "Users can create a programme activity" do
       visit activities_path
       click_on(t("page_content.organisation.button.create_activity"))
 
-      fill_in_activity_form(delivery_partner_identifier: identifier, level: "programme", parent: fund)
+      fill_in_activity_form(roda_identifier_fragment: identifier, level: "programme", parent: fund)
 
-      activity = Activity.find_by(delivery_partner_identifier: identifier)
-      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
+      activity = Activity.find_by(roda_identifier_fragment: identifier)
+      expect(activity.transparency_identifier).to eql("GB-GOV-13-#{fund.roda_identifier_fragment}-#{activity.roda_identifier_fragment}")
     end
 
     scenario "programme creation is tracked with public_activity" do

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -44,10 +44,10 @@ RSpec.feature "Users can create a project" do
         visit activities_path
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(delivery_partner_identifier: identifier, level: "project", parent: programme)
+        fill_in_activity_form(roda_identifier_fragment: identifier, level: "project", parent: programme)
 
-        activity = Activity.find_by(delivery_partner_identifier: identifier)
-        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{programme.parent.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
+        activity = Activity.find_by(roda_identifier_fragment: identifier)
+        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{programme.parent.roda_identifier_fragment}-#{programme.roda_identifier_fragment}-#{activity.roda_identifier_fragment}")
       end
 
       scenario "project creation is tracked with public_activity" do

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "the activity saves its identifier as read-only `transparency_identifier`" do
         project = create(:project_activity, organisation: user.organisation)
-        identifier = "a-third-party-project"
+        identifier = "3rd-party-proj"
 
         visit activities_path
 
@@ -35,10 +35,10 @@ RSpec.feature "Users can create a project" do
 
         click_on(t("page_content.organisation.button.create_activity"))
 
-        fill_in_activity_form(level: "third_party_project", delivery_partner_identifier: identifier, parent: project)
+        fill_in_activity_form(level: "third_party_project", roda_identifier_fragment: identifier, parent: project)
 
-        activity = Activity.find_by(delivery_partner_identifier: identifier)
-        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{project.parent.parent.delivery_partner_identifier}-#{project.parent.delivery_partner_identifier}-#{project.delivery_partner_identifier}-#{activity.delivery_partner_identifier}")
+        activity = Activity.find_by(roda_identifier_fragment: identifier)
+        expect(activity.transparency_identifier).to eql("GB-GOV-13-#{project.parent.parent.roda_identifier_fragment}-#{project.parent.roda_identifier_fragment}-#{project.roda_identifier_fragment}#{activity.roda_identifier_fragment}")
       end
 
       scenario "third party project creation is tracked with public_activity" do

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -60,7 +60,6 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
     end
-
     context "before the activity has a level" do
       it "shows add link on the level step" do
         activity = create(:activity, :level_form_state, organisation: user.organisation)
@@ -122,36 +121,26 @@ RSpec.feature "Users can edit an activity" do
       context "when the activity is complete" do
         it "editing and saving a step returns the user to the activity page details tab" do
           activity = create(:fund_activity, organisation: user.organisation)
-          new_title = "Another new title"
+          identifier = "AB-CDE-1234"
           visit organisation_activity_details_path(activity.organisation, activity)
 
-          within(".title") do
+          within(".identifier") do
             click_on(t("default.link.edit"))
           end
 
-          fill_in "activity[title]", with: new_title
+          fill_in "activity[delivery_partner_identifier]", with: identifier
           click_button t("form.button.activity.submit")
 
           expect(page).to have_content t("action.fund.update.success")
           expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
         end
 
-        it "all edit links (except identifier) are available to take the user to the right step" do
+        it "all edit links are available to take the user to the right step" do
           activity = create(:fund_activity, organisation: user.organisation)
 
           visit organisation_activity_details_path(activity.organisation, activity)
 
           assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
-        end
-
-        it "does not show an edit link for the identifier" do
-          activity = create(:fund_activity, organisation: user.organisation)
-
-          visit organisation_activity_details_path(activity.organisation, activity)
-
-          within(".identifier") do
-            expect(page).to_not have_content t("default.link.edit")
-          end
         end
 
         it "does not show an edit link for the transparency identifier" do
@@ -166,20 +155,20 @@ RSpec.feature "Users can edit an activity" do
 
         it "tracks activity updates with public_activity" do
           activity = create(:fund_activity, organisation: user.organisation)
-          new_title = "A new title"
+          identifier = "AB-CDE-1234"
           PublicActivity.with_tracking do
             visit organisation_activity_details_path(activity.organisation, activity)
 
-            within(".title") do
+            within(".identifier") do
               click_on(t("default.link.edit"))
             end
 
-            fill_in "activity[title]", with: new_title
+            fill_in "activity[delivery_partner_identifier]", with: identifier
             click_button t("form.button.activity.submit")
 
             # grab the most recently created auditable_event
             auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
-            expect(auditable_events.first.key).to eq "activity.update.purpose"
+            expect(auditable_events.first.key).to eq "activity.update.identifier"
             expect(auditable_events.first.owner_id).to eq user.id
             expect(auditable_events.first.trackable_id).to eq activity.id
           end
@@ -206,14 +195,14 @@ RSpec.feature "Users can edit an activity" do
         end
 
         context "when the activity only has an identifier" do
-          it "does not show edit link on the identifier, and add link on only the next step" do
+          it "shows edit link on the identifier, and add link on only the next step" do
             activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
 
             visit organisation_activity_details_path(activity.organisation, activity)
 
             # Click the first edit link that opens the form on step 1
             within(".identifier") do
-              expect(page).to_not have_content(t("default.link.edit"))
+              expect(page).to have_content(t("default.link.edit"))
             end
 
             within(".title") do
@@ -397,8 +386,13 @@ end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   within(".identifier") do
-    expect(page).to_not have_content t("default.link.edit")
+    click_on t("default.link.edit")
+    expect(page).to have_current_path(
+      activity_step_path(activity, :identifier)
+    )
   end
+  click_on t("default.link.back")
+  click_on t("tabs.activity.details")
 
   within(".sector") do
     click_on(t("default.link.edit"))

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -812,6 +812,18 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#iati_identifier" do
+    it "returns the previous_identifier if it exists" do
+      activity = create(:activity, previous_identifier: "previous-id", transparency_identifier: "transparency-id")
+      expect(activity.iati_identifier).to eq("previous-id")
+    end
+
+    it "returns the transparency_identifier if previous_identifier is not set" do
+      activity = create(:activity, previous_identifier: nil, transparency_identifier: "transparency-id")
+      expect(activity.iati_identifier).to eq("transparency-id")
+    end
+  end
+
   describe "#can_set_roda_identifier?" do
     let!(:fund) { create(:fund_activity, roda_identifier_fragment: "Level/A") }
     let!(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "Level/B") }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -761,52 +761,52 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#iati_identifier" do
+  describe "#transparency_identifier" do
     context "when the activity is a fund" do
-      it "returns a composite delivery_partner_identifier formed with the reporting organisation" do
-        fund = build(:fund_activity, delivery_partner_identifier: "GCRF-1", reporting_organisation: create(:beis_organisation))
-        expect(fund.iati_identifier).to eql("GB-GOV-13-GCRF-1")
+      it "returns a composite identifier formed with the reporting organisation" do
+        fund = create(:fund_activity, roda_identifier_fragment: "GCRF-1", reporting_organisation: create(:beis_organisation))
+        expect(fund.transparency_identifier).to eql("GB-GOV-13-GCRF-1")
       end
     end
 
     context "when the activity is a programme" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an delivery_partner_identifier with the reporting organisation, fund and programme" do
+        it "returns an identifier with the reporting organisation, fund and programme" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           programme = create(:programme_activity, organisation: government_organisation)
           fund = programme.parent
 
-          expect(programme.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}")
+          expect(programme.transparency_identifier)
+            .to eql("GB-GOV-13-#{fund.roda_identifier_fragment}-#{programme.roda_identifier_fragment}")
         end
       end
     end
 
     context "when the activity is a project" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an delivery_partner_identifier with the reporting organisation, fund, programme and project" do
+        it "returns an identifier with the reporting organisation, fund, programme and project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           project = create(:project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
           programme = project.parent
           fund = programme.parent
 
-          expect(project.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{project.delivery_partner_identifier}")
+          expect(project.transparency_identifier)
+            .to eql("GB-GOV-13-#{fund.roda_identifier_fragment}-#{programme.roda_identifier_fragment}-#{project.roda_identifier_fragment}")
         end
       end
     end
 
     context "when the activity is a third-party project" do
       context "when the reporting organisation is a government organisation" do
-        it "returns an delivery_partner_identifier with the reporting organisation, fund, programme, project and third-party project" do
+        it "returns an identifier with the reporting organisation, fund, programme, project and third-party project" do
           government_organisation = build(:organisation, iati_reference: "GB-GOV-13")
           third_party_project = create(:third_party_project_activity, organisation: government_organisation, reporting_organisation: government_organisation)
           project = third_party_project.parent
           programme = project.parent
           fund = programme.parent
 
-          expect(third_party_project.iati_identifier)
-            .to eql("GB-GOV-13-#{fund.delivery_partner_identifier}-#{programme.delivery_partner_identifier}-#{project.delivery_partner_identifier}-#{third_party_project.delivery_partner_identifier}")
+          expect(third_party_project.transparency_identifier)
+            .to eql("GB-GOV-13-#{fund.roda_identifier_fragment}-#{programme.roda_identifier_fragment}-#{project.roda_identifier_fragment}#{third_party_project.roda_identifier_fragment}")
         end
       end
     end
@@ -866,6 +866,11 @@ RSpec.describe Activity, type: :model do
     it "caches the compound RODA identifier on a project" do
       project.cache_roda_identifier!
       expect(project.roda_identifier_compound).to eq("Level/A-Level/B-Level/C")
+    end
+
+    it "caches the transparency identifier on a project" do
+      project.cache_roda_identifier!
+      expect(project.transparency_identifier).to eq("GB-GOV-13-Level-A-Level-B-Level-C")
     end
 
     it "caches the compound RODA identifier on a third-party project" do


### PR DESCRIPTION
## Changes in this PR

These commits replace our existing method of generating the transparency identifier so that it's generated from the RODA identifier, not from the Delivery Partner identifier. With that change in place, we can make it possible to edit Delivery Partner identifiers again.

## Screenshots of UI changes

When viewing an activity, it is possible to edit its delivery partner identifier.

<img width="1097" alt="Screenshot 2020-09-02 at 16 14 18" src="https://user-images.githubusercontent.com/9265/92005450-687b8400-ed3b-11ea-8de2-ee8227a4ac2d.png">

After setting the RODA identifier, the Transparency identifier is generated.

<img width="1097" alt="Screenshot 2020-09-02 at 16 14 40" src="https://user-images.githubusercontent.com/9265/92005455-6a454780-ed3b-11ea-903b-8117966e9c6a.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
