### PR TITLE
(1114) Set capital spend on Activity and export to IATI xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,8 @@
 ## [unreleased]
 
 - Fix allow application to create new users in Auth0
+- Activity capital-spend is always exported as 0 to the IATI xml
+- Fix allow application to create new users in Auth0
 - Filter out unused aid types.
 - Replace the hints in the aid type form with shorter, more accessible copy if available.
 - Option `No - was never eligible` added to ODA eligibility form step

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,6 +4,7 @@ class Activity < ApplicationRecord
 
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
+  CAPITAL_SPEND_PERCENTAGE = 0
 
   VALIDATION_STEPS = [
     :level_step,
@@ -131,6 +132,10 @@ class Activity < ApplicationRecord
 
   def tied_status
     UNTIED_TIED_STATUS_CODE
+  end
+
+  def capital_spend
+    CAPITAL_SPEND_PERCENTAGE
   end
 
   def default_currency

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -47,6 +47,7 @@
   -if planned_disbursements
     - planned_disbursements.each do |planned_disbursement|
       = render partial: "staff/shared/xml/planned_disbursement", locals: { planned_disbursement: PlannedDisbursementXmlPresenter.new(planned_disbursement) }
+  %capital-spend{"percentage" => activity.capital_spend}/
   - if transactions
     - transactions.each do |transaction|
       = render partial: "staff/shared/xml/transaction", locals: { transaction: transaction }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#capital_spend" do
+    it "always returns 0" do
+      activity = Activity.new
+      expect(activity.capital_spend).to eq 0
+    end
+  end
+
   describe "scopes" do
     describe ".funds" do
       it "only returns fund level activities" do

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -60,6 +60,12 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/default-finance-type/@code").text).to eq("110")
   end
 
+  it "contains the default value of 0% capital spend" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    expect(xml.at("iati-activity/capital-spend/@percentage").text).to eq("0")
+  end
+
   it "contains the default value for Tied Status" do
     visit organisation_activity_path(organisation, activity, format: :xml)
 


### PR DESCRIPTION
## Changes in this PR
All activities that BEIS publish have no capital spend on them, however
publishing this fact awards them publish what you fund points – a good
thing.

I added the capital-spend to the Activity model as I feel that it is an attribute, just a static one so I want to document it for developers, as opposed to hiding it away in the view layer.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
