### PR TITLE
(1147) Only allow one original planned disbursement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,8 +373,9 @@
 - Fix allow application to create new users in Auth0
 - Filter out unused aid types.
 - Replace the hints in the aid type form with shorter, more accessible copy if available.
-
 - Option `No - was never eligible` added to ODA eligibility form step
+- Two original planned disbursements for the same activity, financial quarter
+  and year cannot be created.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
 [release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -6,6 +6,8 @@ class PlannedDisbursement < ApplicationRecord
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
 
+  validate :only_one_original, on: :create
+
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :planned_disbursement_type,
     :period_start_date,
@@ -17,4 +19,10 @@ class PlannedDisbursement < ApplicationRecord
     :financial_quarter,
     :financial_year
   validates :value, inclusion: {in: 0.01..99_999_999_999.00}
+
+  def only_one_original
+    if PlannedDisbursement.find_by(financial_quarter: financial_quarter, financial_year: financial_year, parent_activity: parent_activity, planned_disbursement_type: :original).present?
+      errors.add(:base, I18n.t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.only_one_original", financial_quarter: financial_quarter, financial_year_start: financial_year, financial_year_end: financial_year + 1))
+    end
+  end
 end

--- a/app/views/staff/planned_disbursements/_form.html.haml
+++ b/app/views/staff/planned_disbursements/_form.html.haml
@@ -1,4 +1,4 @@
-= f.govuk_error_summary
+= f.govuk_error_summary link_base_errors_to: :financial_quarter
 
 = f.govuk_fieldset legend: { text: nil } do
   .govuk-grid-row

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -48,3 +48,5 @@ en:
             value:
               inclusion: Value must be between 0.01 and 99,999,999,999.00
               not_a_number: "Value must be a valid number"
+            planned_disbursement_type:
+              only_one_original: There is already an original forecasted spend for Q%{financial_quarter} %{financial_year_start}-%{financial_year_end}

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1045,22 +1045,21 @@ RSpec.describe Activity, type: :model do
 
   describe "#forecasted_total_for_report_financial_quarter" do
     it "returns the total of all the activity's planned disbursements scoped to a report's financial quarter only" do
-      project = create(:project_activity, :with_report)
-      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      report = create(:report, financial_quarter: 1, financial_year: 2020, state: :active, created_at: Date.parse("2020-04-01"))
+      project = create(:project_activity)
 
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
+      create(:planned_disbursement, parent_activity: project, report: report, value: 1000.00, period_start_date: Date.parse("2020-04-01"), financial_quarter: 1, financial_year: 2020)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.parse("2020-01-01"), financial_quarter: 4, financial_year: 2019)
 
-      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(2000.00)
+      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(1000.00)
     end
 
     it "does not include totals for any planned disbursements outside the report's date range" do
-      project = create(:project_activity, :with_report)
-      report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
+      report = create(:report, financial_quarter: 3, financial_year: 2020, state: :active, created_at: Date.parse("2020-10-01"))
+      project = create(:project_activity)
 
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 6.months.ago)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.parse("2020-04-01"), financial_quarter: 1, financial_year: 2020)
+      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.parse("2020-07-01"), financial_quarter: 2, financial_year: 2020)
 
       expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(0)
     end
@@ -1073,17 +1072,16 @@ RSpec.describe Activity, type: :model do
       create(:transaction, parent_activity: project, value: 100, report: report, date: Date.today)
       create(:transaction, parent_activity: project, value: 200, report: report, date: Date.today)
       create(:planned_disbursement, parent_activity: project, value: 1500, report: report, period_start_date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 500, report: report, period_start_date: Date.today)
 
-      expect(project.variance_for_report_financial_quarter(report: report)).to eq(-1700)
+      expect(project.variance_for_report_financial_quarter(report: report)).to eq(-1200)
     end
   end
 
   describe "#forecasted_total_for_date_range" do
     it "returns the total of all the activity's planned disbursements scoped to a date range" do
       project = create(:project_activity, :with_report)
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200, period_start_date: Date.parse("13 April 2020"))
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1000, period_start_date: Date.parse("20 November 2020"))
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200, period_start_date: Date.parse("13 April 2020"), financial_quarter: 1, financial_year: 2020)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1000, period_start_date: Date.parse("20 November 2020"), financial_quarter: 3, financial_year: 2020)
 
       expect(project.forecasted_total_for_date_range(range: Date.parse("1 April 2020")..Date.parse("30 June 2020"))).to eq 200
       expect(project.forecasted_total_for_date_range(range: Date.parse("1 October 2020")..Date.parse("31 December 2020"))).to eq 1000

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -9,6 +9,40 @@ RSpec.describe PlannedDisbursement, type: :model do
     it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:value) }
 
+    it "does not allow two original planned disbursements for the same activity, financial quarter and year" do
+      beis = create(:beis_organisation)
+      report = create(:report)
+      first_planned_disbursement = create(:planned_disbursement, parent_activity: activity, financial_quarter: 1, financial_year: 2020)
+      second_planned_disbursement = PlannedDisbursement.new(
+        value: 1000,
+        planned_disbursement_type: :original,
+        financial_quarter: 1,
+        financial_year: 2020,
+        period_start_date: Date.parse("2020-04-01"),
+        providing_organisation_name: beis.name,
+        providing_organisation_type: beis.organisation_type,
+        providing_organisation_reference: beis.iati_reference,
+        currency: "GBP",
+        parent_activity: activity,
+        report: report
+      )
+
+      error_message = t("activerecord.errors.models.planned_disbursement.attributes.planned_disbursement_type.only_one_original",
+        financial_quarter: first_planned_disbursement.financial_quarter,
+        financial_year_start: first_planned_disbursement.financial_year,
+        financial_year_end: first_planned_disbursement.financial_year + 1)
+
+      expect(second_planned_disbursement).to be_invalid
+      expect(second_planned_disbursement.errors[:base]).to eq [error_message]
+    end
+
+    it "does allow the same original planned disbursement when editing" do
+      planned_disbursement = create(:planned_disbursement, parent_activity: activity, financial_quarter: 1, financial_year: 2020)
+      planned_disbursement.value = "200000.00"
+
+      expect(planned_disbursement).to be_valid
+    end
+
     context "when the activity belongs to a delivery partner organisation" do
       before { activity.update(organisation: build_stubbed(:delivery_partner_organisation)) }
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe ActivityPresenter do
       project = create(:project_activity, :with_report)
       report = Report.find_by(fund: project.associated_fund, organisation: project.organisation)
       _disbursement_1 = create(:planned_disbursement, parent_activity: project, report: report, value: 200.20, period_start_date: Date.today)
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500.00)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500.00, financial_quarter: 4, financial_year: 2019)
 
       expect(described_class.new(project).forecasted_total_for_report_financial_quarter(report: report))
         .to eq "200.20"
@@ -499,14 +499,17 @@ RSpec.describe ActivityPresenter do
   describe "#forecasted_total_for_date_range" do
     it "returns the planned disbursement total for a date range as a formatted number" do
       project = create(:project_activity, :with_report)
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200.20, period_start_date: Date.today)
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: 3.months.ago)
+      current_financial_quarter = Date.parse("2020-07-01")
+      last_financial_quarter = Date.parse("2020-04-01")
+      next_financial_quarter = Date.parse("2020-10-01")
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200.20, period_start_date: current_financial_quarter, financial_quarter: 2, financial_year: 2020)
+      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: last_financial_quarter, financial_quarter: 1, financial_year: 2019)
 
-      expect(described_class.new(project).forecasted_total_for_date_range(range: Date.today.all_quarter))
+      expect(described_class.new(project).forecasted_total_for_date_range(range: current_financial_quarter.all_quarter))
         .to eq "200.20"
-      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.ago.all_quarter))
+      expect(described_class.new(project).forecasted_total_for_date_range(range: last_financial_quarter.all_quarter))
         .to eq "1500.00"
-      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.from_now.all_quarter))
+      expect(described_class.new(project).forecasted_total_for_date_range(range: next_financial_quarter.all_quarter))
         .to eq "0.00"
     end
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ExportActivityToCsv do
 
   describe "#next_four_quarter_forecasts" do
     it "gets the forecasted total for the date ranges of the next four quarters" do
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, period_start_date: 3.months.from_now, value: 1000)
+      _disbursement_1 = create(:planned_disbursement, parent_activity: project, period_start_date: 3.months.from_now, value: 1000, financial_quarter: FinancialPeriod.quarter_from_date(3.months.from_now), financial_year: FinancialPeriod.year_from_date(3.months.from_now))
       _disbursement_2 = create(:planned_disbursement, parent_activity: project, period_start_date: 9.months.from_now, value: 500)
       totals = ExportActivityToCsv.new(activity: project, report: report).next_four_quarter_forecasts
 


### PR DESCRIPTION
## Changes in this PR
There should only ever be one original planned disbursement for a given
activity, financial quarter and year. This commit enforces that with a
validation on planned disbursement type that only apples when creating a
new planned disbursement.

This also meant updating a number of specs that are creating multiple
planned disbursements in the same financial quarter.

As there is no field in the UI to link an error to we add the error to
the base and use the GOVUK form builders link_base_errors_to option to
make the link the financial quarter, however there seems to be a bug
with this that the id for the link is not generated correctly, it is
missing the `--error` part- I don't feel that this should block this
work however.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
