### PR TITLE
(1002) Show the deadline on the report edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,7 @@
 ## [unreleased]
 - New reports are created when the prior is approved
 - `Total applications` and `Total awards` form step added to create activity journey
+- Report deadline value is shown on the edit form
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -32,22 +32,22 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def edit
-    report = Report.find(id)
-    authorize report
+    @report = Report.find(id)
+    authorize @report
 
-    @report_presenter = ReportPresenter.new(report)
+    @report_presenter = ReportPresenter.new(@report)
   end
 
   def update
-    report = Report.find(id)
-    authorize report
+    @report = Report.find(id)
+    authorize @report
 
-    @report_presenter = ReportPresenter.new(report)
+    @report_presenter = ReportPresenter.new(@report)
 
-    report.assign_attributes(report_params)
-    if report.valid?
-      report.save!
-      report.create_activity key: "report.update", owner: current_user
+    @report.assign_attributes(report_params)
+    if @report.valid?
+      @report.save!
+      @report.create_activity key: "report.update", owner: current_user
       flash[:notice] = t("action.report.update.success")
       redirect_to reports_path
     else

--- a/app/views/staff/reports/_form.html.haml
+++ b/app/views/staff/reports/_form.html.haml
@@ -1,15 +1,15 @@
 = f.govuk_error_summary
 .govuk-form-group
   = label_tag "organisation", t("form.label.report.organisation"), class: "govuk-label"
-  = content_tag :p, f.object.organisation.name, class: "govuk-body", id: "organisation"
+  = content_tag :p, report_presenter.organisation.name, class: "govuk-body", id: "organisation"
 
 .govuk-form-group
   = label_tag "financial-quarter-and_year", t("form.label.report.financial_quarter_and_year"), class: "govuk-label"
-  = content_tag :p, f.object.financial_quarter_and_year, class: "govuk-body", id: "finacial-quarter-and-year"
+  = content_tag :p, report_presenter.financial_quarter_and_year, class: "govuk-body", id: "finacial-quarter-and-year"
 
 .govuk-form-group
   = label_tag "level-a-activity", t("form.label.report.level_a_activity"), class: "govuk-label"
-  = content_tag :p, f.object.fund.title, class: "govuk-body", id: "level-a-acitivty"
+  = content_tag :p, report_presenter.fund.title, class: "govuk-body", id: "level-a-activity"
 
 = f.govuk_text_field :description
 = f.govuk_date_field :deadline, legend: {  size: "s" }

--- a/app/views/staff/reports/edit.html.haml
+++ b/app/views/staff/reports/edit.html.haml
@@ -6,6 +6,5 @@
       %h1.govuk-heading-xl
         = t("page_title.report.edit")
 
-
-      = form_with model: @report_presenter, url: report_path(@report_presenter) do |f|
-        = render partial: "form", locals: { f: f }
+      = form_with model: @report do |f|
+        = render partial: "form", locals: { f: f, report_presenter: @report_presenter }

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -24,7 +24,11 @@ RSpec.feature "BEIS users can edit a report" do
       expect(page).to have_content t("action.report.update.success")
       within "##{report.id}" do
         expect(page).to have_content("31 Jan 2021")
+        click_on t("default.link.edit")
       end
+      expect(page).to have_field("report[deadline(1i)]", with: "2021")
+      expect(page).to have_field("report[deadline(2i)]", with: "1")
+      expect(page).to have_field("report[deadline(3i)]", with: "31")
     end
 
     scenario "editing a Report creates a log in PublicActivity" do


### PR DESCRIPTION
## Changes in this PR
When the financial year and quarter were added to the edit form as
read-only values we had to use a presenter rather than the report
itself.

Something about doing so stops the value of the deadline field showing
in the form. If we switch to the report object itself,everything works
as expected so we instead pass in the report presenter as a local to the
form partial and use that to render the financial quarter and year.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
