### PR TITLE
(1037) Add content to confirm activation of report

### DIFF
--- a/app/views/staff/reports_state/activate/complete.html.haml
+++ b/app/views/staff/reports_state/activate/complete.html.haml
@@ -2,7 +2,7 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
+    .govuk-grid-column-full
       .govuk-panel.govuk-panel--confirmation
         %h1.govuk-panel__title
           = t("action.report.activate.complete.title")
@@ -11,15 +11,7 @@
           = t("action.report.activate.complete.body", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
       %h2.govuk-heading-m
-        What happens next
+        = t("page_content.report.activate.complete.heading")
 
-      %p.govuk-body
-        This report is now activated and the delivery partner now has access to edit data, finalise and submit the report in RODA before the deadline.
-
-      %p.govuk-body
-        NOTE - the deadline is not enforced in RODA. If a report is not submitted within the timeframe it will need to be followed up outside of the service, i.e. by email
-
-      %p.govuk-body
-        The Service Manager will send the delivery partner an email notifying them that RODA is now open and their reporting cycle has begun.  ODA PMO Finance Lead will send the commissioning email confirming the deadline and relevant service updates to DPs 2 weeks before the report submission deadline.
-
+      = t("page_content.report.activate.complete.html")
 

--- a/app/views/staff/reports_state/activate/confirm.html.haml
+++ b/app/views/staff/reports_state/activate/confirm.html.haml
@@ -2,9 +2,11 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
+    .govuk-grid-column-full
       %h1.govuk-heading-xl
         = t("page_title.report.activate.confirm", report_financial_quarter: @report_presenter.financial_quarter_and_year, report_organisation: @report.organisation.name)
+      %p.govuk-body
+        = t("page_content.report.activate.confirm")
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
         = hidden_field_tag :state, "active"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -37,8 +37,19 @@ en:
       title: Reports
     report:
       activate:
-        confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will will associate to this report only.
-
+        confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will associate to this report only.
+        complete:
+          heading: What happens next
+          html:
+            <p class="govuk-body">
+            This report is now activated and the delivery partner now has access to edit data, finalise and submit the report in RODA before the deadline.
+            </p>
+            <p class="govuk-body">
+            NOTE - the deadline is not enforced in RODA. If a report is not submitted within the timeframe it will need to be followed up outside of the service, i.e. by email
+            </p>
+            <p class="govuk-body">
+            The Service Manager will send the delivery partner an email notifying them that RODA is now open and their reporting cycle has begun.  ODA PMO Finance Lead will send the commissioning email confirming the deadline and relevant service updates to DPs 2 weeks before the report submission deadline.
+            </p>
   label:
     report:
      state:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -35,6 +35,10 @@ en:
   page_content:
     reports:
       title: Reports
+    report:
+      activate:
+        confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will will associate to this report only.
+
   label:
     report:
      state:


### PR DESCRIPTION
## Changes in this PR

Trello: https://trello.com/c/CvKV2afG/1037-add-content-to-confirm-activation-of-report-beis

Add content to the report activation page. Also change the page layout to be full width. 

## Screenshots of UI changes

<img width="1119" alt="Screenshot 2020-09-28 at 11 06 58" src="https://user-images.githubusercontent.com/1089521/94420524-331c5780-017c-11eb-8c06-d378baacf436.png">

<img width="1237" alt="Screenshot 2020-09-28 at 11 15 42" src="https://user-images.githubusercontent.com/1089521/94420532-36174800-017c-11eb-8604-f9210cb90375.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
