### PR TITLE
(1167) Add missing regions back in RODA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,8 @@
 - Two original planned disbursements for the same activity, financial quarter
   and year cannot be created.
 - Add a field to report Free Standing Technical Cooperation
+- Missing regions have been added back to RODA, except `West Indies` and `States Ex-Yugoslavia unspecified`
+- The re-introduced regions map to countries within all the relevant sub-regions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...HEAD
 [release-21]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-20...release-21

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -2,6 +2,44 @@
 
 module CodelistHelper
   DEVELOPING_COUNTRIES_CODE = "998"
+  AFRICA_REGIONAL_SUBREGIONS = [
+    "1027",
+    "1028",
+    "189",
+    "1029",
+    "1030",
+  ]
+  SOUTH_SAHARA_SUBREGIONS = [
+    "1027",
+    "1028",
+    "1029",
+    "1030",
+  ]
+  AMERICA_REGIONAL_SUBREGIONS = [
+    "1031",
+    "1032",
+    "489",
+  ]
+  NORTH_AND_CENTRAL_AMERICA_REGIONAL_SUBREGIONS = [
+    "1031",
+    "1032",
+  ]
+  ASIA_REGIONAL_SUBREGIONS = [
+    "789",
+    "589",
+    "689",
+  ]
+  CENTRAL_ASIA_REGIONAL_SUBREGIONS = [
+    "689",
+  ]
+  SOUTH_ASIA_REGIONAL_SUBREGIONS = [
+    "689",
+  ]
+  OCEANIA_REGIONAL_SUBREGIONS = [
+    "1033",
+    "1034",
+    "1035",
+  ]
   ALLOWED_AID_TYPE_CODES = [
     "B02",
     "B03",
@@ -82,8 +120,22 @@ module CodelistHelper
   def intended_beneficiaries_checkbox_options
     recipient_region = @activity.recipient_region
     list = load_yaml(entity: "activity", type: "intended_beneficiaries")
-    show_list = if recipient_region == DEVELOPING_COUNTRIES_CODE
+    show_list = if recipient_region == DEVELOPING_COUNTRIES_CODE || @activity.recipient_country?
       list.values.flatten
+    elsif recipient_region == "298" # Africa, regional
+      AFRICA_REGIONAL_SUBREGIONS.map { |subregion| list[subregion] }.flatten
+    elsif recipient_region == "289" # South of Sahara
+      SOUTH_SAHARA_SUBREGIONS.map { |subregion| list[subregion] }.flatten
+    elsif recipient_region == "498" # America, regional
+      AMERICA_REGIONAL_SUBREGIONS.map { |subregion| list[subregion] }.flatten
+    elsif recipient_region == "389" # North & Central America, regional
+      NORTH_AND_CENTRAL_AMERICA_REGIONAL_SUBREGIONS.map { |subregion| list[subregion] }.flatten
+    elsif recipient_region == "798" # Asia, regional
+      ASIA_REGIONAL_SUBREGIONS.map { |subregion| list[subregion] }.flatten
+    elsif recipient_region == "619" || recipient_region == "679" # Central Asia, regional and South Asia, regional. No matching countries as single regions so mapping to South & Central Asia instead
+      list["689"]
+    elsif recipient_region == "889" # Oceania, regional
+      OCEANIA_REGIONAL_SUBREGIONS.map { |subregion| list[subregion] }.flatten
     else
       list[recipient_region]
     end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -48,7 +48,7 @@ class Activity < ApplicationRecord
   validates :recipient_region, presence: true, on: :region_step, if: :recipient_region?
   validates :recipient_country, presence: true, on: :country_step, if: :recipient_country?
   validates :requires_additional_benefitting_countries, inclusion: {in: [true, false]}, on: :requires_additional_benefitting_countries_step, if: :recipient_country?
-  validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
+  validates :intended_beneficiaries, presence: true, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
   validates :gdi, presence: true, on: :gdi_step
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -97,7 +97,7 @@ en:
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
-        intended_beneficiaries: You can select up to 10 different countries. This field is optional if you already selected a recipient country on the previous step
+        intended_beneficiaries: This field is optional if you already selected a recipient country on the previous step
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           click_button t("form.button.activity.submit")
           expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
-        scenario "the user has the option of selecting other intended beneficiaries based on a reduced list depending on the region of the country selected" do
+        scenario "the user has the option of selecting other intended beneficiaries based from the full list of countries available" do
           visit activity_step_path(activity, :geography)
           choose "Country"
           click_button t("form.button.activity.submit")
@@ -48,14 +48,15 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           click_button t("form.button.activity.submit")
 
           expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
-          expect(page).to have_content("Argentina")
-          expect(page).to have_content("Venezuela")
-          check "Argentina"
-          check "Colombia"
-          check "Peru"
+          expect(page).to have_selector(".govuk-checkboxes__item", count: 145)
+          expect(page).to have_content("Afghanistan")
+          expect(page).to have_content("Zimbabwe")
+          check "Gambia"
+          check "Indonesia"
+          check "Yemen"
           click_button t("form.button.activity.submit")
           activity.reload
-          expect(activity.intended_beneficiaries).to eq(["AR", "CO", "PE"])
+          expect(activity.intended_beneficiaries).to eq(["GM", "ID", "YE"])
           expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
 
@@ -114,6 +115,33 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
         click_button t("form.button.activity.submit")
         activity.reload
         expect(activity.intended_beneficiaries).to eq(["KE", "TR"])
+      end
+
+      context "if they choose one of the wider regions" do
+        scenario "they will be able to select benefitting countries from the sub-regions the wider region maps to" do
+          visit activity_step_path(activity, :geography)
+          choose "Region"
+          click_button t("form.button.activity.submit")
+          expect(page).to have_content t("form.label.activity.recipient_region")
+
+          select "Africa, regional"
+          click_button t("form.button.activity.submit")
+          expect(activity.reload.recipient_region).to eq("298")
+
+          expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
+          expect(page).to have_selector(".govuk-checkboxes__item", count: 54)
+          expect(page).to have_content("Algeria")
+          expect(page).to have_content("Zimbabwe")
+          expect(page).to_not have_content("Ukraine")
+
+          check "Cameroon"
+          check "Mozambique"
+          check "Senegal"
+          check "Egypt"
+          click_button t("form.button.activity.submit")
+          activity.reload
+          expect(activity.intended_beneficiaries).to eq(["CM", "EG", "MZ", "SN"])
+        end
       end
     end
   end

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
 
-        scenario "the user will not be able to select more than 10 intended beneficiaries" do
+        scenario "the user will be able to select more than 10 intended beneficiaries" do
           visit activity_step_path(activity, :geography)
           choose "Country"
           click_button t("form.button.activity.submit")
@@ -84,9 +84,9 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
           check "Uganda"
           check "Zambia"
           click_button t("form.button.activity.submit")
-
-          expect(page).to have_content t("activerecord.errors.models.activity.attributes.intended_beneficiaries.too_long")
-          expect(activity.intended_beneficiaries).to be_nil
+          activity.reload
+          expect(activity.intended_beneficiaries).to eq(["KM", "ER", "ET", "KE", "MG", "MZ", "SO", "SD", "TZ", "UG", "ZM"])
+          expect(page).to have_current_path(activity_step_path(activity, :gdi))
         end
       end
     end

--- a/vendor/data/codelists/IATI/2_03/activity/recipient_region.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/recipient_region.yml
@@ -10,14 +10,26 @@ data:
     name: North of Sahara, regional
   - code: '289'
     name: South of Sahara, regional
+  - code: '298'
+    name: Africa, regional
+  - code: '389'
+    name: North & Central America, regional
   - code: '489'
     name: South America, regional
+  - code: '498'
+    name: America, regional
   - code: '589'
     name: Middle East, regional
+  - code: '619'
+    name: Central Asia, regional
+  - code: '679'
+    name: South Asia, regional
   - code: '689'
     name: South & Central Asia, regional
   - code: '789'
     name: Far East Asia, regional
+  - code: '798'
+    name: Asia, regional
   - code: '889'
     name: Oceania, regional
   - code: '998'


### PR DESCRIPTION
Trello: https://trello.com/c/MDYZXq2B

## Changes in this PR

After user feedback on the previous financial quarter that some regions were missing on the service but they were used on the trackers to allocate activities, we have now re-introduced those regions back in RODA.

The reason these regions were removed at first was that they did not match to any countries for intended beneficiaries and the decision was made back then not to include them and access countries by selecting the relevant sub-regions when needed.

We now have modified the way the service handles the list displayed for `intended_beneficiaries`, to include the missing regions. These regions are wider regions that "wrap" different subregions. If a user selects one of these wider regions on the geography step, the list displayed for intended beneficiaries will be one containing all the countries in the sub-regions that this wider region covers.

On the other hand, if a user selects a country in the geography step, they still have the option of choosing other benefitting countries, and they will be able to select them from a global list of all the countries recognised by DAC OECD.

We are aware this is not ideal and will mean that BEIS need to do some assurance work to make sure all the benefitting countries are correct for each activity (in the case that the user approach `intended_beneficiaries` through `recipient_country`), but we agreed with the client that this would be a good compromise from both parts so they have a better functioning app for Q3 reporting.

We have also removed the limit of 10 intended beneficiaries. This responds to a request from the client. Users are now allowed to select an unlimited number of countries as intended beneficiaries from a given list.

After Q3, the plan is to re-design this geography step from scratch and these changes will probably be removed. This quick fix will allow the users complete their reporting tasks on time, while giving the dev team time to implement other fields necessary for the Q3 reporting.


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
