### PR TITLE
(1056) New forecasts only collect the required information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,7 @@
 - No longer collect start and end dates for planned disbursements (forecasts)
   through the application interface.
 - Planned disbursements are always original when created
+- Planned disbursement currency is always GBP
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,7 @@
   through the application interface.
 - Planned disbursements are always original when created
 - Planned disbursement currency is always GBP
+- Planned disbursement providing organisation is always BEIS
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,7 @@
   instead of start and end dates (the values of which are calculated).
 - No longer collect start and end dates for planned disbursements (forecasts)
   through the application interface.
+- Planned disbursements are always original when created
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,8 @@
 - Planned disbursement providing organisation is always BEIS
 - Planned disbursement receiving organisations is no longer collect, but is
   retained for existing records
+- Planned disbursements do not include receiving organisation in the IATI xml
+  export
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,8 @@
 - Planned disbursements are always original when created
 - Planned disbursement currency is always GBP
 - Planned disbursement providing organisation is always BEIS
+- Planned disbursement receiving organisations is no longer collect, but is
+  retained for existing records
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -5,7 +5,6 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     @activity = Activity.find(params["activity_id"])
     @planned_disbursement = PlannedDisbursement.new
     @planned_disbursement.parent_activity = @activity
-    pre_fill_providing_organisation
     pre_fill_financial_quarter_and_year
 
     authorize @planned_disbursement
@@ -55,21 +54,12 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     params.require(:planned_disbursement).permit(
       :currency,
       :value,
-      :providing_organisation_name,
-      :providing_organisation_type,
-      :providing_organisation_reference,
       :receiving_organisation_name,
       :receiving_organisation_type,
       :receiving_organisation_reference,
       :financial_quarter,
       :financial_year,
     )
-  end
-
-  private def pre_fill_providing_organisation
-    @planned_disbursement.providing_organisation_name = @activity.providing_organisation.name
-    @planned_disbursement.providing_organisation_type = @activity.providing_organisation.organisation_type
-    @planned_disbursement.providing_organisation_reference = @activity.providing_organisation.iati_reference
   end
 
   private def pre_fill_financial_quarter_and_year

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -54,9 +54,6 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     params.require(:planned_disbursement).permit(
       :currency,
       :value,
-      :receiving_organisation_name,
-      :receiving_organisation_type,
-      :receiving_organisation_reference,
       :financial_quarter,
       :financial_year,
     )

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -53,7 +53,6 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
 
   private def planned_disbursement_params
     params.require(:planned_disbursement).permit(
-      :planned_disbursement_type,
       :currency,
       :value,
       :providing_organisation_name,

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -20,18 +20,6 @@ module FormHelper
     end
   end
 
-  def list_of_planned_disbursement_budget_types
-    @list_of_planned_disbursement_budget_types ||= begin
-      PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.map do |id, name|
-        OpenStruct.new(
-          id: id,
-          name: t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.name"),
-          description: t("form.label.planned_disbursement.planned_disbursement_type_options.#{name}.description")
-        )
-      end
-    end
-  end
-
   def list_of_budget_statuses
     @list_of_budget_statuses ||= begin
       Budget::STATUSES.map { |id, name| OpenStruct.new(id: id, name: t("form.label.budget.status_options.#{name}")) }

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -2,7 +2,7 @@ class PlannedDisbursement < ApplicationRecord
   include PublicActivity::Common
   PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
 
-  strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
+  strip_attributes only: :receiving_organisation_reference
 
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
@@ -17,7 +17,8 @@ class PlannedDisbursement < ApplicationRecord
     :receiving_organisation_name,
     :receiving_organisation_type,
     :financial_quarter,
-    :financial_year
+    :financial_year,
+    :providing_organisation_reference
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
 
   def unknown_receiving_organisation_type?

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -2,8 +2,6 @@ class PlannedDisbursement < ApplicationRecord
   include PublicActivity::Common
   PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
 
-  strip_attributes only: :receiving_organisation_reference
-
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
 
@@ -14,11 +12,9 @@ class PlannedDisbursement < ApplicationRecord
     :value,
     :providing_organisation_name,
     :providing_organisation_type,
-    :receiving_organisation_name,
-    :receiving_organisation_type,
+    :providing_organisation_reference,
     :financial_quarter,
-    :financial_year,
-    :providing_organisation_reference
+    :financial_year
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
 
   def unknown_receiving_organisation_type?

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -17,8 +17,4 @@ class PlannedDisbursement < ApplicationRecord
     :financial_quarter,
     :financial_year
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
-
-  def unknown_receiving_organisation_type?
-    receiving_organisation_type == "0"
-  end
 end

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -1,6 +1,7 @@
 class PlannedDisbursement < ApplicationRecord
   include PublicActivity::Common
-  PLANNED_DISBURSEMENT_BUDGET_TYPES = {"1": "original", "2": "revised"}
+
+  enum planned_disbursement_type: {original: "1", revised: "2"}
 
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true

--- a/app/presenters/planned_disbursement_xml_presenter.rb
+++ b/app/presenters/planned_disbursement_xml_presenter.rb
@@ -16,4 +16,8 @@ class PlannedDisbursementXmlPresenter < SimpleDelegator
   def value
     number_to_currency(super, unit: "", delimiter: "")
   end
+
+  def planned_disbursement_type
+    PlannedDisbursement.planned_disbursement_types[super]
+  end
 end

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -12,6 +12,7 @@ class CreatePlannedDisbursement
     planned_disbursement.parent_activity = activity
     planned_disbursement.assign_attributes(attributes)
     planned_disbursement.planned_disbursement_type = PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.key("original").to_s
+    planned_disbursement.currency = activity.organisation.default_currency
 
     if attributes.key?(:financial_quarter) && attributes.key?(:financial_year)
       planned_disbursement.period_start_date =

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -11,7 +11,7 @@ class CreatePlannedDisbursement
 
     planned_disbursement.parent_activity = activity
     planned_disbursement.assign_attributes(attributes)
-    planned_disbursement.planned_disbursement_type = PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.key("original").to_s
+    planned_disbursement.planned_disbursement_type = "1"
     planned_disbursement.currency = activity.organisation.default_currency
 
     if attributes.key?(:financial_quarter) && attributes.key?(:financial_year)

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -21,6 +21,10 @@ class CreatePlannedDisbursement
         FinancialPeriod.end_date_from_quarter_and_year(attributes.fetch(:financial_quarter), attributes.fetch(:financial_year))
     end
 
+    planned_disbursement.providing_organisation_name = service_owner.name
+    planned_disbursement.providing_organisation_type = service_owner.organisation_type
+    planned_disbursement.providing_organisation_reference = service_owner.iati_reference
+
     convert_and_assign_value(planned_disbursement, attributes[:value])
 
     unless activity.organisation.service_owner?
@@ -36,11 +40,13 @@ class CreatePlannedDisbursement
     result
   end
 
-  private
-
-  def convert_and_assign_value(planned_disbursement, value)
+  private def convert_and_assign_value(planned_disbursement, value)
     planned_disbursement.value = ConvertFinancialValue.new.convert(value.to_s)
   rescue ConvertFinancialValue::Error
     planned_disbursement.errors.add(:value, I18n.t("activerecord.errors.models.planned_disbursement.attributes.value.not_a_number"))
+  end
+
+  private def service_owner
+    Organisation.find_by_service_owner(true)
   end
 end

--- a/app/services/create_planned_disbursement.rb
+++ b/app/services/create_planned_disbursement.rb
@@ -11,6 +11,7 @@ class CreatePlannedDisbursement
 
     planned_disbursement.parent_activity = activity
     planned_disbursement.assign_attributes(attributes)
+    planned_disbursement.planned_disbursement_type = PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.key("original").to_s
 
     if attributes.key?(:financial_quarter) && attributes.key?(:financial_year)
       planned_disbursement.period_start_date =

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -18,15 +18,6 @@
 
 = f.govuk_text_field :value, width: 20
 
-= f.govuk_fieldset legend: { text: t("form.legend.planned_disbursement.providing_organisation") } do
-  %span.govuk-hint= t("form.hint.planned_disbursement.providing_organisation")
-  = f.govuk_text_field :providing_organisation_name
-  = f.govuk_collection_select :providing_organisation_type,
-                       yaml_to_objects(entity: "organisation", type: "organisation_type"),
-                       :code,
-                       :name
-  = f.govuk_text_field :providing_organisation_reference
-
 = f.govuk_fieldset legend: { text: t("form.legend.planned_disbursement.receiving_organisation") } do
   %span.govuk-hint= t("form.hint.planned_disbursement.receiving_organisation")
   = f.govuk_text_field :receiving_organisation_name

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -18,13 +18,4 @@
 
 = f.govuk_text_field :value, width: 20
 
-= f.govuk_fieldset legend: { text: t("form.legend.planned_disbursement.receiving_organisation") } do
-  %span.govuk-hint= t("form.hint.planned_disbursement.receiving_organisation")
-  = f.govuk_text_field :receiving_organisation_name
-  = f.govuk_collection_select :receiving_organisation_type,
-                      yaml_to_objects(entity: "organisation", type: "organisation_type"),
-                      :code,
-                      :name
-  = f.govuk_text_field :receiving_organisation_reference
-
 = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -16,11 +16,6 @@
         :name,
         label: { text: "Financial year", tag: :h2, size: "m" }
 
-= f.govuk_collection_select :currency,
-                               currency_select_options,
-                               :code,
-                               :name
-
 = f.govuk_text_field :value, width: 20
 
 = f.govuk_fieldset legend: { text: t("form.legend.planned_disbursement.providing_organisation") } do

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -1,12 +1,5 @@
 = f.govuk_error_summary
 
-= f.govuk_collection_radio_buttons :planned_disbursement_type,
-  list_of_planned_disbursement_budget_types,
-  :id,
-  :name,
-  :description,
-  legend: { tag: :h2, size: "s" }
-
 = f.govuk_fieldset legend: { text: nil } do
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/shared/xml/_planned_disbursement.xml.haml
+++ b/app/views/staff/shared/xml/_planned_disbursement.xml.haml
@@ -5,8 +5,3 @@
   %value{"currency" => planned_disbursement.currency, "value-date" => planned_disbursement.period_start_date}= planned_disbursement.value
   %provider-org{"provider-activity-id" => "", "type" => planned_disbursement.providing_organisation_type, "ref" => planned_disbursement.providing_organisation_reference}
     %narrative=planned_disbursement.providing_organisation_name
-  - if planned_disbursement.unknown_receiving_organisation_type?
-    %receiver-org
-  - else
-    %receiver-org{"receiver-activity-id" => "", "type" => planned_disbursement.receiving_organisation_type, "ref" => planned_disbursement.receiving_organisation_reference}
-      %narrative=planned_disbursement.receiving_organisation_name

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -9,30 +9,20 @@ en:
   form:
     label:
       planned_disbursement:
-        planned_disbursement_type: Budget type
         providing_organisation_name: Providing organisation name
         providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name
         receiving_organisation_type: Receiving organisation type
         currency: Currency
-        planned_disbursement_type_options:
-          original:
-            description: The original budget allocated to the activity
-            name: Original
-          revised:
-            description: The updated budget for an activity
-            name: Revised
         providing_organisation_reference: International Aid Transparency Initiative (IATI) Reference (optional)
         receiving_organisation_reference: IATI Reference (optional)
         value: Forecasted spend amount
     legend:
       planned_disbursement:
-        planned_disbursement_type: Budget type
         providing_organisation: Providing organisation
         receiving_organisation: Receiving organisation
     hint:
       planned_disbursement:
-        planned_disbursement_type: Whether this is an original plan (prepared when the original commitment was made) or has subsequently been revised
         providing_organisation: The organisation where this planned disbursement is coming from
         providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
         receiving_organisation: The organisation receiving the money from this transaction.
@@ -66,8 +56,6 @@ en:
       models:
         planned_disbursement:
           attributes:
-            planned_disbursement_type:
-              blank: Budget type can't be blank
             value:
               inclusion: Value must be between 0.01 and 99,999,999,999.00
               not_a_number: "Value must be a valid number"

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -13,7 +13,6 @@ en:
         providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name
         receiving_organisation_type: Receiving organisation type
-        currency: Currency
         providing_organisation_reference: International Aid Transparency Initiative (IATI) Reference (optional)
         receiving_organisation_reference: IATI Reference (optional)
         value: Forecasted spend amount

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -29,8 +29,8 @@ en:
     body:
       planned_disbursement:
         planned_disbursement_type_options:
-          '1': Original
-          '2': Revised
+          original: Original
+          revised: Revised
         edit_noun: planned disbursement
   page_content:
     planned_disbursements:

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -9,13 +9,9 @@ en:
   form:
     label:
       planned_disbursement:
-        receiving_organisation_name: Receiving organisation name
-        receiving_organisation_type: Receiving organisation type
-        receiving_organisation_reference: IATI Reference (optional)
         value: Forecasted spend amount
     legend:
       planned_disbursement:
-        receiving_organisation: Receiving organisation
     hint:
       planned_disbursement:
         receiving_organisation: The organisation receiving the money from this transaction.

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -9,21 +9,15 @@ en:
   form:
     label:
       planned_disbursement:
-        providing_organisation_name: Providing organisation name
-        providing_organisation_type: Providing organisation type
         receiving_organisation_name: Receiving organisation name
         receiving_organisation_type: Receiving organisation type
-        providing_organisation_reference: International Aid Transparency Initiative (IATI) Reference (optional)
         receiving_organisation_reference: IATI Reference (optional)
         value: Forecasted spend amount
     legend:
       planned_disbursement:
-        providing_organisation: Providing organisation
         receiving_organisation: Receiving organisation
     hint:
       planned_disbursement:
-        providing_organisation: The organisation where this planned disbursement is coming from
-        providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
         receiving_organisation: The organisation receiving the money from this transaction.
         receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
   table:

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Users can create a planned disbursement" do
 
       expect(page).to have_content t("page_title.planned_disbursement.new")
 
-      choose t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
       choose "Q1"
       select "2020-2021", from: "Financial year"
       select "Pound Sterling", from: "planned_disbursement[currency]"

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "Users can create a planned disbursement" do
 
       choose "Q1"
       select "2020-2021", from: "Financial year"
-      select "Pound Sterling", from: "planned_disbursement[currency]"
       fill_in "planned_disbursement[value]", with: "1000.00"
       fill_in "planned_disbursement[providing_organisation_name]", with: "org"
       select "Government", from: "planned_disbursement[providing_organisation_type]"

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe "Users can create a planned disbursement" do
       choose "Q1"
       select "2020-2021", from: "Financial year"
       fill_in "planned_disbursement[value]", with: "1000.00"
-      fill_in "planned_disbursement[providing_organisation_name]", with: "org"
-      select "Government", from: "planned_disbursement[providing_organisation_type]"
       fill_in "planned_disbursement[receiving_organisation_name]", with: "another org"
       select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
       click_button t("default.button.submit")
@@ -86,74 +84,6 @@ RSpec.describe "Users can create a planned disbursement" do
 
       planned_disbursement = PlannedDisbursement.last
       expect(planned_disbursement.report).to eq(report)
-    end
-
-    context "when the delivery partner is a government organisation" do
-      context "and the activity is a project" do
-        it "pre fills the providing organisation details with those of BEIS" do
-          beis = create(:beis_organisation)
-          government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
-          user.update(organisation: government_delivery_partner)
-          project = create(:project_activity, :with_report, organisation: user.organisation)
-
-          visit activities_path
-          click_on project.title
-          click_on t("page_content.planned_disbursements.button.create")
-
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
-        end
-      end
-
-      context "and the activity is a third-party project" do
-        it "pre fills the providing organisation details with those of BEIS" do
-          beis = create(:beis_organisation)
-          government_delivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
-          user.update(organisation: government_delivery_partner)
-          project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
-
-          visit organisation_activity_path(user.organisation, project)
-          click_on t("page_content.planned_disbursements.button.create")
-
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
-        end
-      end
-    end
-
-    context "when the delivery partner is a non-government organisation" do
-      context "and the activity is a project" do
-        it "pre fills the providing organisation details with those of BEIS" do
-          beis = create(:beis_organisation)
-          government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "10")
-          user.update(organisation: government_devlivery_partner)
-          project = create(:project_activity, :with_report, organisation: user.organisation)
-
-          visit activities_path
-          click_on project.title
-          click_on t("page_content.planned_disbursements.button.create")
-
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: beis.name)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: beis.organisation_type)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: beis.iati_reference)
-        end
-      end
-      context "and the activity is a third-party project" do
-        it "pre fills the providing organisation details with those of the delivery partner" do
-          non_government_devlivery_partner = create(:delivery_partner_organisation, organisation_type: "22")
-          user.update(organisation: non_government_devlivery_partner)
-          project = create(:third_party_project_activity, :with_report, organisation: user.organisation)
-
-          visit organisation_activity_path(user.organisation, project)
-          click_on t("page_content.planned_disbursements.button.create")
-
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_name"), with: non_government_devlivery_partner.name)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_type"), with: non_government_devlivery_partner.organisation_type)
-          expect(page).to have_field(t("form.label.planned_disbursement.providing_organisation_reference"), with: non_government_devlivery_partner.iati_reference)
-        end
-      end
     end
   end
 

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe "Users can create a planned disbursement" do
       choose "Q1"
       select "2020-2021", from: "Financial year"
       fill_in "planned_disbursement[value]", with: "1000.00"
-      fill_in "planned_disbursement[receiving_organisation_name]", with: "another org"
-      select "Other Public Sector", from: "planned_disbursement[receiving_organisation_type]"
       click_button t("default.button.submit")
 
       expect(page).to have_current_path organisation_activity_financials_path(user.organisation, project)

--- a/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_an_planned_disbursement_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe "Users can edit a planned disbursement" do
 
       expect(page).to have_http_status(:success)
 
-      fill_in "Receiving organisation", with: "An Organisation"
+      fill_in "Forecasted spend amount", with: "£20000"
       click_button "Submit"
 
       expect(page).to have_content t("action.planned_disbursement.update.success")
-      expect(page).to have_content "An Organisation"
+      expect(page).to have_content "£20,000"
     end
 
     scenario "the correct financial quarter and year are selected" do

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -18,15 +18,6 @@ RSpec.describe FormHelper, type: :helper do
     end
   end
 
-  describe "#list_of_planned_disbursement_budget_types" do
-    it "builds a list of budget types for a planned disbursement" do
-      budget_types = helper.list_of_planned_disbursement_budget_types
-
-      expect(budget_types[0].name).to eq t("form.label.planned_disbursement.planned_disbursement_type_options.original.name")
-      expect(budget_types[0].description).to eq t("form.label.planned_disbursement.planned_disbursement_type_options.original.description")
-    end
-  end
-
   describe "#scoped_parent_activities" do
     context "when the activity is a fund" do
       it "returns an empty result" do

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -42,14 +42,4 @@ RSpec.describe PlannedDisbursement, type: :model do
     it { should strip_attribute(:providing_organisation_reference) }
     it { should strip_attribute(:receiving_organisation_reference) }
   end
-
-  describe "validations" do
-    context "when the planned_disbursement_type is blank" do
-      it "displays the appropriate error message" do
-        planned_disbursement = build(:planned_disbursement, planned_disbursement_type: nil)
-        expect(planned_disbursement.valid?).to be_falsey
-        expect(planned_disbursement.errors[:planned_disbursement_type]).to include t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.blank")
-      end
-    end
-  end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe PlannedDisbursement, type: :model do
   end
 
   describe "sanitation" do
-    it { should strip_attribute(:providing_organisation_reference) }
     it { should strip_attribute(:receiving_organisation_reference) }
   end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -37,8 +37,4 @@ RSpec.describe PlannedDisbursement, type: :model do
       expect(planned_disbursement.unknown_receiving_organisation_type?).to be false
     end
   end
-
-  describe "sanitation" do
-    it { should strip_attribute(:receiving_organisation_reference) }
-  end
 end

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -27,14 +27,4 @@ RSpec.describe PlannedDisbursement, type: :model do
       end
     end
   end
-
-  describe "#unknown_receiving_organisation_type?" do
-    it "returns true when receiving organisation type is 0" do
-      planned_disbursement = create(:planned_disbursement, receiving_organisation_type: "0")
-      expect(planned_disbursement.unknown_receiving_organisation_type?).to be true
-
-      planned_disbursement.update(receiving_organisation_type: "10")
-      expect(planned_disbursement.unknown_receiving_organisation_type?).to be false
-    end
-  end
 end

--- a/spec/presenters/planned_disbursement_xml_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_xml_presenter_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe PlannedDisbursementXmlPresenter do
       expect(described_class.new(planned_disbursement).value).to eq("100000.00")
     end
   end
+
+  describe "#planned_disbursement_type" do
+    it "returns the numeric value for the planned disbursement type" do
+      expect(described_class.new(planned_disbursement).planned_disbursement_type).to eq "1"
+    end
+  end
 end

--- a/spec/services/create_planned_disbursement_spec.rb
+++ b/spec/services/create_planned_disbursement_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe CreatePlannedDisbursement do
       expect(result.object.planned_disbursement_type).to eql original_key_value
     end
 
+    it "always sets the currency to that of the organisation that owns the activity" do
+      result = described_class.new(activity: activity).call
+      expect(result.object.currency).to eql activity.organisation.default_currency
+    end
+
     context "when the planned disbursement is valid" do
       it "sets the parent activity" do
         result = described_class.new(activity: activity).call

--- a/spec/services/create_planned_disbursement_spec.rb
+++ b/spec/services/create_planned_disbursement_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe CreatePlannedDisbursement do
       expect(result.object.currency).to eql activity.organisation.default_currency
     end
 
+    it "always sets the providing organisation to BEIS" do
+      result = described_class.new(activity: activity).call
+      beis = Organisation.find_by(service_owner: true)
+
+      expect(result.object.providing_organisation_name).to eql beis.name
+      expect(result.object.providing_organisation_type).to eql beis.organisation_type
+      expect(result.object.providing_organisation_reference).to eql beis.iati_reference
+    end
+
     context "when the planned disbursement is valid" do
       it "sets the parent activity" do
         result = described_class.new(activity: activity).call

--- a/spec/services/create_planned_disbursement_spec.rb
+++ b/spec/services/create_planned_disbursement_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe CreatePlannedDisbursement do
     subject { described_class.new(activity: create(:activity)) }
     it_behaves_like "sanitises monetary field"
 
+    it "always sets the type to original" do
+      result = described_class.new(activity: activity).call
+      original_key_value = PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.key("original").to_s
+
+      expect(result.object.planned_disbursement_type).to eql original_key_value
+    end
+
     context "when the planned disbursement is valid" do
       it "sets the parent activity" do
         result = described_class.new(activity: activity).call

--- a/spec/services/create_planned_disbursement_spec.rb
+++ b/spec/services/create_planned_disbursement_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe CreatePlannedDisbursement do
 
     it "always sets the type to original" do
       result = described_class.new(activity: activity).call
-      original_key_value = PlannedDisbursement::PLANNED_DISBURSEMENT_BUDGET_TYPES.key("original").to_s
 
-      expect(result.object.planned_disbursement_type).to eql original_key_value
+      expect(result.object).to be_original
     end
 
     it "always sets the currency to that of the organisation that owns the activity" do

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe IngestIatiActivities do
         ingested_planned_disbursement = planned_disbursements.first
 
         expect(ingested_planned_disbursement).to be_valid
-        expect(ingested_planned_disbursement.planned_disbursement_type).to eql("1")
+        expect(ingested_planned_disbursement).to be_original
         expect(ingested_planned_disbursement.period_start_date).to eq "2019-07-01".to_date
         expect(ingested_planned_disbursement.period_end_date).to eq "2020-04-30".to_date
         expect(ingested_planned_disbursement.financial_quarter).to eq 2

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -307,18 +307,13 @@ module FormHelpers
   def fill_in_planned_disbursement_form(
     financial_quarter: "Q2",
     financial_year: "2020-2021",
-    value: "100000",
-    receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-987", type: "Private Sector")
+    value: "100000"
   )
 
     choose financial_quarter
     select financial_year, from: "Financial year"
 
     fill_in "planned_disbursement[value]", with: value
-
-    fill_in "planned_disbursement[receiving_organisation_name]", with: receiving_organisation.name
-    select receiving_organisation.type, from: "planned_disbursement[receiving_organisation_type]"
-    fill_in "planned_disbursement[receiving_organisation_reference]", with: receiving_organisation.reference
 
     click_on(t("default.button.submit"))
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -304,14 +304,13 @@ module FormHelpers
     end
   end
 
-  def fill_in_planned_disbursement_form(planned_disbursement_type: "Original",
+  def fill_in_planned_disbursement_form(
     financial_quarter: "Q2",
     financial_year: "2020-2021",
     currency: "Pound Sterling",
     value: "100000",
-    receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-987", type: "Private Sector"))
-
-    choose planned_disbursement_type
+    receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-987", type: "Private Sector")
+  )
 
     choose financial_quarter
     select financial_year, from: "Financial year"

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -307,7 +307,6 @@ module FormHelpers
   def fill_in_planned_disbursement_form(
     financial_quarter: "Q2",
     financial_year: "2020-2021",
-    currency: "Pound Sterling",
     value: "100000",
     receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-987", type: "Private Sector")
   )
@@ -315,7 +314,6 @@ module FormHelpers
     choose financial_quarter
     select financial_year, from: "Financial year"
 
-    select currency, from: "planned_disbursement[currency]"
     fill_in "planned_disbursement[value]", with: value
 
     fill_in "planned_disbursement[receiving_organisation_name]", with: receiving_organisation.name

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -100,10 +100,5 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/@provider-activity-id").text).to eq ""
     expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/@ref").text).to eq planned_disbursement_presenter.providing_organisation_reference
     expect(xml.xpath("//iati-activity/planned-disbursement/provider-org/narrative").text).to eq planned_disbursement_presenter.providing_organisation_name
-
-    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@type").text).to eq planned_disbursement_presenter.receiving_organisation_type
-    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@provider-activity-id").text).to eq ""
-    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/@ref").text).to eq planned_disbursement_presenter.receiving_organisation_reference
-    expect(xml.xpath("//iati-activity/planned-disbursement/receiver-org/narrative").text).to eq planned_disbursement_presenter.receiving_organisation_name
   end
 end


### PR DESCRIPTION
## Changes in this PR
Following on from #692, we remove the fields from the form that collects values we can infer ourselves:

- planned disbursement type is always original (when creating an new one)
- currency is always GBP
- providing organisation is always BEIS
-  we do not collect a recieving organisation

There is a refactor here to store the planned_disbursement_type as an enum, this gives us nice helper methods to use with planned disbursements like `original?` that makes the code a little more readable.

### Keeping the columns
The general principal here is to not remove the columns of data we are now infering, the main reason being we might have values for them in production and it seems wise to keep those for moment.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/480578/96978723-951b7300-1516-11eb-8d8d-c8af6f9a7488.png)

### After
![image](https://user-images.githubusercontent.com/480578/96978752-9f3d7180-1516-11eb-8966-bb5af09ec862.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
