### PR TITLE
(872) Show an error message if the user does not select a recipient country

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "wicked"
 gem "strip_attributes"
 
 # Authentication
-gem "omniauth-auth0", "~> 2.3"
+gem "omniauth-auth0", "~> 2.4"
 gem "omniauth-rails_csrf_protection", "~> 0.1"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     money (6.13.7)
       i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
@@ -226,10 +226,10 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-auth0 (2.3.1)
+    omniauth-auth0 (2.4.0)
       omniauth-oauth2 (~> 1.5)
-    omniauth-oauth2 (1.6.0)
-      oauth2 (~> 1.1)
+    omniauth-oauth2 (1.7.0)
+      oauth2 (~> 1.4)
       omniauth (~> 1.9)
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
@@ -464,7 +464,7 @@ DEPENDENCIES
   mail-notify
   mini_racer
   monetize
-  omniauth-auth0 (~> 2.3)
+  omniauth-auth0 (~> 2.4)
   omniauth-rails_csrf_protection (~> 0.1)
   parser (~> 2.6.3.0)
   pg

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -124,8 +124,12 @@ class Staff::ActivityFormsController < Staff::BaseController
     when :region
       @activity.assign_attributes(recipient_region: recipient_region)
     when :country
-      inferred_region = country_to_region_mapping.find { |pair| pair["country"] == recipient_country }["region"]
-      @activity.assign_attributes(recipient_region: inferred_region, recipient_country: recipient_country)
+      if recipient_country.blank?
+        @activity.assign_attributes(recipient_country: nil)
+      else
+        inferred_region = country_to_region_mapping.find { |pair| pair["country"] == recipient_country }["region"]
+        @activity.assign_attributes(recipient_region: inferred_region, recipient_country: recipient_country)
+      end
     when :requires_additional_benefitting_countries
       @activity.assign_attributes(requires_additional_benefitting_countries: requires_additional_benefitting_countries)
     when :intended_beneficiaries

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -282,6 +282,33 @@ RSpec.feature "Users can create a fund level activity" do
         click_button t("form.button.activity.submit")
         expect(page).to have_content Activity.find_by(delivery_partner_identifier: identifier).title
       end
+
+      scenario "failing to select a country shows an error message" do
+        visit activities_path
+        click_on(t("page_content.organisation.button.create_activity"))
+
+        choose custom_capitalisation(t("page_content.activity.level.fund"))
+        click_button t("form.button.activity.submit")
+        fill_in "activity[delivery_partner_identifier]", with: "no-country-selected"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[roda_identifier_fragment]", with: "roda-identifier"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[title]", with: "My title"
+        fill_in "activity[description]", with: "My description"
+        click_button t("form.button.activity.submit")
+        choose "Basic Education"
+        click_button t("form.button.activity.submit")
+        choose "School feeding"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[planned_start_date(3i)]", with: "01"
+        fill_in "activity[planned_start_date(2i)]", with: "01"
+        fill_in "activity[planned_start_date(1i)]", with: "2020"
+        click_button t("form.button.activity.submit")
+        choose "Country"
+        click_button t("form.button.activity.submit")
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content "Recipient country can't be blank"
+      end
     end
 
     scenario "fund creation is tracked with public_activity" do


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/KdWvWhzX/872-bug-no-error-message-shown-when-you-dont-select-a-country

Previously we were not showing an error message if the user did not select a
recipient country. Instead a 500 error would be thrown.

If no country was selected, we were attempting to find the associated recipient
region despite the country being blank. This was causing the error.

How, if the country is blank, we assign it to the activity, thereby forcing a
validation error to be shown. We do not try to associate the blank country value
to a region.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
