### PR TITLE
Users can edit invalid activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,7 @@
 - The user type is tracked in Google Analytics
 - `providing_organisation_reference` is set when the user uploads transactions
 - Separate the list of intended beneficiaries in the report CSV with semicolons
+- Users can now edit fields on invalid completed activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...HEAD
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -284,9 +284,15 @@ class Staff::ActivityFormsController < Staff::BaseController
   end
 
   def update_form_state
-    return if @activity.invalid?
+    return if @activity.invalid?(step)
 
-    if @activity.form_steps_completed?
+    if step == :geography && @activity.geography == "recipient_country"
+      jump_to :country
+    elsif step == :geography && @activity.geography == "recipient_region"
+      jump_to :region
+    elsif step == :sector_category
+      jump_to :sector
+    elsif @activity.form_steps_completed?
       flash[:notice] ||= t("action.#{@activity.level}.update.success")
       jump_to Wicked::FINISH_STEP
     else

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -384,6 +384,26 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to have_content(t("action.third_party_project.update.success"))
       end
     end
+
+    context "when editing an invalid activity that is already saved" do
+      let(:activity) { create(:project_activity, organisation: user.organisation) }
+
+      it "saves the value and shows an update success message" do
+        activity.update_columns(title: nil, programme_status: "Replace me")
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within(".programme_status") do
+          click_on(t("default.link.edit"))
+        end
+        choose "Spend in progress"
+        click_button t("form.button.activity.submit")
+
+        expect(page).to have_content(t("action.project.update.success"))
+        expect(activity.reload.programme_status).to eql("07")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Trello: https://trello.com/c/VCBQEBMr

## Changes in this PR

Updating activities through the wizard should behave in the same way as creation - only validating attributes relevant to the current form step. Currently the wizard behaves differently when creating and updating activities:

- When creating a brand new activity, the wizard validates only the attributes that appear on the current form step, which makes sense

- When updating an activity, we validate against all validation rules, rather than those relevant to the current step.

This was fine when activities could only be entered through the wizard, as each step required the previous steps to all validate before moving on. Now, we have incomplete/invalid activities - so you can be on one page of the wizard, fix the data, and will receive an error message triggered by a validation error caused by an attribute on a completely different form step.

This PR introduces changes so when the user needs to edit an invalid activity they will be able to do so without getting any errors. Eventually, being able to fill empty activity fields that are required will make the activity valid.

To achieve this new behaviour from the Wizard, we have modified the `update_form_state` method to return only if the current step is invalid (rather than the whole activity being invalid). After introducing this change, we got 3 failing tests in relation to the geography step (`recipient_country` and `recipient_region`) and the sector step. They have a slightly different behaviour since when a user sets the geography to, for example, a country, it is required that they select what country the activity is going to be related to. And this is done on a separate Wizard step. Similar situation with Sector step: once the user selects a sector category, they need to select a specific sector within that category. This last selection happens on a different Wizard step. We have preserved that behaviour by introducing an if-elsif-else statement on `update_form_state` method 

Co-authored-by: Leeky <leeky@leeky.org.uk>

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
