### PR TITLE
(1010) BEIS users can add entities to activities without a report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,7 @@
   can be edited
 - Only show the add planned disbursement button when the activity can be edited
 - BEIS users can add transactions regardless of report state
+- BEIS users can add planned disbursements regardless of report state
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,7 @@
 - Only show the edit planned disbursement link then it the planned disbursement
   can be edited
 - Only show the add planned disbursement button when the activity can be edited
+- BEIS users can add transactions regardless of report state
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -5,8 +5,9 @@ class PlannedDisbursement < ApplicationRecord
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"
-  belongs_to :report
+  belongs_to :report, optional: true
 
+  validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :planned_disbursement_type,
     :period_start_date,
     :currency,

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,8 +4,9 @@ class Transaction < ApplicationRecord
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"
-  belongs_to :report
+  belongs_to :report, optional: true
 
+  validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :description,
     :transaction_type,
     :date,

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -9,9 +9,12 @@ class CreatePlannedDisbursement
     planned_disbursement = PlannedDisbursement.new
 
     planned_disbursement.parent_activity = activity
-    planned_disbursement.report = report
     planned_disbursement.assign_attributes(attributes)
     planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
+
+    unless activity.organisation.service_owner?
+      planned_disbursement.report = report(activity: activity)
+    end
 
     result = if planned_disbursement.valid?
       Result.new(planned_disbursement.save, planned_disbursement)
@@ -28,7 +31,7 @@ class CreatePlannedDisbursement
     Monetize.parse(value)
   end
 
-  def report
+  def report(activity:)
     organisation = activity.organisation
     fund = activity.associated_fund
     Report.active.find_by(organisation: organisation, fund: fund)

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -10,8 +10,11 @@ class CreateTransaction
 
     transaction.parent_activity = activity
     transaction.assign_attributes(attributes)
-    transaction.report = report(activity: activity)
     transaction.value = sanitize_monetary_string(value: attributes[:value])
+
+    unless activity.organisation.service_owner?
+      transaction.report = report(activity: activity)
+    end
 
     result = if transaction.valid?
       Result.new(transaction.save, transaction)

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -1,11 +1,31 @@
 require "rails_helper"
 
 RSpec.describe PlannedDisbursement, type: :model do
+  let(:activity) { build(:activity) }
+
   describe "validations" do
     it { should validate_presence_of(:planned_disbursement_type) }
     it { should validate_presence_of(:period_start_date) }
     it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:value) }
+
+    context "when the activity belongs to a delivery partner organisation" do
+      before { activity.update(organisation: build_stubbed(:delivery_partner_organisation)) }
+
+      it "should validate the prescence of report" do
+        transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
+        expect(transaction.valid?).to be false
+      end
+    end
+
+    context "when the activity belongs to BEIS" do
+      before { activity.update(organisation: build_stubbed(:beis_organisation)) }
+
+      it "should not validate the prescence of report" do
+        transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
+        expect(transaction.valid?).to be true
+      end
+    end
   end
 
   describe "#unknown_receiving_organisation_type?" do
@@ -16,10 +36,6 @@ RSpec.describe PlannedDisbursement, type: :model do
       planned_disbursement.update(receiving_organisation_type: "10")
       expect(planned_disbursement.unknown_receiving_organisation_type?).to be false
     end
-  end
-
-  describe "associations" do
-    it { should belong_to(:report) }
   end
 
   describe "sanitation" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -14,10 +14,24 @@ RSpec.describe Transaction, type: :model do
     it { should validate_presence_of(:providing_organisation_type) }
     it { should validate_presence_of(:receiving_organisation_name) }
     it { should validate_presence_of(:receiving_organisation_type) }
-  end
 
-  describe "associations" do
-    it { should belong_to(:report) }
+    context "when the activity belongs to a delivery partner organisation" do
+      before { activity.update(organisation: build_stubbed(:delivery_partner_organisation)) }
+
+      it "should validate the prescence of report" do
+        transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
+        expect(transaction.valid?).to be false
+      end
+    end
+
+    context "when the activity belongs to BEIS" do
+      before { activity.update(organisation: build_stubbed(:beis_organisation)) }
+
+      it "should not validate the prescence of report" do
+        transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
+        expect(transaction.valid?).to be true
+      end
+    end
   end
 
   describe "sanitation" do

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe CreateTransaction do
       end
     end
 
+    context "when the activity belongs to BEIS" do
+      it "does not set the report" do
+        activity.update(organisation: build_stubbed(:beis_organisation))
+        result = described_class.new(activity: activity).call
+        expect(result.object.report).to be_nil
+      end
+    end
+
+    context "when the activity belongs to a delivery partner organisation" do
+      it "does set the report" do
+        activity.update(organisation: build_stubbed(:delivery_partner_organisation))
+        editable_report_for_activity = create(:report, state: :active, organisation: activity.organisation, fund: activity.associated_fund)
+        result = described_class.new(activity: activity).call
+        expect(result.object.report).to eql editable_report_for_activity
+      end
+    end
+
     context "when attributes are passed in" do
       it "sets the attributes passed in as transaction attributes" do
         attributes = ActionController::Parameters.new(description: "foo").permit!


### PR DESCRIPTION
BEIS users should be able to add transactions and planned disbursements
to an activity when there is no editable report for the activity. Because the report
association is required they cannot as the object is considered invalid.

Make the association optional but validate the presence of the value if
the activity is for a delivery partner.

This change removes the shoulda spec for the report association as it
is now covered by the validations spec i.e. we check that the
association is set or not based on the activity organisation.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
