### PR TITLE
(964) New reports are created automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@
 - Update activity policy to account for the report state
 
 ## [unreleased]
+- New reports are created when the prior is approved
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -61,6 +61,9 @@ class Staff::ReportsStateController < Staff::BaseController
     if report.valid?
       report.update!(state: state)
       report.create_activity key: "report.state.changed_to.#{state}", owner: current_user
+
+      find_or_create_new_report(organisation_id: report.organisation.id, fund_id: report.fund.id) if state == :approved
+
       @report_presenter = ReportPresenter.new(report)
       render "staff/reports_state/#{policy_action}/complete"
     else
@@ -71,5 +74,9 @@ class Staff::ReportsStateController < Staff::BaseController
 
   private def report
     @report ||= Report.find(params[:report_id])
+  end
+
+  private def find_or_create_new_report(organisation_id:, fund_id:)
+    Report.where.not(state: :approved).find_or_create_by!(organisation_id: organisation_id, fund_id: fund_id)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,7 +3,7 @@ class Report < ApplicationRecord
 
   attr_readonly :financial_quarter, :financial_year
 
-  validates_presence_of :description
+  validates_presence_of :description, on: :update
   validates_presence_of :state
 
   belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -17,6 +17,33 @@ RSpec.feature "Users can approve reports" do
       expect(report.reload.state).to eql "approved"
     end
 
+    scenario "a new report is created for the delivery partner and level A activity" do
+      organisation = create(:delivery_partner_organisation)
+      fund = create(:fund_activity)
+      _approved_report = create(:report, state: :approved, organisation: organisation, fund: fund)
+      report = create(:report, state: :in_review, organisation: organisation, fund: fund)
+
+      travel_to Date.parse("2019-7-1") do
+        visit report_path(report)
+        click_link t("action.report.approve.button")
+        click_button t("action.report.approve.confirm.button")
+
+        expect(report.reload.state).to eql "approved"
+
+        expect(Report.where(state: :inactive, organisation: report.organisation, fund: report.fund).count).to eql 1
+
+        new_report = Report.where(state: :inactive, organisation: report.organisation, fund: report.fund).first
+
+        visit reports_path
+
+        within "##{new_report.id}" do
+          expect(page).to have_content new_report.organisation.name
+          expect(page).to have_content new_report.fund.title
+          expect(page).to have_content "Q2 2019-2020"
+        end
+      end
+    end
+
     context "when the report is already approved" do
       scenario "it cannot be approved" do
         report = create(:report, state: :approved)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Report, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:description).on(:update) }
     it { should validate_presence_of(:state) }
     it { should have_readonly_attribute(:financial_quarter) }
     it { should have_readonly_attribute(:financial_year) }


### PR DESCRIPTION
## Changes in this PR

When the current report is approved we go ahead and create the next report
in the inactive state, ready for BEIS to activate.

The application relies on there only ever being one active report for a
given delivery partner organisation and level A activity so we want the
application to handle the creation of the new one to avoid error.

We also know that due to the nature of the service a report will have to
be approved either in the financial quarter in which it was created or
the following one - in both cases creating the new report upon approval
means that the new report has the correct financial year.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
