### PR TITLE
(1004) (866) Fix two bugs on dates page

### DIFF
--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -70,8 +70,8 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def update
-    @page_title = t("page_title.activity_form.show.#{step}")
     @activity = Activity.find(activity_id)
+    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
     authorize @activity
 
     if @activity.fund?

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -55,7 +55,7 @@ en:
       activity:
         aid_type: Aid type
         actual_end_date: Actual end date (optional)
-        actual_start_date: Actual start date (optional)
+        actual_start_date: Actual start date (optional if planned start date is entered)
         call_present: Is there a call for this %{level}?
         call_open_date: Call open date
         call_close_date: Call close date


### PR DESCRIPTION
## Changes in this PR

https://trello.com/c/ualvREql/1004-locale-string-for-activity-start-and-end-dates-is-missing-an-level-argument
https://trello.com/c/Kj0muayQ/866-wizard-date-steps-optional-fields-dont-match-validation-rules

Update the label on `Actual start date` field to reflect that it is optional only if the Planned start date is present.

Fix the page title on this page to add a missing label attribute.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
