### PR TITLE
Correct typo in Report copy

### DIFF
--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -123,7 +123,7 @@ en:
         report:
           attributes:
             description:
-              blank: Reporting period can't be bank
+              blank: Reporting period can't be blank
             fund:
               level: Activity must be a fund-level Activity
             deadline:


### PR DESCRIPTION
I just noticed this typo in one of the `Report` validation messages while testing something else.