### PR TITLE
(876) Upload transactions as CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,7 @@
 - Report variance is shown in a tab
 - Show budgets added in a report on the reports view
 - `Collaboration type` form field added to create activity journey and activity XML
+- Upload transaction data in bulk as CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/controllers/staff/report_variance_controller.rb
+++ b/app/controllers/staff/report_variance_controller.rb
@@ -8,7 +8,7 @@ class Staff::ReportVarianceController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
+    @report_activities = Activity.includes(:organisation).projects_and_third_party_projects_for_report(@report)
 
     @activities = @report_activities.map { |activity| ActivityPresenter.new(activity) }
     render "staff/reports/variance"

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class Staff::TransactionUploadsController < Staff::BaseController
+  include Secured
+
+  before_action :authorize_report
+
+  def new
+    @report_presenter = ReportPresenter.new(@report)
+  end
+
+  def show
+    response.headers["Content-Type"] = "text/csv"
+    response.headers["Content-Disposition"] = "attachment; filename=transactions.csv"
+
+    response.stream.write(CSV.generate_line(csv_headers))
+    @report.reportable_activities.each do |activity|
+      response.stream.write(CSV.generate_line(csv_row(activity)))
+    end
+    response.stream.close
+  end
+
+  private def authorize_report
+    @report = Report.find(params[:report_id])
+    authorize @report, :show?
+  end
+
+  private def csv_headers
+    ["Activity Name", "Activity Delivery Partner Identifier"] + ImportTransactions.column_headings
+  end
+
+  private def csv_row(activity)
+    [
+      activity.description,
+      activity.delivery_partner_identifier,
+      activity.roda_identifier_compound,
+    ]
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -94,6 +94,7 @@ class Activity < ApplicationRecord
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
   scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
+  scope :with_roda_identifier, -> { where.not(roda_identifier_compound: nil) }
 
   scope :projects_and_third_party_projects_for_report, ->(report) {
     programmes = where(level: :programme, parent_id: report.fund_id)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -94,10 +94,15 @@ class Activity < ApplicationRecord
   scope :funds, -> { where(level: :fund) }
   scope :programmes, -> { where(level: :programme) }
   scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
+
   scope :projects_and_third_party_projects_for_report, ->(report) {
-    where(level: [:project, :third_party_project], organisation: report.organisation).select {
-      |activity| activity.associated_fund == report.fund
-    }
+    programmes = where(level: :programme, parent_id: report.fund_id)
+    projects = where(level: :project, parent_id: programmes.pluck(:id))
+    third_party_projects = where(level: :third_party_project, parent_id: projects.pluck(:id))
+
+    for_organisation = where(organisation_id: report.organisation_id)
+
+    for_organisation.merge(projects.or(third_party_projects))
   }
 
   def valid?(context = nil)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,6 +49,10 @@ class Report < ApplicationRecord
     end
   end
 
+  def reportable_activities
+    Activity.projects_and_third_party_projects_for_report(self).with_roda_identifier
+  end
+
   def next_four_financial_quarters
     case current_financial_quarter
     when 1

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -25,6 +25,17 @@ class Report < ApplicationRecord
     approved: "approved",
   }
 
+  scope :editable, -> do
+    where(state: [:active, :awaiting_changes])
+  end
+
+  def self.editable_for_activity(activity)
+    editable.find_by(
+      organisation_id: activity.organisation_id,
+      fund_id: activity.associated_fund.id,
+    )
+  end
+
   def initialize(attributes = nil)
     super(attributes)
     self.financial_quarter = current_financial_quarter

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -1,8 +1,9 @@
 class CreatePlannedDisbursement
-  attr_accessor :activity
+  attr_accessor :activity, :report
 
-  def initialize(activity:)
+  def initialize(activity:, report: nil)
     self.activity = activity
+    self.report = report || Report.editable_for_activity(activity)
   end
 
   def call(attributes: {})
@@ -13,7 +14,7 @@ class CreatePlannedDisbursement
     planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
 
     unless activity.organisation.service_owner?
-      planned_disbursement.report = report(activity: activity)
+      planned_disbursement.report = report
     end
 
     result = if planned_disbursement.valid?
@@ -29,11 +30,5 @@ class CreatePlannedDisbursement
 
   def sanitize_monetary_string(value:)
     Monetize.parse(value)
-  end
-
-  def report(activity:)
-    organisation = activity.organisation
-    fund = activity.associated_fund
-    Report.active.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -1,8 +1,9 @@
 class CreateTransaction
-  attr_accessor :activity
+  attr_accessor :activity, :report
 
-  def initialize(activity:)
+  def initialize(activity:, report: nil)
     self.activity = activity
+    self.report = report || Report.editable_for_activity(activity)
   end
 
   def call(attributes: {})
@@ -13,7 +14,7 @@ class CreateTransaction
     transaction.value = sanitize_monetary_string(value: attributes[:value])
 
     unless activity.organisation.service_owner?
-      transaction.report = report(activity: activity)
+      transaction.report = report
     end
 
     result = if transaction.valid?
@@ -29,11 +30,5 @@ class CreateTransaction
 
   def sanitize_monetary_string(value:)
     Monetize.parse(value)
-  end
-
-  def report(activity:)
-    organisation = activity.organisation
-    fund = activity.associated_fund
-    Report.active.find_by(organisation: organisation, fund: fund)
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -1,7 +1,11 @@
 require "date"
 
 class ImportTransactions
-  Error = Struct.new(:row, :column, :value, :message)
+  Error = Struct.new(:row, :column, :value, :message) {
+    def csv_row
+      row + 2
+    end
+  }
 
   attr_reader :errors
 

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -120,5 +120,20 @@ class ImportTransactions
     rescue ArgumentError
       raise I18n.t("importer.errors.transaction.invalid_date")
     end
+
+    def convert_receiving_organisation_type(type)
+      codelist = YAML.safe_load(File.read(organisation_type_path))
+      valid_codes = codelist.fetch("data").map { |entry| entry.fetch("code") }
+
+      if valid_codes.include?(type)
+        type
+      else
+        raise I18n.t("importer.errors.transaction.invalid_iati_organisation_type")
+      end
+    end
+
+    def organisation_type_path
+      Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION, "organisation", "organisation_type.yml")
+    end
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -135,5 +135,22 @@ class ImportTransactions
     def organisation_type_path
       Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION, "organisation", "organisation_type.yml")
     end
+
+    def convert_disbursement_channel(channel)
+      return nil if channel.blank?
+
+      codelist = YAML.safe_load(File.read(disbursement_channel_path))
+      valid_codes = codelist.fetch("data").map { |entry| entry.fetch("code") }
+
+      if valid_codes.include?(channel)
+        channel
+      else
+        raise I18n.t("importer.errors.transaction.invalid_iati_disbursement_channel")
+      end
+    end
+
+    def disbursement_channel_path
+      Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION, "transaction", "disbursement_channel.yml")
+    end
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -1,0 +1,73 @@
+require "date"
+
+class ImportTransactions
+  DEFAULT_CURRENCY = "GBP"
+  TRANSACTION_TYPE_DISBURSEMENT = "3"
+
+  def import(transactions)
+    transactions.each { |row| import_row(row) }
+  end
+
+  def import_row(row)
+    converter = Converter.new(row)
+    attrs = converter.to_h
+    activity = converter.activity
+
+    assign_default_values(attrs, activity)
+
+    CreateTransaction.new(activity: activity).call(attributes: attrs)
+  end
+
+  def assign_default_values(attrs, activity)
+    organisation = activity.providing_organisation
+
+    attrs[:currency] = DEFAULT_CURRENCY
+    attrs[:transaction_type] = TRANSACTION_TYPE_DISBURSEMENT
+    attrs[:providing_organisation_name] = organisation.name
+    attrs[:providing_organisation_type] = organisation.organisation_type
+  end
+
+  class Converter
+    FIELDS = {
+      activity: "Activity RODA Identifier",
+      date: "Date",
+      value: "Value",
+      receiving_organisation_name: "Receiving Organisation Name",
+      receiving_organisation_type: "Receiving Organisation Type",
+      receiving_organisation_reference: "Receiving Organisation IATI Reference",
+      disbursement_channel: "Disbursement Channel",
+      description: "Description",
+    }
+
+    attr_reader :activity
+
+    def initialize(row)
+      @row = row
+      @attributes = convert_to_attributes
+      @activity = @attributes.delete(:activity)
+    end
+
+    def to_h
+      @attributes
+    end
+
+    def convert_to_attributes
+      FIELDS.each_with_object({}) do |(attr_name, column_name), attrs|
+        attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name])
+      end
+    end
+
+    def convert_to_attribute(attr_name, value)
+      value = value.to_s.strip
+
+      converter = "convert_#{attr_name}"
+      value = __send__(converter, value) if respond_to?(converter)
+
+      value
+    end
+
+    def convert_activity(id)
+      Activity.find_by(roda_identifier_compound: id)
+    end
+  end
+end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -62,6 +62,11 @@ class ImportTransactions
     attrs[:transaction_type] = TRANSACTION_TYPE_DISBURSEMENT
     attrs[:providing_organisation_name] = organisation.name
     attrs[:providing_organisation_type] = organisation.organisation_type
+
+    if attrs[:description].blank?
+      presenter = ReportPresenter.new(@report)
+      attrs[:description] = "#{presenter.financial_quarter_and_year} spend on #{activity.description}"
+    end
   end
 
   class Converter

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -8,7 +8,8 @@ class ImportTransactions
 
   attr_reader :errors
 
-  def initialize
+  def initialize(report:)
+    @report = report
     @errors = []
   end
 
@@ -45,7 +46,8 @@ class ImportTransactions
     attrs = converter.to_h
     assign_default_values(attrs, activity)
 
-    result = CreateTransaction.new(activity: activity).call(attributes: attrs)
+    creator = CreateTransaction.new(activity: activity, report: @report)
+    result = creator.call(attributes: attrs)
     return unless result
 
     result.object.errors.each do |attr_name, message|

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -122,35 +122,35 @@ class ImportTransactions
     end
 
     def convert_receiving_organisation_type(type)
-      codelist = YAML.safe_load(File.read(organisation_type_path))
-      valid_codes = codelist.fetch("data").map { |entry| entry.fetch("code") }
-
-      if valid_codes.include?(type)
-        type
-      else
-        raise I18n.t("importer.errors.transaction.invalid_iati_organisation_type")
-      end
-    end
-
-    def organisation_type_path
-      Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION, "organisation", "organisation_type.yml")
+      validate_from_codelist(
+        type,
+        "organisation/organisation_type.yml",
+        I18n.t("importer.errors.transaction.invalid_iati_organisation_type"),
+      )
     end
 
     def convert_disbursement_channel(channel)
-      return nil if channel.blank?
-
-      codelist = YAML.safe_load(File.read(disbursement_channel_path))
-      valid_codes = codelist.fetch("data").map { |entry| entry.fetch("code") }
-
-      if valid_codes.include?(channel)
-        channel
-      else
-        raise I18n.t("importer.errors.transaction.invalid_iati_disbursement_channel")
-      end
+      validate_from_codelist(
+        channel,
+        "transaction/disbursement_channel.yml",
+        I18n.t("importer.errors.transaction.invalid_iati_disbursement_channel"),
+      )
     end
 
-    def disbursement_channel_path
-      Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION, "transaction", "disbursement_channel.yml")
+    def validate_from_codelist(code, codelist_file, message)
+      return nil if code.blank?
+
+      codelist_path = codelist_root.join(codelist_file)
+      codelist = YAML.safe_load(File.read(codelist_path))
+      valid_codes = codelist.fetch("data").map { |entry| entry.fetch("code") }
+
+      raise message unless valid_codes.include?(code)
+
+      code
+    end
+
+    def codelist_root
+      Rails.root.join("vendor", "data", "codelists", "IATI", IATI_VERSION)
     end
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -5,6 +5,10 @@ class ImportTransactions
 
   attr_reader :errors
 
+  def self.column_headings
+    Converter::FIELDS.values
+  end
+
   def initialize(report:, uploader:)
     @report = report
     @uploader = uploader

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -1,5 +1,7 @@
 .govuk-grid-row
   .govuk-grid-column-full.page-actions
+    = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+
     - if policy(@report_presenter).download?
       = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 

--- a/app/views/staff/transaction_uploads/_error_table.html.haml
+++ b/app/views/staff/transaction_uploads/_error_table.html.haml
@@ -1,0 +1,15 @@
+%table.govuk-table
+  %caption.govuk-table__caption List of errors in your uploaded CSV file
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Column
+      %th.govuk-table__header{scope: "col"} Row
+      %th.govuk-table__header{scope: "col"} Current Value
+      %th.govuk-table__header{scope: "col"} Error description
+  %tbody.govuk-table__body
+    - @errors.each do |error|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= error.column
+        %td.govuk-table__cell= error.csv_row
+        %td{class: "govuk-table__cell govuk-!-font-weight-bold error-text"}= error.value
+        %td.govuk-table__cell= error.message

--- a/app/views/staff/transaction_uploads/_upload_form.html.haml
+++ b/app/views/staff/transaction_uploads/_upload_form.html.haml
@@ -1,0 +1,9 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @report_presenter, url: report_transaction_upload_path(@report_presenter) do |f|
+
+      = f.govuk_file_field :transaction_csv,
+        label: { text: t("form.label.transaction.csv_file") },
+        hint_text: t("form.hint.transaction.csv_file")
+
+      = f.govuk_submit t("action.transaction.upload.button")

--- a/app/views/staff/transaction_uploads/new.html.haml
+++ b/app/views/staff/transaction_uploads/new.html.haml
@@ -1,0 +1,9 @@
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.transaction.upload")
+
+  .govuk-grid-row
+    .govuk-grid-column-full.page-actions
+      = link_to t("action.transaction.download.button"), report_transaction_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"

--- a/app/views/staff/transaction_uploads/new.html.haml
+++ b/app/views/staff/transaction_uploads/new.html.haml
@@ -7,3 +7,5 @@
   .govuk-grid-row
     .govuk-grid-column-full.page-actions
       = link_to t("action.transaction.download.button"), report_transaction_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+
+  = render partial: "upload_form"

--- a/app/views/staff/transaction_uploads/update.html.haml
+++ b/app/views/staff/transaction_uploads/update.html.haml
@@ -1,0 +1,12 @@
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.transaction.upload")
+
+  - unless @errors.empty?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "error_table"
+
+  = render partial: "upload_form"

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -84,4 +84,5 @@ en:
         invalid_date: Date must be a valid date
         invalid_iati_disbursement_channel: The disbursement channel must be a valid IATI Disbursement Channel code
         invalid_iati_organisation_type: The receiving organisation type must be a valid IATI Organisation Type code
+        unauthorised: You are not authorised to report against this activity
         unknown_identifier: Identifier is not recognised

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -78,3 +78,7 @@ en:
               blank: Enter a receiving organisation name
             receiving_organisation_type:
               blank: Select the organisation type
+  importer:
+    errors:
+      transaction:
+        unknown_identifier: Identifier is not recognised

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -6,6 +6,10 @@ en:
         success: Transaction successfully created
       update:
         success: Transaction sucessfully updated
+      download:
+        button: Download CSV template
+      upload:
+        link: Upload actuals
   form:
     label:
       transaction:
@@ -57,6 +61,7 @@ en:
     transaction:
       edit: Edit transaction
       new: Add a transaction
+      upload: Upload bulk transactions data
   activerecord:
     errors:
       models:

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -81,4 +81,5 @@ en:
   importer:
     errors:
       transaction:
+        invalid_date: Date must be a valid date
         unknown_identifier: Identifier is not recognised

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -82,4 +82,5 @@ en:
     errors:
       transaction:
         invalid_date: Date must be a valid date
+        invalid_iati_organisation_type: The receiving organisation type must be a valid IATI Organisation Type code
         unknown_identifier: Identifier is not recognised

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -82,5 +82,6 @@ en:
     errors:
       transaction:
         invalid_date: Date must be a valid date
+        invalid_iati_disbursement_channel: The disbursement channel must be a valid IATI Disbursement Channel code
         invalid_iati_organisation_type: The receiving organisation type must be a valid IATI Organisation Type code
         unknown_identifier: Identifier is not recognised

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -9,10 +9,14 @@ en:
       download:
         button: Download CSV template
       upload:
+        button: Upload and continue
+        file_missing: Please upload a valid CSV file
         link: Upload actuals
+        success: The transactions were successfully imported.
   form:
     label:
       transaction:
+        csv_file: Transaction spreadsheet
         currency: Currency
         description: Describe the transaction
         disbursement_channel: Disbursement channel (optional)
@@ -31,6 +35,7 @@ en:
         receiving_organisation: Receiving organisation
     hint:
       transaction:
+        csv_file: Upload a spreadsheet containing transaction information in CSV format.
         date: If you're reporting quarterly data, select the last day of the quarter. For example, 31 12 2020
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
         disbursement_channel: The channel through which the funds will flow for this transaction.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
     resources :reports, only: [:show, :edit, :update, :index] do
       resource :state, only: [:edit, :update], controller: :reports_state
-      resource :transaction_upload, only: [:new, :show]
+      resource :transaction_upload, only: [:new, :show, :update]
       get "variance" => "report_variance#show"
       get "budgets" => "report_budgets#show"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
     resources :reports, only: [:show, :edit, :update, :index] do
       resource :state, only: [:edit, :update], controller: :reports_state
+      resource :transaction_upload, only: [:new, :show]
       get "variance" => "report_variance#show"
       get "budgets" => "report_budgets#show"
     end

--- a/spec/features/staff/users_can_upload_transactions.rb
+++ b/spec/features/staff/users_can_upload_transactions.rb
@@ -1,0 +1,54 @@
+RSpec.feature "users can upload transactions" do
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+
+  let!(:project) { create(:project_activity, organisation: organisation) }
+  let!(:sibling_project) { create(:project_activity, organisation: organisation, parent: project.parent) }
+  let!(:cousin_project) { create(:project_activity, organisation: organisation) }
+
+  let! :report do
+    create(:report,
+      state: :active,
+      fund: project.associated_fund,
+      organisation: organisation)
+  end
+
+  before do
+    authenticate!(user: user)
+    visit report_path(report)
+    click_link t("action.transaction.upload.link")
+  end
+
+  scenario "downloading a CSV template with activities for the current report" do
+    click_link t("action.transaction.download.button")
+
+    rows = CSV.parse(page.body, headers: true).map(&:to_h)
+
+    expect(rows).to eq([
+      {
+        "Activity Name" => project.description,
+        "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,
+        "Activity RODA Identifier" => project.roda_identifier_compound,
+        "Date" => nil,
+        "Value" => nil,
+        "Receiving Organisation Name" => nil,
+        "Receiving Organisation Type" => nil,
+        "Receiving Organisation IATI Reference" => nil,
+        "Disbursement Channel" => nil,
+        "Description" => nil,
+      },
+      {
+        "Activity Name" => sibling_project.description,
+        "Activity Delivery Partner Identifier" => sibling_project.delivery_partner_identifier,
+        "Activity RODA Identifier" => sibling_project.roda_identifier_compound,
+        "Date" => nil,
+        "Value" => nil,
+        "Receiving Organisation Name" => nil,
+        "Receiving Organisation Type" => nil,
+        "Receiving Organisation IATI Reference" => nil,
+        "Disbursement Channel" => nil,
+        "Description" => nil,
+      },
+    ])
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -190,4 +190,23 @@ RSpec.describe Report, type: :model do
       end
     end
   end
+
+  describe "reportable_activities" do
+    let!(:report) { create(:report) }
+    let!(:programme) { create(:programme_activity, parent: report.fund, organisation: report.organisation) }
+    let!(:project_a) { create(:project_activity, parent: programme, organisation: report.organisation) }
+    let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }
+    let!(:third_party_project) { create(:third_party_project_activity, parent: project_b, organisation: report.organisation) }
+    let!(:project_in_another_fund) { create(:project_activity, organisation: report.organisation) }
+
+    it "returns the level C and D activities belonging to the report's fund and organisation" do
+      expect(report.reportable_activities).to include(project_a)
+      expect(report.reportable_activities).to include(project_b)
+      expect(report.reportable_activities).to include(third_party_project)
+
+      expect(report.reportable_activities).not_to include(report.fund)
+      expect(report.reportable_activities).not_to include(programme)
+      expect(report.reportable_activities).not_to include(project_in_another_fund)
+    end
+  end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -179,5 +179,38 @@ RSpec.describe ImportTransactions do
         ])
       end
     end
+
+    context "when the Receiving Organisation Name is blank" do
+      let :transaction_row do
+        super().merge("Receiving Organisation Name" => "")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Receiving Organisation Name", "", t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank")),
+        ])
+      end
+    end
+
+    # https://iatistandard.org/en/iati-standard/203/codelists/organisationtype/
+    context "when the Receiving Organisation Type is not a valid IATI type" do
+      let :transaction_row do
+        super().merge("Receiving Organisation Type" => "81")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Receiving Organisation Type", "81", t("importer.errors.transaction.invalid_iati_organisation_type")),
+        ])
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -84,5 +84,21 @@ RSpec.describe ImportTransactions do
         ])
       end
     end
+
+    context "when the Date is not an existing date" do
+      let :transaction_row do
+        super().merge("Date" => "2020-04-31")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Date", "2020-04-31", t("importer.errors.transaction.invalid_date")),
+        ])
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe ImportTransactions do
       end
     end
 
+    context "when the Date is blank" do
+      let :transaction_row do
+        super().merge("Date" => "")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Date", "", t("activerecord.errors.models.transaction.attributes.date.blank")),
+        ])
+      end
+    end
+
     context "when the Date is not an existing date" do
       let :transaction_row do
         super().merge("Date" => "2020-04-31")

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -68,5 +68,21 @@ RSpec.describe ImportTransactions do
         providing_organisation_type: project.providing_organisation.organisation_type,
       )
     end
+
+    context "when the Activity Identifier is not recognised" do
+      let :transaction_row do
+        super().merge("Activity RODA Identifier" => "not-a-real-id")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Activity RODA Identifier", "not-a-real-id", t("importer.errors.transaction.unknown_identifier")),
+        ])
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -227,5 +227,53 @@ RSpec.describe ImportTransactions do
         expect(transaction.receiving_organisation_reference).to eq("Rec-Org-IATI-Ref")
       end
     end
+
+    context "when Disbursement Channel is blank" do
+      let :transaction_row do
+        super().merge("Disbursement Channel" => "")
+      end
+
+      it "imports the transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "assigns nil for the transaction's disbursement channel" do
+        transaction = report.transactions.first
+        expect(transaction.disbursement_channel).to be_nil
+      end
+    end
+
+    # https://iatistandard.org/en/iati-standard/203/codelists/disbursementchannel/
+    context "when Disbursement Channel is a valid IATI type" do
+      let :transaction_row do
+        super().merge("Disbursement Channel" => "4")
+      end
+
+      it "imports the transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "assigns the transaction's disbursement channel" do
+        transaction = report.transactions.first
+        expect(transaction.disbursement_channel).to eq("4")
+      end
+    end
+
+    # https://iatistandard.org/en/iati-standard/203/codelists/disbursementchannel/
+    context "when Disbursement Channel is not a valid IATI type" do
+      let :transaction_row do
+        super().merge("Disbursement Channel" => "5")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Disbursement Channel", "5", t("importer.errors.transaction.invalid_iati_disbursement_channel")),
+        ])
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe ImportTransactions do
+  let(:project) { create(:project_activity) }
+
+  let! :report do
+    create(:report,
+      fund: project.associated_fund,
+      organisation: project.organisation,
+      state: :active)
+  end
+
+  let :importer do
+    ImportTransactions.new
+  end
+
+  describe "importing a single transaction" do
+    let :transaction_row do
+      {
+        "Activity RODA Identifier" => project.roda_identifier_compound,
+        "Date" => "2020-09-08",
+        "Value" => "50.00",
+        "Receiving Organisation Name" => "Example University",
+        "Receiving Organisation Type" => "80",
+        "Receiving Organisation IATI Reference" => "",
+        "Disbursement Channel" => "",
+        "Description" => "Fees for Q3",
+      }
+    end
+
+    before do
+      importer.import([transaction_row])
+    end
+
+    it "imports a single transaction" do
+      expect(report.transactions.count).to eq(1)
+    end
+
+    it "assigns the attributes from the row data" do
+      transaction = report.transactions.first
+
+      expect(transaction).to have_attributes(
+        parent_activity: project,
+        date: Date.new(2020, 9, 8),
+        value: 50.0,
+        receiving_organisation_name: "Example University",
+        receiving_organisation_type: "80",
+        description: "Fees for Q3",
+      )
+    end
+
+    it "assigns a default currency" do
+      transaction = report.transactions.first
+      expect(transaction.currency).to eq("GBP")
+    end
+
+    # https://iatistandard.org/en/iati-standard/203/codelists/transactiontype/
+    it "assigns 'disbursement' as the transaction type" do
+      transaction = report.transactions.first
+      expect(transaction.transaction_type).to eq("3")
+    end
+
+    it "assigns the providing organisation based on the activity" do
+      transaction = report.transactions.first
+
+      expect(transaction).to have_attributes(
+        providing_organisation_name: project.providing_organisation.name,
+        providing_organisation_type: project.providing_organisation.organisation_type,
+      )
+    end
+  end
+end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -116,5 +116,68 @@ RSpec.describe ImportTransactions do
         ])
       end
     end
+
+    context "with additional formatting in the Value field" do
+      let :transaction_row do
+        super().merge("Value" => "£ 12,345.67")
+      end
+
+      it "imports the transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "interprets the Value as a number" do
+        transaction = report.transactions.first
+        expect(transaction.value).to eq(12_345.67)
+      end
+    end
+
+    context "when the Value is blank" do
+      let :transaction_row do
+        super().merge("Value" => "")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Value", "", t("activerecord.errors.models.transaction.attributes.value.other_than")),
+        ])
+      end
+    end
+
+    context "when the Value is zero" do
+      let :transaction_row do
+        super().merge("Value" => "0")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Value", "0", t("activerecord.errors.models.transaction.attributes.value.other_than")),
+        ])
+      end
+    end
+
+    context "when the Value is not numeric" do
+      let :transaction_row do
+        super().merge("Value" => "This is not a number")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Value", "This is not a number", t("activerecord.errors.models.transaction.attributes.value.other_than")),
+        ])
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -212,5 +212,20 @@ RSpec.describe ImportTransactions do
         ])
       end
     end
+
+    context "when a Receiving Organisation IATI Reference is provided" do
+      let :transaction_row do
+        super().merge("Receiving Organisation IATI Reference" => "Rec-Org-IATI-Ref")
+      end
+
+      it "imports the transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "saves the IATI reference on the transaction" do
+        transaction = report.transactions.first
+        expect(transaction.receiving_organisation_reference).to eq("Rec-Org-IATI-Ref")
+      end
+    end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ImportTransactions do
   end
 
   let :importer do
-    ImportTransactions.new
+    ImportTransactions.new(report: report)
   end
 
   describe "importing a single transaction" do

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.describe ImportTransactions do
-  let(:project) { create(:project_activity) }
+  let(:project) { create(:project_activity, description: "Example Project") }
 
   let! :report do
     create(:report,
       fund: project.associated_fund,
       organisation: project.organisation,
-      state: :active)
+      state: :active,
+      financial_year: 1999,
+      financial_quarter: 4)
   end
 
   let :importer do
@@ -273,6 +275,21 @@ RSpec.describe ImportTransactions do
         expect(importer.errors).to eq([
           ImportTransactions::Error.new(0, "Disbursement Channel", "5", t("importer.errors.transaction.invalid_iati_disbursement_channel")),
         ])
+      end
+    end
+
+    context "when Description is blank" do
+      let :transaction_row do
+        super().merge("Description" => "")
+      end
+
+      it "imports the transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "generates a default description" do
+        transaction = report.transactions.first
+        expect(transaction.description).to eq("Q4 1999-2000 spend on Example Project")
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

This allows delivery partner users to upload transactions for a report by uploading a CSV. They work by filling out a template we give them, which contains the required column headings, and the IDs of all the activities they need to report on. The RODA ID is used to identify activities on upload, while the Delivery Partner ID and Name are there for the user's information and are ignored on upload.

This is quite a large PR but the code is mostly fairly boring validation and translation of CSV fields onto database columns, plus a little glue at the end to expose the functionality via the service. I'd recommend reading each commit rather than all the changes at once.

I'd like to check that all the logic for validation and translation the fields is correct, that the right associations between transactions, activities and reports are created, and that any permissions-related checks are correct.

## Screenshots of UI changes

When viewing a report, a new button is available in the menu to "Upload actuals":

<img width="1182" alt="Screenshot 2020-09-17 at 09 56 58" src="https://user-images.githubusercontent.com/9265/93449896-38042000-f8cd-11ea-8924-b03d344c36d5.png">

This links to a page where the user can download a CSV template, and upload their finished spreadsheet:

<img width="1181" alt="Screenshot 2020-09-17 at 09 58 16" src="https://user-images.githubusercontent.com/9265/93449907-3b97a700-f8cd-11ea-8e1a-9bc32a8270bf.png">

The download gives them a CSV with the required column headings, and the IDs of each activity they need to provide actuals for in this report.

<img width="1372" alt="Screenshot 2020-09-17 at 09 57 52" src="https://user-images.githubusercontent.com/9265/93449900-39cde380-f8cd-11ea-8c8a-c605426deb84.png">

The user fills this spreadsheet out and re-exports as CSV. If what they upload contains any errors, then the transactions are not created, and the errors are displayed.

<img width="1181" alt="Screenshot 2020-09-17 at 09 58 33" src="https://user-images.githubusercontent.com/9265/93449910-3c303d80-f8cd-11ea-8685-c3395518fc6f.png">

If they don't upload a file at all, an error message is shown:

<img width="1181" alt="Screenshot 2020-09-17 at 14 52 35" src="https://user-images.githubusercontent.com/9265/93481750-cfca3400-f8f6-11ea-9efc-f11560ce9942.png">

If all the data is valid and the transactions are saved, a success message is shown.

<img width="1181" alt="Screenshot 2020-09-17 at 14 54 24" src="https://user-images.githubusercontent.com/9265/93481779-d9539c00-f8f6-11ea-8d72-74072aeee420.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)