### PR TITLE
(898)`ODA eligibility` form step added to activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,9 +291,9 @@
 - Show Level A (Fund), organisation and financial quarter on the report edit
   page
 - Handle attempts to activate invalid reports
-
 - `Recipient_region` codelist modified
 - `Intended beneficiaries` form field added, including validations, and country to region mapping
+- `ODA eligibility` form step added to create activity journey
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -25,6 +25,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :intended_beneficiaries,
     :flow,
     :aid_type,
+    :oda_eligibility,
   ]
 
   steps(*FORM_STEPS)
@@ -123,6 +124,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(flow: flow)
     when :aid_type
       @activity.assign_attributes(aid_type: aid_type)
+    when :oda_eligibility
+      @activity.assign_attributes(oda_eligibility: oda_eligibility)
     end
 
     update_form_state
@@ -234,6 +237,10 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def aid_type
     params.require(:activity).permit(:aid_type).fetch("aid_type", nil)
+  end
+
+  def oda_eligibility
+    params.require(:activity).permit(:oda_eligibility).fetch("oda_eligibility", nil)
   end
 
   def finish_wizard_path

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -23,6 +23,7 @@ class Activity < ApplicationRecord
     :intended_beneficiaries_step,
     :flow_step,
     :aid_type,
+    :oda_eligibility_step,
   ]
 
   strip_attributes only: [:delivery_partner_identifier, :roda_identifier_fragment]
@@ -43,6 +44,7 @@ class Activity < ApplicationRecord
   validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
+  validates :oda_eligibility, inclusion: {in: [true, false]}, on: :oda_eligibility_step
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :roda_identifier_compound, uniqueness: true, allow_nil: true

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -83,6 +83,11 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.flow.#{super}")
   end
 
+  def oda_eligibility
+    return if super.nil?
+    I18n.t("activity.oda_eligibility.#{super}")
+  end
+
   def call_to_action(attribute)
     send(attribute).present? ? "edit" : "add"
   end

--- a/app/views/staff/activity_forms/oda_eligibility.html.haml
+++ b/app/views/staff/activity_forms/oda_eligibility.html.haml
@@ -1,0 +1,5 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_radio_buttons_fieldset(:oda_eligibility, legend: { text: t("form.legend.activity.oda_eligibility"), size: "xl", tag: "h1" }) do
+    = f.hidden_field :oda_eligibility, value: nil
+    = f.govuk_radio_button :oda_eligibility, :true, label: { text: t("form.label.activity.oda_eligibility.true") }
+    = f.govuk_radio_button :oda_eligibility, :false, label: { text: t("form.label.activity.oda_eligibility.false") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -213,6 +213,15 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("summary.label.activity.aid_type"))
 
+  .govuk-summary-list__row.oda_eligibility
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.oda_eligibility")
+    %dd.govuk-summary-list__value
+      = activity_presenter.oda_eligibility
+    %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :oda_eligibility)
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:oda_eligibility)}"), activity_step_path(activity_presenter, :oda_eligibility), t("summary.label.activity.oda_eligibility"))
+
   - if policy(activity_presenter).redact_from_iati?
     .govuk-summary-list__row.publish_to_iati
       %dt.govuk-summary-list__key

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -692,6 +692,9 @@ en:
       '4': Post-completion
       '5': Cancelled
       '6': Suspended
+    oda_eligibility:
+      'true': 'Eligible'
+      'false': 'No longer eligible'
   generic:
     default_currency:
       aed: UAE Dirham

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -28,6 +28,9 @@ en:
         delivery_partner_identifier: Enter your unique identifier
         roda_identifier_fragment: Enter a unique identifier for RODA
         intended_beneficiaries: What are the intended beneficiaries?
+        oda_eligibility:
+          'true': 'Eligible'
+          'false': 'No longer eligible'
         region: Recipient region
         actual_end_date: Actual end date
         actual_start_date: Actual start date
@@ -54,6 +57,7 @@ en:
         geography: Will the benefitting recipient be a region or country?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
+        oda_eligibility: Is this activity ODA eligible?
         parent: Select the parent activity
         planned_end_date: Planned end date
         planned_start_date: Planned start date
@@ -74,6 +78,7 @@ en:
         delivery_partner_identifier: This could be the reference you use in your internal systems
         roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set
         intended_beneficiaries: You can select up to 10 different countries. This field is optional if you already selected a recipient country on the previous step
+        oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
         sector_category: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
@@ -107,6 +112,7 @@ en:
         geography: Benefitting recipient geography
         delivery_partner_identifier: Delivery partner identifier
         intended_beneficiaries: Intended beneficiaries
+        oda_eligibility: ODA eligibility
         roda_identifier: RODA identifier
         level: Level
         organisation: Organisation

--- a/db/migrate/20200907094528_add_oda_eligibility_to_activities.rb
+++ b/db/migrate/20200907094528_add_oda_eligibility_to_activities.rb
@@ -1,0 +1,5 @@
+class AddOdaEligibilityToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :oda_eligibility, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_103039) do
+ActiveRecord::Schema.define(version: 2020_09_07_094528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_09_03_103039) do
     t.string "roda_identifier_fragment"
     t.string "roda_identifier_compound"
     t.boolean "requires_additional_benefitting_countries"
+    t.boolean "oda_eligibility", default: true
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -264,6 +264,10 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose("activity[aid_type]", option: "A01")
         click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.oda_eligibility")
+
+        # oda_eligibility has the default value already selected
+        click_button t("form.button.activity.submit")
         expect(page).to have_content Activity.find_by(delivery_partner_identifier: identifier).title
       end
     end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -503,4 +503,13 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   end
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
+
+  within(".oda_eligibility") do
+    click_on(t("default.link.edit"))
+    expect(page).to have_current_path(
+      activity_step_path(activity, :oda_eligibility)
+    )
+  end
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -454,6 +454,13 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when oda_eligibility is blank" do
+      subject(:activity) { build(:activity, oda_eligibility: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:oda_eligibility_step)).to be_falsey
+      end
+    end
+
     context "when saving in the update_extending_organisation context" do
       subject { build(:activity) }
       it { should validate_presence_of(:extending_organisation_id).on(:update_extending_organisation) }

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -271,6 +271,24 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#oda_eligibility" do
+    context "when the activity is ODA eligible" do
+      it "returns the locale value for this option" do
+        activity = build(:project_activity, oda_eligibility: "true")
+        result = described_class.new(activity)
+        expect(result.oda_eligibility).to eq("Eligible")
+      end
+    end
+
+    context "when the activity is no longer ODA eligible" do
+      it "returns the locale value for this option" do
+        activity = build(:project_activity, oda_eligibility: "false")
+        result = described_class.new(activity)
+        expect(result.oda_eligibility).to eq("No longer eligible")
+      end
+    end
+  end
+
   describe "#call_to_action" do
     it "returns 'edit' if the desired attribute is present" do
       activity = build(:activity, title: "My title")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -31,6 +31,7 @@ module FormHelpers
     intended_beneficiaries: "Haiti",
     flow: "ODA",
     aid_type: "A01",
+    oda_eligibility: "true",
     level:,
     parent: nil
   )
@@ -172,6 +173,11 @@ module FormHelpers
     choose("activity[aid_type]", option: aid_type)
     click_button t("form.button.activity.submit")
 
+    expect(page).to have_content t("form.legend.activity.oda_eligibility")
+    expect(page).to have_content t("form.hint.activity.oda_eligibility")
+    choose "Eligible"
+    click_button t("form.button.activity.submit")
+
     expect(page).to have_content delivery_partner_identifier
     expect(page).to have_content title
     expect(page).to have_content description
@@ -188,6 +194,7 @@ module FormHelpers
     expect(page).to have_content intended_beneficiaries
     expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
+    expect(page).to have_content t("activity.oda_eligibility.#{oda_eligibility}")
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,
       month: planned_start_date_month,


### PR DESCRIPTION
Trello: https://trello.com/c/Kt1vrYSS

## Changes in this PR

As part of the new fields on create activity journey requested by the client, the ODA eligibility has been added to every level activity. Worth noting that `ODA eligibility` is a requirement only for levels C and D activities, but the client suggested we implemented this on all levels for now. They are happy with refining this later if needed.

This new field has two options: `Eligible` and `No longer eligible`. A defaulted to `Eligible` has been implemented, as requested by the client. This field does not get reported to IATI or included in any XML.

This commit introduces the new form step, as well as tests to assert we achieve the desired behaviour.

## Screenshots of UI changes

### After

<img width="1214" alt="Screenshot 2020-09-07 at 11 35 44" src="https://user-images.githubusercontent.com/48016017/92380251-bcea7f00-f100-11ea-9045-50ee86cc8dc6.png">

<img width="1214" alt="Screenshot 2020-09-07 at 11 36 07" src="https://user-images.githubusercontent.com/48016017/92380259-c4118d00-f100-11ea-8d61-1db5286b0c6c.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
