### PR TITLE
(1103) Add `No` to ODA eligibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,8 @@
 ## [unreleased]
 - Fix allow application to create new users in Auth0
 
+- Option `No - was never eligible` added to ODA eligibility form step
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
 [release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -51,7 +51,7 @@ class Activity < ApplicationRecord
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
-  validates :oda_eligibility, inclusion: {in: [true, false]}, on: :oda_eligibility_step
+  validates :oda_eligibility, presence: true, on: :oda_eligibility_step
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :roda_identifier_compound, uniqueness: true, allow_nil: true
@@ -89,6 +89,12 @@ class Activity < ApplicationRecord
   enum geography: {
     recipient_region: "Recipient region",
     recipient_country: "Recipient country",
+  }
+
+  enum oda_eligibility: {
+    never_eligible: 0,
+    eligible: 1,
+    no_longer_eligible: 2,
   }
 
   scope :funds, -> { where(level: :fund) }

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -110,7 +110,7 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def oda_eligibility
-    return if super.nil?
+    return if super.blank?
     I18n.t("activity.oda_eligibility.#{super}")
   end
 

--- a/app/services/ingest_csv_row.rb
+++ b/app/services/ingest_csv_row.rb
@@ -53,9 +53,10 @@ class IngestCsvRow
   end
 
   def process_oda_eligibility(value)
-    return false if value.nil?
+    value = value.to_s.strip.downcase
+    return :skip if value.blank? || value.downcase == "n/a" || value.downcase == "not applicable"
 
-    value.downcase == "eligible"
+    oda_eligibility_mapping[value] || :skip
   end
 
   def process_gdi(value)
@@ -275,6 +276,14 @@ class IngestCsvRow
   def aid_type_mapping
     @aid_type_mapping ||= begin
       yaml_to_objects(entity: "activity", type: "aid_type")
+        .map { |status| [status["name"].downcase, status["code"]] }
+        .to_h
+    end
+  end
+
+  def oda_eligibility_mapping
+    @oda_eligibility_mapping ||= begin
+      yaml_to_objects(entity: "activity", type: "oda_eligibility")
         .map { |status| [status["name"].downcase, status["code"]] }
         .to_h
     end

--- a/app/views/staff/activity_forms/oda_eligibility.html.haml
+++ b/app/views/staff/activity_forms/oda_eligibility.html.haml
@@ -1,5 +1,8 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset(:oda_eligibility, legend: { text: t("form.legend.activity.oda_eligibility"), size: "xl", tag: "h1" }) do
-    = f.hidden_field :oda_eligibility, value: nil
-    = f.govuk_radio_button :oda_eligibility, :true, label: { text: t("form.label.activity.oda_eligibility.true") }
-    = f.govuk_radio_button :oda_eligibility, :false, label: { text: t("form.label.activity.oda_eligibility.false") }
+  = f.hidden_field :oda_eligibility, value: nil
+  = f.govuk_collection_radio_buttons :oda_eligibility,
+    yaml_to_objects_with_description(entity: "activity", type: "oda_eligibility"),
+    :code,
+    :name,
+    :description,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.oda_eligibility") }

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -707,8 +707,9 @@ en:
       '5': Cancelled
       '6': Suspended
     oda_eligibility:
-      'true': 'Eligible'
-      'false': 'No longer eligible'
+      never_eligible: No - was never eligible
+      eligible: Eligible
+      no_longer_eligible: No longer eligible
     tied_status:
       '5': Untied
     finance:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -32,8 +32,9 @@ en:
         roda_identifier_fragment: Enter a unique identifier for RODA
         intended_beneficiaries: What are the intended beneficiaries?
         oda_eligibility:
-          'true': 'Eligible'
-          'false': 'No longer eligible'
+          never_eligible: No - was never eligible
+          eligible: Eligible
+          no_longer_eligible: No longer eligible
         region: Recipient region
         actual_end_date: Actual end date
         actual_start_date: Actual start date
@@ -237,6 +238,7 @@ en:
         roda_identifier: Enter your unique RODA identifier
         intended_beneficiaries: What are the intended beneficiaries?
         level: Hierarchy level
+        oda_eligibility: ODA eligibility
         parent: Select the parent
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?

--- a/db/migrate/20201102105419_change_oda_eligibility_type.rb
+++ b/db/migrate/20201102105419_change_oda_eligibility_type.rb
@@ -1,0 +1,19 @@
+class ChangeOdaEligibilityType < ActiveRecord::Migration[6.0]
+  def up
+    add_column :activities, :oda_eligibility_integer, :integer, default: 1, null: false
+    Activity.where(oda_eligibility: nil).update_all(oda_eligibility_integer: 1)
+    Activity.where(oda_eligibility: true).update_all(oda_eligibility_integer: 1)
+    Activity.where(oda_eligibility: false).update_all(oda_eligibility_integer: 2)
+    remove_column :activities, :oda_eligibility, :boolean
+    rename_column :activities, :oda_eligibility_integer, :oda_eligibility
+  end
+
+  def down
+    add_column :activities, :oda_eligibility_boolean, :boolean, default: true
+    Activity.where(oda_eligibility: 0).update_all(oda_eligibility_boolean: false)
+    Activity.where(oda_eligibility: 1).update_all(oda_eligibility_boolean: true)
+    Activity.where(oda_eligibility: 2).update_all(oda_eligibility_boolean: false)
+    remove_column :activities, :oda_eligibility, :integer
+    rename_column :activities, :oda_eligibility_boolean, :oda_eligibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_06_091457) do
+ActiveRecord::Schema.define(version: 2020_11_02_105419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -59,11 +59,11 @@ ActiveRecord::Schema.define(version: 2020_10_06_091457) do
     t.string "roda_identifier_fragment"
     t.string "roda_identifier_compound"
     t.boolean "requires_additional_benefitting_countries"
-    t.boolean "oda_eligibility", default: true
     t.string "gdi"
     t.integer "total_applications"
     t.integer "total_awards"
     t.string "collaboration_type"
+    t.integer "oda_eligibility", default: 1, null: false
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe ActivityPresenter do
   describe "#oda_eligibility" do
     context "when the activity is ODA eligible" do
       it "returns the locale value for this option" do
-        activity = build(:project_activity, oda_eligibility: "true")
+        activity = build(:project_activity, oda_eligibility: 1)
         result = described_class.new(activity)
         expect(result.oda_eligibility).to eq("Eligible")
       end
@@ -361,9 +361,17 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity is no longer ODA eligible" do
       it "returns the locale value for this option" do
-        activity = build(:project_activity, oda_eligibility: "false")
+        activity = build(:project_activity, oda_eligibility: 2)
         result = described_class.new(activity)
         expect(result.oda_eligibility).to eq("No longer eligible")
+      end
+    end
+
+    context "when the activity was never ODA eligible" do
+      it "returns the locale value for this option" do
+        activity = build(:project_activity, oda_eligibility: 0)
+        result = described_class.new(activity)
+        expect(result.oda_eligibility).to eq("No - was never eligible")
       end
     end
   end

--- a/spec/services/ingest_csv_row_spec.rb
+++ b/spec/services/ingest_csv_row_spec.rb
@@ -136,19 +136,24 @@ RSpec.describe IngestCsvRow do
   end
 
   context "#process_oda_eligibility" do
-    it "returns true when the value is 'eligible'" do
+    it "returns 1 when the value is 'Eligible'" do
       expect(IngestCsvRow.new.process_oda_eligibility("ELIgibLE"))
-        .to be(true)
+        .to eql("eligible")
     end
 
-    it "returns false when the value is not 'eligible'" do
-      expect(IngestCsvRow.new.process_oda_eligibility("something-else"))
-        .to be(false)
+    it "returns 2 when the value is 'No longer eligible'" do
+      expect(IngestCsvRow.new.process_oda_eligibility("no longer eligible"))
+        .to eql("no_longer_eligible")
     end
 
-    it "returns false when the value is nil" do
-      expect(IngestCsvRow.new.process_oda_eligibility(nil))
-        .to be(false)
+    it "returns 0 when the value is 'No - was never eligible'" do
+      expect(IngestCsvRow.new.process_oda_eligibility("no - was never eligible"))
+        .to eql("never_eligible")
+    end
+
+    it "is skipped when value is blank" do
+      expect(IngestCsvRow.new.process_oda_eligibility(""))
+        .to eql :skip
     end
   end
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -36,7 +36,7 @@ module FormHelpers
     collaboration_type: "Bilateral",
     flow: "ODA",
     aid_type: "A01",
-    oda_eligibility: "true",
+    oda_eligibility: "Eligible",
     level:,
     parent: nil
   )
@@ -203,7 +203,7 @@ module FormHelpers
 
     expect(page).to have_content t("form.legend.activity.oda_eligibility")
     expect(page).to have_content t("form.hint.activity.oda_eligibility")
-    choose "Eligible"
+    choose oda_eligibility
     click_button t("form.button.activity.submit")
 
     expect(page).to have_content delivery_partner_identifier
@@ -227,7 +227,7 @@ module FormHelpers
     expect(page).to have_content gdi
     expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
-    expect(page).to have_content t("activity.oda_eligibility.#{oda_eligibility}")
+    expect(page).to have_content oda_eligibility
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,
       month: planned_start_date_month,

--- a/vendor/data/codelists/IATI/2_03/activity/oda_eligibility.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/oda_eligibility.yml
@@ -1,0 +1,15 @@
+---
+attributes:
+  category-codelist:
+  name: OdaEligibility
+  complete: '1'
+data:
+  - code: never_eligible
+    name: No - was never eligible
+    description: The activity was reported as eligible but was actually never ODA eligible, this applies to past and future spend
+  - code: eligible
+    name: Eligible
+    description: The activity adheres to the OECD DAC rules for ODA Eligibility
+  - code: no_longer_eligible
+    name: No longer eligible
+    description: The activity used to be ODA eligible but no longer meets the OECD DAC rules for future spend


### PR DESCRIPTION
https://trello.com/c/a0PhOuZx

## Changes in this PR

We already had `oda_eligibility` as one of the fields in the activity form. On the codebase, this used to be a boolean since we only handled two types of values( `Eligible` and `No longer eligible`). Recently, the client requested to add a new option for this field (`No - was never eligible`), since this allows them to report activities that were never ODA eligible. 

For this we have had to change the type of column `oda_eligibility` is on the database. We have chosen to make it an integer, so we can make this field an enum, which allows us to include the three different options and it also gives us helper methods that could simplify future queries on the database. 

Please, note that the presence of existing data in this column prior to convert it into an integer made it very difficult to make this change. I tried to change the type following the Rails documentation but I kept getting data type mismatch errors warning me that the column couldn't be cast to a type integer. The way around it that ended up working was to create a column as an integer, migrating the existing records from one column to the newly created one, deleting the old column, and renaming the new column to match the name of the deleted column. This worked well and the final result is that `oda_eligibility` is an integer with a default of 1, and the existing data have been migrated to reflect the new way we store this value.

Apart from adding the new option for `oda_eligibility`, we have added hints on the radio buttons to give users more context and help them decide what category best reflect the eligibility of their activities. 

Specs and ingest work have also been modified to reflect the new situation.

## Screenshots of UI changes

### Before

<img width="891" alt="Screenshot 2020-11-02 at 13 45 00" src="https://user-images.githubusercontent.com/48016017/97874935-a4b66b00-1d11-11eb-95c6-0b4bd6d57dc6.png">

### After

<img width="909" alt="Screenshot 2020-11-02 at 09 26 25" src="https://user-images.githubusercontent.com/48016017/97874971-ada73c80-1d11-11eb-9d18-943e6baee878.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
