### PR TITLE
(851) Add `collaboration type` to create activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,7 @@
 - Update the budget policy
 - Report variance is shown in a tab
 - Show budgets added in a report on the reports view
+- `Collaboration type` form field added to create activity journey and activity XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -25,6 +25,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :requires_additional_benefitting_countries,
     :intended_beneficiaries,
     :gdi,
+    :collaboration_type,
     :flow,
     :aid_type,
     :oda_eligibility,
@@ -60,6 +61,9 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step if @activity.recipient_region?
     when :intended_beneficiaries
       skip_step unless @activity.requires_intended_beneficiaries?
+    when :collaboration_type
+      skip_step if @activity.fund?
+      assign_default_collaboration_type_value_if_nil
     end
 
     render_wizard
@@ -128,6 +132,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(intended_beneficiaries: intended_beneficiaries.drop(1))
     when :gdi
       @activity.assign_attributes(gdi: gdi)
+    when :collaboration_type
+      @activity.assign_attributes(collaboration_type: collaboration_type)
     when :flow
       @activity.assign_attributes(flow: flow)
     when :aid_type
@@ -251,6 +257,10 @@ class Staff::ActivityFormsController < Staff::BaseController
     params.require(:activity).permit(:gdi).fetch("gdi", nil)
   end
 
+  def collaboration_type
+    params.require(:activity).permit(:collaboration_type).fetch("collaboration_type", nil)
+  end
+
   def flow
     params.require(:activity).permit(:flow).fetch("flow", nil)
   end
@@ -288,5 +298,10 @@ class Staff::ActivityFormsController < Staff::BaseController
   def country_to_region_mapping
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/BEIS/country_to_region_mapping.yml"))
     yaml["data"]
+  end
+
+  def assign_default_collaboration_type_value_if_nil
+    # This allows us to pre-select a specific radio button on collaboration_type form step (value "Bilateral" in this case)
+    @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
   end
 end

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -80,6 +80,10 @@ module CodelistHelper
     }.compact.sort_by(&:name)
   end
 
+  def collaboration_type_radio_options
+    yaml_to_objects(entity: "activity", type: "collaboration_type", with_empty_item: false).sort_by(&:code)
+  end
+
   def flow_select_options
     objects = yaml_to_objects(entity: "activity", type: "flow", with_empty_item: false)
     objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -23,6 +23,7 @@ class Activity < ApplicationRecord
     :requires_additional_benefitting_countries_step,
     :intended_beneficiaries_step,
     :gdi_step,
+    :collaboration_type_step,
     :flow_step,
     :aid_type,
     :oda_eligibility_step,
@@ -47,6 +48,7 @@ class Activity < ApplicationRecord
   validates :requires_additional_benefitting_countries, inclusion: {in: [true, false]}, on: :requires_additional_benefitting_countries_step, if: :recipient_country?
   validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
   validates :gdi, presence: true, on: :gdi_step
+  validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
   validates :oda_eligibility, inclusion: {in: [true, false]}, on: :oda_eligibility_step
@@ -246,5 +248,9 @@ class Activity < ApplicationRecord
 
   def comment_for_report(report_id:)
     comments.find_by(report_id: report_id)
+  end
+
+  def requires_collaboration_type?
+    !ingested? && !fund?
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -94,6 +94,11 @@ class ActivityPresenter < SimpleDelegator
     I18n.t("activity.gdi.#{super}")
   end
 
+  def collaboration_type
+    return if super.blank?
+    I18n.t("activity.collaboration_type.#{super}")
+  end
+
   def flow
     return if super.blank?
     I18n.t("activity.flow.#{super}")

--- a/app/views/staff/activity_forms/collaboration_type.html.haml
+++ b/app/views/staff/activity_forms/collaboration_type.html.haml
@@ -1,0 +1,2 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_collection_radio_buttons :collaboration_type, collaboration_type_radio_options, :code, :name, legend: { tag: 'h1', size: 'xl', text: t("form.label.activity.collaboration_type") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -224,6 +224,15 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gdi)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gdi)}"), activity_step_path(activity_presenter, :gdi), t("summary.label.activity.gdi"))
 
+  - unless activity_presenter.fund?
+    .govuk-summary-list__row.collaboration_type
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.collaboration_type")
+      %dd.govuk-summary-list__value
+        = activity_presenter.collaboration_type
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :collaboration_type)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:collaboration_type)}"), activity_step_path(activity_presenter, :collaboration_type), t("summary.label.activity.collaboration_type"))
 
   .govuk-summary-list__row.flow
     %dt.govuk-summary-list__key

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -35,6 +35,8 @@
     %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}
       %narrative= region_name_from_code(activity.recipient_region)
   %sector{"vocabulary" => "1", "code" => activity.sector}/
+  - if activity.collaboration_type?
+    %collaboration-type{"code" => activity.collaboration_type}/
   %default-flow-type{"code" => activity.flow}/
   %default-finance-type{"code" => activity.finance}/
   %default-aid-type{"code" => activity.aid_type}/

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -20,6 +20,14 @@ en:
     call_present:
       'true': 'Yes'
       'false': 'No'
+    collaboration_type:
+      '1': Bilateral
+      '2': Multilateral (inflows)
+      '3': Bilateral, core contributions to NGOs and other private bodies / PPPs
+      '4': Multilateral outflows
+      '6': Private Sector Outflows
+      '7': Bilateral, ex-post reporting on NGOs’ activities funded through core contributions
+      '8': Bilateral, triangular co-operation
     flow:
       '10': ODA
       '20': OOF

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -23,6 +23,7 @@ en:
         call_present:
           'true': 'Yes'
           'false': 'No'
+        collaboration_type: What is the collaboration type for this activity?
         gdi: GDI
         geography_options:
           recipient_region: Region
@@ -114,6 +115,7 @@ en:
         call_present: Calls
         call_open_date: Call open date
         call_close_date: Call close date
+        collaboration_type: Collaboration type
         description: Description
         form_state:
           complete: Complete
@@ -224,6 +226,7 @@ en:
         aid_type: Aid type
         call_dates: What are the call open and close dates for this %{level}?
         call_present: Is there a call for this %{level}?
+        collaboration_type: Collaboration type
         country: What country will benefit from this activity?
         dates: What are the start and end dates for the %{level}?
         flow: Flow

--- a/db/migrate/20200915124739_add_collaboration_type_to_activities.rb
+++ b/db/migrate/20200915124739_add_collaboration_type_to_activities.rb
@@ -1,0 +1,5 @@
+class AddCollaborationTypeToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :collaboration_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_15_101558) do
+ActiveRecord::Schema.define(version: 2020_09_15_124739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2020_09_15_101558) do
     t.string "gdi"
     t.integer "total_applications"
     t.integer "total_awards"
+    t.string "collaboration_type"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -56,6 +56,7 @@ FactoryBot.define do
     factory :programme_activity do
       parent factory: :fund_activity
       level { :programme }
+      collaboration_type { "1" }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
@@ -74,6 +75,7 @@ FactoryBot.define do
       call_present { "true" }
       call_open_date { Date.yesterday }
       call_close_date { Date.tomorrow }
+      collaboration_type { "1" }
       total_applications { "25" }
       total_awards { "12" }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
@@ -103,6 +105,7 @@ FactoryBot.define do
       call_present { "true" }
       call_open_date { Date.yesterday }
       call_close_date { Date.tomorrow }
+      collaboration_type { "1" }
       total_applications { "25" }
       total_awards { "12" }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
@@ -134,6 +137,7 @@ FactoryBot.define do
     geography { nil }
     recipient_region { nil }
     recipient_country { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -156,6 +160,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -176,6 +181,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -185,6 +191,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
   end
@@ -195,12 +202,20 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
   end
 
   trait :nil_form_state do
     form_state { nil }
+  end
+
+  trait :at_collaboration_type_step do
+    form_state { "collaboration_type" }
+    collaboration_type { nil }
+    flow { nil }
+    aid_type { nil }
   end
 
   trait :blank_form_state do
@@ -219,6 +234,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }
@@ -244,6 +260,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }
@@ -267,6 +284,7 @@ FactoryBot.define do
     recipient_country { nil }
     intended_beneficiaries { nil }
     gdi { nil }
+    collaboration_type { nil }
     flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -259,6 +259,10 @@ RSpec.feature "Users can create a fund level activity" do
 
         choose "No"
         click_button t("form.button.activity.submit")
+        expect(page). to have_content t("form.label.activity.collaboration_type")
+
+        # Collaboration_type has a pre-selected option
+        click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.label.activity.flow")
 
         # Flow has a default and can't be set to blank so we skip

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -518,6 +518,17 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
 
+  unless activity.fund?
+    within(".collaboration_type") do
+      click_on(t("default.link.edit"))
+      expect(page).to have_current_path(
+        activity_step_path(activity, :collaboration_type)
+      )
+    end
+    click_on(t("default.link.back"))
+    click_on t("tabs.activity.details")
+  end
+
   within(".flow") do
     click_on(t("default.link.edit"))
     expect(page).to have_current_path(

--- a/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
+++ b/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
@@ -1,0 +1,40 @@
+RSpec.feature "Users can add a collaboration type for an activity" do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+  let(:activity) { create(:programme_activity, :at_collaboration_type_step, organisation: user.organisation) }
+
+  context "when the user creates a new activity, on the collaboration_type form step" do
+    scenario "the activity has a pre-selected radio button for collaboration_type with value '1 -Bilateral'" do
+      visit activity_step_path(activity, :collaboration_type)
+
+      expect(find_field("activity-collaboration-type-1-field")).to be_checked
+      expect(find_field("activity-collaboration-type-2-field")).not_to be_checked
+    end
+
+    context "and they save this step without changing the selected radio button" do
+      it "saves collaboration_type as value '1' (Bilateral)" do
+        visit activity_step_path(activity, :collaboration_type)
+        click_button t("form.button.activity.submit")
+
+        expect(activity.reload.collaboration_type).to eq("1")
+      end
+    end
+  end
+
+  context "when the user wants to edit the collaboration_type on an existing activity" do
+    it "shows the correct radio button selected" do
+      programme = create(:programme_activity, organisation: user.organisation, collaboration_type: "2")
+      visit organisation_activity_details_path(programme.organisation, programme)
+      within(".collaboration_type") do
+        click_on(t("default.link.edit"))
+      end
+
+      expect(find_field("activity-collaboration-type-2-field")).to be_checked
+
+      choose "Private Sector Outflows"
+      click_button t("form.button.activity.submit")
+
+      expect(programme.reload.collaboration_type).to eq("6")
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -118,11 +118,26 @@ RSpec.feature "Users can view an activity as XML" do
         end
       end
 
+      context "when the activity has a collaboration_type" do
+        let(:activity) { create(:programme_activity, organisation: organisation, delivery_partner_identifier: "IND-ENT-IFIER", collaboration_type: "1") }
+        let(:xml) { Nokogiri::XML::Document.parse(page.body) }
+
+        it "contains the relevant collaboration_type code" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml.at("iati-activity/collaboration-type/@code").text).to eq "1"
+        end
+      end
+
       context "when the activity is a fund activity" do
         let(:activity) { create(:fund_activity, :with_transparency_identifier, organisation: organisation, delivery_partner_identifier: "IND-ENT-IFIER") }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
+
+        it "does not include collaboration_type field" do
+          visit organisation_activity_path(organisation, activity, format: :xml)
+          expect(xml).not_to have_selector("iati-activity/collaboration-type")
+        end
       end
 
       context "when the activity is a programme activity" do

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
+    describe "#collaboration_type_radio_options" do
+      it "returns the different options for collaboration type sorted by code" do
+        options = helper.collaboration_type_radio_options
+
+        expect(options.length).to eq 7
+        expect(options.first.code).to eq "1"
+        expect(options.first.name).to eq "Bilateral"
+        expect(options.last.code).to eq "8"
+        expect(options.last.name).to eq "Bilateral, triangular co-operation"
+      end
+    end
+
     describe "#flow_select_options" do
       it "returns an array of flow objects with 10 as the first (default) option" do
         expect(helper.flow_select_options.first)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -480,6 +480,31 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when activity is not a fund" do
+      context "and is 'ingested: false'" do
+        context "and the collaboration_type is blank" do
+          subject(:activity) { build(:programme_activity, collaboration_type: nil, ingested: false) }
+          it "should not be valid" do
+            expect(activity.valid?(:collaboration_type_step)).to be_falsey
+          end
+        end
+      end
+
+      context "but the activity is 'ingested:true'" do
+        subject(:activity) { build(:programme_activity, collaboration_type: nil, ingested: true) }
+        it "should be valid" do
+          expect(activity.valid?(:collaboration_type_step)).to be_truthy
+        end
+      end
+    end
+
+    context "when activity is a fund and collaboration_type is blank" do
+      subject(:activity) { build(:fund_activity, collaboration_type: nil) }
+      it "should be valid" do
+        expect(activity.valid?(:collaboration_type_step)).to be_truthy
+      end
+    end
+
     context "when flow is blank" do
       subject(:activity) { build(:activity, flow: nil) }
       it "should not be valid" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -307,6 +307,24 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#collaboration_type" do
+    context "when collaboration_type exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, collaboration_type: "1")
+        result = described_class.new(activity).collaboration_type
+        expect(result).to eql("Bilateral")
+      end
+    end
+
+    context "when the activity does not have a collaboration_type set" do
+      it "returns nil" do
+        activity = build(:activity, collaboration_type: nil)
+        result = described_class.new(activity)
+        expect(result.collaboration_type).to be_nil
+      end
+    end
+  end
+
   describe "#flow" do
     context "when flow aid_type exists" do
       it "returns the locale value for the code" do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -33,6 +33,7 @@ module FormHelpers
     recipient_region: "Developing countries, unspecified",
     intended_beneficiaries: "Haiti",
     gdi: "No",
+    collaboration_type: "Bilateral",
     flow: "ODA",
     aid_type: "A01",
     oda_eligibility: "true",
@@ -184,6 +185,12 @@ module FormHelpers
     choose "No"
     click_button t("form.button.activity.submit")
 
+    unless level == "fund"
+      expect(page).to have_content t("form.label.activity.collaboration_type")
+      choose "Bilateral"
+      click_button t("form.button.activity.submit")
+    end
+
     expect(page).to have_content t("form.label.activity.flow")
     expect(page.html).to include t("form.hint.activity.flow")
     select flow, from: "activity[flow]"
@@ -213,6 +220,7 @@ module FormHelpers
       expect(page).not_to have_content t("activity.programme_status.#{programme_status}")
     else
       expect(page).to have_content t("activity.programme_status.#{programme_status}")
+      expect(page).to have_content collaboration_type
     end
     expect(page).to have_content recipient_region
     expect(page).to have_content intended_beneficiaries

--- a/vendor/data/codelists/IATI/2_03/activity/collaboration_type.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/collaboration_type.yml
@@ -1,0 +1,24 @@
+---
+attributes:
+  category-codelist:
+  name: CollaborationType
+  complete: '1'
+data:
+  - code: '1'
+    name: Bilateral
+  - code: '2'
+    name: Multilateral (inflows)
+  - code: '3'
+    name: Bilateral, core contributions to NGOs and other private bodies / PPPs
+  - code: '4'
+    name: Multilateral outflows
+  - code: '6'
+    name: Private Sector Outflows
+  - code: '7'
+    name: Bilateral, ex-post reporting on NGOs’ activities funded through core contributions
+  - code: '8'
+    name: Bilateral, triangular co-operation
+metadata:
+  url: ''
+  name: Collaboration Type
+  description: ''


### PR DESCRIPTION
Trello: https://trello.com/c/E95quVyI

## Changes in this PR

`Collaboration type` is a new field required when users create new activities through RODA. It is required for levels B, C, and D. It is optional for ingested activities. The client requested to have this option as radio buttons with a pre-selected
value of `Bilateral`, since it is the most common value for this field on the existing activities. Form builder seems not to allow pre-selected radio buttons (we use pre-selected dropdown menus in RODA, but not radio buttons). To work around this, avoiding having to default a value on the database that could affect level A activities, we are assigning a default value through the `activity_forms_controller`, and only at the moment when we display the `collaboration_type` form step, whenever the value for `collaboration_type` is nil (see relevant code below).

This new field needs to be reported to IATI through the activity XML, so in this PR you will also find the logic that makes that possible. These changes have been checked with the new IATI validator, to make sure they are inline with the requirements and standards.

## Screenshots of UI changes

### After

<img width="1136" alt="Screenshot 2020-09-16 at 16 08 33" src="https://user-images.githubusercontent.com/48016017/93357163-ea89a380-f837-11ea-9798-021d83157b02.png">

<img width="1136" alt="Screenshot 2020-09-16 at 16 08 57" src="https://user-images.githubusercontent.com/48016017/93357193-f1181b00-f837-11ea-9282-c9cc985d17c5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
