### PR TITLE
Correct GDI value in Activity factory

### DIFF
--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     recipient_country { nil }
     requires_additional_benefitting_countries { true }
     intended_beneficiaries { ["CU", "DM", "DO"] }
-    gdi { "No" }
+    gdi { "4" }
     flow { "10" }
     aid_type { "A01" }
     level { :fund }


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/2jy2pVG2/1041-activity-factory-sets-incorrect-value-for-gdi

In https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/627
we added the GDI step to the Activity forms. The Activity factory had the
incorrect value of "No" for GDI, when it should be 1-4.

We have amended this to be "4", the equivalent of "No".


## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
