### PR TITLE
(1195) Start building out the Activity import machinery

### DIFF
--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -72,6 +72,7 @@ module Activities
         title: "Title",
         description: "Description",
         recipient_region: "Recipient Region",
+        delivery_partner_identifier: "Delivery partner identifier",
       }
 
       def initialize(row)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -1,0 +1,130 @@
+module Activities
+  class ImportFromCsv
+    Error = Struct.new(:row, :column, :value, :message) {
+      def csv_row
+        row + 2
+      end
+    }
+
+    attr_reader :errors
+
+    def initialize(organisation:)
+      @organisation = organisation
+      @errors = []
+    end
+
+    def import(activities)
+      ActiveRecord::Base.transaction do
+        activities.each_with_index { |row, index| import_row(row, index) }
+        raise ActiveRecord::Rollback unless @errors.empty?
+      end
+    end
+
+    def import_row(row, index)
+      activity = Activity.by_roda_identifier(row["RODA ID"])
+
+      if activity.nil?
+        add_error(index, :roda_id, row["RODA ID"], I18n.t("importer.errors.activity.not_found"))
+      else
+        updater = ActivityUpdater.new(activity, @organisation, row)
+        updater.update
+
+        updater.errors.each do |attr_name, (value, message)|
+          add_error(index, attr_name, value, message)
+        end
+      end
+    end
+
+    def add_error(row_number, column, value, message)
+      @errors << Error.new(row_number, column, value, message)
+    end
+
+    class ActivityUpdater
+      attr_reader :errors
+
+      def initialize(activity, organisation, row)
+        @activity = activity
+        @organisation = organisation
+        @errors = {}
+        @converter = Converter.new(row)
+        @errors.update(@converter.errors)
+      end
+
+      def update
+        return unless @activity && @errors.empty?
+
+        attributes = @converter.to_h
+
+        return if @activity.update(attributes)
+
+        @activity.errors.each do |attr_name, message|
+          @errors[attr_name] ||= [@converter.raw(attr_name), message]
+        end
+      end
+    end
+
+    class Converter
+      include CodelistHelper
+
+      attr_reader :errors
+
+      FIELDS = {
+        title: "Title",
+        description: "Description",
+        recipient_region: "Recipient Region",
+      }
+
+      def initialize(row)
+        @row = row
+        @errors = {}
+        @attributes = convert_to_attributes
+      end
+
+      def raw(attr_name)
+        @row[FIELDS[attr_name]]
+      end
+
+      def to_h
+        @attributes
+      end
+
+      def convert_to_attributes
+        FIELDS.each_with_object({}) do |(attr_name, column_name), attrs|
+          attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if @row[column_name].present?
+        end
+      end
+
+      def convert_to_attribute(attr_name, value)
+        original_value = value.clone
+        value = value.to_s.strip
+
+        converter = "convert_#{attr_name}"
+        value = __send__(converter, value) if respond_to?(converter)
+
+        value
+      rescue => error
+        @errors[attr_name] = [original_value, error.message]
+        nil
+      end
+
+      def convert_recipient_region(region)
+        validate_from_codelist(
+          region,
+          :recipient_region,
+          I18n.t("importer.errors.activity.invalid_region"),
+        )
+      end
+
+      def validate_from_codelist(code, entity, message)
+        return nil if code.blank?
+
+        codelist = load_yaml(entity: :activity, type: entity)
+        valid_codes = codelist.map { |entry| entry.fetch("code") }
+
+        raise message unless valid_codes.include?(code)
+
+        code
+      end
+    end
+  end
+end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -318,3 +318,8 @@ en:
               blank: Select an extending organisation
             fstc_applies:
               inclusion: You must select "Yes" or "No"
+  importer:
+    errors:
+      activity:
+        not_found: Cannot be found
+        invalid_region: The region cannot be found

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Activities::ImportFromCsv do
+  let(:organisation) { create(:organisation) }
+  let(:existing_activity) { create(:activity) }
+  let(:activity_attributes) do
+    {
+      "RODA ID" => existing_activity.roda_identifier_compound,
+      "Title" => "Here is a title",
+      "Description" => "Some description goes here...",
+      "Recipient Region" => "789",
+    }
+  end
+
+  subject { described_class.new(organisation: organisation) }
+
+  it "has an error if an Activity does not exist" do
+    activity_attributes["RODA ID"] = "FAKE RODA ID"
+
+    subject.import([activity_attributes])
+
+    expect(subject.errors.count).to eq(1)
+
+    expect(subject.errors.first.csv_row).to eq(2)
+    expect(subject.errors.first.column).to eq(:roda_id)
+    expect(subject.errors.first.value).to eq("FAKE RODA ID")
+    expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
+  end
+
+  it "updates an existing activity" do
+    subject.import([activity_attributes])
+
+    expect(subject.errors.count).to eq(0)
+
+    expect(existing_activity.reload.title).to eq(activity_attributes["Title"])
+    expect(existing_activity.description).to eq(activity_attributes["Description"])
+    expect(existing_activity.recipient_region).to eq(activity_attributes["Recipient Region"])
+  end
+
+  it "ignores any blank columns" do
+    activity_attributes["Title"] = ""
+
+    expect { subject.import([activity_attributes]) }.to_not change { existing_activity.title }
+    expect(subject.errors.count).to eq(0)
+  end
+
+  it "has an error and does not update any other activities if an Activity does not exist" do
+    activities = [
+      activity_attributes,
+      {
+        "RODA ID" => "FAKE RODA ID",
+        "Title" => "Here is another title",
+        "Description" => "Another description goes here...",
+        "Recipient Region" => "789",
+      },
+    ]
+
+    expect { subject.import(activities) }.to_not change { existing_activity }
+
+    expect(subject.errors.count).to eq(1)
+    expect(subject.errors.first.csv_row).to eq(3)
+    expect(subject.errors.first.column).to eq(:roda_id)
+    expect(subject.errors.first.value).to eq("FAKE RODA ID")
+    expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
+  end
+
+  it "has an error and does not update any other activities if a region does not exist" do
+    activity_2 = create(:activity)
+
+    activities = [
+      activity_attributes,
+      {
+        "RODA ID" => activity_2.roda_identifier_compound,
+        "Title" => "Here is another title",
+        "Description" => "Another description goes here...",
+        "Recipient Region" => "111111",
+      },
+    ]
+
+    expect { subject.import(activities) }.to_not change { existing_activity }
+
+    expect(subject.errors.count).to eq(1)
+    expect(subject.errors.first.csv_row).to eq(3)
+    expect(subject.errors.first.column).to eq(:recipient_region)
+    expect(subject.errors.first.value).to eq("111111")
+    expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_region"))
+  end
+end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Title" => "Here is a title",
       "Description" => "Some description goes here...",
       "Recipient Region" => "789",
+      "Delivery partner identifier" => "1234567890",
     }
   end
 
@@ -35,6 +36,7 @@ RSpec.describe Activities::ImportFromCsv do
     expect(existing_activity.reload.title).to eq(activity_attributes["Title"])
     expect(existing_activity.description).to eq(activity_attributes["Description"])
     expect(existing_activity.recipient_region).to eq(activity_attributes["Recipient Region"])
+    expect(existing_activity.delivery_partner_identifier).to eq(activity_attributes["Delivery partner identifier"])
   end
 
   it "ignores any blank columns" do


### PR DESCRIPTION
This adds a couple of classes that start to build out the code that will eventually backfill missing activity data. It's heavily influenced by work already done by @jcoglan 

So far it accepts an array of hashes (which will eventually come from a CSV) to update an existing Activity (which is fetched by its RODA ID). 

If a field is blank, it is ignored. If any activities in the array of attribute hashes are missing, then the entire operation fails and the main classes error array is populated.