### PR TITLE
(1014) Do not strip alphabetical characters from values, reject the value instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,8 @@
 - Add and amend Activity data fields in the Report CSV export
 - Accept strictly numeric values in the `Value` column for bulk transaction
   import
+- Do not automatically strip letters from numeric value fields; instead reject
+  the values as invalid and show an error to the user  
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...HEAD
 [release-17]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-16...release-17

--- a/app/services/convert_financial_value.rb
+++ b/app/services/convert_financial_value.rb
@@ -1,5 +1,5 @@
 class ConvertFinancialValue
-  VALUE_FORMAT = /^(?:£ *)?((?:- *)?[0-9,]+(?:\.[0-9]{2})?)$/
+  VALUE_FORMAT = /^(?:£ *)?((?:- *)?[0-9,]+(?:\.[0-9]{1,2})?)$/
 
   Error = Class.new(StandardError)
 

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -11,7 +11,8 @@ class CreatePlannedDisbursement
 
     planned_disbursement.parent_activity = activity
     planned_disbursement.assign_attributes(attributes)
-    planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
+
+    convert_and_assign_value(planned_disbursement, attributes[:value])
 
     unless activity.organisation.service_owner?
       planned_disbursement.report = report
@@ -28,7 +29,9 @@ class CreatePlannedDisbursement
 
   private
 
-  def sanitize_monetary_string(value:)
-    Monetize.parse(value)
+  def convert_and_assign_value(planned_disbursement, value)
+    planned_disbursement.value = ConvertFinancialValue.new.convert(value.to_s)
+  rescue ConvertFinancialValue::Error
+    planned_disbursement.errors.add(:value, I18n.t("activerecord.errors.models.planned_disbursement.attributes.value.not_a_number"))
   end
 end

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -11,7 +11,8 @@ class CreateTransaction
 
     transaction.parent_activity = activity
     transaction.assign_attributes(attributes)
-    transaction.value = sanitize_monetary_string(value: attributes[:value])
+
+    convert_and_assign_value(transaction, attributes[:value])
 
     unless activity.organisation.service_owner?
       transaction.report = report
@@ -28,7 +29,9 @@ class CreateTransaction
 
   private
 
-  def sanitize_monetary_string(value:)
-    Monetize.parse(value)
+  def convert_and_assign_value(transaction, value)
+    transaction.value = ConvertFinancialValue.new.convert(value.to_s)
+  rescue ConvertFinancialValue::Error
+    transaction.errors.add(:value, I18n.t("activerecord.errors.models.transaction.attributes.value.not_a_number"))
   end
 end

--- a/app/services/update_budget.rb
+++ b/app/services/update_budget.rb
@@ -7,7 +7,8 @@ class UpdateBudget
 
   def call(attributes: {})
     budget.assign_attributes(attributes)
-    budget.value = sanitize_monetary_string(value: attributes[:value])
+
+    convert_and_assign_value(budget, attributes[:value])
 
     result = if budget.valid?
       Result.new(budget.save, budget)
@@ -20,7 +21,9 @@ class UpdateBudget
 
   private
 
-  def sanitize_monetary_string(value:)
-    Monetize.parse(value)
+  def convert_and_assign_value(budget, value)
+    budget.value = ConvertFinancialValue.new.convert(value.to_s)
+  rescue ConvertFinancialValue::Error
+    budget.errors.add(:value, I18n.t("activerecord.errors.models.budget.attributes.value.not_a_number"))
   end
 end

--- a/app/services/update_planned_disbursement.rb
+++ b/app/services/update_planned_disbursement.rb
@@ -7,7 +7,8 @@ class UpdatePlannedDisbursement
 
   def call(attributes: {})
     planned_disbursement.assign_attributes(attributes)
-    planned_disbursement.value = sanitize_monetary_string(value: attributes[:value])
+
+    convert_and_assign_value(planned_disbursement, attributes[:value])
 
     result = if planned_disbursement.valid?
       Result.new(planned_disbursement.save!, planned_disbursement)
@@ -20,7 +21,9 @@ class UpdatePlannedDisbursement
 
   private
 
-  def sanitize_monetary_string(value:)
-    Monetize.parse(value)
+  def convert_and_assign_value(planned_disbursement, value)
+    planned_disbursement.value = ConvertFinancialValue.new.convert(value.to_s)
+  rescue ConvertFinancialValue::Error
+    planned_disbursement.errors.add(:value, I18n.t("activerecord.errors.models.planned_disbursement.attributes.value.not_a_number"))
   end
 end

--- a/app/services/update_transaction.rb
+++ b/app/services/update_transaction.rb
@@ -7,7 +7,8 @@ class UpdateTransaction
 
   def call(attributes: {})
     transaction.assign_attributes(attributes)
-    transaction.value = sanitize_monetary_string(value: attributes[:value])
+
+    convert_and_assign_value(transaction, attributes[:value])
 
     result = if transaction.valid?
       Result.new(transaction.save, transaction)
@@ -20,7 +21,9 @@ class UpdateTransaction
 
   private
 
-  def sanitize_monetary_string(value:)
-    Monetize.parse(value)
+  def convert_and_assign_value(transaction, value)
+    transaction.value = ConvertFinancialValue.new.convert(value.to_s)
+  rescue ConvertFinancialValue::Error
+    transaction.errors.add(:value, I18n.t("activerecord.errors.models.transaction.attributes.value.not_a_number"))
   end
 end

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -71,6 +71,7 @@ en:
               less_than_or_equal_to: Value must not be more than 99,999,999,999.00
               other_than: Value must not be zero
               blank: Enter a budget amount
+              not_a_number: Value must be a valid number
             budget_type:
               blank: Enter a budget type
             status:

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -78,3 +78,4 @@ en:
               blank: Budget type can't be blank
             value:
               inclusion: Value must be between 0.01 and 99,999,999,999.00
+              not_a_number: "Value must be a valid number"

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -80,6 +80,7 @@ en:
               less_than_or_equal_to: Value must be less than or equal to 99,999,999,999.00
               other_than: Value must not be zero
               blank: Enter a transaction amount
+              not_a_number: Value must be a valid number
             transaction_type:
               blank: Select a transaction type
             description:

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Users can create a budget" do
         expect(page).to have_content(t("activerecord.errors.models.budget.attributes.status.blank"))
         expect(page).to have_content(t("activerecord.errors.models.budget.attributes.period_start_date.blank"))
         expect(page).to have_content(t("activerecord.errors.models.budget.attributes.period_end_date.blank"))
-        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.other_than")
+        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.blank")
       end
 
       scenario "sees validation error when the value is more than allowed" do

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -45,23 +45,47 @@ RSpec.feature "Users can create a transaction" do
       end
     end
 
-    scenario "validations" do
-      activity = create(:programme_activity, :with_report, organisation: user.organisation)
+    context "when all values are missing" do
+      scenario "validations" do
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
-      visit activities_path
+        visit activities_path
 
-      click_on(activity.title)
+        click_on(activity.title)
 
-      click_on(t("page_content.transactions.button.create"))
-      click_on(t("default.button.submit"))
+        click_on(t("page_content.transactions.button.create"))
+        click_on(t("default.button.submit"))
 
-      expect(page).to_not have_content(t("action.transaction.create.success"))
-      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.description.blank"))
-      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
-      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
-      expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.other_than")
-      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
-      expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
+        expect(page).to_not have_content(t("action.transaction.create.success"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.description.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.blank")
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
+      end
+    end
+
+    context "when the value is not a number" do
+      scenario "validations" do
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
+
+        visit activities_path
+
+        click_on(activity.title)
+
+        click_on(t("page_content.transactions.button.create"))
+        fill_in "transaction[value]", with: "234r.67"
+        click_on(t("default.button.submit"))
+
+        expect(page).to_not have_content(t("action.transaction.create.success"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.description.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.transaction_type.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.not_a_number")
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
+      end
     end
 
     scenario "disbursement channel is optional" do

--- a/spec/services/convert_financial_value_spec.rb
+++ b/spec/services/convert_financial_value_spec.rb
@@ -11,8 +11,16 @@ RSpec.describe ConvertFinancialValue do
     expect(converter.convert("42")).to eq(BigDecimal("42"))
   end
 
-  it "converts a fractional value" do
+  it "converts a fractional value with one decimal place" do
+    expect(converter.convert("5.2")).to eq(BigDecimal("5.20"))
+  end
+
+  it "converts a fractional value with two decimal places" do
     expect(converter.convert("5.02")).to eq(BigDecimal("5.02"))
+  end
+
+  it "rejects a fractional value with three decimal places" do
+    expect { converter.convert("5.222") }.to raise_error(ConvertFinancialValue::Error)
   end
 
   it "converts a negative value" do

--- a/spec/support/shared_examples/sanitises_monetary_fields.rb
+++ b/spec/support/shared_examples/sanitises_monetary_fields.rb
@@ -1,10 +1,10 @@
 RSpec.shared_examples "sanitises monetary field" do
   context "when a value is passed in" do
     context "and that value contains alphabetical characters" do
-      it "sets a value without these characters" do
+      it "returns an unsuccessful result" do
         attributes = ActionController::Parameters.new(value: "abc 123.00 xyz").permit!
         result = subject.call(attributes: attributes)
-        expect(result.object.value).to eq(BigDecimal("123.00"))
+        expect(result.success).to be false
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/ZU0SW2pm/1014-when-a-monetary-value-is-supplied-with-letters-in-it-do-not-strip-lettters-and-accept-the-numbers-fail

Previously, letters accidentally entered in the `value` fields for budgets,
transactions and planned disbursements were being stripped and the numbers
accepted.

We would prefer these entries to be rejected as an error instead of silently
stripped and passed through.

Use the `ConvertFinancialValue` to sanitize the values before they are added
to their parent entities, and show a relevant error message if any letters are
present.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
