### PR TITLE
(1179) Fix activity parent level mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -382,6 +382,7 @@
 - Policy markers added to activity form, including BEIS custom answer `not assessed`
 
 ## [unreleased]
+- Fix parent level strings
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...HEAD
 [release-22]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...release-22

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -214,9 +214,9 @@ class Activity < ApplicationRecord
   def parent_level
     case level
     when "fund" then nil
-    when "programme" then "fund (level A)"
-    when "project" then "programme (level B)"
-    when "third_party_project" then "project (level C)"
+    when "programme" then "fund"
+    when "project" then "programme"
+    when "third_party_project" then "project"
     end
   end
 

--- a/app/views/staff/activity_forms/parent.html.haml
+++ b/app/views/staff/activity_forms/parent.html.haml
@@ -7,5 +7,5 @@
     ->(activity){ ActivityPresenter.new(activity).display_title },
     legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.parent", parent_level: f.object.parent_level, level: f.object.level) },
     hint: { text: t("form.hint.activity.parent",
-      parent_level: f.object.parent_level,
+      parent_level: I18n.t("page_content.activity.level.#{f.object.parent_level}"),
       level: I18n.t("page_content.activity.level.#{f.object.level}")) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -830,21 +830,21 @@ RSpec.describe Activity, type: :model do
     context "when the level is a programme" do
       it "returns a string for fund" do
         result = described_class.new(level: :programme).parent_level
-        expect(result).to eql("fund (level A)")
+        expect(result).to eql("fund")
       end
     end
 
     context "when the level is a project" do
       it "returns a string for programme" do
         result = described_class.new(level: :project).parent_level
-        expect(result).to eql("programme (level B)")
+        expect(result).to eql("programme")
       end
     end
 
     context "when the level is a third-party project" do
       it "returns a string for project" do
         result = described_class.new(level: :third_party_project).parent_level
-        expect(result).to eql("project (level C)")
+        expect(result).to eql("project")
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -693,7 +693,7 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#form_stpes_completed?" do
+  describe "#form_steps_completed?" do
     it "is true when a user has completed all of the form steps" do
       activity = build(:activity, form_state: :complete)
 


### PR DESCRIPTION
## Changes in this PR

- Fix parent level strings to return enum values for `level`.
- Fix form hint to use the page content translation string for parent level.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
