### PR TITLE
(1052) Intended Beneficiaries should be separated by a semicolon in report CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,7 @@
 ## [unreleased]
 - The user type is tracked in Google Analytics
 - `providing_organisation_reference` is set when the user uploads transactions
+- Separate the list of intended beneficiaries in the report CSV with semicolons
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...HEAD
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -1,0 +1,6 @@
+class ActivityCsvPresenter < ActivityPresenter
+  def intended_beneficiaries
+    return if super.blank?
+    to_model.intended_beneficiaries.map { |item| I18n.t("activity.recipient_country.#{item}") }.join("; ")
+  end
+end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -89,7 +89,7 @@ class ExportActivityToCsv
   end
 
   private def activity_presenter
-    @activity_presenter ||= ActivityPresenter.new(activity)
+    @activity_presenter ||= ActivityCsvPresenter.new(activity)
   end
 
   private def report_presenter

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ActivityCsvPresenter do
+  describe "#intended_beneficiaries" do
+    context "when there are other benefiting countries" do
+      it "returns the benefiting countries separated by semicolons" do
+        activity = build(:activity, intended_beneficiaries: ["AR", "EC", "BR"])
+        result = described_class.new(activity).intended_beneficiaries
+        expect(result).to eql("Argentina; Ecuador; Brazil")
+      end
+    end
+
+    context "when there are no other benefiting countries" do
+      it "returns nil" do
+        activity = build(:activity, intended_beneficiaries: nil)
+        result = described_class.new(activity).intended_beneficiaries
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ExportActivityToCsv do
 
   describe "#call" do
     it "creates a CSV line representation of the Activity" do
-      activity_presenter = ActivityPresenter.new(project)
+      activity_presenter = ActivityCsvPresenter.new(project)
       export_service = ExportActivityToCsv.new(activity: project, report: report)
       result = export_service.call
       next_four_quarter_totals = export_service.next_four_quarter_forecasts


### PR DESCRIPTION

## Changes in this PR

Trello: https://trello.com/c/ACZgsbLv/1052-in-report-csv-separate-intended-beneficiary-countries-with-a-semicolon

The Intended Beneficiaries on an activity are stored as an array. In the UI we
display the countries as "Country, Country and Country". However in the Report
CSV these need to be expressed as "Country; Country; Country".

This commit introduces an ActivityCsvPresenter which inherits from ActivityPresenter
and overrides `#intended_beneficiaries` to generate the list of countries
separated by a semicolon.


## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
