### PR TITLE
(1013) Report the user type to analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,7 @@
 - the sign out navigation link is not active on the users page
 
 ## [unreleased]
+- The user type is tracked in Google Analytics
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...HEAD
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,8 @@
 %html.govuk-template.app-html-class{lang: "en"}
   /<![endif]
   %head
+    - if current_user.present?
+      = render partial: 'shared/google_tag_manager_service_owner', locals: { user_type: current_user.service_owner? ? "service_owner" : "non_service_owner" }
     = render partial: 'shared/google_tag_manager_head'
     %meta{charset: "utf-8"}/
     %title #{content_for :page_title_prefix} — #{t('app.title')}

--- a/app/views/public/privacy_policy/index.html.haml
+++ b/app/views/public/privacy_policy/index.html.haml
@@ -38,6 +38,7 @@
 
       %ul.govuk-list.govuk-list--bullet
         %li the pages you visit on RODA
+        %li whether you act on behalf of BEIS or a third party, which third party is not collected
         %li how long you spend on each RODA page
         %li how you got to the site
         %li what you click on while you’re visiting the site

--- a/app/views/shared/_google_tag_manager_service_owner.html.haml
+++ b/app/views/shared/_google_tag_manager_service_owner.html.haml
@@ -1,0 +1,3 @@
+%script
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({'userType' : '#{user_type}'});


### PR DESCRIPTION
The team want to use Google Analytics and understand which users are
doing what actions to help better understand how users are interacting
with the service.

As we use Google tag manager, the first step is to add the which type of
user is signed in (BEIS or non-BEIS) to the dataLayer so the tag manager
can pick it up and pass it to Google Analytics as a 'dimension'.

The principal is to create a dataLayer object before the tag manager
code is fired and add the data to that.

Although we are adding further identifiers to the tracking, I don't
believe it to be personally identifiable, I have however, made it clear
that BEIS must understand this change and any associated risk.

I originally had this as a boolean 'service_owner` but once in GA it
just would not segment the data the way the team wanted, so I ended up
using the strings in the commit.

There is a load of work in Google Tag manager and Google Analytics that goes along with this (its horrible).

Once merge we should:

- publish the changes to the staging and production environments in Tag Manager
- create the dimension in Analytics for staging and production
- create the segments in Analytics for staging and production
- confirm it is working in staging and production

## Next steps

- [x] Update Tag Manager and Analytics
- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
