### PR TITLE
(1070) Fix: report object is valid when deadline passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,7 +348,7 @@
 - Users can now edit fields on invalid completed activities
 
 ## [unreleased]
-
+- Fix bug that prevented delivery partners from submitting a report.
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...HEAD
 [release-19]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...release-19
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18

--- a/app/assets/stylesheets/partials/_alerts.css.scss
+++ b/app/assets/stylesheets/partials/_alerts.css.scss
@@ -1,32 +1,24 @@
-.alert {
-  padding: 0 govuk-spacing(4);
-  @include govuk-font($size: 24, $weight: bold);
-  border-width: govuk-spacing(1);
-  border-style: solid;
-  border-color: govuk-colour("black");
-
-  &.alert-success {
-    border-color: govuk-colour("green");
-
-    .alert-message {
-      color: govuk-colour("green");
-    }
+.govuk-error-summary.govuk-error-summary--notice,
+.govuk-error-summary.govuk-error-summary--success {
+  color: govuk-colour("green");
+  border-color: govuk-colour("green");
+  margin-bottom: 0;
+  h2 {
+    margin-bottom: 0;
   }
+}
 
-  &.alert-notice {
-    border-color: govuk-colour("blue");
-
-    .alert-message {
-      color: govuk-colour("blue");
-    }
+.govuk-error-summary.govuk-error-summary--error,
+.govuk-error-summary.govuk-error-summary--alert {
+  color: govuk-colour("red");
+  border-color: govuk-colour("red");
+  margin-bottom: 0;
+  h2 {
+    margin-bottom: 0;
   }
+}
 
-  &.alert-danger {
-    border-color: govuk-colour("red");
-
-    .alert-message {
-      color: govuk-colour("red");
-    }
-  }
-
+ul.govuk-list.govuk-error-summary__list li {
+  @include govuk-font($size: 19, $weight: bold)
+  color:  $govuk-error-colour;
 }

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -45,8 +45,8 @@ class Staff::ReportsController < Staff::BaseController
     @report_presenter = ReportPresenter.new(@report)
 
     @report.assign_attributes(report_params)
-    if @report.valid?
-      @report.save!
+    if @report.valid?(:edit)
+      @report.save
       @report.create_activity key: "report.update", owner: current_user
       flash[:notice] = t("action.report.update.success")
       redirect_to reports_path

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -53,7 +53,7 @@ class Staff::ReportsStateController < Staff::BaseController
 
     unless report.valid?(policy_action.to_sym)
       authorize report
-      flash[:error] = t("action.report.#{policy_action}.failure")
+      flash[:error] = {title: t("action.report.#{policy_action}.failure"), errors: report.errors}
       return redirect_to report_path(report)
     end
 

--- a/app/controllers/staff/reports_state_controller.rb
+++ b/app/controllers/staff/reports_state_controller.rb
@@ -51,7 +51,7 @@ class Staff::ReportsStateController < Staff::BaseController
   private def change_report_state_to(state)
     policy_action = STATE_TO_POLICY_ACTION.fetch(state)
 
-    unless report.valid?
+    unless report.valid?(policy_action.to_sym)
       authorize report
       flash[:error] = t("action.report.#{policy_action}.failure")
       return redirect_to report_path(report)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,7 +5,7 @@ class Report < ApplicationRecord
 
   attr_readonly :financial_quarter, :financial_year
 
-  validates_presence_of :description, on: :update
+  validates_presence_of :description, on: [:edit, :activate]
   validates_presence_of :state
 
   belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"
@@ -14,7 +14,7 @@ class Report < ApplicationRecord
   has_many :planned_disbursements
 
   validate :activity_must_be_a_fund
-  validates :deadline, date_not_in_past: true, date_within_boundaries: true
+  validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit
 
   enum state: {
     inactive: "inactive",

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -1,5 +1,15 @@
--# Rails flash messages styled for Bootstrap 4.0 TODO restyle for gov.uk
 - flash.each do |name, msg|
   - if msg.is_a?(String)
-    %div{:class => "alert alert-#{name.to_s == 'notice' ? 'success' : 'danger'}", :role  => "alert"}
-      = content_tag :p, msg, :id => "flash_#{name}", :class => ["alert-message"]
+    %div{class: ["govuk-error-summary", "govuk-error-summary--#{name.to_s}"], options: {aria_labelledby: "error-summary-title", role: "alert", data_module: "govuk-error-summary"}}
+      %h2{class: "govuk-error-summary__title", id: "error-summary-title"}
+        = msg
+
+  - elsif  msg.is_a?(Hash) & msg.key?(:errors) & msg.key?(:title)
+    %div{class: "govuk-error-summary", options: {aria_labelledby: "error-summary-title", role: "alert", data_module: "govuk-error-summary"}}
+      %h2{class: "govuk-error-summary__title", id: "error-summary-title"}
+        = msg[:title]
+      %div{class: "govuk-error-summary__body"}
+        %ul{class: "govuk-list govuk-error-summary__list"}
+          - msg[:errors].each do |attribute, error|
+            %li
+              = error

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -146,7 +146,7 @@ en:
         report:
           attributes:
             description:
-              blank: Reporting period can't be blank
+              blank: Report decription cannot be blank
             fund:
               level: Activity must be a Fund (level A) activity
             deadline:

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Report, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:description).on(:update) }
+    it { should validate_presence_of(:description).on([:edit, :activate]) }
     it { should validate_presence_of(:state) }
     it { should have_readonly_attribute(:financial_quarter) }
     it { should have_readonly_attribute(:financial_year) }
@@ -68,9 +68,16 @@ RSpec.describe Report, type: :model do
     expect(report.errors[:fund]).to include t("activerecord.errors.models.report.attributes.fund.level")
   end
 
-  it "does not allow a Deadline which is in the past" do
+  it "allows a deadline which is in the past by default" do
     report = build(:report, deadline: Date.yesterday)
-    expect(report).not_to be_valid
+    expect(report).to be_valid
+  end
+
+  context "when editing the report details i.e. in the `edit` validation context" do
+    it "does not allow a deadline which is in the past" do
+      report = build(:report, deadline: Date.yesterday)
+      expect(report.valid?(:edit)).to eq false
+    end
   end
 
   describe "#financial_quarter" do

--- a/spec/views/staff/shared/message_spec.rb
+++ b/spec/views/staff/shared/message_spec.rb
@@ -1,0 +1,25 @@
+describe "layouts/_messages" do
+  context "when passed a flash message with a string" do
+    it "renders a simple message" do
+      flash[:notice] = "This is a notice!"
+      render
+      expect(response).to include "This is a notice!"
+    end
+  end
+
+  context "when passed a flash message with a hash" do
+    it "renders a flash message with a hash that has title and errors keys" do
+      flash[:notice] = {title: "The title", errors: {attribute: "Attribute", another_attribute: "Another attribute"}}
+      render
+      expect(response).to include "The title"
+      expect(response).to include "Attribute"
+      expect(response).to include "Another attribute"
+    end
+
+    it "renders nothing if the correct keys are missing" do
+      flash[:notice] = {a_thing: "A thing", another_thing: "Another thing"}
+      render
+      expect(response).to eql ""
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Our Report objects can only change state if they are vaild and they were only vaild when the deadlne was not in the past. This meant after 12:00 on the day of the deadline, delivery partners could not submit their reports.

This has been fixed here by only validating the deadline when submtted the edit form.

The PR also passes a validation context based on the report state changing, this lets us keep the behaviour that a report must have a description in order to be activated without causes validation issues later.

The second commit adds a way to show Rails flashes as GOVUK error summarys - which in turns allows us to give the user the reason a report could not be activated, see the screen shots.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/480578/95059997-96186c00-06f1-11eb-959f-f9a31fb4da33.png)

### After
![image](https://user-images.githubusercontent.com/480578/95059971-8ac54080-06f1-11eb-95e2-df760b40da5a.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
