### PR TITLE
(911) Users can view budgets added in a report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,7 @@
   The comments are exported to the report CSV
 - For delivery partners, Budgets relate to the report that creates them
 - Ingest can handle the new budget/report relationship
+- Update the budget policy
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,7 @@
 - Delivery partners can create & update comments associated to an activity & a report
   The comments are exported to the report CSV
 - For delivery partners, Budgets relate to the report that creates them
+- Ingest can handle the new budget/report relationship
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,7 @@
 - Ingest can handle the new budget/report relationship
 - Update the budget policy
 - Report variance is shown in a tab
+- Show budgets added in a report on the reports view
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,7 @@
 - For delivery partners, Budgets relate to the report that creates them
 - Ingest can handle the new budget/report relationship
 - Update the budget policy
+- Report variance is shown in a tab
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,7 @@
   except Funds (Level A)
 - Delivery partners can create & update comments associated to an activity & a report
   The comments are exported to the report CSV
+- For delivery partners, Budgets relate to the report that creates them
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/controllers/staff/report_budgets_controller.rb
+++ b/app/controllers/staff/report_budgets_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Staff::ReportBudgetsController < Staff::BaseController
+  include Secured
+
+  def show
+    @report = Report.find(params["report_id"])
+    authorize @report
+
+    @report_presenter = ReportPresenter.new(@report)
+    budgets_for_this_report = Budget.where(report: @report)
+
+    @budgets = budgets_for_this_report.map { |activity| BudgetPresenter.new(activity) }
+
+    render "staff/reports/budgets"
+  end
+end

--- a/app/controllers/staff/report_variance_controller.rb
+++ b/app/controllers/staff/report_variance_controller.rb
@@ -8,14 +8,9 @@ class Staff::ReportVarianceController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = level_c_and_d_activities_for_report(report: @report)
+    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
 
     @activities = @report_activities.map { |activity| ActivityPresenter.new(activity) }
     render "staff/reports/variance"
-  end
-
-  private def level_c_and_d_activities_for_report(report:)
-    return Activity.none if report.nil?
-    Activity.where(level: [:project, :third_party_project], organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
   end
 end

--- a/app/controllers/staff/report_variance_controller.rb
+++ b/app/controllers/staff/report_variance_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Staff::ReportVarianceController < Staff::BaseController
+  include Secured
+
+  def show
+    @report = Report.find(params["report_id"])
+    authorize @report
+
+    @report_presenter = ReportPresenter.new(@report)
+    @report_activities = level_c_and_d_activities_for_report(report: @report)
+
+    @activities = @report_activities.map { |activity| ActivityPresenter.new(activity) }
+    render "staff/reports/variance"
+  end
+
+  private def level_c_and_d_activities_for_report(report:)
+    return Activity.none if report.nil?
+    Activity.where(level: [:project, :third_party_project], organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
+  end
+end

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -23,7 +23,7 @@ class Staff::ReportsController < Staff::BaseController
 
     respond_to do |format|
       format.html do
-        @activities = @report_activities.map { |activity| ActivityPresenter.new(activity) }
+        redirect_to report_variance_path(@report)
       end
       format.csv do
         send_csv

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -19,7 +19,7 @@ class Staff::ReportsController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = level_c_and_d_activities_for_report(report: @report)
+    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
 
     respond_to do |format|
       format.html do
@@ -156,10 +156,5 @@ class Staff::ReportsController < Staff::BaseController
       response.stream.write ExportActivityToCsv.new(activity: activity, report: @report).call
     end
     response.stream.close
-  end
-
-  def level_c_and_d_activities_for_report(report:)
-    return Activity.none if report.nil?
-    Activity.where(level: [:project, :third_party_project], organisation: report.organisation).select { |activity| activity.associated_fund == report.fund }
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -92,6 +92,11 @@ class Activity < ApplicationRecord
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
   scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
+  scope :projects_and_third_party_projects_for_report, ->(report) {
+    where(level: [:project, :third_party_project], organisation: report.organisation).select {
+      |activity| activity.associated_fund == report.fund
+    }
+  }
 
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -2,7 +2,9 @@ class Budget < ApplicationRecord
   include PublicActivity::Common
 
   belongs_to :parent_activity, class_name: "Activity"
+  belongs_to :report, optional: true
 
+  validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :budget_type,
     :status,
     :period_start_date,

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -1,13 +1,43 @@
 class BudgetPolicy < ApplicationPolicy
+  def show?
+    return true if beis_user?
+    record.parent_activity.organisation == user.organisation
+  end
+
   def create?
-    Pundit.policy!(user, record.parent_activity).edit?
+    return false if record.parent_activity.level.nil?
+
+    if beis_user?
+      return true if record.parent_activity.fund? || record.parent_activity.programme?
+    end
+
+    if delivery_partner_user?
+      return true if editable_report_for_organisation_and_fund.present?
+    end
+
+    false
   end
 
   def update?
-    Pundit.policy!(user, record.parent_activity).update?
+    return false if record.parent_activity.level.nil?
+
+    if beis_user?
+      return true if record.parent_activity.fund? || record.parent_activity.programme?
+    end
+
+    if delivery_partner_user? && editable_report_for_organisation_and_fund.present?
+      return true if editable_report_for_organisation_and_fund == record.report
+    end
+
+    false
   end
 
   def destroy?
-    Pundit.policy!(user, record.parent_activity).destroy?
+    false
+  end
+
+  private def editable_report_for_organisation_and_fund
+    activity = record.parent_activity
+    Report.find_by(organisation: activity.organisation, fund: activity.associated_fund, state: Report::EDITABLE_STATES)
   end
 end

--- a/app/services/create_budget.rb
+++ b/app/services/create_budget.rb
@@ -11,6 +11,10 @@ class CreateBudget
     budget.assign_attributes(attributes)
     budget.value = sanitize_monetary_string(value: attributes[:value])
 
+    unless activity.organisation.service_owner?
+      budget.report = editable_report_for_activity(activity: activity)
+    end
+
     result = if budget.valid?
       Result.new(budget.save, budget)
     else
@@ -20,9 +24,11 @@ class CreateBudget
     result
   end
 
-  private
+  private def editable_report_for_activity(activity:)
+    Report.find_by(organisation: activity.organisation, fund: activity.associated_fund, state: Report::EDITABLE_STATES)
+  end
 
-  def sanitize_monetary_string(value:)
+  private def sanitize_monetary_string(value:)
     Monetize.parse(value)
   end
 end

--- a/app/services/ingest_iati_activities.rb
+++ b/app/services/ingest_iati_activities.rb
@@ -194,6 +194,8 @@ class IngestIatiActivities
       value = budget_element.children.detect { |child| child.name.eql?("value") }.children.text
       currency = budget_element.children.detect { |child| child.name.eql?("value") }.attributes["currency"]&.value || "GBP"
 
+      report = Report.find_by(fund: roda_activity.associated_fund, organisation: roda_activity.organisation)
+
       budget = Budget.new(
         status: status,
         budget_type: budget_type,
@@ -202,6 +204,7 @@ class IngestIatiActivities
         value: value,
         currency: currency,
         parent_activity: roda_activity,
+        report: report,
         ingested: true
       )
 

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -1,0 +1,20 @@
+.govuk-grid-row
+  .govuk-grid-column-full.page-actions
+    - if policy(@report_presenter).download?
+      = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+
+    - if policy(@report_presenter).activate?
+      = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+    - if policy(@report_presenter).review?
+      = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+    - if policy(@report_presenter).request_changes?
+      = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
+
+
+    - if policy(@report_presenter).approve?
+      = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+    - if policy(@report_presenter).submit?
+      = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -6,26 +6,7 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
-  .govuk-grid-row
-    .govuk-grid-column-full.page-actions
-      - if policy(@report_presenter).download?
-        = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).activate?
-        = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).review?
-        = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).request_changes?
-        = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
-
-
-      - if policy(@report_presenter).approve?
-        = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).submit?
-        = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+  = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -1,4 +1,4 @@
-=content_for :page_title_prefix, t("page_title.report.show",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+=content_for :page_title_prefix, t("page_title.report.budgets",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
@@ -29,4 +29,22 @@
 
   .govuk-grid-row
     .govuk-grid-column-full
-      = render partial: "staff/shared/reports/table_variance", locals: { activities: @activities, readonly: false }
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.report.variance"),
+              report_variance_path(@report),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.report.budgets"),
+              report_budgets_path(@report),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: true } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("tabs.report.budgets")
+
+          = render partial: "staff/shared/reports/table_budgets", locals: { budgets: @budgets }

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -1,0 +1,50 @@
+=content_for :page_title_prefix, t("page_title.report.variance",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+  .govuk-grid-row
+    .govuk-grid-column-full.page-actions
+      - if policy(@report_presenter).download?
+        = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+
+      - if policy(@report_presenter).activate?
+        = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+      - if policy(@report_presenter).review?
+        = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+      - if policy(@report_presenter).request_changes?
+        = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
+
+
+      - if policy(@report_presenter).approve?
+        = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+      - if policy(@report_presenter).submit?
+        = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.report.variance"),
+              report_variance_path(@report),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: true } }
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.report.budgets"),
+              report_budgets_path(@report),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: false } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("tabs.report.variance")
+
+          = render partial: "staff/shared/reports/table_variance", locals: { activities: @activities, readonly: false }

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -6,26 +6,7 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
-  .govuk-grid-row
-    .govuk-grid-column-full.page-actions
-      - if policy(@report_presenter).download?
-        = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).activate?
-        = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).review?
-        = link_to t("action.report.in_review.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).request_changes?
-        = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
-
-
-      - if policy(@report_presenter).approve?
-        = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
-
-      - if policy(@report_presenter).submit?
-        = link_to t("action.report.submit.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
+  = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/shared/reports/_table_budgets.html.haml
+++ b/app/views/staff/shared/reports/_table_budgets.html.haml
@@ -1,0 +1,24 @@
+- unless budgets.empty?
+  %table.govuk-table.budgets
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          =t("table.header.activity.identifier")
+        %th.govuk-table__header
+          =t("table.header.budget.period_start_date")
+        %th.govuk-table__header
+          =t("table.header.budget.period_end_date")
+        %th.govuk-table__header
+          =t("table.header.budget.value")
+        %th.govuk-table__header
+
+    %tbody.govuk-table__body
+      - budgets.each do |budget|
+        %tr.govuk-table__row{id: budget.id}
+          %td.govuk-table__cell= budget.parent_activity.delivery_partner_identifier
+          %td.govuk-table__cell= budget.period_start_date
+          %td.govuk-table__cell= budget.period_end_date
+          %td.govuk-table__cell= budget.value
+          %td.govuk-table__cell
+            - if policy(budget).edit?
+              = link_to t("default.link.edit"), edit_activity_budget_path(budget.parent_activity, budget)

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -31,6 +31,7 @@ en:
   tabs:
     report:
       variance: Variance
+      budgets: Budgets
   page_content:
     reports:
       title: Reports
@@ -77,6 +78,7 @@ en:
         confirm: Confirm approval for %{report_financial_quarter} %{report_description}
         complete: This report is approved
       variance: "%{report_financial_quarter} %{report_description} variance"
+      budgets: "%{report_financial_quarter} %{report_description} budgets"
   action:
     report:
       activate:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -28,6 +28,9 @@ en:
         add_comment: Add comment
         edit_comment: Edit comment
         comment: Comment
+  tabs:
+    report:
+      variance: Variance
   page_content:
     reports:
       title: Reports
@@ -73,6 +76,7 @@ en:
       approve:
         confirm: Confirm approval for %{report_financial_quarter} %{report_description}
         complete: This report is approved
+      variance: "%{report_financial_quarter} %{report_description} variance"
   action:
     report:
       activate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
     resources :reports, only: [:show, :edit, :update, :index] do
       resource :state, only: [:edit, :update], controller: :reports_state
+      get "variance" => "report_variance#show"
     end
 
     concern :transactionable do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :reports, only: [:show, :edit, :update, :index] do
       resource :state, only: [:edit, :update], controller: :reports_state
       get "variance" => "report_variance#show"
+      get "budgets" => "report_budgets#show"
     end
 
     concern :transactionable do

--- a/db/migrate/20200915101558_add_report_reference_to_budgets.rb
+++ b/db/migrate/20200915101558_add_report_reference_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddReportReferenceToBudgets < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :budgets, :report, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_09_131047) do
+ActiveRecord::Schema.define(version: 2020_09_15_101558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,7 +100,9 @@ ActiveRecord::Schema.define(version: 2020_09_09_131047) do
     t.string "currency"
     t.uuid "parent_activity_id"
     t.boolean "ingested", default: false
+    t.uuid "report_id"
     t.index ["parent_activity_id"], name: "index_budgets_on_parent_activity_id"
+    t.index ["report_id"], name: "index_budgets_on_report_id"
   end
 
   create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     currency { "gbp" }
     ingested { false }
     association :parent_activity, factory: :activity
+    association :report, factory: :report
   end
 end

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "Users can edit a budget" do
 
     scenario "a budget can be successfully edited" do
       activity = create(:project_activity, organisation: user.organisation)
-      budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10")
-      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10", report: report)
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
@@ -47,8 +47,8 @@ RSpec.describe "Users can edit a budget" do
 
     scenario "budget update is tracked with public_activity" do
       activity = create(:project_activity, organisation: user.organisation)
-      budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10")
-      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      budget = create(:budget, parent_activity: activity, budget_type: "original", value: "10", report: report)
 
       PublicActivity.with_tracking do
         visit organisation_activity_path(user.organisation, activity)
@@ -69,8 +69,8 @@ RSpec.describe "Users can edit a budget" do
 
     scenario "validation errors work as expected" do
       activity = create(:project_activity, organisation: user.organisation)
-      budget = create(:budget, parent_activity: activity, budget_type: "1", value: "10")
-      _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+      budget = create(:budget, parent_activity: activity, budget_type: "1", value: "10", report: report)
 
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -64,6 +64,18 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content report.description
     end
 
+    scenario "they can view budgets in a report" do
+      report = create(:report, :active)
+      budget = create(:budget, report: report)
+
+      visit report_budgets_path(report)
+
+      within "##{budget.id}" do
+        expect(page).to have_content budget.parent_activity.delivery_partner_identifier
+        expect(page).to have_content budget.value
+      end
+    end
+
     scenario "can download a CSV of the report" do
       report = create(:report, :active, description: "Legacy Report")
 
@@ -146,6 +158,20 @@ RSpec.feature "Users can view reports" do
             expect(page).to have_content "100.00"
             expect(page).to have_link t("default.link.view"), href: organisation_activity_path(activity.organisation, activity)
           end
+        end
+      end
+
+      scenario "they can view and edit budgets in a report" do
+        activity = create(:project_activity, organisation: delivery_partner_user.organisation)
+        report = create(:report, :active, organisation: delivery_partner_user.organisation, fund: activity.associated_fund)
+        budget = create(:budget, report: report, parent_activity: activity)
+
+        visit report_budgets_path(report)
+
+        within "##{budget.id}" do
+          expect(page).to have_content budget.parent_activity.delivery_partner_identifier
+          expect(page).to have_content budget.value
+          expect(page).to have_link t("default.link.edit"), href: edit_activity_budget_path(budget.parent_activity, budget)
         end
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -46,6 +46,32 @@ RSpec.describe Activity, type: :model do
         expect(Activity.publishable_to_iati).to eq [complete_activity]
       end
     end
+
+    describe ".projects_and_third_party_projects_for_report" do
+      it "only returns projects and third party projects that are for the reports organisation and fund" do
+        organisation = create(:delivery_partner_organisation)
+        fund = create(:fund_activity, organisation: organisation)
+        programme = create(:programme_activity, parent: fund, organisation: organisation)
+        project = create(:project_activity, parent: programme, organisation: organisation)
+        third_party_project = create(:third_party_project_activity, parent: project, organisation: organisation)
+        report = create(:report, organisation: third_party_project.organisation, fund: fund)
+
+        another_fund = create(:fund_activity, organisation: organisation)
+        another_programme = create(:programme_activity, parent: another_fund, organisation: organisation)
+        another_project = create(:project_activity, parent: another_programme, organisation: organisation)
+        another_third_party_project = create(:third_party_project_activity, parent: another_project, organisation: organisation)
+
+        expect(Activity.projects_and_third_party_projects_for_report(report)).to include third_party_project
+        expect(Activity.projects_and_third_party_projects_for_report(report)).to include project
+
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include fund
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include programme
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_fund
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_programme
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_project
+        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_third_party_project
+      end
+    end
   end
 
   describe "sanitisation" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe Budget do
     it { should validate_presence_of(:period_end_date) }
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:currency) }
+
+    context "when the activity belongs to a delivery partner" do
+      it "should validate that the report association exists" do
+        activity = build(:activity, organisation: build_stubbed(:delivery_partner_organisation))
+        report_for_activity = build_stubbed(:report, organisation: activity.organisation, fund: activity.associated_fund)
+        budget = build(:budget, parent_activity: activity, report: nil)
+
+        expect(budget).to be_invalid
+
+        budget.report = report_for_activity
+
+        expect(budget).to be_valid
+      end
+    end
+
+    context "when the activity belongs to BEIS" do
+      it "should validate that the report association exists" do
+        activity = build(:activity, organisation: build_stubbed(:beis_organisation))
+        budget = build(:budget, parent_activity: activity, report: nil)
+
+        expect(budget).to be_valid
+      end
+    end
   end
 
   context "value must be between 0.01 and 99,999,999,999.00 (100 billion minus one)" do

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -1,42 +1,186 @@
 require "rails_helper"
 
 RSpec.describe BudgetPolicy do
-  let(:user) { create(:beis_user) }
-  let(:activity) { create(:activity, organisation: user.organisation) }
   let(:budget) { create(:budget, parent_activity: activity) }
 
   subject { described_class.new(user, budget) }
 
-  describe "#create?" do
-    context "when the user belongs to the authoring organisation" do
-      let(:budget) { create(:budget, parent_activity: activity) }
-      it { is_expected.to permit_action(:create) }
-    end
+  context "when signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
 
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      let(:budget) { create(:budget, parent_activity: activity) }
+    context "when the activity has no level" do
+      let(:activity) { CreateActivity.new(organisation_id: user.organisation.id).call }
+
+      it { is_expected.to permit_action(:show) }
+
       it { is_expected.to forbid_action(:create) }
-    end
-  end
-
-  describe "#update?" do
-    context "when the user belongs to the authoring organisation" do
-      let(:budget) { create(:budget, parent_activity: activity) }
-      it { is_expected.to permit_action(:update) }
-    end
-
-    context "when the user does NOT belong to the authoring organisation" do
-      let(:another_organisation) { create(:organisation) }
-      let(:activity) { create(:activity, organisation: another_organisation) }
-      let(:budget) { create(:budget, parent_activity: activity) }
+      it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:create) }
+      it { is_expected.to permit_action(:edit) }
+      it { is_expected.to permit_action(:update) }
+
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:create) }
+      it { is_expected.to permit_action(:edit) }
+      it { is_expected.to permit_action(:update) }
+
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a third party project" do
+      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
     end
   end
 
-  describe "#destroy?" do
-    let(:budget) { create(:budget, parent_activity: activity) }
-    it { is_expected.to forbid_action(:destroy) }
+  context "when signed in as a Delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    context "when the activity has no level" do
+      let(:activity) { CreateActivity.new(organisation_id: user.organisation.id).call }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity) }
+
+      context "and the activity does not belong to the users organiastion" do
+        it { is_expected.to forbid_action(:show) }
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+
+      context "and the activity does belong to the users organisation" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        context "when there is no editable report" do
+          let(:report) { create(:report, state: :inactive) }
+
+          it { is_expected.to permit_action(:show) }
+
+          it { is_expected.to forbid_action(:create) }
+          it { is_expected.to forbid_action(:edit) }
+          it { is_expected.to forbid_action(:update) }
+          it { is_expected.to forbid_action(:destroy) }
+        end
+
+        context "when there is an editiable report" do
+          let(:report) { create(:report, state: :active) }
+
+          context "and the report is not for the organisation or fund of the activity" do
+            it { is_expected.to permit_action(:show) }
+
+            it { is_expected.to forbid_action(:create) }
+            it { is_expected.to forbid_action(:edit) }
+            it { is_expected.to forbid_action(:update) }
+            it { is_expected.to forbid_action(:destroy) }
+          end
+
+          context "and the report is for the organisation but not the fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation)
+            end
+
+            it { is_expected.to permit_action(:show) }
+
+            it { is_expected.to forbid_action(:create) }
+            it { is_expected.to forbid_action(:edit) }
+            it { is_expected.to forbid_action(:update) }
+            it { is_expected.to forbid_action(:destroy) }
+          end
+
+          context "and the report is for the organisation and fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation, fund: activity.associated_fund)
+            end
+
+            context "when the report is not the one in which the budtet was created" do
+              it { is_expected.to permit_action(:show) }
+              it { is_expected.to permit_action(:create) }
+
+              it { is_expected.to forbid_action(:edit) }
+              it { is_expected.to forbid_action(:update) }
+              it { is_expected.to forbid_action(:destroy) }
+            end
+
+            context "when the report is the one in which the budget was created" do
+              before do
+                budget.update(report: report)
+              end
+
+              it { is_expected.to permit_action(:show) }
+              it { is_expected.to permit_action(:create) }
+              it { is_expected.to permit_action(:edit) }
+              it { is_expected.to permit_action(:update) }
+
+              it { is_expected.to forbid_action(:destroy) }
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/create_budget_spec.rb
+++ b/spec/services/create_budget_spec.rb
@@ -9,6 +9,28 @@ RSpec.describe CreateBudget do
       expect(result.object.parent_activity).to eq(activity)
     end
 
+    context "when the activity belongs to a delivery partner" do
+      it "sets the value of report to the editable report for the activity" do
+        activity.update(organisation: build_stubbed(:delivery_partner_organisation))
+        editable_report_for_activity = create(:report, state: :active, organisation: activity.organisation, fund: activity.associated_fund)
+
+        budget = described_class.new(activity: activity).call
+
+        expect(budget.object.report).to eql editable_report_for_activity
+      end
+    end
+
+    context "when the activity belongs to BEIS" do
+      it "does not set the value of report" do
+        activity.update(organisation: build_stubbed(:beis_organisation))
+        _editable_report_for_activity = create(:report, state: :active, organisation: activity.organisation, fund: activity.associated_fund)
+
+        budget = described_class.new(activity: activity).call
+
+        expect(budget.object.report).to be_nil
+      end
+    end
+
     it "returns a successful result" do
       allow_any_instance_of(Budget).to receive(:valid?).and_return(true)
       allow_any_instance_of(Budget).to receive(:save).and_return(true)

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -236,7 +236,8 @@ RSpec.describe IngestIatiActivities do
 
       it "allows negative budgets" do
         rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
-        create(:programme_activity, organisation: rs, delivery_partner_identifier: "Brazil-Newton-Mob-RS")
+        programme = create(:programme_activity, organisation: rs, delivery_partner_identifier: "Brazil-Newton-Mob-RS")
+        _report = create(:report, organisation: programme.organisation, fund: programme.associated_fund)
 
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/rs/with_negative_budget.xml")
 
@@ -340,7 +341,8 @@ RSpec.describe IngestIatiActivities do
     describe "default aid type" do
       it "leaves aid_type blank if there is no attribute" do
         rs = create(:organisation, name: "Royal Society", iati_reference: "GB-COH-RC000519")
-        create(:programme_activity, organisation: rs, delivery_partner_identifier: "South Africa-Newton-Adv-RS")
+        programme = create(:programme_activity, organisation: rs, delivery_partner_identifier: "South Africa-Newton-Adv-RS")
+        _report = create(:report, organisation: programme.organisation, fund: programme.associated_fund)
 
         legacy_activities = File.read("#{Rails.root}/spec/fixtures/activities/rs/with_missing_default_aid_type.xml")
 


### PR DESCRIPTION
## Changes in this PR
As budgets do not appear in the report CSV download (or the trackers) we need a way to review the budgets that have been added in a report.

I've added a tabbed view to the report show page so the variance and budgets can live alongside each other, as per this mockup:

https://miro.com/app/board/o9J_kpLoc7Y=/?moveToWidget=3074457349383556686&cot=12

The Budget policy is an exact copy of the transaction one, I have kept the duplication as I can live with it right now, there are changes that will makes these diverge to come.

I've added a new scope to Activity with a super long name! This is used accross the two tab views so made sense to have it in a single place and as it returns Activities, this felt right.

Like the tabs on Activities, I've kept things really simple so there is some duplication of the tab markup - again, I am happy to live with this tradeoff right now.

Delivery partners can edit their budgets right from the report view, but there is no budget#show for BEIS users, I think that is good for now to get a minimum feature out.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/480578/93224084-a7143400-f768-11ea-9f63-7e6025b3f036.png)

![image](https://user-images.githubusercontent.com/480578/93224103-ad0a1500-f768-11ea-8973-69a480918988.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
