### PR TITLE
(1036) BEIS Users can download Programme (Level B) xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,7 @@
 - Do not automatically strip letters from numeric value fields; instead reject
   the values as invalid and show an error to the user  
 - the sign out navigation link is not active on the users page
+- BEIS users can download IATI XML for programmes (level B)
 
 ## [unreleased]
 

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -1,11 +1,12 @@
 class FindProgrammeActivities
   include Pundit
 
-  attr_accessor :organisation, :user
+  attr_accessor :organisation, :user, :fund_id
 
-  def initialize(organisation:, user:)
+  def initialize(organisation:, user:, fund_id: nil)
     @organisation = organisation
     @user = user
+    @fund_id = fund_id
   end
 
   def call(eager_load_parent: true)
@@ -17,11 +18,11 @@ class FindProgrammeActivities
       .includes(eager_load_associations)
       .order("created_at ASC")
 
-    programmes = if organisation.service_owner
-      programmes.all
-    else
-      programmes.where(extending_organisation_id: organisation.id)
-    end
-    programmes
+    return programmes if organisation.service_owner
+
+    query_conditions = {extending_organisation_id: organisation.id}
+    query_conditions[:parent_id] = fund_id if fund_id.present?
+
+    programmes.where(query_conditions)
   end
 end

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -8,6 +8,19 @@
       %h1.govuk-heading-xl
         = @organisation_presenter.name
 
+  - if policy(@organisation_presenter).download? && @funds.any?
+    .govuk-grid-row
+      .govuk-grid-column-full.download-projects
+        %h2.govuk-heading-m
+          = t("page_content.organisation.programmes")
+        %div.govuk-body
+          = t("page_content.organisation.download.programmes.explanation")
+
+        - @funds.each do |fund|
+          = link_to t("page_content.organisation.download.programmes.button", fund_title: fund.title),
+              organisation_path(@organisation_presenter, format: :xml, level: :programme, fund_id: fund.id),
+              class: "govuk-button"
+
   - if policy(@organisation_presenter).download? && @project_activities.present?
     .govuk-grid-row
       .govuk-grid-column-full.download-projects

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -47,6 +47,9 @@ en:
       details: Organisation details
       download:
         explanation: Download all activities for this organisation
+        programmes:
+          explanation: "Download all programme (level B) activities for this organisation as XML from:"
+          button: Download %{fund_title} XML
         projects:
           explanation: Download all project (level C) activities for this organisation as XML
         third-party-projects:

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -18,7 +18,23 @@ RSpec.feature "Users can view an organisation as XML" do
     end
 
     context "when the user is viewing any other organisation show page" do
-      context "whe organisation has projects" do
+      context "when the organisation has programmes which it is the extending organisation of" do
+        scenario "they can see the download xml button for programmes" do
+          fund = create(:fund_activity)
+          another_fund = create(:fund_activity)
+          _programme = create(:programme_activity, parent: fund, extending_organisation: organisation)
+          _anohter_programme = create(:programme_activity, parent: another_fund, extending_organisation: organisation)
+
+          visit organisation_path(organisation)
+
+          expect(page).to have_link t("page_content.organisation.download.programmes.button", fund_title: fund.title),
+            href: organisation_path(organisation, format: :xml, level: :programme, fund_id: fund.id)
+          expect(page).to have_link t("page_content.organisation.download.programmes.button", fund_title: another_fund.title),
+            href: organisation_path(organisation, format: :xml, level: :programme, fund_id: another_fund.id)
+        end
+      end
+
+      context "when the organisation has projects" do
         scenario "they can download the organisation's projects as XML" do
           _project = create(:project_activity, organisation: organisation)
 
@@ -173,6 +189,17 @@ RSpec.feature "Users can view an organisation as XML" do
 
         expect(page).to have_content(organisation.name)
         expect(page).to_not have_content(t("default.button.download_as_xml"))
+      end
+
+      scenario "they do not see the programmes download buttons" do
+        programme = create(:programme_activity, extending_organisation: organisation)
+        _project = create(:project_activity, parent: programme, organisation: organisation)
+        fund = programme.parent
+
+        visit organisation_path(organisation)
+
+        expect(page).not_to have_link t("page_content.organisation.download.programmes.button", fund_title: fund.title),
+          href: organisation_path(organisation, format: :xml, level: :programme, fund_id: fund.id)
       end
     end
 

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -53,5 +53,19 @@ RSpec.describe FindProgrammeActivities do
         expect(result).to match_array [extending_organisation_programme]
       end
     end
+
+    context "when a fund is passed" do
+      it "includes only the programmes for the organisaiton and the fund" do
+        delivery_partner_organisation = create(:delivery_partner_organisation)
+        fund = create(:fund_activity)
+        programme = create(:programme_activity, parent: fund, extending_organisation: delivery_partner_organisation)
+        programme_from_another_fund = create(:programme_activity, extending_organisation: delivery_partner_organisation)
+
+        result = described_class.new(organisation: delivery_partner_organisation, user: user, fund_id: fund.id).call
+
+        expect(result).to include programme
+        expect(result).not_to include programme_from_another_fund
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
The service needs to publish Programme (Level B) activities to IATI.

I first allowed the `FindProgrammeService` to optionally take a fund id and if provided, returns only the programmes for that fund and organisation - I also tidied up this class a little as it felt like it was working harder than  it needed to.

I ended up with quite a 🧙 magaical bit of code to my eye, so I am on the fence about it, the commit message explains, but basically `where` can take nothing as it's condition and not be run (TIL a 'no-op'), so we provide the fund id in a hash or nil and let Rails figure it all out. The method was pretty tough to name so I am wondering if something more approachable would be better - love to hear your views.

Then we move on to the super odd 'organisation controller that returns activity xml' - this really irks me but now doesn't feel like the time to fix it.

I refactored it a bit, story in the commit, but basically working a bit harder than it might need to checking for projects and third-party projects and in the remote channce no activities are publishable was going to return an empty xml file to the user.

With that one in the bag it was simple to work out which funds to show buttons for and provides the activities using the updated service.

Once I got a good set of activities in my DB, I was able to export the programmes as xml and validate it with IATI ✅ 

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/480578/94162817-0536ca80-fe7f-11ea-9a58-60378c222f26.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [X] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
