### PR TITLE
(987) Ingest additional fields from CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ terraform/.terraform/*
 
 # debug
 .byebug_history
+
+# CSV left in root
+/*.csv

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "mail-notify"
 gem "monetize"
 gem "mini_racer"
 gem "parser", "~> 2.6.3.0"
+gem "pry-rails"
 gem "puma", "~> 4.3"
 gem "public_activity", "~> 1.5"
 gem "pundit"
@@ -50,7 +51,6 @@ group :development, :test do
   gem "i18n-tasks", "~> 0.9.31"
   gem "rspec-rails"
   gem "standard"
-  gem "pry-rails"
 end
 
 group :development do

--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -1,0 +1,57 @@
+require "csv"
+
+class IngestCsv
+  ACCEPTABLE_INVALID_ATTRIBUTES = [:gdi].freeze
+
+  attr_accessor :csv, :filename
+
+  def initialize(filename)
+    self.filename = filename
+    self.csv = CSV.foreach(filename, headers: true, skip_blanks: true, encoding: "bom|utf-8", header_converters: ->(h) { h.strip.downcase })
+  end
+
+  def call
+    write_log("Starting ingest of #{filename}")
+
+    ActiveRecord::Base.transaction do
+      csv.each do |row|
+        activity = activity_for(row)
+
+        if activity.nil?
+          write_log("Couldn't find Activity where #{row.first.first} is #{row.first.last}")
+          next
+        end
+
+        attributes = IngestCsvRow.new(row).call
+
+        # Ignore attributes that have been set to :skip
+        attributes.delete_if { |_key, value| value == :skip }
+
+        activity.assign_attributes(attributes)
+
+        if activity.valid?
+          # Clean save
+          activity.save!
+        elsif (activity.errors.keys - ACCEPTABLE_INVALID_ATTRIBUTES).empty?
+          # Force validation if the only invalid fields are ones we're ok with
+          activity.save!(validate: false)
+        else
+          # Skip row and write message
+          write_log("Skipping Activity #{row}: #{activity.errors.full_messages}")
+        end
+      end
+    end
+  end
+
+  private
+
+  def activity_for(row)
+    Activity.where.not(level: nil).find_by(
+      delivery_partner_identifier: row["delivery_partner_identifier"]
+    )
+  end
+
+  def write_log(message)
+    Rails.logger.info(message)
+  end
+end

--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -22,24 +22,26 @@ class IngestCsv
           next
         end
 
-        attributes = IngestCsvRow.new(row).call
+        Rails.logger.tagged(["IngestCsv", "activity:#{activity.id}"]) do
+          attributes = IngestCsvRow.new(row).call
 
-        # Ignore attributes that have been set to :skip
-        attributes.delete_if { |_key, value| value == :skip }
+          # Ignore attributes that have been set to :skip
+          attributes.delete_if { |_key, value| value == :skip }
 
-        activity.assign_attributes(attributes)
+          activity.assign_attributes(attributes)
 
-        if activity.valid?
-          # Clean save
-          activity.save!
-        elsif (activity.errors.keys - ACCEPTABLE_INVALID_ATTRIBUTES).empty?
-          # Force validation if the only invalid fields are ones we're ok with
-          activity.save!(validate: false)
-        else
-          # Skip row and write message
-          write_log("Skipping Activity #{row}: #{activity.errors.full_messages}")
-          write_log("attributes: #{attributes.inspect}")
-          # binding.pry
+          if activity.valid?
+            # Clean save
+            activity.save!
+          elsif (activity.errors.keys - ACCEPTABLE_INVALID_ATTRIBUTES).empty?
+            # Force validation if the only invalid fields are ones we're ok with
+            activity.save!(validate: false)
+          else
+            # Skip row and write message
+            write_log("Skipping Activity #{row}: #{activity.errors.full_messages}")
+            write_log("attributes: #{attributes.inspect}")
+            # binding.pry
+          end
         end
       end
     end

--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class IngestCsv
-  ACCEPTABLE_INVALID_ATTRIBUTES = [:gdi].freeze
+  ACCEPTABLE_INVALID_ATTRIBUTES = [:gdi, :intended_beneficiaries].freeze
 
   attr_accessor :csv, :filename
 
@@ -38,6 +38,8 @@ class IngestCsv
         else
           # Skip row and write message
           write_log("Skipping Activity #{row}: #{activity.errors.full_messages}")
+          write_log("attributes: #{attributes.inspect}")
+          # binding.pry
         end
       end
     end

--- a/app/services/ingest_csv_row.rb
+++ b/app/services/ingest_csv_row.rb
@@ -1,0 +1,118 @@
+class IngestCsvRow
+  attr_accessor :attributes, :updated_attributes
+
+  include CodelistHelper
+
+  def initialize(row = {})
+    self.attributes = row.to_h
+    self.updated_attributes = {}
+  end
+
+  def call
+    attributes.each do |name, value|
+      method_name = "process_#{name}"
+
+      # Convert weird whitespace to regular spaces
+      value = value.gsub(/[[:space:]]/, " ").strip if value.is_a?(String)
+
+      updated_attributes[name] = if respond_to?(method_name)
+        send(method_name, value)
+      else
+        value
+      end
+    end
+
+    # Set call_present if call_open_date or call_close_date provided
+    updated_attributes["call_present"] = updated_attributes["call_open_date"].present? || updated_attributes["call_close_date"].present?
+
+    # Return the processed set of attributes
+    updated_attributes
+  end
+
+  def process_call_open_date(value)
+    return :skip if value.blank? || value == "N/A"
+    Date.parse(value)
+  end
+
+  def process_call_close_date(value)
+    return :skip if value.blank? || value == "N/A"
+    Date.parse(value)
+  end
+
+  def process_programme_status(value)
+    mapped_programme_status = programme_status_mapping.fetch(value.to_s.downcase)
+    updated_attributes["status"] = ProgrammeToIatiStatus.new.programme_status_to_iati_status(mapped_programme_status)
+
+    mapped_programme_status
+  end
+
+  def process_oda_eligibility(value)
+    return false if value.nil?
+
+    value.downcase == "eligible"
+  end
+
+  def process_gdi(value)
+    value = value.to_s.strip.downcase
+    return nil if value == "not applicable"
+
+    gdi_mapping[value] || :skip
+  end
+
+  def process_total_applications(value)
+    return "0" if value.blank? || value.downcase == "not applicable"
+    value
+  end
+
+  def process_total_awards(value)
+    return "0" if value.blank? || value.downcase == "not applicable"
+    value
+  end
+
+  def process_intended_beneficiaries(value)
+    updated_attributes["requires_additional_benefitting_countries"] = false
+    return [] if value.blank?
+
+    countries = value.split("|").map { |country| country.gsub(/[[:space:]]/, " ").downcase.strip }
+    return [] if countries.none?
+
+    updated_attributes["requires_additional_benefitting_countries"] = true
+
+    countries.map! do |country|
+      country_to_code_mapping.fetch(country)
+    rescue KeyError
+      Rails.logger.warn "#{attributes} no such country '#{country}'"
+      nil
+    end
+
+    countries.compact
+  end
+
+  private
+
+  def programme_status_mapping
+    @programme_status_mapping ||= begin
+      yaml_to_objects(entity: "activity", type: "programme_status")
+        .map { |status| [status["name"].downcase, status["code"]] }
+        .to_h
+    end
+  end
+
+  def gdi_mapping
+    @gdi_mapping ||= begin
+      yaml_to_objects(entity: "activity", type: "gdi")
+        .map { |status| [status["name"].downcase, status["code"]] }
+        .to_h
+    end
+  end
+
+  def country_to_code_mapping
+    @country_to_code_mapping ||= begin
+      load_yaml(entity: "activity", type: "intended_beneficiaries")
+        .values
+        .flatten
+        .map { |status| [status["name"].downcase, status["code"]] }
+        .to_h
+    end
+  end
+end

--- a/spec/fixtures/csv/additional_fields.csv
+++ b/spec/fixtures/csv/additional_fields.csv
@@ -1,0 +1,4 @@
+﻿delivery_partner_identifier,programme_status,call_open_date,call_close_date,gdi,oda_eligibility,intended_beneficiaries,total_applications,total_awards
+EXAMPLE_01,Spend in Progress,01/02/2016,20/12/2020,Not Applicable,Eligible,Colombia|Mexico|Paraguay,,
+EXAMPLE_02,Spend in Progress,28/02/2018,28/02/2021,Not Applicable,Eligible,Peru,,
+EXAMPLE_03,Completed,01/01/2015,01/03/2015,Not Applicable,,,2,1

--- a/spec/services/ingest_csv_row_spec.rb
+++ b/spec/services/ingest_csv_row_spec.rb
@@ -1,0 +1,206 @@
+require "rails_helper"
+
+RSpec.describe IngestCsvRow do
+  describe "#call" do
+    it "takes an attribute hash, processes each key and returns a new hash" do
+      input = {
+        "call_open_date" => "28/04/2019",
+        "call_close_date" => "28/04/2021",
+      }
+
+      output = IngestCsvRow.new(input).call
+
+      expect(output).to include(
+        "call_open_date" => Date.new(2019, 4, 28),
+        "call_close_date" => Date.new(2021, 4, 28),
+        "call_present" => true,
+      )
+    end
+
+    it "strips whitespace from string values" do
+      input = {
+        "dummy_value_1" => "   value",
+        "dummy_value_2" => "value  ",
+      }
+
+      output = IngestCsvRow.new(input).call
+
+      expect(output).to include(
+        "dummy_value_1" => "value",
+        "dummy_value_2" => "value",
+      )
+    end
+
+    context "setting call_present" do
+      it "is set to true if call_open_date is provided" do
+        input = {
+          "call_open_date" => "25/12/2020",
+        }
+
+        output = IngestCsvRow.new(input).call
+
+        expect(output).to include(
+          "call_present" => true
+        )
+      end
+
+      it "is set to true if call_open_close is provided" do
+        input = {
+          "call_close_date" => "25/12/2020",
+        }
+
+        output = IngestCsvRow.new(input).call
+
+        expect(output).to include(
+          "call_present" => true
+        )
+      end
+
+      it "is set to false if neither call_open_date or call_close_date is provided" do
+        input = {}
+
+        output = IngestCsvRow.new(input).call
+
+        expect(output).to include(
+          "call_present" => false
+        )
+      end
+    end
+  end
+
+  context "#process_call_open_date" do
+    it "returns the parsed date" do
+      expect(IngestCsvRow.new.process_call_open_date("25/12/2020"))
+        .to eql Date.new(2020, 12, 25)
+    end
+
+    it "returns :skip for a blank value" do
+      expect(IngestCsvRow.new.process_call_open_date(nil)).to eql :skip
+    end
+
+    it "returns :skip when value is N/A" do
+      expect(IngestCsvRow.new.process_call_open_date("N/A")).to eql :skip
+    end
+  end
+
+  context "#process_call_close_date" do
+    it "returns the parsed date" do
+      expect(IngestCsvRow.new.process_call_close_date("2020-12-25"))
+        .to eql Date.new(2020, 12, 25)
+    end
+
+    it "returns :skip for a blank value" do
+      expect(IngestCsvRow.new.process_call_close_date(nil)).to eql :skip
+    end
+
+    it "returns :skip when value is N/A" do
+      expect(IngestCsvRow.new.process_call_close_date("N/A")).to eql :skip
+    end
+  end
+
+  context "#process_programme_status" do
+    it "maps the textual programme status to its equivalent status code" do
+      expect(IngestCsvRow.new.process_programme_status("Delivery"))
+        .to eql "01"
+    end
+
+    it "sets the status attribute to the IATI-equivalent status" do
+      input = {"programme_status" => "Delivery"}
+      output = IngestCsvRow.new(input).call
+
+      expect(output).to include(
+        "status" => "2"
+      )
+    end
+  end
+
+  context "#process_oda_eligibility" do
+    it "returns true when the value is 'eligible'" do
+      expect(IngestCsvRow.new.process_oda_eligibility("ELIgibLE"))
+        .to be(true)
+    end
+
+    it "returns false when the value is not 'eligible'" do
+      expect(IngestCsvRow.new.process_oda_eligibility("something-else"))
+        .to be(false)
+    end
+
+    it "returns false when the value is nil" do
+      expect(IngestCsvRow.new.process_oda_eligibility(nil))
+        .to be(false)
+    end
+  end
+
+  context "#process_gdi" do
+    it "returns the mapped gdi code" do
+      expect(IngestCsvRow.new.process_gdi("NO"))
+        .to eql "4"
+    end
+
+    it "returns nil when the value is 'not applicable'" do
+      expect(IngestCsvRow.new.process_gdi("Not Applicable"))
+        .to be_nil
+    end
+
+    it "skips for other values" do
+      expect(IngestCsvRow.new.process_gdi("xxxx"))
+        .to eql :skip
+    end
+  end
+
+  context "#process_total_applications" do
+    it "returns non-zero values untouched" do
+      expect(IngestCsvRow.new.process_total_applications("1234"))
+        .to eql "1234"
+    end
+
+    it "returns empty values as zero" do
+      expect(IngestCsvRow.new.process_total_applications(""))
+        .to eql "0"
+    end
+
+    it "returns zero when value is 'Not Applicable'" do
+      expect(IngestCsvRow.new.process_total_applications("NOT APPLICABLE"))
+        .to eql "0"
+    end
+  end
+
+  context "#process_total_awards" do
+    it "returns non-zero values untouched" do
+      expect(IngestCsvRow.new.process_total_awards("5678"))
+        .to eql "5678"
+    end
+
+    it "returns empty values as zero" do
+      expect(IngestCsvRow.new.process_total_awards(""))
+        .to eql "0"
+    end
+
+    it "returns zero when value is 'Not Applicable'" do
+      expect(IngestCsvRow.new.process_total_awards("not applicable"))
+        .to eql "0"
+    end
+  end
+
+  context "#process_intended_beneficiaries" do
+    it "returns an array of country codes" do
+      expect(IngestCsvRow.new.process_intended_beneficiaries("Peru|Zambia"))
+        .to include("PE", "ZM")
+    end
+
+    it "still returns an array if one of the countries is unknown" do
+      expect(IngestCsvRow.new.process_intended_beneficiaries("Peru|Scarfolk|Zambia"))
+        .to include("PE", "ZM")
+    end
+
+    it "returns an empty array if value is empty" do
+      expect(IngestCsvRow.new.process_intended_beneficiaries("  "))
+        .to eql []
+    end
+
+    it "returns an empty array if delimitered list is empty" do
+      expect(IngestCsvRow.new.process_intended_beneficiaries(" |  "))
+        .to eql []
+    end
+  end
+end

--- a/spec/services/ingest_csv_spec.rb
+++ b/spec/services/ingest_csv_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe IngestCsv do
 
         IngestCsv.new(csv_file).call
 
-        expect(Activity.where(updated_at: Date.today..).count).to eql 3
+        expect(Activity.programme.where(updated_at: Date.today..).count).to eql 3
       end
     end
   end

--- a/spec/services/ingest_csv_spec.rb
+++ b/spec/services/ingest_csv_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe IngestCsv do
+  describe "#call" do
+    context "with a CSV file which references identifiers that already exist in RODA" do
+      before do
+        create(:fund_activity, title: "Newton fund") do |fund|
+          ["EXAMPLE_01", "EXAMPLE_02", "EXAMPLE_03", "EXAMPLE_XX"].each do |identifier|
+            create(:programme_activity, delivery_partner_identifier: identifier, parent: fund, updated_at: 1.month.ago)
+          end
+        end
+      end
+
+      it "updates those activities" do
+        csv_file = "#{Rails.root}/spec/fixtures/csv/additional_fields.csv"
+
+        IngestCsv.new(csv_file).call
+
+        expect(Activity.where(updated_at: Date.today..).count).to eql 3
+      end
+    end
+  end
+end


### PR DESCRIPTION
Given a CSV with the following columns, update the relevant activities with additional information:

 - delivery_partner_identifier
 - programme_status
 - call_open_date
 - call_close_date
 - gdi
 - oda_eligibility
 - intended_beneficiaries (containing a `|`-separated list of country names)
 - total_applications
 - total_awards

**NB: The CSV dataset is *NOT* included in this PR as it contains some data that shouldn't be publicly accessible. Instead, this will be manually copied onto the server before it is manually run.**

This code exists *ONLY* for the purposes of preparing production for real users and will likely be removed once this work is completed.