### PR TITLE
Pass report state as a parameter

### DIFF
--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -30,11 +30,15 @@ class Staff::ReportsStateController < Staff::BaseController
   end
 
   def update
-    if STATE_TO_POLICY_ACTION.key?(params[:state])
-      change_report_state_to(params[:state])
-    else
-      authorize report
-      redirect_to report_path(report)
+    state = params[:state]
+
+    Report.transaction do
+      if STATE_TO_POLICY_ACTION.key?(state)
+        change_report_state_to(state)
+      else
+        authorize report
+        redirect_to report_path(report)
+      end
     end
   end
 
@@ -47,24 +51,25 @@ class Staff::ReportsStateController < Staff::BaseController
   private def change_report_state_to(state)
     policy_action = STATE_TO_POLICY_ACTION.fetch(state)
 
-    authorize report, policy_action + "?"
+    unless report.valid?
+      authorize report
+      flash[:error] = t("action.report.#{policy_action}.failure")
+      return redirect_to report_path(report)
+    end
 
-    if report.valid?
+    unless report.state == state
+      authorize report, policy_action + "?"
       report.update!(state: state)
       report.create_activity key: "report.state.changed_to.#{state}", owner: current_user
-
       find_or_create_new_report(organisation_id: report.organisation.id, fund_id: report.fund.id) if state == "approved"
-
-      @report_presenter = ReportPresenter.new(report)
-      render "staff/reports_state/#{policy_action}/complete"
-    else
-      flash[:error] = t("action.report.#{policy_action}.failure")
-      redirect_to report_path(report)
     end
+
+    @report_presenter = ReportPresenter.new(report)
+    render "staff/reports_state/#{policy_action}/complete"
   end
 
   private def report
-    @report ||= Report.find(params[:report_id])
+    @report ||= Report.lock.find(params[:report_id])
   end
 
   private def find_or_create_new_report(organisation_id:, fund_id:)

--- a/app/views/staff/reports_state/activate/confirm.html.haml
+++ b/app/views/staff/reports_state/activate/confirm.html.haml
@@ -13,4 +13,5 @@
         %li
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag :state, "active"
         = f.govuk_submit t("action.report.activate.confirm.button")

--- a/app/views/staff/reports_state/approve/confirm.html.haml
+++ b/app/views/staff/reports_state/approve/confirm.html.haml
@@ -16,4 +16,5 @@
           The associated transactions and planned disbursements will not be editable
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag :state, "approved"
         = f.govuk_submit t("action.report.approve.confirm.button")

--- a/app/views/staff/reports_state/request_changes/confirm.html.haml
+++ b/app/views/staff/reports_state/request_changes/confirm.html.haml
@@ -13,5 +13,5 @@
         %li
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
-        = hidden_field_tag "request_changes", "true"
+        = hidden_field_tag :state, "awaiting_changes"
         = f.govuk_submit t("action.report.request_changes.confirm.button")

--- a/app/views/staff/reports_state/review/confirm.html.haml
+++ b/app/views/staff/reports_state/review/confirm.html.haml
@@ -13,4 +13,5 @@
         %li
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag :state, "in_review"
         = f.govuk_submit t("action.report.in_review.confirm.button")

--- a/app/views/staff/reports_state/submit/confirm.html.haml
+++ b/app/views/staff/reports_state/submit/confirm.html.haml
@@ -20,6 +20,7 @@
           You will be the contact for any freedom of information requests about this data once it has been published
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag :state, "submitted"
         = f.govuk_submit t("action.report.submit.confirm.button")
 
   = render partial: "shared/help_and_support"


### PR DESCRIPTION
While thinking through some consistency problems in relation to how identifiers and bulk actions are handled, it occurred to me that the `ReportsStateController` is vulnerable to a couple of race conditions that coule occur if two or more people are working on the same report. Descriptions of those conditions are in the commit messages.