### PR TITLE
(994) Activity hierarchy levels displayed on UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,8 @@
 - New reports are created when the prior is approved
 - `Total applications` and `Total awards` form step added to create activity journey
 - Report deadline value is shown on the edit form
+- Change on hierarchy terminology to display activity levels A, B, C and D along with old terminology in the UI across the service
+- Update on the definitions for each level of activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -17,4 +17,8 @@ module ActivityHelper
     return parent.title if parent.fund? && user.delivery_partner?
     link_to parent.title, organisation_activity_path(parent.organisation, parent), {class: "govuk-link govuk-link--no-visited-state"}
   end
+
+  def custom_capitalisation(level)
+    "#{level.chars.first.upcase}#{level[1..-1]}"
+  end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -69,7 +69,7 @@ module FormHelper
     authorised_levels.keys.map do |level|
       OpenStruct.new(
         level: level,
-        name: I18n.t("page_content.activity.level.#{level}").capitalize,
+        name: custom_capitalisation(I18n.t("page_content.activity.level.#{level}")),
         description: I18n.t("form.hint.activity.level_step.#{level}")
       )
     end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -149,9 +149,9 @@ class Activity < ApplicationRecord
   def parent_level
     case level
     when "fund" then nil
-    when "programme" then "fund"
-    when "project" then "programme"
-    when "third_party_project" then "project"
+    when "programme" then "fund (level A)"
+    when "project" then "programme (level B)"
+    when "third_party_project" then "project (level C)"
     end
   end
 

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -2,6 +2,7 @@
 
 class ActivityPresenter < SimpleDelegator
   include CodelistHelper
+  include ActivityHelper
 
   def aid_type
     return if super.blank?
@@ -119,7 +120,8 @@ class ActivityPresenter < SimpleDelegator
 
   def level
     return if super.blank?
-    I18n.t("page_content.activity.level.#{super}").capitalize
+    activity_level = I18n.t("page_content.activity.level.#{super}")
+    custom_capitalisation(activity_level)
   end
 
   def link_to_roda

--- a/app/views/staff/activity_forms/purpose.html.haml
+++ b/app/views/staff/activity_forms/purpose.html.haml
@@ -1,7 +1,7 @@
 = render layout: "wrapper" do |f|
   = f.govuk_fieldset legend: { text: t("form.legend.activity.purpose", level: t("page_content.activity.level.#{f.object.level}")), tag: :h1, size: "xl" } do
     = f.govuk_text_field :title,
-      label: { text: t("form.label.activity.title", level: t("page_content.activity.level.#{f.object.level}")).capitalize },
+      label: { text: t("form.label.activity.title", level: custom_capitalisation(t("page_content.activity.level.#{f.object.level}"))) },
       hint_text: t("form.hint.activity.title", level: t("page_content.activity.level.#{f.object.level}"))
 
     = f.govuk_text_area :description, rows: 5

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -52,7 +52,7 @@
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
-      = t("summary.label.activity.title", level: activity_presenter.level).capitalize
+      = custom_capitalisation(t("summary.label.activity.title", level: activity_presenter.level))
     %dd.govuk-summary-list__value
       = activity_presenter.title
     %dd.govuk-summary-list__actions

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -92,10 +92,10 @@ en:
         title: A short title that explains the purpose of the %{level}
         level: Select the type of activity
         level_step:
-          fund: Total fund allocation to BEIS from the Treasury
-          programme: Breakdown of funds to delivery partners from BEIS. This is confirmed in the allocation letter or in the memorandum of understanding (MOU). For example, how a £50m fund will be allocated to different activities or spending
-          project: Records a set of activities of a delivery partner and details of how the money is forecast and/or spent. A delivery partner can record if it plans to award to third parties or a delivery partner could spend these funds on its own activities. For example, on workshops
-          third_party_project: How funding from delivery partners to third parties like universities and research institutes is forecast and spent. For example, spending on 10 research grants of £500k totalling £5m
+          fund: The amount of funding each delivery partner will receive
+          programme: A breakdown of each delivery partner's funding detailed and confirmed in allocation letters and MOUs
+          project: The activities of a delivery partner and details of how the funding is forecast and spent
+          third_party_project: The activities of third parties such as universities and how the funding is forecast and spent
         parent: Which existing %{parent_level} will this new %{level} belong to?
         total_applications: You can enter 0 if this field is not applicable at the moment
         total_awards: You can enter 0 if this field is not applicable at the moment

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -131,7 +131,7 @@ en:
         planned_end_date: Planned end date
         planned_start_date: Planned start date
         programme_status: Activity status
-        projects: Projects
+        projects: Projects (level C)
         recipient_country: Recipient country
         recipient_region: Recipient region
         requires_additional_benefitting_countries: Other benefitting countries?
@@ -139,7 +139,7 @@ en:
         sector_category: Focus area category
         stage: Stage
         status: Status
-        third_party_projects: Third-party projects
+        third_party_projects: Third-party projects (level D)
         title: '%{level} name'
         publish_to_iati:
           label: Publish to IATI?
@@ -160,10 +160,10 @@ en:
     body:
       activity:
         level:
-          fund: Fund
-          programme: Programme
-          project: Project
-          third_party_project: Third-party project
+          fund: Fund (level A)
+          programme: Programme (level B)
+          project: Project (level C)
+          third_party_project: Third-party project (level D)
         view_activity: View
   filters:
     activity:
@@ -185,21 +185,21 @@ en:
         button:
           edit: Choose extending organisation
         heading: Extending organisation
-        hint: The extending organisation will be able to create and report project information against this programme
+        hint: The extending organisation will be able to create and report project (level C) information against this programme (level B)
       implementing_organisation:
         button:
           new: Add implementing organisation
         heading: Implementing organisations
       level:
-        fund: fund
-        programme: programme
-        project: project
-        third_party_project: third-party project
+        fund: fund (level A)
+        programme: programme (level B)
+        project: project (level C)
+        third_party_project: third-party project (level D)
       planned_disbursements: Forecasted spend
-      projects: Projects
+      projects: Projects (level C)
       recipient_country:
         default_selection_value: Select a recipient country
-      third_party_projects: Third-party projects
+      third_party_projects: Third-party projects (level D)
       transactions: Transactions
   tabs:
     activity:
@@ -271,10 +271,10 @@ en:
               blank: Enter a unique identifier
             roda_identifier_fragment:
               invalid_characters: Must contain only letters, digits, dashes, underscores and slashes
-              level_a_too_long: Fund identifiers must be at most %{limit} characters long
-              level_b_too_long: This programme's identifier must be at most %{limit} characters long
-              level_c_too_long: This project's identifier must be at most %{limit} characters long
-              level_d_too_long: This third-party project's identifier must be at most %{limit} characters long
+              level_a_too_long: Fund's (level A) identifiers must be at most %{limit} characters long
+              level_b_too_long: This programme's (level B) identifier must be at most %{limit} characters long
+              level_c_too_long: This project's (level C) identifier must be at most %{limit} characters long
+              level_d_too_long: This third-party project's (level D) identifier must be at most %{limit} characters long
             title:
               blank: Enter a title
             description:

--- a/config/locales/models/fund.en.yml
+++ b/config/locales/models/fund.en.yml
@@ -3,9 +3,9 @@ en:
   action:
     fund:
       create:
-        success: Fund successfully created
+        success: Fund (level A) successfully created
       update:
-        success: Fund successfully updated
+        success: Fund (level A) successfully updated
   table:
     header:
       fund:

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -52,10 +52,10 @@ en:
         third-party-projects:
           explanation: Download all third-party project (level D) activities for this organisation as XML
         title: Download as XML
-      funds: Funds
-      programmes: Programmes
-      projects: Projects
-      third_party_projects: Third-party projects
+      funds: Funds (level A)
+      programmes: Programmes (level B)
+      projects: Projects (level C)
+      third_party_projects: Third-party projects (level D)
   page_title:
     organisation:
       edit: Edit organisation

--- a/config/locales/models/programme.en.yml
+++ b/config/locales/models/programme.en.yml
@@ -3,12 +3,12 @@ en:
   action:
     programme:
       create:
-        success: Programme successfully created
+        success: Programme (level B) successfully created
       update:
-        success: Programme successfully updated
+        success: Programme (level B) successfully updated
   table:
     header:
       programme:
         title: Title
         identifier: Identifier
-        fund: Fund
+        fund: Fund (level A)

--- a/config/locales/models/project.en.yml
+++ b/config/locales/models/project.en.yml
@@ -3,12 +3,12 @@ en:
   action:
     project:
       create:
-        success: Project successfully created
+        success: Project (level C) successfully created
       update:
-        success: Project successfully updated
+        success: Project (level C) successfully updated
   table:
     header:
       project:
         title: Title
         identifier: Identifier
-        programme: Programme
+        programme: Programme (level B)

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -15,7 +15,7 @@ en:
         state: State
         description: Description
         organisation: Organisation
-        fund: Level A
+        fund: Fund (level A)
         deadline: Deadline
     body:
       report:
@@ -37,11 +37,11 @@ en:
     label:
       report:
         description: Report description
-        fund: Level A
+        fund: Fund (level A)
         organisation: Organisation
         state: State
         deadline: Deadline
-        level_a_activity: Level A
+        level_a_activity: Fund (level A)
         financial_quarter_and_year: Financial quarter
     legend:
       report:
@@ -125,7 +125,7 @@ en:
             description:
               blank: Reporting period can't be blank
             fund:
-              level: Activity must be a fund-level Activity
+              level: Activity must be a Fund (level A) activity
             deadline:
               not_in_past: The deadline must be a date in the future
               between: Date must be between %{min} years ago and %{max} years in the future

--- a/config/locales/models/third_party_project.en.yml
+++ b/config/locales/models/third_party_project.en.yml
@@ -3,12 +3,12 @@ en:
   action:
     third_party_project:
       create:
-        success: Third-party project successfully created
+        success: Third-party project (level D) successfully created
       update:
-        success: Third-party project successfully updated
+        success: Third-party project (level D) successfully updated
   table:
     header:
       third_party_project:
         title: Title
         identifier: Identifier
-        project: Project
+        project: Project (level C)

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -171,8 +171,8 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[roda_identifier_fragment]", with: identifier
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("form.legend.activity.purpose", level: "programme")
-        expect(page).to have_content t("form.hint.activity.title", level: "programme")
+        expect(page).to have_content custom_capitalisation(t("form.legend.activity.purpose", level: "programme (level B)"))
+        expect(page).to have_content t("form.hint.activity.title", level: "programme (level B)")
 
         # Don't provide a title and description
         click_button t("form.button.activity.submit")
@@ -184,7 +184,7 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[description]", with: Faker::Lorem.paragraph
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("form.legend.activity.sector_category", level: "programme")
+        expect(page).to have_content t("form.legend.activity.sector_category", level: "programme (level B)")
 
         # Don't provide a sector category
         click_button t("form.button.activity.submit")
@@ -193,14 +193,14 @@ RSpec.feature "Users can create a fund level activity" do
         choose "Basic Education"
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("form.legend.activity.sector", sector_category: "Basic Education", level: "programme")
+        expect(page).to have_content t("form.legend.activity.sector", sector_category: "Basic Education", level: "programme (level B)")
         # Don't provide a sector
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("activerecord.errors.models.activity.attributes.sector.blank")
 
         choose "Primary education"
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("form.legend.activity.programme_status", level: "programme")
+        expect(page).to have_content t("form.legend.activity.programme_status", level: "programme (level B)")
 
         # Don't provide a programme status
         click_button t("form.button.activity.submit")
@@ -208,7 +208,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose("activity[programme_status]", option: "07")
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("page_title.activity_form.show.dates", level: "programme")
+        expect(page).to have_content t("page_title.activity_form.show.dates", level: "programme (level B)")
 
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("activerecord.errors.models.activity.attributes.dates")

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can manage Sectors" do
         click_button t("form.button.activity.submit")
 
         expect(page).to have_current_path(activity_step_path(activity, :sector))
-        expect(page).to have_content t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{activity.reload.sector_category}"), level: activity.level)
+        expect(page).to have_content t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{activity.reload.sector_category}"), level: "fund (level A)")
       end
     end
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -103,4 +103,13 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
   end
+
+  describe "#custom_capitalisation" do
+    context "when a string needs to be presented with the first letter of the first word upcased" do
+      it "takes that string, upcases that letter and leaves the rest of the string as it is" do
+        sample_string = "programme (level B)"
+        expect(custom_capitalisation(sample_string)).to eql("Programme (level B)")
+      end
+    end
+  end
 end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe FormHelper, type: :helper do
         expect(result).to eq([
           OpenStruct.new(
             level: "fund",
-            name: "Fund",
+            name: "Fund (level A)",
             description: t("form.hint.activity.level_step.fund"),
           ),
           OpenStruct.new(
             level: "programme",
-            name: "Programme",
+            name: "Programme (level B)",
             description: t("form.hint.activity.level_step.programme"),
           ),
         ])
@@ -89,8 +89,8 @@ RSpec.describe FormHelper, type: :helper do
         it "tells Pundit to return only the levels of activity a user can create or update" do
           user = create(:delivery_partner_user)
           result = helper.create_activity_level_options(user: user)
-          expect(result.detect { |options| options.name.eql?("Project") }).to be_truthy
-          expect(result.detect { |options| options.name.eql?("Third-party project") }).to be_truthy
+          expect(result.detect { |options| options.name.eql?("Project (level C)") }).to be_truthy
+          expect(result.detect { |options| options.name.eql?("Third-party project (level D)") }).to be_truthy
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -758,21 +758,21 @@ RSpec.describe Activity, type: :model do
     context "when the level is a programme" do
       it "returns a string for fund" do
         result = described_class.new(level: :programme).parent_level
-        expect(result).to eql("fund")
+        expect(result).to eql("fund (level A)")
       end
     end
 
     context "when the level is a project" do
       it "returns a string for programme" do
         result = described_class.new(level: :project).parent_level
-        expect(result).to eql("programme")
+        expect(result).to eql("programme (level B)")
       end
     end
 
     context "when the level is a third-party project" do
       it "returns a string for project" do
         result = described_class.new(level: :third_party_project).parent_level
-        expect(result).to eql("project")
+        expect(result).to eql("project (level C)")
       end
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -390,30 +390,30 @@ RSpec.describe ActivityPresenter do
 
   describe "#level" do
     context "when the activity is a fund" do
-      it "returns the titelized version of the string" do
+      it "returns the custom_capitalisation version of the string" do
         fund = create(:fund_activity)
-        expect(described_class.new(fund).level).to eql("Fund")
+        expect(described_class.new(fund).level).to eql("Fund (level A)")
       end
     end
 
     context "when the activity is a programme" do
-      it "returns the titelized version of the string" do
+      it "returns the custom_capitalisation version of the string" do
         programme = create(:programme_activity)
-        expect(described_class.new(programme).level).to eql("Programme")
+        expect(described_class.new(programme).level).to eql("Programme (level B)")
       end
     end
 
     context "when the activity is a project" do
-      it "returns the titelized version of the string" do
+      it "returns the custom_capitalisation version of the string" do
         project = create(:project_activity)
-        expect(described_class.new(project).level).to eql("Project")
+        expect(described_class.new(project).level).to eql("Project (level C)")
       end
     end
 
     context "when the activity is a third_party_project" do
-      it "returns the titelized version of the string" do
+      it "returns the custom_capitalisation version of the string" do
         third_party_project = create(:third_party_project_activity)
-        expect(described_class.new(third_party_project).level).to eql("Third-party project")
+        expect(described_class.new(third_party_project).level).to eql("Third-party project (level D)")
       end
     end
   end

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -16,7 +16,7 @@ module ActivityHelpers
     expect(page).to have_content t("summary.label.activity.delivery_partner_identifier")
     expect(page).to have_content activity_presenter.delivery_partner_identifier
 
-    expect(page).to have_content t("summary.label.activity.title", level: activity_presenter.level).capitalize
+    expect(page).to have_content custom_capitalisation(t("summary.label.activity.title", level: activity_presenter.level))
     expect(page).to have_content activity_presenter.title
 
     expect(page).to have_content t("summary.label.activity.description")

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,4 +1,5 @@
 module FormHelpers
+  include ActivityHelper
   def fill_in_activity_form(
     delivery_partner_identifier: "A-Unique-Identifier",
     roda_identifier_fragment: "RODA-ID",
@@ -42,12 +43,12 @@ module FormHelpers
     expect(page).to have_content t("form.legend.activity.level")
     expect(page).to have_content t("form.hint.activity.level")
     expect(page).to have_content t("form.hint.activity.level_step.#{level}")
-    choose t("page_content.activity.level.#{level}").capitalize
+    choose custom_capitalisation(t("page_content.activity.level.#{level}"))
     click_button t("form.button.activity.submit")
 
     if parent.present?
-      expect(page).to have_content t("form.legend.activity.parent", parent_level: parent.level, level: t("page_content.activity.level.#{level}"))
-      expect(page).to have_content t("form.hint.activity.parent", parent_level: parent.level, level: t("page_content.activity.level.#{level}"))
+      expect(page).to have_content t("form.legend.activity.parent", parent_level: t("page_content.activity.level.#{level}", level: parent.level), level: t("page_content.activity.level.#{level}"))
+      expect(page).to have_content t("form.hint.activity.parent", parent_level: t("page_content.activity.level.#{parent.level}"), level: t("page_content.activity.level.#{level}"))
       choose parent.title
       click_button t("form.button.activity.submit")
     end
@@ -65,7 +66,7 @@ module FormHelpers
     end
 
     expect(page).to have_content t("form.legend.activity.purpose", level: activity_level(level))
-    expect(page).to have_content t("form.label.activity.title", level: activity_level(level).humanize)
+    expect(page).to have_content custom_capitalisation(t("form.label.activity.title", level: activity_level(level)))
     expect(page).to have_content t("form.label.activity.description")
     fill_in "activity[title]", with: title
     fill_in "activity[description]", with: description


### PR DESCRIPTION
Trello: https://trello.com/c/09vlNklC

## Changes in this PR

As a request from the client, in order to ensure consistency in how people view the service, we have updated the terminology for activity levels. They now show both the former terminology (`Fund`, `Programme`, `Project`, and `Third-party project`) along with their respective levels (A, B, C, and D), which the users are more familiar with.

This is only a change on the UI, mainly in the translation files, so we can still keep our code without causing much disruption at this moment.

This PR includes changes on the translation files, amendments on the specs, and a custom method for capitalisation when presenting the activity levels in some of the views. It also introduces the updated definitions for each activity level that will be displayed when users click on `Add activity` and choose the level of activity they want to create.

## Screenshots of UI changes

### Before

<img width="1291" alt="Screenshot 2020-09-11 at 10 04 32" src="https://user-images.githubusercontent.com/48016017/92917407-5d54e200-f426-11ea-9089-fd74dece767a.png">

<img width="1291" alt="Screenshot 2020-09-11 at 10 05 04" src="https://user-images.githubusercontent.com/48016017/92917424-62199600-f426-11ea-8922-15d043929984.png">

### After

<img width="1321" alt="Screenshot 2020-09-11 at 10 02 17" src="https://user-images.githubusercontent.com/48016017/92917469-6ba2fe00-f426-11ea-8d63-be35192d759d.png">

<img width="1182" alt="Screenshot 2020-09-11 at 10 01 35" src="https://user-images.githubusercontent.com/48016017/92917488-71004880-f426-11ea-932a-78011b9a643d.png">

<img width="1291" alt="Screenshot 2020-09-11 at 10 03 28" src="https://user-images.githubusercontent.com/48016017/92917520-79f11a00-f426-11ea-9f29-386c367c602a.png">

<img width="967" alt="Screenshot 2020-09-11 at 10 02 49" src="https://user-images.githubusercontent.com/48016017/92917541-7e1d3780-f426-11ea-8f8f-83432fd3e22b.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
