### PR TITLE
(1018) `recipient_country` list amended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,7 @@
 - `Collaboration type` form field added to create activity journey and activity XML
 - Upload transaction data in bulk as CSV
 - Display the parent activity's RODA identifier when adding RODA IDs
+- Missing `West Bank and Gaza Strip` country included in `recipient_country` list
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...HEAD
 [release-16]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-15...release-16

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -231,7 +231,7 @@ en:
       PM: Saint Pierre and Miquelon
       PN: Pitcairn
       PR: Puerto Rico
-      PS: Palestine, State of
+      PS: West Bank and Gaza Strip (Palestinian territory)
       PT: Portugal
       PW: Palau
       PY: Paraguay

--- a/vendor/data/codelists/BEIS/country_to_region_mapping.yml
+++ b/vendor/data/codelists/BEIS/country_to_region_mapping.yml
@@ -279,6 +279,8 @@
     region: "789"
   - country: "WF"
     region: "1035"
+  - country: "PS"
+    region: "589"
   - country: "YE"
     region: "589"
   - country: "ZM"

--- a/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
@@ -427,6 +427,9 @@ data:
 - code: WF
   name: Wallis and Futuna
   status: active
+- code: PS
+  name: West Bank and Gaza Strip (Palestinian territory)
+  status: active
 - code: YE
   name: Yemen
   status: active


### PR DESCRIPTION
Trello: https://trello.com/c/AtIOH9nE

## Changes in this PR

When the client provided us with an up-to-date list of countries and regions to be included in RODA, we updated the existing lists for both, as well as the `country_to_region_mapping` yml file. We missed to include `West Bank and Gaza
Strip` on the list, probably due to ambiguity on the naming, as it appears as `Palestine` in the IATI list, under the same country code.

We are now amending the `recipient_country` list to include this country, under the name `West Bank and Gaza Strip (Palestinian territory)`. This is the name the client wants us to use on the app. In order to be consistent on the changes,
I have modified the IATI country codelist to match this name, as we use this list on the `activity_presenter` to show the info in the activity details.

## Screenshots of UI changes

### After

<img width="1106" alt="Screenshot 2020-09-18 at 08 55 36" src="https://user-images.githubusercontent.com/48016017/93571865-f5098180-f98c-11ea-8fd2-bf93bcdfc96d.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
