### PR TITLE
(996) Update activity financials view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,8 @@
 - Only show the add planned disbursement button when the activity can be edited
 - BEIS users can add transactions regardless of report state
 - BEIS users can add planned disbursements regardless of report state
+- Update the activity financials view to show all financials on all levels
+  except Funds (Level A)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -38,17 +38,13 @@
             = t("page_title.activity.financials")
 
           - if @activity.fund? && policy(:fund).create?
-            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+            = render partial: "staff/shared/activities/budgets",
+              locals: { activity: @activity, budget_presenters: @budget_presenters }
 
-          - if @activity.programme?
-            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-
-          - if @activity.programme? && policy(:programme).create?
-            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
-
-
-          - if @activity.project? || @activity.third_party_project?
-            = render partial: "staff/shared/activities/budgets", locals: { activity: @activity, budget_presenters: @budget_presenters }
-            = render partial: "staff/shared/activities/planned_disbursements", locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
-            = render partial: "staff/shared/activities/transactions", locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+          - else
+            = render partial: "staff/shared/activities/budgets",
+              locals: { activity: @activity, budget_presenters: @budget_presenters }
+            = render partial: "staff/shared/activities/planned_disbursements",
+              locals: { activity: @activity, planned_disbursements: @planned_disbursement_presenters }
+            = render partial: "staff/shared/activities/transactions",
+              locals: { activity: @activity, transaction_presenters: @transaction_presenters }

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can create a transaction" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
-      activity = create(:fund_activity)
+      activity = create(:programme_activity)
       visit organisation_activity_path(activity.organisation, activity)
       expect(current_path).to eq(root_path)
     end
@@ -12,7 +12,7 @@ RSpec.feature "Users can create a transaction" do
     let(:user) { create(:beis_user) }
 
     scenario "successfully creates a transaction on an activity" do
-      activity = create(:fund_activity, :with_report, organisation: user.organisation)
+      activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
       visit activities_path
 
@@ -26,7 +26,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "transaction creation is tracked with public_activity" do
-      activity = create(:fund_activity, :with_report, organisation: user.organisation)
+      activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
       PublicActivity.with_tracking do
         visit activities_path
@@ -46,7 +46,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "validations" do
-      activity = create(:fund_activity, :with_report, organisation: user.organisation)
+      activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
       visit activities_path
 
@@ -65,7 +65,7 @@ RSpec.feature "Users can create a transaction" do
     end
 
     scenario "disbursement channel is optional" do
-      activity = create(:fund_activity, :with_report, organisation: user.organisation)
+      activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
       visit activities_path
 
@@ -80,7 +80,7 @@ RSpec.feature "Users can create a transaction" do
 
     context "Value number validation" do
       scenario "Value must be maximum 99,999,999,999" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -102,7 +102,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "Value cannot be 0" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -124,7 +124,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "Value can be negative" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -148,7 +148,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes a pound sign" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -162,7 +162,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes alphabetical characters" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -176,7 +176,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes decimal places" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -190,7 +190,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the value includes commas" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -206,7 +206,7 @@ RSpec.feature "Users can create a transaction" do
 
     context "Date validation" do
       scenario "When the date is in the future" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -220,7 +220,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the date is in the past" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -235,7 +235,7 @@ RSpec.feature "Users can create a transaction" do
       end
 
       scenario "When the date is nil" do
-        activity = create(:fund_activity, :with_report, organisation: user.organisation)
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit activities_path
 
@@ -263,7 +263,6 @@ RSpec.feature "Users can create a transaction" do
 
       visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-      expect(page).not_to have_content(t("page_content.activity.transactions"))
       expect(page).not_to have_content(t("page_content.transactions.button.create"))
     end
 

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -9,11 +9,11 @@ RSpec.feature "Users can edit a transaction" do
   context "when the user belongs to BEIS" do
     before { authenticate!(user: user) }
     let(:user) { create(:beis_user) }
-    let!(:activity) { create(:fund_activity, organisation: user.organisation) }
-    let(:report) { create(:report, :active, organisation: user.organisation, fund: activity) }
+    let!(:activity) { create(:programme_activity, organisation: user.organisation) }
+    let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
     let!(:transaction) { create(:transaction, parent_activity: activity, report: report) }
 
-    scenario "editing a transaction on a fund" do
+    scenario "editing a transaction on a programme" do
       visit activities_path
 
       click_on(activity.title)

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -156,7 +156,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "the activity financials can be viewed" do
-      activity = create(:activity, organisation: user.organisation)
+      activity = create(:programme_activity, organisation: user.organisation)
       transaction = create(:transaction, parent_activity: activity)
       budget = create(:budget, parent_activity: activity)
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -6,11 +6,11 @@ RSpec.feature "Users can view transactions on an activity page" do
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
 
-    context "when the activity is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
-      let(:other_activity) { create(:fund_activity, organisation: user.organisation) }
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      let(:other_activity) { create(:programme_activity, organisation: user.organisation) }
 
-      scenario "only transactions belonging to this fund activity are shown on the Activity#show page" do
+      scenario "only transactions belonging to this programme activity are shown on the Activity#show page" do
         transaction = create(:transaction, parent_activity: activity, value: "100")
         other_transaction = create(:transaction, parent_activity: other_activity, value: "200")
 


### PR DESCRIPTION
## Changes in this PR

Programmes, Projects and Third-party projects (levels B, C and D) all
have Budgets, Forecasts and Actuals (planned disbursements and
transactions).

Funds (Level A) only have budgets.

The UI should reflect this.

Please note you won't be able to add transactions or planned disbursements unless there is an editabe report or #640 is merged for BEIS users.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
