### PR TITLE
Reject non-numeric values in bulk transaction import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,8 @@
 ## [unreleased]
 
 - Add and amend Activity data fields in the Report CSV export
+- Accept strictly numeric values in the `Value` column for bulk transaction
+  import
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...HEAD
 [release-17]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...release-17

--- a/app/services/convert_financial_value.rb
+++ b/app/services/convert_financial_value.rb
@@ -1,0 +1,13 @@
+class ConvertFinancialValue
+  VALUE_FORMAT = /^(?:£ *)?((?:- *)?[0-9,]+(?:\.[0-9]{2})?)$/
+
+  Error = Class.new(StandardError)
+
+  def convert(value)
+    match = VALUE_FORMAT.match(value.strip)
+    raise Error if match.nil?
+
+    numeric = match[1].gsub(/[, ]/, "")
+    BigDecimal(numeric, 2)
+  end
+end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -169,6 +169,12 @@ class ImportTransactions
       raise I18n.t("importer.errors.transaction.invalid_date")
     end
 
+    def convert_value(value)
+      ConvertFinancialValue.new.convert(value)
+    rescue ConvertFinancialValue::Error
+      raise I18n.t("importer.errors.transaction.non_numeric_value")
+    end
+
     def convert_receiving_organisation_type(type)
       validate_from_codelist(
         type,

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -94,5 +94,6 @@ en:
         invalid_date: Date must be a valid date
         invalid_iati_disbursement_channel: The disbursement channel must be a valid IATI Disbursement Channel code
         invalid_iati_organisation_type: The receiving organisation type must be a valid IATI Organisation Type code
+        non_numeric_value: The value must be numeric
         unauthorised: You are not authorised to report against this activity
         unknown_identifier: Identifier is not recognised

--- a/spec/services/convert_financial_value_spec.rb
+++ b/spec/services/convert_financial_value_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ConvertFinancialValue do
+  let(:converter) { ConvertFinancialValue.new }
+
+  it "converts zero" do
+    expect(converter.convert("0")).to eq(BigDecimal("0"))
+  end
+
+  it "converts an integer" do
+    expect(converter.convert("42")).to eq(BigDecimal("42"))
+  end
+
+  it "converts a fractional value" do
+    expect(converter.convert("5.02")).to eq(BigDecimal("5.02"))
+  end
+
+  it "converts a negative value" do
+    expect(converter.convert("- 3")).to eq(BigDecimal("-3"))
+  end
+
+  it "converts a number with a leading £ sign" do
+    expect(converter.convert("£ 10")).to eq(BigDecimal("10"))
+  end
+
+  it "converts a number containing commas" do
+    expect(converter.convert("1,234,567")).to eq(BigDecimal("1234567"))
+  end
+
+  it "converts a number with surrounding spaces" do
+    expect(converter.convert(" 9 ")).to eq(BigDecimal("9"))
+  end
+
+  it "converts a number with all supported features" do
+    expect(converter.convert(" £  - 12,345.67 ")).to eq(BigDecimal("-12345.67"))
+  end
+
+  it "rejects a number containing a letter" do
+    expect { converter.convert("1a2") }.to raise_error(ConvertFinancialValue::Error)
+  end
+end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ImportTransactions do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportTransactions::Error.new(0, "Value", "", t("activerecord.errors.models.transaction.attributes.value.other_than")),
+          ImportTransactions::Error.new(0, "Value", "", t("importer.errors.transaction.non_numeric_value")),
         ])
       end
     end
@@ -212,7 +212,23 @@ RSpec.describe ImportTransactions do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportTransactions::Error.new(0, "Value", "This is not a number", t("activerecord.errors.models.transaction.attributes.value.other_than")),
+          ImportTransactions::Error.new(0, "Value", "This is not a number", t("importer.errors.transaction.non_numeric_value")),
+        ])
+      end
+    end
+
+    context "when the Value is partially numeric" do
+      let :transaction_row do
+        super().merge("Value" => "3a4b5.c67")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Value", "3a4b5.c67", t("importer.errors.transaction.non_numeric_value")),
         ])
       end
     end


### PR DESCRIPTION
Monetary values entered in the `Value` column in bulk upload are passed
through the `CreateTransaction` service, which uses `Monetize.parse` to
interpret them. This is much more permissive than we want; it allows
various currency symbols and many different kinds of formatting, whereas
we want to specifically allow this format:

- an optional `£` symbol, followed by
- an optional minus (`-`) symbol, followed by
- at least 1 digit, with comma (`,`) allowed for readability
- an optional decimal point followed by 2 digits

We also cannot just remove the Monetize call, as passing the string
directly through to ActiveRecord results in truncation; a string like
"3a45" is truncated to the value 3.0. We would like any non-numeric
characters in the input treated as an error, as they may represent a
mistake on the user's part. This is especially important in bulk upload,
where a user is adding a lot of data at once and not necessarily
checking all of it afterwards.

The ConvertFinancialValue service implements the desired format, and
ImportTransactions can then report any parsing errors back to the user.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
