### PR TITLE
(1180) Fix Auth0 create_user call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,7 @@
 - Use scripts to rule them all for development tasks
 
 ## [unreleased]
+- Fix allow application to create new users in Auth0
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
 [release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21

--- a/app/services/create_user_in_auth0.rb
+++ b/app/services/create_user_in_auth0.rb
@@ -9,10 +9,10 @@ class CreateUserInAuth0
 
   def call
     auth0_response = auth0_client.create_user(
-      user.name,
+      "Username-Password-Authentication",
+      name: user.name,
       email: user.email,
-      password: CreateUserInAuth0.temporary_password,
-      connection: "Username-Password-Authentication",
+      password: CreateUserInAuth0.temporary_password
     )
     user.update(identifier: auth0_response.fetch("user_id"))
   end

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -6,13 +6,13 @@ module Auth0Helpers
 
   def stub_auth0_create_user_request(email:, auth0_identifier: "auth0|123456789")
     stub_request(:post, "https://testdomain/api/v2/users")
-      .with(body: hash_including(email: email))
+      .with(body: hash_including(connection: "Username-Password-Authentication", email: email))
       .to_return(status: 200, body: "{\"user_id\":\"#{auth0_identifier}\"}")
   end
 
   def stub_auth0_create_user_request_failure(email:, body: "{\"message\":\"The user already exists.\"}")
     stub_request(:post, "https://testdomain/api/v2/users")
-      .with(body: hash_including(email: email))
+      .with(body: hash_including(connection: "Username-Password-Authentication", email: email))
       .to_return(status: 500, body: body)
   end
 


### PR DESCRIPTION
## Changes in this PR
We recently updated the Auth0 gem and I missed a breaking change.

The signature of the `create_user` method has changed; the connection
name, which is just a string that matches the default database
connection in Auth0, comes first and is required and the name of the
user is passed in the options as `name`.

Without this change the application cannot create new users in Auth0.
The application handles the error gracefully as the API simply returns
an error code 'connection not found' that we display to the user.

I settled on not creating a test for this case as I should have spotted the change in the API when I was looking at the dependabot update, I feel the system responded correctly as we were passing the wrong value as the connection. If folks feel differently, please shout and I'll have a go at a test.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
