### PR TITLE
(fix) Transaction and Planned disbursements can be added

### DIFF
--- a/app/policies/planned_disbursement_policy.rb
+++ b/app/policies/planned_disbursement_policy.rb
@@ -1,13 +1,13 @@
 class PlannedDisbursementPolicy < ApplicationPolicy
   def create?
     return false if record.parent_activity.fund? || record.parent_activity.programme?
-    Pundit.policy!(user, record.parent_activity).create? && !!associated_report&.active?
+    Pundit.policy!(user, record.parent_activity).create? && associated_report.present?
   end
 
   def update?
     return false if record.parent_activity.fund? || record.parent_activity.programme?
     return false if associated_report&.approved?
-    Pundit.policy!(user, record.parent_activity).update? && !!associated_report&.active?
+    Pundit.policy!(user, record.parent_activity).update? && associated_report.present?
   end
 
   def destroy?
@@ -20,6 +20,6 @@ class PlannedDisbursementPolicy < ApplicationPolicy
     parent_activity = record.parent_activity
     organisation = parent_activity.organisation
     fund = parent_activity.associated_fund
-    Report.find_by(organisation: organisation, fund: fund)
+    Report.find_by(organisation: organisation, fund: fund, state: [:active, :awaiting_changes])
   end
 end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -1,11 +1,11 @@
 class TransactionPolicy < ApplicationPolicy
   def create?
-    Pundit.policy!(user, record.parent_activity).create? && !!associated_report&.active?
+    Pundit.policy!(user, record.parent_activity).create? && associated_report.present?
   end
 
   def update?
     return false if associated_report&.approved?
-    Pundit.policy!(user, record.parent_activity).update? && !!associated_report&.active?
+    Pundit.policy!(user, record.parent_activity).update? && associated_report.present?
   end
 
   def destroy?
@@ -18,6 +18,6 @@ class TransactionPolicy < ApplicationPolicy
     parent_activity = record.parent_activity
     organisation = parent_activity.organisation
     fund = parent_activity.associated_fund
-    Report.find_by(organisation: organisation, fund: fund)
+    Report.find_by(organisation: organisation, fund: fund, state: [:active, :awaiting_changes])
   end
 end


### PR DESCRIPTION
## Changes in this PR
When there are more than one reports for an organisation and fund we can
be in the position that the policies for transactions and planned
disbursements stop them from being created.

We have work planned to refactor both of these policies, but we also
have a need to add some today for a training session.

To fix the issue short term we make the associated_report only return
reports that are in the editable state of either active or awaiting
changes and not any state that has potential to return reports in other
states that would stop the transactions being added.

This work does not replace the refactor, merely enables us to run
training session today (10 Sep 2020)

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
