### PR TITLE
Downgrade better_errors to 2.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       jwt (~> 2.2.0)
       rest-client (~> 2.0.0)
       zache (~> 0.12.0)
-    better_errors (2.8.2)
+    better_errors (2.8.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)


### PR DESCRIPTION
There is a bug in better_errors 2.8.2, where it uses its VERSION
constant without having loaded it first [1]. This is preventing our app
from booting so I'm reverting this version bump until that issue is
fixed.

This reverts commit a6e2172a42abefaf4e2cf5f50762d0d52999def2, reversing
changes made to ce4f953ada4ef1b01db0289f9a161bfe6b20706b.

[1]: https://github.com/BetterErrors/better_errors/issues/483