### PR TITLE
BEIS reference is set when uploading transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,12 +337,13 @@
 - Accept strictly numeric values in the `Value` column for bulk transaction
   import
 - Do not automatically strip letters from numeric value fields; instead reject
-  the values as invalid and show an error to the user  
+  the values as invalid and show an error to the user
 - the sign out navigation link is not active on the users page
 - BEIS users can download IATI XML for programmes (level B)
 
 ## [unreleased]
 - The user type is tracked in Google Analytics
+- `providing_organisation_reference` is set when the user uploads transactions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...HEAD
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -40,7 +40,6 @@ class ImportTransactions
   end
 
   class RowImporter
-    DEFAULT_CURRENCY = "GBP"
     TRANSACTION_TYPE_DISBURSEMENT = "3"
 
     attr_reader :errors
@@ -98,8 +97,9 @@ class ImportTransactions
     def assign_default_values(attrs)
       organisation = @activity.providing_organisation
 
-      attrs[:currency] = DEFAULT_CURRENCY
+      attrs[:currency] = organisation.default_currency
       attrs[:transaction_type] = TRANSACTION_TYPE_DISBURSEMENT
+      attrs[:providing_organisation_reference] = organisation.iati_reference
       attrs[:providing_organisation_name] = organisation.name
       attrs[:providing_organisation_type] = organisation.organisation_type
 

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe ImportTransactions do
       expect(transaction).to have_attributes(
         providing_organisation_name: project.providing_organisation.name,
         providing_organisation_type: project.providing_organisation.organisation_type,
+        providing_organisation_reference: project.providing_organisation.iati_reference,
       )
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/R5mTxhrD

## Changes in this PR

While testing transactions uploads, one of the devs realised that the `providing_organisation_reference` value was not getting set on the transaction. We know this is always BEIS, and their IATI reference is `GB-GOV-13`.

We have now amended the code to include this reference when a user uploads transactions on RODA.

I have also changed the way the currency is set in the attributes. It was previously set as a constant for `GBP`, but I noticed that the organisation model gives us `default_currency` as an option, so I thought it would be more appropriate to get the value from the model than from a default constant.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
