### PR TITLE
Fixes to the report journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,8 @@
 - Reports no longer have to be unique
 - Reports cannot be unique for the Level A activity
 - Add empty states for report tables
+- Show Level A (Fund), organisation and financial quarter on the report edit
+  page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,7 @@
 - Add empty states for report tables
 - Show Level A (Fund), organisation and financial quarter on the report edit
   page
+- Handle attempts to activate invalid reports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,8 @@
 - Delivery Partner Identifiers can be edited
 
 ## [unreleased]
+=======
+- Reports no longer have to be unique
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,8 @@
 ## [unreleased]
 =======
 - Reports no longer have to be unique
+- Reports cannot be unique for the Level A activity
+- Add empty states for report tables
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -32,18 +32,22 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def edit
-    @report = Report.find(id)
-    authorize @report
+    report = Report.find(id)
+    authorize report
+
+    @report_presenter = ReportPresenter.new(report)
   end
 
   def update
-    @report = Report.find(id)
-    authorize @report
+    report = Report.find(id)
+    authorize report
 
-    @report.assign_attributes(report_params)
-    if @report.valid?
-      @report.save!
-      @report.create_activity key: "report.update", owner: current_user
+    @report_presenter = ReportPresenter.new(report)
+
+    report.assign_attributes(report_params)
+    if report.valid?
+      report.save!
+      report.create_activity key: "report.update", owner: current_user
       flash[:notice] = t("action.report.update.success")
       redirect_to reports_path
     else

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -47,10 +47,15 @@ class Staff::ReportsStateController < Staff::BaseController
 
   private def change_report_state_to_active
     authorize report, :activate?
-    report.update!(state: :active)
-    report.create_activity key: "report.activated", owner: current_user
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/activate/complete"
+    if report.valid?
+      report.update!(state: :active)
+      report.create_activity key: "report.activated", owner: current_user
+      @report_presenter = ReportPresenter.new(report)
+      render "staff/reports_state/activate/complete"
+    else
+      flash[:error] = t("action.report.activate.failure")
+      redirect_to report_path(report)
+    end
   end
 
   private def confirm_submission

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,7 +11,6 @@ class Report < ApplicationRecord
   has_many :transactions
   has_many :planned_disbursements
 
-  validates_uniqueness_of :fund, scope: :organisation
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true, date_within_boundaries: true
 

--- a/app/views/staff/reports/_form.html.haml
+++ b/app/views/staff/reports/_form.html.haml
@@ -1,4 +1,16 @@
 = f.govuk_error_summary
+.govuk-form-group
+  = label_tag "organisation", t("form.label.report.organisation"), class: "govuk-label"
+  = content_tag :p, f.object.organisation.name, class: "govuk-body", id: "organisation"
+
+.govuk-form-group
+  = label_tag "financial-quarter-and_year", t("form.label.report.financial_quarter_and_year"), class: "govuk-label"
+  = content_tag :p, f.object.financial_quarter_and_year, class: "govuk-body", id: "finacial-quarter-and-year"
+
+.govuk-form-group
+  = label_tag "level-a-activity", t("form.label.report.level_a_activity"), class: "govuk-label"
+  = content_tag :p, f.object.fund.title, class: "govuk-body", id: "level-a-acitivty"
+
 = f.govuk_text_field :description
 = f.govuk_date_field :deadline, legend: {  size: "s" }
 

--- a/app/views/staff/reports/edit.html.haml
+++ b/app/views/staff/reports/edit.html.haml
@@ -6,5 +6,6 @@
       %h1.govuk-heading-xl
         = t("page_title.report.edit")
 
-      = form_with model: @report, url: report_path(@report) do |f|
+
+      = form_with model: @report_presenter, url: report_path(@report_presenter) do |f|
         = render partial: "form", locals: { f: f }

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -19,7 +19,7 @@
       %h2.govuk-heading-m
         = t("table.title.report.active")
 
-      = render partial: "staff/shared/reports/table", locals: { reports: @active_report_presenters }
+      = render partial: "staff/shared/reports/table_active", locals: { reports: @active_report_presenters }
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full

--- a/app/views/staff/shared/reports/_table_active.html.haml
+++ b/app/views/staff/shared/reports/_table_active.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#active-reports
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/app/views/staff/shared/reports/_table_approved.html.haml
+++ b/app/views/staff/shared/reports/_table_approved.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#approved-reports
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
+++ b/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#awaiting-changes
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/app/views/staff/shared/reports/_table_empty.html.haml
+++ b/app/views/staff/shared/reports/_table_empty.html.haml
@@ -1,0 +1,6 @@
+%table.govuk-table#no-reports
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t("page_content.reports.title")
+  %tbody.govuk-table__body
+    %tr.govuk-table__row
+      %td.govuk-table__cell= t("table.body.report.no_reports")

--- a/app/views/staff/shared/reports/_table_in_review.html.haml
+++ b/app/views/staff/shared/reports/_table_in_review.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#in-review-reports
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/app/views/staff/shared/reports/_table_inactive.html.haml
+++ b/app/views/staff/shared/reports/_table_inactive.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#inactive-reports
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/app/views/staff/shared/reports/_table_inactive.html.haml
+++ b/app/views/staff/shared/reports/_table_inactive.html.haml
@@ -30,4 +30,4 @@
           %td.govuk-table__cell= report.deadline
           %td.govuk-table__cell
             = link_to t("table.body.report.action.edit"), edit_report_path(report), class: "govuk-link govuk-!-margin-left-2"
-            = link_to t("table.body.report.action.activate"), edit_report_state_path(report), class: "govuk-link govuk-!-margin-left-2"
+            = link_to t("default.link.view"), report_path(report), class: "govuk-link govuk-!-margin-left-2"

--- a/app/views/staff/shared/reports/_table_submitted.html.haml
+++ b/app/views/staff/shared/reports/_table_submitted.html.haml
@@ -1,5 +1,7 @@
-- unless reports.empty?
-  %table.govuk-table.reports
+- if reports.empty?
+  = render partial: "staff/shared/reports/table_empty"
+- else
+  %table.govuk-table#submitted-reports
     %caption.govuk-table__caption.govuk-visually-hidden
       = t("page_content.reports.title")
     %thead.govuk-table__head

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -79,6 +79,7 @@ en:
         complete:
           title: Report activation complete
           body: "%{report_financial_quarter} %{report_description}"
+        failure: Report could not be activated
       update:
         success: Report successfully updated
       submit:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -23,6 +23,8 @@ en:
           edit: Edit
           activate: Activate
           in_review: Mark as in review
+        no_reports:
+          No reports
   page_content:
     reports:
       title: Reports

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -36,11 +36,13 @@ en:
   form:
     label:
       report:
-        description: Reporting period
+        description: Report description
         fund: Level A
         organisation: Organisation
         state: State
         deadline: Deadline
+        level_a_activity: Level A
+        financial_quarter_and_year: Financial quarter
     legend:
       report:
         description: Reporting period

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -151,6 +151,18 @@ RSpec.feature "BEIS users can edit a report" do
       expect(page).to_not have_content t("action.report.update.success")
       expect(page).to have_content t("activerecord.errors.models.report.attributes.description.blank")
     end
+
+    scenario "they see the organisation, level A activity and financial quarter for the report" do
+      authenticate!(user: beis_user)
+      report = create(:report)
+      report_presenter = ReportPresenter.new(report)
+
+      visit edit_report_path(report)
+
+      expect(page).to have_content report_presenter.organisation.name
+      expect(page).to have_content report_presenter.fund.title
+      expect(page).to have_content report_presenter.financial_quarter_and_year
+    end
   end
 
   context "Logged in as a Delivery Partner user" do

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -17,6 +17,19 @@ RSpec.feature "Users can activate reports" do
       expect(report.reload.state).to eql "active"
     end
 
+    scenario "they see a warning when the report is not valid i.e. has no description" do
+      organisation = create(:delivery_partner_organisation)
+      fund = create(:fund_activity)
+      report = Report.new(organisation: organisation, fund: fund)
+      report.save(validate: false)
+
+      visit report_path(report)
+      click_link t("action.report.activate.button")
+      click_button t("action.report.activate.confirm.button")
+
+      expect(page).to have_content t("action.report.activate.failure")
+    end
+
     context "when the report is already active" do
       scenario "it cannot be activated agian" do
         report = create(:report, state: :active)

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -79,6 +79,14 @@ RSpec.feature "Users can view reports" do
       header = page.response_headers["Content-Disposition"]
       expect(header).to match(/Legacy%20Report/)
     end
+
+    context "when there are no reports in a given state" do
+      scenario "an empty state is shown" do
+        visit reports_path
+
+        expect(page).to have_content t("table.body.report.no_reports")
+      end
+    end
   end
 
   context "as a delivery partner user" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -28,15 +28,6 @@ RSpec.describe Report, type: :model do
     expect(report.errors[:fund]).to include t("activerecord.errors.models.report.attributes.fund.level")
   end
 
-  it "does not allow more than one Report for the same Fund and Organisation combination" do
-    organisation = create(:delivery_partner_organisation)
-    fund = create(:fund_activity)
-    _existing_report = create(:report, organisation: organisation, fund: fund)
-
-    new_report = build(:report, organisation: organisation, fund: fund)
-    expect(new_report).not_to be_valid
-  end
-
   it "does not allow a Deadline which is in the past" do
     report = build(:report, deadline: Date.yesterday)
     expect(report).not_to be_valid


### PR DESCRIPTION
## Changes in this PR

Whilst working to create the next report automatically (https://trello.com/c/kllPs5cG) I came accross a few issues I felt needed addressing first:

- We had a constraint on Report that meant reports had to be unique for the level A activity in each organisation, this is incorrect and would stop new reports being created an organisation has many reports for the same level A activity.
- Once you get a few reports in different states the report index page becomes visually cluttered, adding empty states to the tables eases this (hopefully)
- When editing a report (adding the description and/or deadline) it is super helpful for BEIS users to also see the organisation, Level A actvity (fund) and financial quarter.
- Because of the way reports work a BEIS user can try to activate an invalid one resulting in the application failing (500), we need to do more work on this possibly as it feels a bit clunky, as a stop gap handle the invalid report and show an error, whilst not perfect, it is better than the application blowing up.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/480578/92127443-392b4c80-edf9-11ea-8ea2-c77c696d8c59.png)

![image](https://user-images.githubusercontent.com/480578/92127412-303a7b00-edf9-11ea-9954-a509cc37e81d.png)

![image](https://user-images.githubusercontent.com/480578/92127491-45afa500-edf9-11ea-86de-e21cbc826bd0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
