### PR TITLE
(1099) GDI options have been modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,7 @@
   retained for existing records
 - Planned disbursements do not include receiving organisation in the IATI xml
   export
+- Answers for GDI form step have been modified
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -43,7 +43,8 @@ en:
       '1': Yes - China
       '2': Yes - India
       '3': Yes - China and India
-      '4': 'No'
+      '4': GDI not applicable
+      '5': No - This activity benefits China or India but GDI does not apply
     geography:
       recipient_country: Country
       recipient_region: Region

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -257,7 +257,7 @@ RSpec.feature "Users can create a fund level activity" do
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("activerecord.errors.models.activity.attributes.gdi.blank")
 
-        choose "No"
+        choose "GDI not applicable"
         click_button t("form.button.activity.submit")
         expect(page). to have_content t("form.label.activity.collaboration_type")
 

--- a/spec/services/ingest_csv_row_spec.rb
+++ b/spec/services/ingest_csv_row_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe IngestCsvRow do
 
   context "#process_gdi" do
     it "returns the mapped gdi code" do
-      expect(IngestCsvRow.new.process_gdi("NO"))
+      expect(IngestCsvRow.new.process_gdi("gdi not applicable"))
         .to eql "4"
     end
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -32,7 +32,7 @@ module FormHelpers
     geography: "recipient_region",
     recipient_region: "Developing countries, unspecified",
     intended_beneficiaries: "Haiti",
-    gdi: "No",
+    gdi: "GDI not applicable",
     collaboration_type: "Bilateral",
     flow: "ODA",
     aid_type: "A01",
@@ -182,7 +182,7 @@ module FormHelpers
 
     expect(page).to have_content t("form.label.activity.gdi")
     expect(page).to have_content t("form.hint.activity.gdi")
-    choose "No"
+    choose "GDI not applicable"
     click_button t("form.button.activity.submit")
 
     unless level == "fund"

--- a/vendor/data/codelists/IATI/2_03/activity/gdi.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/gdi.yml
@@ -11,4 +11,6 @@ data:
   - code: '3'
     name: Yes - China and India
   - code: '4'
-    name: 'No'
+    name: GDI not applicable
+  - code: '5'
+    name: No - This activity benefits China or India but GDI does not apply


### PR DESCRIPTION
Trello: https://trello.com/c/IidBaA1Y

## Changes in this PR

This PR follows a request from the client. They needed to include one option on GDI for activities that benefit either India or China (or both) but that were created before the GDI policy existed.

Likewise, the option `No` is now presented as `GDI not applicable` as requested by the client. This will be the option users can select for activities benefitting any of the other countries (no China or India).

Specs and factories have also been modified to reflect these changes. There is one spec related to the ingest work, which modification I decided to add on a separate commit. The reason for this is that this work was done by another developer from the team, and now I have introduced an option for `GDI not applicable`, which could conflict with the values this developer created for nil, which are `not applicable` or `n/a`. Ideally I'd like this to be reviewed by that developer or someone senior who is familiar with the ingest work.

## Screenshots of UI changes

### After

<img width="909" alt="Screenshot 2020-10-26 at 16 31 46" src="https://user-images.githubusercontent.com/48016017/97201126-0030a800-17aa-11eb-8b66-454a78f05ed9.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
