### PR TITLE
(1015) Add the report financial quarter & year to the CSV filename

### DIFF
--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -150,7 +150,7 @@ class Staff::ReportsController < Staff::BaseController
 
   def send_csv
     response.headers["Content-Type"] = "text/csv"
-    response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.description)}.csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report_presenter.fund.title)}-#{ERB::Util.url_encode(@report_presenter.financial_quarter_and_year)}-#{ERB::Util.url_encode(@report.description)}.csv"
     response.stream.write ExportActivityToCsv.new(report: @report).headers
     @report_activities.each do |activity|
       response.stream.write ExportActivityToCsv.new(activity: activity, report: @report).call

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -92,6 +92,27 @@ RSpec.feature "Users can view reports" do
       expect(header).to match(/Legacy%20Report/)
     end
 
+    context "if the report description is empty" do
+      scenario "the report csv has a filename made up of the fund name & report financial year & quarter" do
+        travel_to(Date.parse("1 Jan 2020")) do
+          report = create(:report, :active, description: "")
+
+          visit reports_path
+
+          within "##{report.id}" do
+            click_on t("default.link.show")
+          end
+
+          click_on t("action.report.download.button")
+
+          expect(page.response_headers["Content-Type"]).to include("text/csv")
+          header = page.response_headers["Content-Disposition"]
+          expect(header).to match(/#{ERB::Util.url_encode("Q4 2019-2020")}/)
+          expect(header).to match(/#{ERB::Util.url_encode(report.fund.title)}/)
+        end
+      end
+    end
+
     context "when there are no reports in a given state" do
       scenario "an empty state is shown" do
         visit reports_path


### PR DESCRIPTION
Trello: https://trello.com/c/D4NFGkAA/1015-bug-report-csv-filename-is-empty-if-the-report-has-no-description

While testing, we found that some reports did not have descriptions, and
therefore when downloaded did not have a filename (other than `.csv`).

This commit adds the report financial quarter & year to the filename, so if the
report description is empty there is still *something* in the filename.

