### PR TITLE
Release 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,7 +352,7 @@
 
 - Fix bug that prevented delivery partners from submitting a report.
 
-## [unreleased]
+## [release-21] - 2020-11-03
 
 - Collect financial quarter and year for planned disbursements (forecasts)
   instead of start and end dates (the values of which are calculated).
@@ -368,7 +368,10 @@
 - Answers for GDI form step have been modified
 - Use scripts to rule them all for development tasks
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
+[release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21
 [release-20]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-19...release-20
 [release-19]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-18...release-19
 [release-18]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-17...release-18


### PR DESCRIPTION
- Collect financial quarter and year for planned disbursements
  (forecasts) instead of start and end dates (the values of which are
  calculated).
- No longer collect start and end dates for planned disbursements
  (forecasts) through the application interface.
- Planned disbursements are always original when created
- Planned disbursement currency is always GBP
- Planned disbursement providing organisation is always BEIS
- Planned disbursement receiving organisations is no longer collect, but
  is retained for existing records
- Planned disbursements do not include receiving organisation in the
  IATI xml export
- Answers for GDI form step have been modified
- Use scripts to rule them all for development tasks

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
