### PR TITLE
(932) Add GDI form step to activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,7 @@
 - `ODA eligibility` form step added to create activity journey
 - Update any ingested Level B activities that do not have the BEIS organisation as their
   associated organisation. All Level B activities should belong to BEIS.
+- `GDI` form step added to create activity journey
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...HEAD
 [release-15]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-14...release-15

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -23,6 +23,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :country,
     :requires_additional_benefitting_countries,
     :intended_beneficiaries,
+    :gdi,
     :flow,
     :aid_type,
     :oda_eligibility,
@@ -120,6 +121,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(requires_additional_benefitting_countries: requires_additional_benefitting_countries)
     when :intended_beneficiaries
       @activity.assign_attributes(intended_beneficiaries: intended_beneficiaries.drop(1))
+    when :gdi
+      @activity.assign_attributes(gdi: gdi)
     when :flow
       @activity.assign_attributes(flow: flow)
     when :aid_type
@@ -229,6 +232,10 @@ class Staff::ActivityFormsController < Staff::BaseController
 
   def intended_beneficiaries
     params.require(:activity).permit(intended_beneficiaries: []).fetch("intended_beneficiaries", [])
+  end
+
+  def gdi
+    params.require(:activity).permit(:gdi).fetch("gdi", nil)
   end
 
   def flow

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -98,6 +98,10 @@ module CodelistHelper
     end
   end
 
+  def gdi_radio_options
+    yaml_to_objects(entity: "activity", type: "gdi", with_empty_item: false).sort_by(&:code)
+  end
+
   def all_sectors
     yaml_to_objects_with_categories(entity: "activity", type: "sector", include_withdrawn: true)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -21,6 +21,7 @@ class Activity < ApplicationRecord
     :country_step,
     :requires_additional_benefitting_countries_step,
     :intended_beneficiaries_step,
+    :gdi_step,
     :flow_step,
     :aid_type,
     :oda_eligibility_step,
@@ -42,6 +43,7 @@ class Activity < ApplicationRecord
   validates :recipient_country, presence: true, on: :country_step, if: :recipient_country?
   validates :requires_additional_benefitting_countries, inclusion: {in: [true, false]}, on: :requires_additional_benefitting_countries_step, if: :recipient_country?
   validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
+  validates :gdi, presence: true, on: :gdi_step
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
   validates :oda_eligibility, inclusion: {in: [true, false]}, on: :oda_eligibility_step

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -78,6 +78,11 @@ class ActivityPresenter < SimpleDelegator
     super.map { |item| I18n.t("activity.recipient_country.#{item}") }.to_sentence
   end
 
+  def gdi
+    return if super.blank?
+    I18n.t("activity.gdi.#{super}")
+  end
+
   def flow
     return if super.blank?
     I18n.t("activity.flow.#{super}")

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -42,6 +42,7 @@ class IngestIatiActivities
           add_geography(legacy_activity: legacy_activity, new_activity: new_activity)
           add_requires_additional_benefitting_countries(legacy_activity: legacy_activity, new_activity: new_activity)
           add_intended_beneficiaries(legacy_activity: legacy_activity, new_activity: new_activity)
+          add_gdi(legacy_activity: legacy_activity, new_activity: new_activity)
 
           new_activity.form_state = :complete
           new_activity
@@ -289,6 +290,11 @@ class IngestIatiActivities
   private def add_intended_beneficiaries(legacy_activity:, new_activity:)
     # To be ingested once we have the information
     new_activity.intended_beneficiaries = ["Replace me"]
+  end
+
+  private def add_gdi(legacy_activity:, new_activity:)
+    # To be ingested once we have the information
+    new_activity.gdi = "Replace me"
   end
 
   private def add_dates(legacy_activity:, new_activity:)

--- a/app/views/staff/activity_forms/gdi.html.haml
+++ b/app/views/staff/activity_forms/gdi.html.haml
@@ -1,0 +1,7 @@
+= render layout: "wrapper" do |f|
+  = f.hidden_field :gdi, value: nil
+  = f.govuk_collection_radio_buttons :gdi,
+    gdi_radio_options,
+    :code,
+    :name,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.gdi") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -195,6 +195,16 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :intended_beneficiaries)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :intended_beneficiaries), t("summary.label.activity.intended_beneficiaries"))
 
+  .govuk-summary-list__row.gdi
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.gdi")
+    %dd.govuk-summary-list__value
+      = activity_presenter.gdi
+    %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gdi)
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gdi)}"), activity_step_path(activity_presenter, :gdi), t("summary.label.activity.gdi"))
+
+
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key
       = t("summary.label.activity.flow")

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -31,6 +31,11 @@ en:
       '37': Other Private flows at market terms
       '40': Non flow
       '50': Other flows
+    gdi:
+      '1': Yes - China
+      '2': Yes - India
+      '3': Yes - China and India
+      '4': 'No'
     geography:
       recipient_country: Country
       recipient_region: Region

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -22,6 +22,7 @@ en:
         call_present:
           'true': 'Yes'
           'false': 'No'
+        gdi: GDI
         geography_options:
           recipient_region: Region
           recipient_country: Country
@@ -54,6 +55,7 @@ en:
         call_present: Is there a call for this %{level}?
         call_open_date: Call open date
         call_close_date: Call close date
+        gdi: Is your activity affected by the Global Development Impact (GDI) policy?
         geography: Will the benefitting recipient be a region or country?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
@@ -76,6 +78,7 @@ en:
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems
+        gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
         roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set
         intended_beneficiaries: You can select up to 10 different countries. This field is optional if you already selected a recipient country on the previous step
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
@@ -109,6 +112,7 @@ en:
           complete: Complete
           incomplete: Incomplete
         flow: Flow type
+        gdi: GDI
         geography: Benefitting recipient geography
         delivery_partner_identifier: Delivery partner identifier
         intended_beneficiaries: Intended beneficiaries
@@ -212,6 +216,7 @@ en:
         country: What country will benefit from this activity?
         dates: What are the start and end dates for the %{level}?
         flow: Flow
+        gdi: GDI
         geography: Will the benefitting recipient be a region or country?
         delivery_partner_identifier: Enter your unique identifier
         roda_identifier: Enter your unique RODA identifier
@@ -244,6 +249,8 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
             planned_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+            gdi:
+              blank: Select an option for GDI
             intended_beneficiaries:
               blank: Select at least one intended beneficiary
               too_long: A maximum of 10 intended beneficiaries can be added

--- a/db/migrate/20200907141532_add_gdi_to_activities.rb
+++ b/db/migrate/20200907141532_add_gdi_to_activities.rb
@@ -1,0 +1,5 @@
+class AddGdiToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :gdi, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_094528) do
+ActiveRecord::Schema.define(version: 2020_09_07_141532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2020_09_07_094528) do
     t.string "roda_identifier_compound"
     t.boolean "requires_additional_benefitting_countries"
     t.boolean "oda_eligibility", default: true
+    t.string "gdi"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     recipient_country { nil }
     requires_additional_benefitting_countries { true }
     intended_beneficiaries { ["CU", "DM", "DO"] }
+    gdi { "No" }
     flow { "10" }
     aid_type { "A01" }
     level { :fund }
@@ -150,6 +151,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -169,6 +171,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -177,6 +180,7 @@ FactoryBot.define do
     form_state { "region" }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -186,6 +190,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -209,6 +214,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }
@@ -233,6 +239,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }
@@ -255,6 +262,7 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     intended_beneficiaries { nil }
+    gdi { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
           choose "No"
           click_button t("form.button.activity.submit")
-          expect(page).to have_current_path(activity_step_path(activity, :flow))
+          expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
         scenario "the user has the option of selecting other intended beneficiaries based on a reduced list depending on the region of the country selected" do
           visit activity_step_path(activity, :geography)
@@ -56,7 +56,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           click_button t("form.button.activity.submit")
           activity.reload
           expect(activity.intended_beneficiaries).to eq(["AR", "CO", "PE"])
-          expect(page).to have_current_path(activity_step_path(activity, :flow))
+          expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
 
         scenario "the user will not be able to select more than 10 intended beneficiaries" do

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -251,6 +251,14 @@ RSpec.feature "Users can create a fund level activity" do
 
         check "Haiti"
         click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.label.activity.gdi")
+
+        # Don't select a GDI
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.gdi.blank")
+
+        choose "No"
+        click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.label.activity.flow")
 
         # Flow has a default and can't be set to blank so we skip

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -486,6 +486,15 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
 
+  within(".gdi") do
+    click_on(t("default.link.edit"))
+    expect(page).to have_current_path(
+      activity_step_path(activity, :gdi)
+    )
+  end
+  click_on(t("default.link.back"))
+  click_on t("tabs.activity.details")
+
   within(".flow") do
     click_on(t("default.link.edit"))
     expect(page).to have_current_path(

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -447,6 +447,13 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when gdi is blank" do
+      subject(:activity) { build(:activity, gdi: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:gdi_step)).to be_falsey
+      end
+    end
+
     context "when flow is blank" do
       subject(:activity) { build(:activity, flow: nil) }
       it "should not be valid" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -253,6 +253,24 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#gdi" do
+    context "when gdi exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, gdi: "3")
+        result = described_class.new(activity).gdi
+        expect(result).to eql("Yes - China and India")
+      end
+    end
+
+    context "when the activity does not have a gdi set" do
+      it "returns nil" do
+        activity = build(:activity, gdi: nil)
+        result = described_class.new(activity)
+        expect(result.gdi).to be_nil
+      end
+    end
+  end
+
   describe "#flow" do
     context "when flow aid_type exists" do
       it "returns the locale value for the code" do

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe IngestIatiActivities do
       expect(activity.recipient_country).to be_nil
 
       expect(activity.intended_beneficiaries).to eql(["Replace me"])
+      expect(activity.gdi).to eql("Replace me")
       expect(activity.sector).to eql("43082")
       expect(activity.flow).to eql("10")
       expect(activity.aid_type).to eql("C01")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -29,6 +29,7 @@ module FormHelpers
     geography: "recipient_region",
     recipient_region: "Developing countries, unspecified",
     intended_beneficiaries: "Haiti",
+    gdi: "No",
     flow: "ODA",
     aid_type: "A01",
     oda_eligibility: "true",
@@ -163,6 +164,11 @@ module FormHelpers
     check intended_beneficiaries
     click_button t("form.button.activity.submit")
 
+    expect(page).to have_content t("form.label.activity.gdi")
+    expect(page).to have_content t("form.hint.activity.gdi")
+    choose "No"
+    click_button t("form.button.activity.submit")
+
     expect(page).to have_content t("form.label.activity.flow")
     expect(page.html).to include t("form.hint.activity.flow")
     select flow, from: "activity[flow]"
@@ -192,6 +198,7 @@ module FormHelpers
     end
     expect(page).to have_content recipient_region
     expect(page).to have_content intended_beneficiaries
+    expect(page).to have_content gdi
     expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
     expect(page).to have_content t("activity.oda_eligibility.#{oda_eligibility}")

--- a/vendor/data/codelists/IATI/2_03/activity/gdi.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/gdi.yml
@@ -1,0 +1,14 @@
+---
+attributes:
+  category-codelist:
+  name: gdi
+  complete: '1'
+data:
+  - code: '1'
+    name: Yes - China
+  - code: '2'
+    name: Yes - India
+  - code: '3'
+    name: Yes - China and India
+  - code: '4'
+    name: 'No'


### PR DESCRIPTION
Trello: https://trello.com/c/sjNZ0W6D

## Changes in this PR

`Global Development Impact (GDI)` policy is one of the new fields to be added to the create activity journey. This policy refocuses ODA funding when partnering with certain countries, such as China and India. This is a form step for internal BEIS use. It does not get reported to IATI.

This PR introduces the new form step, along with validations and tests, and a short-term solution for the ingest of this field in the existing data from the trackers.

## Screenshots of UI changes

### After

<img width="1166" alt="Screenshot 2020-09-08 at 09 40 25" src="https://user-images.githubusercontent.com/48016017/92453928-cda9fc00-f1b7-11ea-9774-0d25b29c55fa.png">

<img width="1166" alt="Screenshot 2020-09-08 at 09 41 02" src="https://user-images.githubusercontent.com/48016017/92453942-d3074680-f1b7-11ea-8e9f-cc88967c027b.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
