### PR TITLE
(988) Ingest new activity data from CSV

### DIFF
--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -62,21 +62,27 @@ class IngestCsv
       parent = Activity.find_by(roda_identifier_compound: row["parent_roda_identifier_compound"])
       return :missing_parent if parent.nil?
 
-      Activity.new(
+      activity = Activity.find_or_initialize_by(
+        delivery_partner_identifier: row["delivery_partner_identifier"],
         parent: parent,
-        level: parent.child_level,
-        form_state: :complete,
-        ingested: true,
-        funding_organisation_name: "Department for Business, Energy and Industrial Strategy",
-        funding_organisation_reference: "GB-GOV-13",
-        funding_organisation_type: "10",
-        accountable_organisation_name: "Department for Business, Energy and Industrial Strategy",
-        accountable_organisation_reference: "GB-GOV-13",
-        accountable_organisation_type: "10",
-        reporting_organisation: beis_organisation,
-        organisation: parent.organisation,
-        extending_organisation: parent.extending_organisation
-      )
+      ) { |activity|
+        activity.ingested = true
+        activity.funding_organisation_name = "Department for Business, Energy and Industrial Strategy"
+        activity.funding_organisation_reference = "GB-GOV-13"
+        activity.funding_organisation_type = "10"
+        activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
+        activity.accountable_organisation_reference = "GB-GOV-13"
+        activity.accountable_organisation_type = "10"
+        activity.reporting_organisation = beis_organisation
+        activity.organisation = parent.organisation
+        activity.extending_organisation = parent.extending_organisation
+      }
+
+      # Always update these
+      activity.level = parent.child_level
+      activity.form_state = :complete
+
+      activity
     else
       Activity.where.not(level: nil).find_by(
         delivery_partner_identifier: row["delivery_partner_identifier"]

--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -45,9 +45,14 @@ class IngestCsv
             # Force validation if the only invalid fields are ones we're ok with
             activity.save!(validate: false)
           else
-            # Skip row and write message
+            # Skip row and log validation errors, ignoring the ones we've deemed acceptable
+            ACCEPTABLE_INVALID_ATTRIBUTES.each { |attr| activity.errors.delete(attr) }
             write_log("Skipping Activity #{activity.id}: #{activity.errors.full_messages}")
-            write_log("attributes: #{attributes.sort.inspect}")
+
+            attributes.sort.each do |k, v|
+              write_log("attributes: #{k.ljust(30, " ").slice(0...30)} => #{v}")
+            end
+
             # binding.pry
           end
         end

--- a/app/services/ingest_csv.rb
+++ b/app/services/ingest_csv.rb
@@ -22,11 +22,19 @@ class IngestCsv
           next
         end
 
+        if activity == :missing_parent
+          write_log("Couldn't find parent Activity where roda_identifier_compound is #{row["parent_roda_identifier_compound"]}")
+          next
+        end
+
         Rails.logger.tagged(["IngestCsv", "activity:#{activity.id}"]) do
           attributes = IngestCsvRow.new(row).call
 
           # Ignore attributes that have been set to :skip
           attributes.delete_if { |_key, value| value == :skip }
+
+          # Ignore parent_roda_identifier_compound attribute as there's no equivalent in RODA
+          attributes.delete("parent_roda_identifier_compound")
 
           activity.assign_attributes(attributes)
 
@@ -38,8 +46,8 @@ class IngestCsv
             activity.save!(validate: false)
           else
             # Skip row and write message
-            write_log("Skipping Activity #{row}: #{activity.errors.full_messages}")
-            write_log("attributes: #{attributes.inspect}")
+            write_log("Skipping Activity #{activity.id}: #{activity.errors.full_messages}")
+            write_log("attributes: #{attributes.sort.inspect}")
             # binding.pry
           end
         end
@@ -50,12 +58,41 @@ class IngestCsv
   private
 
   def activity_for(row)
-    Activity.where.not(level: nil).find_by(
-      delivery_partner_identifier: row["delivery_partner_identifier"]
-    )
+    if has_parent_identifier?
+      parent = Activity.find_by(roda_identifier_compound: row["parent_roda_identifier_compound"])
+      return :missing_parent if parent.nil?
+
+      Activity.new(
+        parent: parent,
+        level: parent.child_level,
+        form_state: :complete,
+        ingested: true,
+        funding_organisation_name: "Department for Business, Energy and Industrial Strategy",
+        funding_organisation_reference: "GB-GOV-13",
+        funding_organisation_type: "10",
+        accountable_organisation_name: "Department for Business, Energy and Industrial Strategy",
+        accountable_organisation_reference: "GB-GOV-13",
+        accountable_organisation_type: "10",
+        reporting_organisation: beis_organisation,
+        organisation: parent.organisation,
+        extending_organisation: parent.extending_organisation
+      )
+    else
+      Activity.where.not(level: nil).find_by(
+        delivery_partner_identifier: row["delivery_partner_identifier"]
+      )
+    end
+  end
+
+  def has_parent_identifier?
+    @has_parent_identifier ||= csv.first.headers.include?("parent_roda_identifier_compound")
   end
 
   def write_log(message)
     Rails.logger.info(message)
+  end
+
+  def beis_organisation
+    @beis_organisation ||= Organisation.find_by(service_owner: true)
   end
 end

--- a/spec/fixtures/csv/existing_activity.csv
+++ b/spec/fixtures/csv/existing_activity.csv
@@ -1,0 +1,3 @@
+﻿delivery_partner_identifier,parent_roda_identifier_compound,title,description,sector,programme_status,planned_start_date,planned_end_date,actual_start_date,actual_end_date,recipient_country,flow,aid_type,call_open_date,call_close_date,gdi,oda_eligibility,intended_beneficiaries,total_applications,total_awards
+EXAMPLE_02,GCRF-RFFLAIR-FLRR12020,Isolation and redesign of single-celled examples,"Example award with a description",Research for prevention and control of NCDs,Spend in Progress,01/01/2020,31/01/2022,,,"Africa, regional",ODA,Other technical assistance,01/01/2019,17/03/2019,NA,Yes,None,395,30
+

--- a/spec/fixtures/csv/new_activities.csv
+++ b/spec/fixtures/csv/new_activities.csv
@@ -1,0 +1,4 @@
+﻿delivery_partner_identifier,parent_roda_identifier_compound,title,description,sector,programme_status,planned_start_date,planned_end_date,actual_start_date,actual_end_date,recipient_country,flow,aid_type,call_open_date,call_close_date,gdi,oda_eligibility,intended_beneficiaries,total_applications,total_awards
+EXAMPLE\01,GCRF-RFSBA-R5,Programme - Award (round 5),"Future talent generation in developing countries",Medical research,Spend in Progress,10/10/2020,10/10/2021,,,"Africa, regional",ODA,Other technical assistance,11/01/2019,11/05/2019,NA,Yes,None,14,5
+EXAMPLE 02,GCRF-RFFLAIR-FLRR12020,Isolation and redesign of single-celled examples,"Example award with a description",Research for prevention and control of NCDs,Spend in Progress,01/01/2020,31/01/2022,,,"Africa, regional",ODA,Other technical assistance,01/01/2019,17/03/2019,NA,Yes,None,395,30
+

--- a/spec/services/ingest_csv_spec.rb
+++ b/spec/services/ingest_csv_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe IngestCsv do
       end
     end
 
-    context "with a CSV file which contains the 'parent_roda_identifier_compound'" do
+    context "with a CSV file which contains a column which references a parent activity" do
       before do
         create(:fund_activity, roda_identifier_fragment: "GCRF") do |fund|
           create(:programme_activity, parent: fund, roda_identifier_fragment: "RFSBA") do |programme|
@@ -39,6 +39,22 @@ RSpec.describe IngestCsv do
         expect { IngestCsv.new(csv_file).call }
           .to change { Activity.third_party_project.count }
           .by(2)
+      end
+
+      it "updates any existing activities" do
+        parent = Activity.project.find_by(roda_identifier_fragment: "FLRR12020")
+        third_party_project = create(:third_party_project_activity,
+          parent: parent,
+          delivery_partner_identifier: "EXAMPLE_02",
+          title: "OVERWRITE ME")
+
+        csv_file = "#{Rails.root}/spec/fixtures/csv/existing_activity.csv"
+
+        expect { IngestCsv.new(csv_file).call }
+          .not_to change { Activity.third_party_project.count }
+
+        expect(third_party_project.reload.title)
+          .to eql "Isolation and redesign of single-celled examples"
       end
     end
   end


### PR DESCRIPTION
Given a CSV, which includes a `delivery_partner_identifier` and `parent_roda_indentifier_compound` column, ingest activities.

In addition to the above, the following data columns should be provided:

- title
- description
- sector
- programme_status
- planned_start_date
- planned_end_date
- actual_start_date
- actual_end_date
- recipient_country
- flow
- aid_type
- call_open_date
- call_close_date
- gdi
- oda_eligibility
- intended_beneficiaries
- total_applications
- total_awards

NB: The existence of the `parent_roda_identifier_compound` column in the CSV causes us to create activities associated with a parent vs. the existing 'update existing activities with non-IATI fields' behaviour.