### PR TITLE
(1066) Users can see a list of invalid activities in the index page

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :organisation
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
   end
 
   config.hosts = [

--- a/doc/utilities.md
+++ b/doc/utilities.md
@@ -1,0 +1,20 @@
+# Invalid_activities rake task
+
+## Context
+
+We made this task to be able to provide the client with a detailed list of
+invalid activities so they could amend each of them. The information on
+each CSV row is:
+  - Activity organisation name
+  - Activity title
+  - Activity level
+  - Activity URL
+
+The purpose of this task is to be run in production, where the invalid activities
+live at the moment.
+
+## Running the task
+
+You can run this task on the console by typing `rake invalid_activities`. This
+command will run the task and, once it's finished, you will find the file
+`invalid_activities.csv` in the `tmp` folder of this project.

--- a/lib/tasks/invalid_activities.rake
+++ b/lib/tasks/invalid_activities.rake
@@ -1,0 +1,14 @@
+require "csv"
+
+desc "Creates a csv file with a list of completed but invalid activities in RODA"
+task invalid_activities: :environment do
+  activities = Activity.where(form_state: "complete")
+  invalid_activities_array = activities.reject { |activity| activity.valid? }
+
+  CSV.open("tmp/invalid_activities.csv", "wb") do |csv|
+    invalid_activities_array.each do |activity|
+      activity_url = Rails.application.routes.url_helpers.organisation_activity_details_url(activity.organisation, activity, host: ENV["DOMAIN"])
+      csv << [activity.organisation.name, activity.title, activity.level, activity_url]
+    end
+  end
+end

--- a/spec/lib/tasks/invalid_activities_spec.rb
+++ b/spec/lib/tasks/invalid_activities_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require "csv"
+Rails.application.load_tasks
+
+describe "invalid_activities.rake" do
+  it "creates a csv file on tmp folder with a list of invalid activities in RODA" do
+    activities = create_list(:project_activity, 5)
+    activities.first.update_columns(gdi: nil, collaboration_type: nil)
+    activities.last.update_columns(title: nil, programme_status: nil)
+
+    run_task(task_name: "invalid_activities")
+    invalid_activities_from_csv = CSV.read("tmp/invalid_activities.csv")
+
+    expect(invalid_activities_from_csv.count).to eql(2)
+    expect(invalid_activities_from_csv.first).to include(activities.first.title)
+    expect(invalid_activities_from_csv.first).to include(activities.first.organisation.name)
+    expect(invalid_activities_from_csv.first).to include(activities.first.level)
+    expect(invalid_activities_from_csv.first).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(activities.first.organisation, activities.first.id, host: ENV["DOMAIN"]))
+  end
+end
+
+def run_task(task_name:)
+  Rake::Task[task_name].invoke
+end

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe FindProgrammeActivities do
   let!(:extending_organisation_programme) { create(:programme_activity, extending_organisation: other_organisation) }
   let!(:other_programme) { create(:programme_activity) }
 
-  before(:all) do
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
-  end
-
-  after(:all) do
-    Bullet.delete_whitelist(type: :unused_eager_loading, class_name: "Activity", association: :parent)
-  end
-
   describe "#call" do
     it "eager loads the organisation and parent activity" do
       expect_any_instance_of(ActiveRecord::Relation)

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe FindProjectActivities do
   let!(:organisation_project) { create(:project_activity, organisation: other_organisation) }
   let!(:other_project) { create(:project_activity) }
 
-  before(:all) do
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
-  end
-
-  after(:all) do
-    Bullet.delete_whitelist(type: :unused_eager_loading, class_name: "Activity", association: :parent)
-  end
-
   describe "#call" do
     it "eager loads the organisation and parent activity" do
       expect_any_instance_of(ActiveRecord::Relation)

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe FindThirdPartyProjectActivities do
   let!(:organisation_project) { create(:third_party_project_activity, organisation: other_organisation) }
   let!(:other_project) { create(:third_party_project_activity) }
 
-  before(:all) do
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
-  end
-
-  after(:all) do
-    Bullet.delete_whitelist(type: :unused_eager_loading, class_name: "Activity", association: :parent)
-  end
-
   describe "#call" do
     it "eager loads the organisation and parent activity" do
       expect_any_instance_of(ActiveRecord::Relation)


### PR DESCRIPTION
Trello: https://trello.com/c/kJRwvB56

## Changes in this PR

**Update at 22/10/2020**

We have decided to take a different approach and avoid the changes on the UI (see explanation in commit message). We are now doing a rake task that will get us the list of invalid activities we need to provide the client with. We think this is less risky as it doesn't involve changing the codebase for the UI, and less time-consuming, as we won't need to come back to revert those UI changes.

--------------------------------------------------------------------------------------------------------------------

After adding new fields to the create activity journey, and given the fact that some of these fields were mandatory, we found that there are some activities on production that were created through RODA before these fields were added. Now
these activities are invalid because they are missing the data on the mandatory new fields. 

In order to make easier for the client to identify invalid activities from a long list, we have now added a *temporary* change that will allow us to display all the invalid activities on their own list, in the activities index page. This way, the user will be able to click on each activity and amend/fill in the missing data. Once we are certain all the activities in production are valid, we will revert these changes.

During the implementation of this feature, we got a bunch of random Unoptimised query errors from the gem `Bullet`. It would throw errors when running the entire test suite but not when running the tests individually. After some investigation with senior members of the dev team we found out that some code related to Bullet whitelists introduced on different tests was conflicting with our tests (see full explanation on the first commit of this PR). The modifications on the code needed to make all the tests pass and Bullet to behave as we expect are done on this separate commit, since we probably want to keep these changes after we revert the rest.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
