### PR TITLE
(982) Update transaction policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,7 @@
 - Change on hierarchy terminology to display activity levels A, B, C and D along with old terminology in the UI across the service
 - Update on the definitions for each level of activity
 - Updated transaction policy
+- Only show the edit transaction link when the transaction can be edited
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,7 @@
 - Report deadline value is shown on the edit form
 - Change on hierarchy terminology to display activity levels A, B, C and D along with old terminology in the UI across the service
 - Update on the definitions for each level of activity
+- Updated transaction policy
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,7 @@
 - Update on the definitions for each level of activity
 - Updated transaction policy
 - Only show the edit transaction link when the transaction can be edited
+- Only show the add transaction button when the activity can be edited
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,8 @@
 class Report < ApplicationRecord
   include PublicActivity::Common
 
+  EDITABLE_STATES = [:active, :awaiting_changes].freeze
+
   attr_readonly :financial_quarter, :financial_year
 
   validates_presence_of :description, on: :update

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -51,11 +51,11 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   private def editable_report_for_organisation
-    Report.find_by(organisation: record.organisation, state: [:active, :awaiting_changes])
+    Report.find_by(organisation: record.organisation, state: Report::EDITABLE_STATES)
   end
 
   private def editable_report_for_organisation_and_fund
     fund = record.parent.associated_fund
-    Report.find_by(organisation: record.organisation, fund: fund, state: [:active, :awaiting_changes])
+    Report.find_by(organisation: record.organisation, fund: fund, state: Report::EDITABLE_STATES)
   end
 end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -38,6 +38,6 @@ class TransactionPolicy < ApplicationPolicy
 
   private def editable_report_for_organisation_and_fund
     activity = record.parent_activity
-    Report.find_by(organisation: activity.organisation, fund: activity.associated_fund, state: [:active, :awaiting_changes])
+    Report.find_by(organisation: activity.organisation, fund: activity.associated_fund, state: Report::EDITABLE_STATES)
   end
 end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -1,23 +1,43 @@
 class TransactionPolicy < ApplicationPolicy
+  def show?
+    return true if beis_user?
+    record.parent_activity.organisation == user.organisation
+  end
+
   def create?
-    Pundit.policy!(user, record.parent_activity).create? && associated_report.present?
+    return false if record.parent_activity.level.nil?
+
+    if beis_user?
+      return true if record.parent_activity.fund? || record.parent_activity.programme?
+    end
+
+    if delivery_partner_user?
+      return true if editable_report_for_organisation_and_fund.present?
+    end
+
+    false
   end
 
   def update?
-    return false if associated_report&.approved?
-    Pundit.policy!(user, record.parent_activity).update? && associated_report.present?
+    return false if record.parent_activity.level.nil?
+
+    if beis_user?
+      return true if record.parent_activity.fund? || record.parent_activity.programme?
+    end
+
+    if delivery_partner_user? && editable_report_for_organisation_and_fund.present?
+      return true if editable_report_for_organisation_and_fund == record.report
+    end
+
+    false
   end
 
   def destroy?
-    Pundit.policy!(user, record.parent_activity).destroy?
+    false
   end
 
-  private
-
-  def associated_report
-    parent_activity = record.parent_activity
-    organisation = parent_activity.organisation
-    fund = parent_activity.associated_fund
-    Report.find_by(organisation: organisation, fund: fund, state: [:active, :awaiting_changes])
+  private def editable_report_for_organisation_and_fund
+    activity = record.parent_activity
+    Report.find_by(organisation: activity.organisation, fund: activity.associated_fund, state: [:active, :awaiting_changes])
   end
 end

--- a/app/views/staff/shared/activities/_transactions.html.haml
+++ b/app/views/staff/shared/activities/_transactions.html.haml
@@ -2,6 +2,6 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.transactions")
-    - if policy(activity).create?
+    - if policy(activity).edit?
       = link_to(t("page_content.transactions.button.create"), new_activity_transaction_path(activity), class: "govuk-button")
     = render partial: '/staff/shared/transactions/table', locals: { transactions: transaction_presenters }

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -29,5 +29,5 @@
           %td.govuk-table__cell= transaction.providing_organisation_name
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
-            - if policy(transaction).create?
+            - if policy(transaction).edit?
               = a11y_action_link(t('default.link.edit'), edit_activity_transaction_path(transaction.parent_activity_id, transaction), t("page_content.transactions.edit_noun"))

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -296,6 +296,15 @@ RSpec.feature "Users can create a transaction" do
         expect(transaction.report).to eq(report)
       end
     end
+
+    scenario "when the acitivity cannot be edited they cannot see the add transaction button" do
+      activity = create(:project_activity, organisation: user.organisation)
+      _report = create(:report, state: :inactive, organisation: activity.organisation, fund: activity.associated_fund)
+
+      visit organisation_activity_path(activity.organisation, activity)
+
+      expect(page).not_to have_link t("page_content.transactions.button.create"), href: new_activity_transaction_path(activity)
+    end
   end
 
   context "when they are a non-government delivery partner organisation user" do

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -67,4 +67,36 @@ RSpec.feature "Users can edit a transaction" do
       end
     end
   end
+
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    let(:activity) { create(:project_activity, organisation: user.organisation) }
+    let(:transaction) { create(:transaction, parent_activity: activity) }
+    let(:report) { create(:report, organisation: activity.organisation, fund: activity.associated_fund) }
+
+    before { authenticate!(user: user) }
+
+    context "when the transaction can be edited" do
+      before do
+        transaction.update(report: report)
+        report.update(state: :active)
+      end
+
+      scenario "shows the edit link" do
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).to have_link t("default.link.edit"), href: edit_activity_transaction_path(activity, transaction)
+      end
+    end
+
+    context "when the transaction cannot be edited" do
+      before { report.update(state: :active) }
+
+      scenario "does not show the edit link" do
+        visit organisation_activity_path(activity.organisation, activity)
+
+        expect(page).not_to have_link t("default.link.edit"), href: edit_activity_transaction_path(activity, transaction)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
Inline with the report and activity policy this PR updates the Transaction policy. We take the same approach where we test the policy thoroughly and try to use the spec to document to developers under which conditions a transation can be added or edited.

The UI is then updated to reflect the new policy by showning add and edit UI elements only when they can be used.

I added `EDITABLE_STATES` to the Report model as we have started to use this in multiple places and it feels safer and neater to define which states are considered editable in the Report model instead of when they get used.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
