### PR TITLE
(906) Update activity policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,7 @@
   associated organisation. All Level B activities should belong to BEIS.
 - `GDI` form step added to create activity journey
 - Show Aid Type and Sector codes in Report CSV export for activities
+- Update activity policy to account for the report state
 
 ## [unreleased]
 
@@ -313,5 +314,3 @@
 [release-8]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-7...release-8
 [release-7]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-6...release-7
 [release-6]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-5...release-6
-[release-5]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-4...release-5
-[release-4]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-3...release-4

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,25 +1,43 @@
 class ActivityPolicy < ApplicationPolicy
   def show?
-    if record.level.blank?
-      return record.organisation == user.organisation
-    end
-
-    record.fund? && beis_user? ||
-      record.programme? ||
-      record.project? ||
-      record.third_party_project?
+    return true if beis_user?
+    return true if record.organisation == user.organisation
+    return true if record.programme? && record.extending_organisation_id == user.organisation.id
+    false
   end
 
   def create?
+    if beis_user?
+      return true if record.fund? || record.programme? || record.level.nil?
+    end
+    return false if editable_report_for_organisation.nil?
     record.organisation == user.organisation
+  end
+
+  def edit?
+    update?
   end
 
   def update?
-    record.organisation == user.organisation
+    return true if beis_user? && record.organisation == user.organisation
+
+    if delivery_partner_user?
+      return true if record.level.nil? && record.organisation == user.organisation
+      return true if record.parent.nil? && record.organisation == user.organisation
+
+      return false if record.organisation != user.organisation
+      return false if record.fund? || record.programme?
+      return false if editable_report_for_organisation_and_fund.nil?
+      return true
+    end
+    false
   end
 
   def redact_from_iati?
-    beis_user? && record.project? || record.third_party_project?
+    if beis_user?
+      return true if record.project? || record.third_party_project?
+    end
+    false
   end
 
   def destroy?
@@ -30,5 +48,14 @@ class ActivityPolicy < ApplicationPolicy
     def resolve
       scope.all
     end
+  end
+
+  private def editable_report_for_organisation
+    Report.find_by(organisation: record.organisation, state: [:active, :awaiting_changes])
+  end
+
+  private def editable_report_for_organisation_and_fund
+    fund = record.parent.associated_fund
+    Report.find_by(organisation: record.organisation, fund: fund, state: [:active, :awaiting_changes])
   end
 end

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -1,6 +1,6 @@
 class BudgetPolicy < ApplicationPolicy
   def create?
-    Pundit.policy!(user, record.parent_activity).create?
+    Pundit.policy!(user, record.parent_activity).edit?
   end
 
   def update?

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe "Users can create a budget" do
         project_activity = create(:project_activity,
           parent: programme_activity,
           organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: fund_activity)
 
         visit activities_path
 

--- a/spec/features/staff/users_can_create_a_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Users can create a project" do
     context "when viewing a programme" do
       scenario "a new project can be added to the programme" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         visit organisation_activity_children_path(programme.organisation, programme)
 
@@ -25,6 +26,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "a new project can be added when the program has no RODA identifier" do
         programme = create(:programme_activity, extending_organisation: user.organisation, roda_identifier_fragment: nil)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         visit organisation_activity_children_path(programme.organisation, programme)
         click_on(t("page_content.organisation.button.create_activity"))
@@ -39,6 +41,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "the activity saves its identifier as read-only `transparency_identifier`" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
         identifier = "a-project"
 
         visit activities_path
@@ -52,6 +55,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "project creation is tracked with public_activity" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         PublicActivity.with_tracking do
           visit organisation_activity_children_path(programme.organisation, programme)

--- a/spec/features/staff/users_can_create_a_third_party_project_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Users can create a project" do
     context "when viewing a project" do
       scenario "a new third party project can be added to the project" do
         project = create(:project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
 
         visit activities_path
 
@@ -26,6 +27,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "the activity saves its identifier as read-only `transparency_identifier`" do
         project = create(:project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
         identifier = "3rd-party-proj"
 
         visit activities_path
@@ -43,6 +45,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "third party project creation is tracked with public_activity" do
         project = create(:project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
 
         PublicActivity.with_tracking do
           visit activities_path

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Users can edit a budget" do
     scenario "a budget can be successfully edited" do
       activity = create(:project_activity, organisation: user.organisation)
       budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10")
+      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
@@ -47,6 +48,7 @@ RSpec.describe "Users can edit a budget" do
     scenario "budget update is tracked with public_activity" do
       activity = create(:project_activity, organisation: user.organisation)
       budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10")
+      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
       PublicActivity.with_tracking do
         visit organisation_activity_path(user.organisation, activity)
@@ -68,6 +70,7 @@ RSpec.describe "Users can edit a budget" do
     scenario "validation errors work as expected" do
       activity = create(:project_activity, organisation: user.organisation)
       budget = create(:budget, parent_activity: activity, budget_type: "1", value: "10")
+      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -300,6 +300,7 @@ RSpec.feature "Users can edit an activity" do
     context "when the activity is a project" do
       it "shows an update success message" do
         activity = create(:project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
         visit organisation_activity_details_path(activity.organisation, activity)
 
@@ -325,6 +326,7 @@ RSpec.feature "Users can edit an activity" do
 
         scenario "a RODA identifier can be added" do
           activity = create(:project_activity, organisation: user.organisation, parent: programme, roda_identifier_fragment: nil)
+          _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".roda_identifier") { click_on(t("default.link.add")) }
@@ -370,6 +372,7 @@ RSpec.feature "Users can edit an activity" do
     context "when the activity is a third-party project" do
       it "shows an update success message" do
         activity = create(:third_party_project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
         visit organisation_activity_details_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -2,6 +2,7 @@ RSpec.feature "Users can manage the implementing organisations" do
   context "when they are signed in as a delivery partner" do
     let(:delivery_partner) { create(:organisation) }
     let(:project) { create(:project_activity, organisation: delivery_partner) }
+    let!(:report) { create(:report, state: :active, organisation: delivery_partner, fund: project.associated_fund) }
 
     before { authenticate!(user: create(:delivery_partner_user, organisation: delivery_partner)) }
 
@@ -32,6 +33,7 @@ RSpec.feature "Users can manage the implementing organisations" do
     scenario "they can edit an implementing organisation" do
       other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
       project.implementing_organisations << other_public_sector_organisation
+      _report = create(:report, state: :active, organisation: project.organisation, fund: project.associated_fund)
 
       visit organisation_activity_details_path(project.organisation, project)
 

--- a/spec/features/staff/users_can_view_a_project_spec.rb
+++ b/spec/features/staff/users_can_view_a_project_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Users can view a project" do
     context "when viewing a programme" do
       scenario "links to the programmes projects" do
         fund = create(:fund_activity)
-        programme = create(:programme_activity)
+        programme = create(:programme_activity, extending_organisation: user.organisation)
         fund.child_activities << programme
         project = create(:project_activity, organisation: user.organisation)
         programme.child_activities << project

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Users can view activities" do
     end
 
     scenario "they do not see a Publish to Iati column & status against projects" do
-      programme = create(:programme_activity)
+      programme = create(:programme_activity, extending_organisation: user.organisation)
       project = create(:project_activity, organisation: user.organisation, parent: programme)
 
       visit activities_path
@@ -151,7 +151,7 @@ RSpec.feature "Users can view activities" do
 
     scenario "an activity can be viewed" do
       programme = create(:programme_activity, organisation: user.organisation)
-      activity = create(:project_activity, parent: programme)
+      activity = create(:project_activity, parent: programme, organisation: user.organisation)
 
       visit activities_path
 
@@ -188,7 +188,8 @@ RSpec.feature "Users can view activities" do
         activity = create(:project_activity, planned_start_date: Date.new(2020, 2, 3),
                                              planned_end_date: Date.new(2024, 6, 22),
                                              actual_start_date: Date.new(2020, 1, 2),
-                                             actual_end_date: Date.new(2020, 1, 29))
+                                             actual_end_date: Date.new(2020, 1, 29),
+                                             organisation: user.organisation)
 
         visit organisation_activity_path(user.organisation, activity)
         click_on t("tabs.activity.details")

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -253,7 +253,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "they do not see a Publish to Iati column & status against third-party projects" do
-      project = create(:project_activity)
+      project = create(:project_activity, organisation: user.organisation)
       third_party_project = create(:third_party_project_activity, parent: project)
 
       visit organisation_activity_children_path(project.organisation, project)

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -149,6 +149,7 @@ RSpec.feature "Users can view budgets on an activity page" do
       scenario "a delivery partner can edit/create a budget" do
         programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
         project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: project_activity.associated_fund)
 
         budget = create(:budget, parent_activity: project_activity)
 

--- a/spec/features/staff/users_can_view_third_party_projects_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_projects_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can view a third-party project" do
 
     scenario "can view a third-party project" do
       project = create(:project_activity, organisation: user.organisation)
-      third_party_project = create(:third_party_project_activity, parent: project)
+      third_party_project = create(:third_party_project_activity, parent: project, organisation: user.organisation)
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
@@ -24,6 +24,7 @@ RSpec.feature "Users can view a third-party project" do
       third_party_project = create(:third_party_project_activity, organisation: user.organisation)
       budget = create(:budget, parent_activity: third_party_project)
       transaction = create(:transaction, parent_activity: third_party_project)
+      _report = create(:report, state: :active, organisation: user.organisation, fund: third_party_project.associated_fund)
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -1,98 +1,237 @@
 require "rails_helper"
 
 RSpec.describe ActivityPolicy do
+  let(:report) { create(:report, organisation: user.organisation) }
   let(:user) { build_stubbed(:beis_user) }
+
   subject { described_class.new(user, activity) }
 
-  describe "#show?" do
-    context "when the activity doesn't have a level yet" do
-      context "and the user belongs to the authoring organisation" do
-        let(:activity) { create(:activity, :blank_form_state, level: nil, organisation: user.organisation) }
+  context "as a BEIS user" do
+    let(:user) { create(:beis_user) }
+    let(:activity) { CreateActivity.new(organisation_id: user.organisation.id).call }
+
+    it { is_expected.to permit_action(:create) }
+
+    context "when the activity has no level" do
+      let(:activity) { CreateActivity.new(organisation_id: create(:delivery_partner_organisation).id).call }
+
+      context "and the activity does not belong to the same organiasiton as the user" do
         it { is_expected.to permit_action(:show) }
+
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
 
-      context "and the user DOES NOT belong to the authoring organisation" do
-        let(:another_organisation) { create(:organisation) }
-        let(:activity) { create(:activity, :blank_form_state, level: nil, organisation: another_organisation) }
-        it { is_expected.to forbid_action(:show) }
+      context "and the activity belongs to the same organisation as the user" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:edit) }
+        it { is_expected.to permit_action(:update) }
+
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
 
-    context "when the user is a BEIS user" do
-      let(:user) { build_stubbed(:beis_user) }
-      context "when the activity is a fund" do
-        let(:activity) { create(:fund_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
 
-      context "when the activity is a programme" do
-        let(:activity) { create(:programme_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-
-      context "when the activity is a project" do
-        let(:activity) { create(:project_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-
-      context "when the activity is a third_party_project" do
-        let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-    end
-
-    context "when the user is not a BEIS user" do
-      let(:user) { build_stubbed(:delivery_partner_user) }
-      context "when the activity is a fund" do
-        let(:activity) { create(:fund_activity, organisation: user.organisation) }
-        it { is_expected.to forbid_action(:show) }
-      end
-
-      context "when the activity is a programme" do
-        let(:activity) { create(:programme_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-
-      context "when the activity is a project" do
-        let(:activity) { create(:project_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-
-      context "when the activity is a third_party_project" do
-        let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
-        it { is_expected.to permit_action(:show) }
-      end
-    end
-  end
-
-  describe "#create?" do
-    context "when the user belongs to the authoring organisation" do
-      let(:activity) { create(:activity, organisation: user.organisation) }
+      it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:create) }
-    end
-
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      it { is_expected.to forbid_action(:create) }
-    end
-  end
-
-  describe "#update?" do
-    context "when the user belongs to the authoring organisation" do
-      let(:activity) { create(:activity, organisation: user.organisation) }
+      it { is_expected.to permit_action(:edit) }
       it { is_expected.to permit_action(:update) }
+
+      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:redact_from_iati) }
     end
 
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:create) }
+      it { is_expected.to permit_action(:edit) }
+      it { is_expected.to permit_action(:update) }
+
+      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:redact_from_iati) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:redact_from_iati) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a third-party project" do
+      let(:activity) { create(:third_party_project_activity) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:redact_from_iati) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
     end
   end
 
-  describe "#destroy?" do
-    let(:activity) { create(:activity, organisation: user.organisation) }
-    it { is_expected.to forbid_action(:destroy) }
+  context "as a Delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    context "when the activity has no level" do
+      let(:activity) { create(:activity, :blank_form_state, level: nil) }
+
+      context "and does not belong to the same organiasiton as the user" do
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+
+      context "and belongs to the same organisation as the user" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:edit) }
+        it { is_expected.to permit_action(:update) }
+
+        it { is_expected.to forbid_action(:destroy) }
+      end
+    end
+
+    context "when the activity has a level but no parent" do
+      let(:activity) { create(:activity, :blank_form_state, level: :project) }
+
+      context "and does not belong to the same organiasiton as the user" do
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+
+      context "and belongs to the same organisation as the user" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:edit) }
+        it { is_expected.to permit_action(:update) }
+
+        it { is_expected.to forbid_action(:destroy) }
+      end
+    end
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity) }
+
+      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to forbid_action(:redact_from_iati) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity) }
+
+      context "and the users organisation is not the extending organisation" do
+        it { is_expected.to forbid_action(:show) }
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+        it { is_expected.to forbid_action(:redact_from_iati) }
+      end
+
+      context "and the users organisation is the extending organiation" do
+        before do
+          activity.update(extending_organisation: user.organisation)
+        end
+
+        it { is_expected.to permit_action(:show) }
+
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+        it { is_expected.to forbid_action(:redact_from_iati) }
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity) }
+
+      context "and the acitivty does not belong to the same organisation as the user" do
+        it { is_expected.to forbid_action(:show) }
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+        it { is_expected.to forbid_action(:redact_from_iati) }
+      end
+
+      context "and the acitivty belongs to the same organisation as the user" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        context "when there is no editable report for the users organisation" do
+          it { is_expected.to permit_action(:show) }
+
+          it { is_expected.to forbid_action(:create) }
+          it { is_expected.to forbid_action(:edit) }
+          it { is_expected.to forbid_action(:update) }
+          it { is_expected.to forbid_action(:destroy) }
+          it { is_expected.to forbid_action(:redact_from_iati) }
+        end
+
+        context "when there is an editable report for the users organisation" do
+          before do
+            report.update(state: :active)
+          end
+
+          context "and the associated fund is not the same as the activity" do
+            it { is_expected.to permit_action(:show) }
+
+            it { is_expected.to forbid_action(:edit) }
+            it { is_expected.to forbid_action(:update) }
+            it { is_expected.to forbid_action(:destroy) }
+            it { is_expected.to forbid_action(:redact_from_iati) }
+          end
+
+          context "and the associated fund is the same as the activity" do
+            before do
+              report.update(fund: activity.associated_fund)
+            end
+
+            it { is_expected.to permit_action(:show) }
+            it { is_expected.to permit_action(:create) }
+            it { is_expected.to permit_action(:edit) }
+            it { is_expected.to permit_action(:update) }
+
+            it { is_expected.to forbid_action(:destroy) }
+            it { is_expected.to forbid_action(:redact_from_iati) }
+          end
+        end
+      end
+    end
+
+    context "when the activity is a third-party project" do
+      let(:activity) { create(:third_party_project_activity) }
+
+      it { is_expected.to forbid_action(:redact_from_iati) }
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
This work started as trying to update the transaction policy but I soon realised it makes more sense to do the Activity policy first as Budgets, Transactions and PlannedDisbursments are all 'added to' an Activity.

The idea is to set out to make the policy spec document what actions a given user can perform on a given Activity under certain conditions.  The new condition here is the state of the 'current active report' but it turned out we have others that I hope have now been covered.

Activities are a bit wierd because they can be created without a level or parent activity, without which we have limited options for calculating the permissions, ultimately though, users should only edit activities that are 'owned' by their own organisation (through the `organisation` association) so this is general rule.

I've taken the stance that BEIS users can see everything and edit their own acitivites at any time - we have no concept of a 'internal BEIS report assurance' so this seems the only way to handle this right now.

For Delivery partners there are a lot of factors that influence what they can do and when, and the hope is that these are now documented in the spec…

The commit that introduces the policy changes breaks the test suite as lots of specs now need a report in the correct state to work correctly, I kept the fixes for these in a seperate commit. The fix used was to just setup a generic report with FactoryBot as I felt, generally speaking, a report in a spec setup will need the organisation and fund so further traits on the factory wouldn't be helpful.

We have more work to do after this, but I have more confidence now that changes cannot be made to the models even when the UI might be a bit behind and make it seem like you can.

We need to followup with at least updates to the transaction and planned disbursement policies, we should also look at how activites and budget relate to reports if possible.

Apologies for the first large commit - I found the metal agitlity to write the new spec hard to come by and wasn't able to also split the work at sensible points! 😞 

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
