### PR TITLE
(1105) Add policy markers to activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,7 @@
 - Two original planned disbursements for the same activity, financial quarter
   and year cannot be created.
 - Add a field to report Free Standing Technical Cooperation
+- Policy markers added to activity form, including BEIS custom answer `not assessed`
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
 [release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -29,6 +29,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     :flow,
     :aid_type,
     :fstc_applies,
+    :policy_markers,
     :oda_eligibility,
   ]
 
@@ -65,6 +66,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     when :collaboration_type
       skip_step if @activity.fund?
       assign_default_collaboration_type_value_if_nil
+    when :policy_markers
+      skip_step unless @activity.is_project?
     end
 
     render_wizard
@@ -145,6 +148,17 @@ class Staff::ActivityFormsController < Staff::BaseController
       @activity.assign_attributes(aid_type: aid_type)
     when :fstc_applies
       @activity.assign_attributes(fstc_applies: fstc_applies)
+    when :policy_markers
+      @activity.assign_attributes(
+        policy_marker_gender: policy_markers_iati_codes_to_enum(policy_marker_gender),
+        policy_marker_climate_change_adaptation: policy_markers_iati_codes_to_enum(policy_marker_climate_change_adaptation),
+        policy_marker_climate_change_mitigation: policy_markers_iati_codes_to_enum(policy_marker_climate_change_mitigation),
+        policy_marker_biodiversity: policy_markers_iati_codes_to_enum(policy_marker_biodiversity),
+        policy_marker_desertification: policy_markers_iati_codes_to_enum(policy_marker_desertification),
+        policy_marker_disability: policy_markers_iati_codes_to_enum(policy_marker_disability),
+        policy_marker_disaster_risk_reduction: policy_markers_iati_codes_to_enum(policy_marker_disaster_risk_reduction),
+        policy_marker_nutrition: policy_markers_iati_codes_to_enum(policy_marker_nutrition),
+      )
     when :oda_eligibility
       @activity.assign_attributes(oda_eligibility: oda_eligibility)
     end
@@ -280,6 +294,38 @@ class Staff::ActivityFormsController < Staff::BaseController
     params.require(:activity).permit(:fstc_applies).fetch("fstc_applies", nil)
   end
 
+  def policy_marker_gender
+    params.require(:activity).permit(:policy_marker_gender).fetch("policy_marker_gender", nil)
+  end
+
+  def policy_marker_climate_change_adaptation
+    params.require(:activity).permit(:policy_marker_climate_change_adaptation).fetch("policy_marker_climate_change_adaptation", nil)
+  end
+
+  def policy_marker_climate_change_mitigation
+    params.require(:activity).permit(:policy_marker_climate_change_mitigation).fetch("policy_marker_climate_change_mitigation", nil)
+  end
+
+  def policy_marker_biodiversity
+    params.require(:activity).permit(:policy_marker_biodiversity).fetch("policy_marker_biodiversity", nil)
+  end
+
+  def policy_marker_desertification
+    params.require(:activity).permit(:policy_marker_desertification).fetch("policy_marker_desertification", nil)
+  end
+
+  def policy_marker_disability
+    params.require(:activity).permit(:policy_marker_disability).fetch("policy_marker_disability", nil)
+  end
+
+  def policy_marker_disaster_risk_reduction
+    params.require(:activity).permit(:policy_marker_disaster_risk_reduction).fetch("policy_marker_disaster_risk_reduction", nil)
+  end
+
+  def policy_marker_nutrition
+    params.require(:activity).permit(:policy_marker_nutrition).fetch("policy_marker_nutrition", nil)
+  end
+
   def oda_eligibility
     params.require(:activity).permit(:oda_eligibility).fetch("oda_eligibility", nil)
   end
@@ -320,5 +366,15 @@ class Staff::ActivityFormsController < Staff::BaseController
   def assign_default_collaboration_type_value_if_nil
     # This allows us to pre-select a specific radio button on collaboration_type form step (value "Bilateral" in this case)
     @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
+  end
+
+  def policy_markers_iati_codes_to_enum(code)
+    case code
+    when "0" then "not_targeted"
+    when "1" then "significant_objective"
+    when "2" then "principal_objective"
+    when "3" then "principal_objective_and_in_support"
+    when "1000" then "not_assessed"
+    end
   end
 end

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -12,6 +12,13 @@ module CodelistHelper
     "G01",
   ]
 
+  ALLOWED_POLICY_MARKERS_SIGNIFICANCES = [
+    "0",
+    "1",
+    "2",
+    "3",
+  ]
+
   def yaml_to_objects(entity:, type:, with_empty_item: true)
     data = load_yaml(entity: entity, type: type)
     return [] if data.empty?
@@ -130,6 +137,14 @@ module CodelistHelper
     )
 
     options.select { |a| ALLOWED_AID_TYPE_CODES.include?(a.code) }
+  end
+
+  def policy_markers_select_options
+    objects = yaml_to_objects(entity: "activity", type: "policy_markers", with_empty_item: false)
+    not_assessed_option = OpenStruct.new(name: "Not assessed", code: "1000")
+
+    filtered_list = objects.select { |object| ALLOWED_POLICY_MARKERS_SIGNIFICANCES.include?(object.code) }.sort_by(&:code)
+    filtered_list.unshift(not_assessed_option)
   end
 
   def load_yaml(entity:, type:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,6 +6,14 @@ class Activity < ApplicationRecord
   UNTIED_TIED_STATUS_CODE = "5"
   CAPITAL_SPEND_PERCENTAGE = 0
 
+  POLICY_MARKER_CODES = {
+    not_targeted: 0,
+    significant_objective: 1,
+    principal_objective: 2,
+    principal_objective_and_in_support: 3,
+    not_assessed: 1000,
+  }
+
   VALIDATION_STEPS = [
     :level_step,
     :parent_step,
@@ -28,6 +36,7 @@ class Activity < ApplicationRecord
     :flow_step,
     :aid_type,
     :fstc_applies_step,
+    :policy_markers_step,
     :oda_eligibility_step,
   ]
 
@@ -54,6 +63,14 @@ class Activity < ApplicationRecord
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :flow, presence: true, on: :flow_step
   validates :aid_type, presence: true, on: :aid_type_step
+  validates :policy_marker_gender, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_climate_change_adaptation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_climate_change_mitigation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_biodiversity, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_desertification, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_disability, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_disaster_risk_reduction, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
+  validates :policy_marker_nutrition, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :oda_eligibility, presence: true, on: :oda_eligibility_step
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
@@ -93,6 +110,22 @@ class Activity < ApplicationRecord
     recipient_region: "Recipient region",
     recipient_country: "Recipient country",
   }
+
+  enum policy_marker_gender: POLICY_MARKER_CODES, _prefix: :gender
+
+  enum policy_marker_climate_change_adaptation: POLICY_MARKER_CODES, _prefix: :climate_change_adaptation
+
+  enum policy_marker_climate_change_mitigation: POLICY_MARKER_CODES, _prefix: :climate_change_mitigation
+
+  enum policy_marker_biodiversity: POLICY_MARKER_CODES, _prefix: :biodiversity
+
+  enum policy_marker_desertification: POLICY_MARKER_CODES, _prefix: :desertification
+
+  enum policy_marker_disability: POLICY_MARKER_CODES, _prefix: :disability
+
+  enum policy_marker_disaster_risk_reduction: POLICY_MARKER_CODES, _prefix: :disaster_risk_reduction
+
+  enum policy_marker_nutrition: POLICY_MARKER_CODES, _prefix: :nutrition
 
   enum oda_eligibility: {
     never_eligible: 0,
@@ -262,7 +295,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_call_dates?
-    !ingested? && (project? || third_party_project?)
+    !ingested? && is_project?
   end
 
   def forecasted_total_for_date_range(range:)
@@ -279,5 +312,13 @@ class Activity < ApplicationRecord
 
   def requires_collaboration_type?
     !ingested? && !fund?
+  end
+
+  def requires_policy_markers?
+    !ingested? && is_project?
+  end
+
+  def is_project?
+    project? || third_party_project?
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -109,6 +109,46 @@ class ActivityPresenter < SimpleDelegator
     "#{flow} (#{to_model.flow})"
   end
 
+  def policy_marker_gender
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_climate_change_adaptation
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_climate_change_mitigation
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_biodiversity
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_desertification
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_disability
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_disaster_risk_reduction
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
+  def policy_marker_nutrition
+    return if super.blank?
+    I18n.t("activity.policy_markers.#{super}")
+  end
+
   def oda_eligibility
     return if super.blank?
     I18n.t("activity.oda_eligibility.#{super}")

--- a/app/views/staff/activity_forms/policy_markers.html.haml
+++ b/app/views/staff/activity_forms/policy_markers.html.haml
@@ -1,0 +1,28 @@
+= render layout: "wrapper" do |f|
+  %h1.govuk-heading-xl= @page_title
+  %span.govuk-hint= t("form.hint.activity.policy_markers.title")
+
+  %details.govuk-details{data:{module:"govuk-details"}}
+    %summary.govuk-details__summary
+      %span.govuk-details__summary-text
+        Explanation of responses
+    .govuk-details__text
+      %h2.govuk-heading-s= t("form.legend.activity.policy_markers.responses.not_assessed")
+      %p= t("form.hint.activity.policy_markers.responses.not_assessed")
+      %h2.govuk-heading-s= t("form.legend.activity.policy_markers.responses.not_targeted")
+      %p= t("form.hint.activity.policy_markers.responses.not_targeted")
+      %h2.govuk-heading-s= t("form.legend.activity.policy_markers.responses.significant_objective")
+      %p= t("form.hint.activity.policy_markers.responses.significant_objective")
+      %h2.govuk-heading-s= t("form.legend.activity.policy_markers.responses.principal_objective")
+      %p= t("form.hint.activity.policy_markers.responses.principal_objective")
+      %h2.govuk-heading-s= t("form.legend.activity.policy_markers.responses.principal_objective_and_in_support")
+      %p= t("form.hint.activity.policy_markers.responses.principal_objective_and_in_support")
+
+  = f.govuk_collection_select :policy_marker_gender, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_gender }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.gender").html_safe }
+  = f.govuk_collection_select :policy_marker_climate_change_adaptation, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_climate_change_adaptation }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.climate_change_adaptation").html_safe }
+  = f.govuk_collection_select :policy_marker_climate_change_mitigation, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_climate_change_mitigation }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.climate_change_mitigation").html_safe }
+  = f.govuk_collection_select :policy_marker_biodiversity, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_biodiversity }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.biodiversity").html_safe }
+  = f.govuk_collection_select :policy_marker_desertification, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_desertification }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.desertification").html_safe }
+  = f.govuk_collection_select :policy_marker_disability, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_disability }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.disability").html_safe }
+  = f.govuk_collection_select :policy_marker_disaster_risk_reduction, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_disaster_risk_reduction }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.disaster_risk_reduction").html_safe }
+  = f.govuk_collection_select :policy_marker_nutrition, policy_markers_select_options, :code, :name, options: { selected: f.object.policy_marker_nutrition }, label: { tag: 'h2', size: 'l' }, hint: { text: t("form.hint.activity.policy_markers.nutrition").html_safe }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -262,6 +262,78 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fstc_applies)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:fstc_applies)}"), activity_step_path(activity_presenter, :fstc_applies), t("summary.label.activity.fstc_applies"))
 
+  - if activity_presenter.project? || activity_presenter.third_party_project?
+    .govuk-summary-list__row.policy_marker_gender
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_gender")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_gender
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_gender)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_gender"))
+
+    .govuk-summary-list__row.policy_marker_climate_change_adaptation
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_climate_change_adaptation")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_climate_change_adaptation
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_climate_change_adaptation)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_climate_change_adaptation"))
+
+    .govuk-summary-list__row.policy_marker_climate_change_mitigation
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_climate_change_mitigation")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_climate_change_mitigation
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_climate_change_mitigation)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_climate_change_mitigation"))
+
+    .govuk-summary-list__row.policy_marker_biodiversity
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_biodiversity")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_biodiversity
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_biodiversity)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_biodiversity"))
+
+    .govuk-summary-list__row.policy_marker_desertification
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_desertification")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_desertification
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_desertification)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_desertification"))
+
+    .govuk-summary-list__row.policy_marker_disability
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_disability")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_disability
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_disability)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_disability"))
+
+    .govuk-summary-list__row.policy_marker_disaster_risk_reduction
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_disaster_risk_reduction")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_disaster_risk_reduction
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_disaster_risk_reduction)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_disaster_risk_reduction"))
+
+    .govuk-summary-list__row.policy_marker_nutrition
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.policy_marker_nutrition")
+      %dd.govuk-summary-list__value
+        = activity_presenter.policy_marker_nutrition
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_nutrition)}"), activity_step_path(activity_presenter, :policy_markers), t("summary.label.activity.policy_marker_nutrition"))
 
   .govuk-summary-list__row.oda_eligibility
     %dt.govuk-summary-list__key

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -35,6 +35,22 @@
     %recipient-region{"code" => activity.recipient_region, vocabulary: "1"}
       %narrative= region_name_from_code(activity.recipient_region)
   %sector{"vocabulary" => "1", "code" => activity.sector}/
+  - unless activity.gender_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "1", "significance" => Activity.policy_marker_genders[activity.policy_marker_gender]}/
+  - unless activity.biodiversity_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "5", "significance" => Activity.policy_marker_biodiversities[activity.policy_marker_biodiversity]}/
+  - unless activity.climate_change_mitigation_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "6", "significance" => Activity.policy_marker_climate_change_mitigations[activity.policy_marker_climate_change_mitigation]}/
+  - unless activity.climate_change_adaptation_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "7", "significance" => Activity.policy_marker_climate_change_adaptations[activity.policy_marker_climate_change_adaptation]}/
+  - unless activity.desertification_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "8", "significance" => Activity.policy_marker_desertifications[activity.policy_marker_desertification]}/
+  - unless activity.disaster_risk_reduction_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "10", "significance" => Activity.policy_marker_disaster_risk_reductions[activity.policy_marker_disaster_risk_reduction]}/
+  - unless activity.disability_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "11", "significance" => Activity.policy_marker_disabilities[activity.policy_marker_disability]}/
+  - unless activity.nutrition_not_assessed?
+    %policy-marker{"vocabulary" => "1", "code" => "12", "significance" => Activity.policy_marker_nutritions[activity.policy_marker_nutrition]}/
   - if activity.collaboration_type?
     %collaboration-type{"code" => activity.collaboration_type}/
   %default-flow-type{"code" => activity.flow}/

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -327,6 +327,12 @@ en:
       '1033': Melanesia, regional
       '1034': Micronesia, regional
       '1035': Polynesia, regional
+    policy_markers:
+      not_targeted: Not targeted
+      significant_objective: Significant objective
+      principal_objective: Principal objective
+      principal_objective_and_in_support: Principal objective AND in support of an action programme
+      not_assessed: Not assessed
     sector:
       '11110': Education policy and administrative management
       '11120': Education facilities and training

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -35,6 +35,14 @@ en:
           never_eligible: No - was never eligible
           eligible: Eligible
           no_longer_eligible: No longer eligible
+        policy_marker_gender: Gender
+        policy_marker_climate_change_adaptation: Climate change - Adaptation
+        policy_marker_climate_change_mitigation: Climate change - Mitigation
+        policy_marker_biodiversity: Biodiversity
+        policy_marker_desertification: Desertification
+        policy_marker_disability: Disability
+        policy_marker_disaster_risk_reduction: Disaster Risk Reduction
+        policy_marker_nutrition: Nutrition Policy
         region: Recipient region
         actual_end_date: Actual end date
         actual_start_date: Actual start date
@@ -78,6 +86,21 @@ en:
         parent: Select the parent activity
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        policy_markers:
+          gender: Gender
+          climate_change_adaptation: Climate change - Adaptation
+          climate_change_mitigation: Climate change - Mitigation
+          biodiversity: Biodiversity
+          desertification: Desertification
+          disability: Disability
+          disaster_risk_reduction: Disaster Risk Reduction
+          nutrition: Nutrition Policy
+          responses:
+            not_assessed: Not assessed
+            not_targeted: Not targeted
+            significant_objective: Significant objective
+            principal_objective: Principal objective
+            principal_objective_and_in_support: Principal objective AND in support of an action programme
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
         requires_additional_benefitting_countries: Does this activity have other benefitting countries?
@@ -112,6 +135,22 @@ en:
           project: The activities of a delivery partner and details of how the funding is forecast and spent
           third_party_project: The activities of third parties such as universities and how the funding is forecast and spent
         parent: Which existing %{parent_level} will this new %{level} belong to?
+        policy_markers:
+          title: The policy markers have been established by DAC to guarantee monitoring and comparability of the official development measures of member states. It is designed to measure the degree to which the member states have put the OECD's development policy objectives into practice, and to identify measures with a particular development-policy focus. Detailed guidance on each marker can be found in the ODA Handbook
+          responses:
+            not_assessed: The activity has not been examined
+            not_targeted: The activity was examined but found not to target the policy objective
+            significant_objective: Significant (secondary) policy objectives are those which, although important, were not the prime motivation for undertaking the activity
+            principal_objective: Fundamental in the design and impact of the activity and which is an explicit objective of the activity. May be selected by answering the question "Would the activity have been undertaken without this objective?"
+            principal_objective_and_in_support: For desertification-related aid only
+          gender: Gender equality is explicitly promoted in activity documentation through specific measures for this activity
+          climate_change_adaptation: This activity intends to reduce the vulnerability of human or natural systems to the impacts of climate change and climate related risks, by maintaining or increasing adaptive capacity and resilience
+          climate_change_mitigation: This activity contributes to the objective of stabilisation of greenhouse gas (GHG) concentrations in the atmosphere at a level that would prevent dangerous anthropogenic interference with the climate system by promoting efforts to reduce or limit GHG emissions or to enhance GHG sequestration
+          biodiversity: 'This activity promotes at least one of the three objectives of the Convention: the conservation of bio-diversity, sustainable use of its components (ecosystems, species or genetic resources), or fair and equitable sharing of the benefits of the utilisation of genetic resources'
+          desertification: This activity is aimed at combating desertification or mitigating the effects of drought in arid, semi arid and dry sub-humid areas through prevention and/or reduction of land degradation, rehabilitation of partly degraded land, or reclamation of desertified land
+          disability: This activity either has a deliberate objective of, contributes to, or supports the implementation and/or monitoring of the Convention on the Rights of Persons with Disabilities
+          disaster_risk_reduction: This activity promotes the goal and global targets of the Sendai Framework , to achieve substantial reduction of disaster risk and losses in lives, livelihoods and health and in the economic, physical, social, cultural and environmental assets of persons, businesses, communities and countries
+          nutrition: This activity is intended to address the immediate or underlying determinants of malnutrition
         total_applications: You can enter 0 if this field is not applicable at the moment
         total_awards: You can enter 0 if this field is not applicable at the moment
         fstc_applies: "<p>Free-standing technical co-operation is defined as financing of activities whose primary purpose is to augment the level of knowledge, skills, technical know-how or productive aptitudes of the population of developing countries.</p><ul><li>If aid type C01, please select FTC1 except in unusual circumstances</li><li>If aid type G01, please select FTC0 as the activity cannot have FTC.</li><li>If aid types E01 and D02, please select FTC1 as the activity must have FTC.</li></ul><p>This activity's aid type is <strong>%{aid_type}</strong></p>"
@@ -151,6 +190,14 @@ en:
         planned_disbursements: Forecasted spend
         planned_end_date: Planned end date
         planned_start_date: Planned start date
+        policy_marker_gender: Gender
+        policy_marker_climate_change_adaptation: Climate change - Adaptation
+        policy_marker_climate_change_mitigation: Climate change - Mitigation
+        policy_marker_biodiversity: Biodiversity
+        policy_marker_desertification: Desertification
+        policy_marker_disability: Disability
+        policy_marker_disaster_risk_reduction: Disaster Risk Reduction
+        policy_marker_nutrition: Nutrition Policy
         programme_status: Activity status
         projects: Projects (level C)
         recipient_country: Recipient country
@@ -256,6 +303,7 @@ en:
         level: Hierarchy level
         oda_eligibility: ODA eligibility
         parent: Select the parent
+        policy_markers: Policy markers
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
         region: What region will benefit from this activity?

--- a/db/migrate/20201109113715_add_policy_markers_to_activities.rb
+++ b/db/migrate/20201109113715_add_policy_markers_to_activities.rb
@@ -1,0 +1,12 @@
+class AddPolicyMarkersToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :policy_marker_gender, :integer
+    add_column :activities, :policy_marker_climate_change_adaptation, :integer
+    add_column :activities, :policy_marker_climate_change_mitigation, :integer
+    add_column :activities, :policy_marker_biodiversity, :integer
+    add_column :activities, :policy_marker_desertification, :integer
+    add_column :activities, :policy_marker_disability, :integer
+    add_column :activities, :policy_marker_disaster_risk_reduction, :integer
+    add_column :activities, :policy_marker_nutrition, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_06_110954) do
+ActiveRecord::Schema.define(version: 2020_11_09_113715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -65,6 +65,14 @@ ActiveRecord::Schema.define(version: 2020_11_06_110954) do
     t.string "collaboration_type"
     t.integer "oda_eligibility", default: 1, null: false
     t.boolean "fstc_applies"
+    t.integer "policy_marker_gender"
+    t.integer "policy_marker_climate_change_adaptation"
+    t.integer "policy_marker_climate_change_mitigation"
+    t.integer "policy_marker_biodiversity"
+    t.integer "policy_marker_desertification"
+    t.integer "policy_marker_disability"
+    t.integer "policy_marker_disaster_risk_reduction"
+    t.integer "policy_marker_nutrition"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -79,6 +79,14 @@ FactoryBot.define do
       collaboration_type { "1" }
       total_applications { "25" }
       total_awards { "12" }
+      policy_marker_gender { "not_assessed" }
+      policy_marker_climate_change_adaptation { "not_assessed" }
+      policy_marker_climate_change_mitigation { "not_assessed" }
+      policy_marker_biodiversity { "not_assessed" }
+      policy_marker_desertification { "not_assessed" }
+      policy_marker_disability { "not_assessed" }
+      policy_marker_disaster_risk_reduction { "not_assessed" }
+      policy_marker_nutrition { "not_assessed" }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
@@ -109,6 +117,14 @@ FactoryBot.define do
       collaboration_type { "1" }
       total_applications { "25" }
       total_awards { "12" }
+      policy_marker_gender { "not_assessed" }
+      policy_marker_climate_change_adaptation { "not_assessed" }
+      policy_marker_climate_change_mitigation { "not_assessed" }
+      policy_marker_biodiversity { "not_assessed" }
+      policy_marker_desertification { "not_assessed" }
+      policy_marker_disability { "not_assessed" }
+      policy_marker_disaster_risk_reduction { "not_assessed" }
+      policy_marker_nutrition { "not_assessed" }
       funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       funding_organisation_reference { "GB-GOV-13" }
       funding_organisation_type { "10" }
@@ -141,6 +157,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :at_roda_identifier_step do
@@ -164,6 +188,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :at_purpose_step do
@@ -185,6 +217,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :at_region_step do
@@ -195,6 +235,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :at_geography_step do
@@ -206,6 +254,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :nil_form_state do
@@ -217,6 +273,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
   end
 
   trait :blank_form_state do
@@ -238,6 +302,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
     extending_organisation_id { nil }
     parent { nil }
     level { nil }
@@ -264,6 +336,14 @@ FactoryBot.define do
     collaboration_type { nil }
     flow { nil }
     aid_type { nil }
+    policy_marker_gender { nil }
+    policy_marker_climate_change_adaptation { nil }
+    policy_marker_climate_change_mitigation { nil }
+    policy_marker_biodiversity { nil }
+    policy_marker_desertification { nil }
+    policy_marker_disability { nil }
+    policy_marker_disaster_risk_reduction { nil }
+    policy_marker_nutrition { nil }
     extending_organisation_id { nil }
     parent { nil }
   end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -204,5 +204,17 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.last.name).to eq "Administrative costs not included elsewhere (G01)"
       end
     end
+
+    describe "#policy_markers_select_options" do
+      it "returns the options for policy markers, prepending the BEIS custom option" do
+        options = helper.policy_markers_select_options
+
+        expect(options.length).to eq 5
+        expect(options.first.name).to eq("Not assessed")
+        expect(options.first.code).to eq("1000")
+        expect(options.last.name).to eq("Principal objective AND in support of an action programme")
+        expect(options.last.code).to eq("3")
+      end
+    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -526,6 +526,13 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when any of the policy markers is blank on levels C or D" do
+      subject(:activity) { build(:project_activity, policy_marker_gender: nil) }
+      it "should not be valid" do
+        expect(activity.valid?(:policy_markers_step)).to be_falsey
+      end
+    end
+
     context "when oda_eligibility is blank" do
       subject(:activity) { build(:activity, oda_eligibility: nil) }
       it "should not be valid" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -350,6 +350,32 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#policy_marker_gender" do
+    context "when gender exists" do
+      it "returns the locale value for the code" do
+        activity = build(:activity, policy_marker_gender: "not_targeted")
+        result = described_class.new(activity).policy_marker_gender
+        expect(result).to eql("Not targeted")
+      end
+    end
+
+    context "when the value is the BEIS custom value" do
+      it "returns the locale value for the custom code" do
+        activity = build(:activity, policy_marker_gender: "not_assessed")
+        result = described_class.new(activity).policy_marker_gender
+        expect(result).to eql("Not assessed")
+      end
+    end
+
+    context "when the activity does not have a gender set" do
+      it "returns nil" do
+        activity = build(:activity, policy_marker_gender: nil)
+        result = described_class.new(activity)
+        expect(result.policy_marker_gender).to be_nil
+      end
+    end
+  end
+
   describe "#oda_eligibility" do
     context "when the activity is ODA eligible" do
       it "returns the locale value for this option" do

--- a/spec/services/ingest_iati_activities_spec.rb
+++ b/spec/services/ingest_iati_activities_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe IngestIatiActivities do
       end
 
       it "sets the level to third-party project when its parent is a project" do
-        existing_activity.update!(level: :project, call_present: false)
+        existing_activity.update!(level: :project, call_present: false, ingested: true)
 
         described_class.new(delivery_partner: uksa, file_io: legacy_activities_xml).call
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -37,6 +37,14 @@ module FormHelpers
     flow: "ODA",
     aid_type: "B02",
     fstc_applies: true,
+    policy_marker_gender: "Not assessed",
+    policy_marker_climate_change_adaptation: "Not targeted",
+    policy_marker_climate_change_mitigation: "Significant objective",
+    policy_marker_biodiversity: "Principal objective",
+    policy_marker_desertification: "Principal objective AND in support of an action programme",
+    policy_marker_disability: "Not assessed",
+    policy_marker_disaster_risk_reduction: "Not assessed",
+    policy_marker_nutrition: "Not assessed",
     oda_eligibility: "Eligible",
     level:,
     parent: nil
@@ -207,6 +215,39 @@ module FormHelpers
     choose("activity[fstc_applies]", option: fstc_applies)
     click_button t("form.button.activity.submit")
 
+    if level == "project" || level == "third_party_project"
+      expect(page).to have_content t("page_title.activity_form.show.policy_markers")
+      expect(page).to have_content t("form.hint.activity.policy_markers.title")
+      expect(page).to have_content("Explanation of responses")
+      expect(page).to have_content t("form.legend.activity.policy_markers.responses.not_assessed")
+      expect(page).to have_content t("form.hint.activity.policy_markers.responses.not_assessed")
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.gender")
+      select policy_marker_gender, from: "activity[policy_marker_gender]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.climate_change_adaptation")
+      select policy_marker_climate_change_adaptation, from: "activity[policy_marker_climate_change_adaptation]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.climate_change_mitigation")
+      select policy_marker_climate_change_mitigation, from: "activity[policy_marker_climate_change_mitigation]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.biodiversity")
+      select policy_marker_biodiversity, from: "activity[policy_marker_biodiversity]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.desertification")
+      select policy_marker_desertification, from: "activity[policy_marker_desertification]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.disability")
+      select policy_marker_disability, from: "activity[policy_marker_disability]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.disaster_risk_reduction")
+      select policy_marker_disaster_risk_reduction, from: "activity[policy_marker_disaster_risk_reduction]"
+
+      expect(page).to have_content t("form.legend.activity.policy_markers.nutrition")
+      select policy_marker_nutrition, from: "activity[policy_marker_nutrition]"
+      click_button t("form.button.activity.submit")
+    end
+
     expect(page).to have_content t("form.legend.activity.oda_eligibility")
     expect(page).to have_content t("form.hint.activity.oda_eligibility")
     choose oda_eligibility
@@ -233,6 +274,32 @@ module FormHelpers
     expect(page).to have_content gdi
     expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
+    if level == "project" || level == "third_party_project"
+      within(".policy_marker_gender") do
+        expect(page).to have_content policy_marker_gender
+      end
+      within(".policy_marker_climate_change_adaptation") do
+        expect(page).to have_content policy_marker_climate_change_adaptation
+      end
+      within(".policy_marker_climate_change_mitigation") do
+        expect(page).to have_content policy_marker_climate_change_mitigation
+      end
+      within(".policy_marker_biodiversity") do
+        expect(page).to have_content policy_marker_biodiversity
+      end
+      within(".policy_marker_desertification") do
+        expect(page).to have_content policy_marker_desertification
+      end
+      within(".policy_marker_disability") do
+        expect(page).to have_content policy_marker_disability
+      end
+      within(".policy_marker_disaster_risk_reduction") do
+        expect(page).to have_content policy_marker_disaster_risk_reduction
+      end
+      within(".policy_marker_nutrition") do
+        expect(page).to have_content policy_marker_nutrition
+      end
+    end
     expect(page).to have_content oda_eligibility
     expect(page).to have_content localise_date_from_input_fields(
       year: planned_start_date_year,

--- a/vendor/data/codelists/IATI/2_03/activity/policy_markers.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/policy_markers.yml
@@ -1,0 +1,25 @@
+---
+attributes:
+  category-codelist:
+  name: PolicySignificance
+  complete: '1'
+data:
+  - code: '0'
+    name: Not targeted
+    description: The score “not targeted” means that the activity was examined but found not to target the policy objective
+  - code: '1'
+    name: Significant objective
+    description: Significant (secondary) policy objectives are those which, although important, were not the prime motivation for undertaking the activity
+  - code: '2'
+    name: Principal objective
+    description: Principal (primary) policy objectives are those which can be identified as being fundamental in the design and impact of the activity and which are an explicit objective of the activity. They may be selected by answering the question “Would the activity have been undertaken without this objective?”
+  - code: '3'
+    name: Principal objective AND in support of an action programme
+    description: For desertification-related aid only
+  - code: '4'
+    name: Explicit primary objective
+    description: ''
+metadata:
+  url: https://iatistandard.org/en/iati-standard/203/codelists/policysignificance/
+  name: Policy Markers
+  description: ''


### PR DESCRIPTION
Trello: https://trello.com/c/hKQ5j2uG

## Changes in this PR

Policy markers are a new field on the activity form requested by the client. IATI considers 12 different policy markers, but BEIS only use 8 of them. These 8 have been added to the form. They share the same 5 answers/values so I have decided to make them `enum` so we can get helper methods that can come handy for future queries. In order to be able to share the enum methods among multiple database columns I am using prefixes as recommended in the [ActiveRecord documentation](https://api.rubyonrails.org/v5.2.3/classes/ActiveRecord/Enum.html)

These markers get reported to IATI, so they have been included on the activity XML and I have checked them against the IATI validator and they pass. Please note, there is only one value we do not report to IATI (`not assessed`) since this is a custom BEIS value they use for internal purposes only. 

Despite these 8 policy markers being different entries on the database, I have grouped them up on the same form step/page for a better user experience, defaulting the value on the select box to the one BEIS uses most (`not assessed`).
I have also created a `details` section that the users can access to get an explanation of the different responses they can select for each marker.

Lastly, an ingest spec needed amendment due to validation errors. This is on a separate commit.

## Screenshots of UI changes

### After

<img width="683" alt="Screenshot 2020-11-11 at 16 28 43" src="https://user-images.githubusercontent.com/48016017/98843285-a9ca9700-2442-11eb-87dd-4d86d093bcfc.png">

<img width="996" alt="Screenshot 2020-11-11 at 16 29 18" src="https://user-images.githubusercontent.com/48016017/98843291-ae8f4b00-2442-11eb-9bbb-7b6af4ac1d8f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
