### PR TITLE
(998) Display the parent activity's RODA Identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,7 @@
 - Show budgets added in a report on the reports view
 - `Collaboration type` form field added to create activity journey and activity XML
 - Upload transaction data in bulk as CSV
+- Display the parent activity's RODA identifier when adding RODA IDs
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/app/views/staff/activity_forms/roda_identifier.html.haml
+++ b/app/views/staff/activity_forms/roda_identifier.html.haml
@@ -1,2 +1,7 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_text_field :roda_identifier_fragment, label: { tag: 'h1', size: 'xl' }
+  - if f.object.parent
+    = f.govuk_text_field :roda_identifier_fragment,
+      label: { tag: 'h1', size: 'xl' },
+      hint_text: t("form.hint.activity.roda_identifier_fragment_with_parent_html", identifier: f.object.parent.roda_identifier_compound)
+  - else
+    = f.govuk_text_field :roda_identifier_fragment, label: { tag: 'h1', size: 'xl' }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -85,11 +85,12 @@ en:
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
-        roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set
         intended_beneficiaries: You can select up to 10 different countries. This field is optional if you already selected a recipient country on the previous step
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
+        roda_identifier_fragment: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set.
+        roda_identifier_fragment_with_parent_html: This should be a unique ID that will be used to report this activity externally. This value cannot be edited once it is set.<br><br>The RODA identifier for this activity's parent is <strong>%{identifier}</strong>.
         sector_category: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the <a href='https://www.oecd.org/dac/stats/documentupload/2015%20CRS%20purpose%20codes%20EN_updated%20April%202016.pdf' target='_blank' class='govuk-link'>CRS purpose codes</a>
         title: A short title that explains the purpose of the %{level}
         level: Select the type of activity


### PR DESCRIPTION
When entering a RODA Identifier, there's nothing to tell the user where
they are, and the data they enter here is final, so it's both easy and
very costly to make a mistake and enter the wrong thing.

As a quick improvement, we can add the parent activity's RODA identifier
to the page, if the activity has a parent. You can only enter a RODA ID
if the parent activity has one completed, so this is guaranteed to
always have a value to display.

## Screenshots of UI changes

<img width="777" alt="Screenshot 2020-09-17 at 16 18 11" src="https://user-images.githubusercontent.com/9265/93493047-66045700-f903-11ea-9186-b42a624df780.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
