### PR TITLE
(970) Update the organisation_id of programmes to be the BEIS organisation ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,7 +284,6 @@
 - Delivery Partner Identifiers can be edited
 
 ## [unreleased]
-=======
 - Reports no longer have to be unique
 - Reports cannot be unique for the Level A activity
 - Add empty states for report tables
@@ -294,6 +293,8 @@
 - `Recipient_region` codelist modified
 - `Intended beneficiaries` form field added, including validations, and country to region mapping
 - `ODA eligibility` form step added to create activity journey
+- Update any ingested Level B activities that do not have the BEIS organisation as their
+  associated organisation. All Level B activities should belong to BEIS.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/db/data/20200907144609_update_organisation_on_all_programme_activities.rb
+++ b/db/data/20200907144609_update_organisation_on_all_programme_activities.rb
@@ -1,0 +1,10 @@
+class UpdateOrganisationOnAllProgrammeActivities < ActiveRecord::Migration[6.0]
+  def up
+    beis_organisation_id = Organisation.find_by(service_owner: true).id
+    Activity.programmes.update_all(organisation_id: beis_organisation_id)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200903140938)
+DataMigrate::Data.define(version: 20200907144609)


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/2bPBRojL/970-all-level-b-activities-should-have-the-organisation-association-set-to-beis

During a recent data migration, some ingested activities were moved from
"Level C" to "Level B". However their organisation_id was not updated to reflect
the fact that Level B activities always belong to the BEIS organisation, not a
Delivery Partner organisation.

This data migration corrects that oversight; all Level B activities now have
the BEIS organisation as their owning organisation.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
