### PR TITLE
Refactor reports state controller

### DIFF
--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -3,18 +3,26 @@
 class Staff::ReportsStateController < Staff::BaseController
   include Secured
 
+  STATE_TO_POLICY_ACTION = {
+    active: :activate,
+    submitted: :submit,
+    in_review: :review,
+    awaiting_changes: :request_changes,
+    approved: :approve,
+  }
+
   def edit
     case report.state
     when "inactive"
-      confirm_activation
+      show_state_change_confirmation(:activate)
     when "active"
-      confirm_submission
+      show_state_change_confirmation(:submit)
     when "submitted"
-      confirm_in_review
+      show_state_change_confirmation(:review)
     when "in_review"
-      params[:request_changes] ? confirm_request_changes : confirm_approve
+      params[:request_changes] ? show_state_change_confirmation(:request_changes) : show_state_change_confirmation(:approve)
     when "awaiting_changes"
-      confirm_submission
+      show_state_change_confirmation(:submit)
     else
       authorize report
       redirect_to report_path(report)
@@ -24,94 +32,41 @@ class Staff::ReportsStateController < Staff::BaseController
   def update
     case report.state
     when "inactive"
-      change_report_state_to_active
+      change_report_state_to(:active)
     when "active"
-      change_report_state_to_submitted
+      change_report_state_to(:submitted)
     when "submitted"
-      change_report_state_to_in_review
+      change_report_state_to(:in_review)
     when "in_review"
-      params[:request_changes] ? change_report_state_to_awaiting_changes : change_report_state_to_approved
+      params[:request_changes] ? change_report_state_to(:awaiting_changes) : change_report_state_to(:approved)
     when "awaiting_changes"
-      change_report_state_to_submitted
+      change_report_state_to(:submitted)
     else
       authorize report
       redirect_to report_path(report)
     end
   end
 
-  private def confirm_activation
-    authorize report, :activate?
+  private def show_state_change_confirmation(policy_action)
+    authorize report, policy_action.to_s + "?"
     @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/activate/confirm"
+    render "staff/reports_state/#{policy_action}/confirm"
   end
 
-  private def change_report_state_to_active
-    authorize report, :activate?
+  private def change_report_state_to(state)
+    policy_action = STATE_TO_POLICY_ACTION.fetch(state).to_s
+
+    authorize report, policy_action + "?"
+
     if report.valid?
-      report.update!(state: :active)
-      report.create_activity key: "report.activated", owner: current_user
+      report.update!(state: state)
+      report.create_activity key: "report.state.changed_to.#{state}", owner: current_user
       @report_presenter = ReportPresenter.new(report)
-      render "staff/reports_state/activate/complete"
+      render "staff/reports_state/#{policy_action}/complete"
     else
-      flash[:error] = t("action.report.activate.failure")
+      flash[:error] = t("action.report.#{policy_action}.failure")
       redirect_to report_path(report)
     end
-  end
-
-  private def confirm_submission
-    authorize report, :submit?
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/submit/confirm"
-  end
-
-  private def change_report_state_to_submitted
-    authorize report, :submit?
-    report.update!(state: :submitted)
-    report.create_activity key: "report.submitted", owner: current_user
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/submit/complete"
-  end
-
-  private def confirm_in_review
-    authorize report, :review?
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/review/confirm"
-  end
-
-  private def change_report_state_to_in_review
-    authorize report, :review?
-    report.update!(state: :in_review)
-    report.create_activity key: "report.in_review", owner: current_user
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/review/complete"
-  end
-
-  private def confirm_request_changes
-    authorize report, :request_changes?
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/request_changes/confirm"
-  end
-
-  private def change_report_state_to_awaiting_changes
-    authorize report, :request_changes?
-    report.update!(state: :awaiting_changes)
-    report.create_activity key: "report.awaiting_changes", owner: current_user
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/request_changes/complete"
-  end
-
-  private def confirm_approve
-    authorize report, :approve?
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/approve/confirm"
-  end
-
-  private def change_report_state_to_approved
-    authorize report, :approve?
-    report.update!(state: :approved)
-    report.create_activity key: "report.approve", owner: current_user
-    @report_presenter = ReportPresenter.new(report)
-    render "staff/reports_state/approve/complete"
   end
 
   private def report

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -80,6 +80,14 @@ en:
           title: Report activation complete
           body: "%{report_financial_quarter} %{report_description}"
         failure: Report could not be activated
+      submit:
+        failure: Report could not be submitted
+      review:
+        failure: Report could not be moved to in review
+      request_changes:
+        failure: Report could not be moved to awaiting changes
+      approve:
+        failure: Report could not be approved
       update:
         success: Report successfully updated
       submit:

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Users can submit a report" do
           click_button t("action.report.submit.confirm.button")
 
           auditable_events = PublicActivity::Activity.all
-          expect(auditable_events.last.key).to include("report.submitted")
+          expect(auditable_events.last.key).to include("report.state.changed_to.submitted")
           expect(auditable_events.last.owner_id).to include delivery_partner_user.id
           expect(auditable_events.last.trackable_id).to include report.id
         end


### PR DESCRIPTION
## Changes in this PR

There was quite a bit of duplication in this controller.

I really like having the policy name and the report state different, I
think it makes things nice and clear. Not wanting to change this meant
having some kind of mapping from state names to policy names – I went
with a hash.

I've renamed the confirm_<state> method to try and better describe the
behaviour and align it with the argument that is passed in (a policy
action name)

I've also changed the key for the Public Activity record, I am confident
this is not an issue as we do not expose public activity records as yet
and we have no report state changes in production either (they are all
inactive).

I added all the state change failure messages to the report.yml locale
file, due to the linear nature of the state change I can't see how any
of these will be triggered but they are in for completeness.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
