### PR TITLE
(1135) Fix intended beneficiaries for q3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,7 @@
 - Policy markers added to the CSV report file
 - Activity Objectives added to the activity form, IATI XML and CSV report
 - Add missing regions back on RODA and open scope of country list for `intended_beneficiaries`
+- `Intended_beneficiaries` is now optional in all cases
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...HEAD
 [release-22]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...release-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,7 @@
 - Collect Sustainable Development Goals (SDGs) for activities
 - Policy markers added to the CSV report file
 - Activity Objectives added to the activity form, IATI XML and CSV report
+- Add missing regions back on RODA and open scope of country list for `intended_beneficiaries`
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...HEAD
 [release-22]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...release-22

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -64,10 +64,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step if @activity.recipient_country?
     when :country
       skip_step if @activity.recipient_region?
-    when :requires_additional_benefitting_countries
-      skip_step if @activity.recipient_region?
     when :intended_beneficiaries
-      skip_step unless @activity.requires_intended_beneficiaries?
+      skip_step unless @activity.requires_additional_benefitting_countries?
     when :collaboration_type
       skip_step if @activity.fund?
       assign_default_collaboration_type_value_if_nil

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -89,14 +89,8 @@ module CodelistHelper
   end
 
   def intended_beneficiaries_checkbox_options
-    recipient_region = @activity.recipient_region
-    list = load_yaml(entity: "activity", type: "intended_beneficiaries")
-    show_list = if recipient_region == DEVELOPING_COUNTRIES_CODE
-      list.values.flatten
-    else
-      list[recipient_region]
-    end
-    show_list.collect { |item|
+    list = load_yaml(entity: "activity", type: "intended_beneficiaries").values.flatten
+    list.collect { |item|
       OpenStruct.new(name: item["name"], code: item["code"])
     }.compact.sort_by(&:name)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -60,8 +60,8 @@ class Activity < ApplicationRecord
   validates :geography, presence: true, on: :geography_step
   validates :recipient_region, presence: true, on: :region_step, if: :recipient_region?
   validates :recipient_country, presence: true, on: :country_step, if: :recipient_country?
-  validates :requires_additional_benefitting_countries, inclusion: {in: [true, false]}, on: :requires_additional_benefitting_countries_step, if: :recipient_country?
-  validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_intended_beneficiaries?
+  validates :requires_additional_benefitting_countries, inclusion: {in: [true, false], message: I18n.t("activerecord.errors.models.activity.attributes.requires_additional_benefitting_countries.blank")}, on: :requires_additional_benefitting_countries_step
+  validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_additional_benefitting_countries?
   validates :gdi, presence: true, on: :gdi_step
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :covid19_related, presence: true, on: :covid19_related_step
@@ -306,10 +306,6 @@ class Activity < ApplicationRecord
 
   def forecasted_total_for_date_range(range:)
     planned_disbursements.where(period_start_date: range).sum(:value)
-  end
-
-  def requires_intended_beneficiaries?
-    recipient_region? || (recipient_country? && requires_additional_benefitting_countries?)
   end
 
   def comment_for_report(report_id:)

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -205,17 +205,16 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :country)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:recipient_country)}"), activity_step_path(activity_presenter, :geography), t("summary.label.activity.recipient_country"))
 
-  - if activity_presenter.recipient_country?
-    .govuk-summary-list__row.requires_additional_benefitting_countries
-      %dt.govuk-summary-list__key
-        = t("summary.label.activity.requires_additional_benefitting_countries")
-      %dd.govuk-summary-list__value
-        = activity_presenter.requires_additional_benefitting_countries
-      %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :requires_additional_benefitting_countries)
-          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:requires_additional_benefitting_countries)}"), activity_step_path(activity_presenter, :requires_additional_benefitting_countries), t("summary.label.activity.requires_additional_benefitting_countries"))
+  .govuk-summary-list__row.requires_additional_benefitting_countries
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.requires_additional_benefitting_countries")
+    %dd.govuk-summary-list__value
+      = activity_presenter.requires_additional_benefitting_countries
+    %dd.govuk-summary-list__actions
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :requires_additional_benefitting_countries)
+        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:requires_additional_benefitting_countries)}"), activity_step_path(activity_presenter, :requires_additional_benefitting_countries), t("summary.label.activity.requires_additional_benefitting_countries"))
 
-  - if activity_presenter.requires_intended_beneficiaries?
+  - if activity_presenter.requires_additional_benefitting_countries?
     .govuk-summary-list__row.intended_beneficiaries
       %dt.govuk-summary-list__key
         = t("summary.label.activity.intended_beneficiaries")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -142,8 +142,8 @@ en:
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
-        intended_beneficiaries: You can select up to 10 different countries. This field is optional if you already selected a recipient country on the previous step
         objectives: Please refrain from using any abbreviations
+        intended_beneficiaries: You can select up to 10 different countries
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         planned_end_date: For example, 28 11 2020
         planned_start_date: For example, 27 3 2020
@@ -335,6 +335,7 @@ en:
         geography: Will the benefitting recipient be a region or country?
         delivery_partner_identifier: Enter your unique identifier
         roda_identifier: Enter your unique RODA identifier
+        requires_additional_benefitting_countries: Additional benefitting countries
         intended_beneficiaries: What are the intended beneficiaries?
         level: Hierarchy level
         objectives: Aims/Objectives
@@ -388,6 +389,8 @@ en:
               level_b_too_long: This programme's (level B) identifier must be at most %{limit} characters long
               level_c_too_long: This project's (level C) identifier must be at most %{limit} characters long
               level_d_too_long: This third-party project's (level D) identifier must be at most %{limit} characters long
+            requires_additional_benefitting_countries:
+              blank: Select an option
             title:
               blank: Enter a title
             description:

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -4,90 +4,33 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
     before { authenticate!(user: user) }
     let(:activity) { create(:activity, :at_geography_step, organisation: user.organisation, intended_beneficiaries: nil) }
 
-    context "if they choose 'recipient country' as geography option" do
-      context "after choosing one country" do
-        scenario "the user will be asked if there are other benefitting countries to be added" do
-          visit activity_step_path(activity, :geography)
-          choose "Country"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_select(t("form.label.activity.recipient_country"))
+    context "after choosing either country or region on the geography step" do
+      scenario "the user will be asked if there are other benefitting countries to be added" do
+        visit activity_step_path(activity, :geography)
+        choose "Country"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_select(t("form.label.activity.recipient_country"))
 
-          select "Bolivia"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-          choose "Yes"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
-        end
+        select "Bolivia"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+        choose "Yes"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
+      end
 
-        scenario "if there are no other benefitting countries the intended_beneficiaries step will be omitted" do
-          visit activity_step_path(activity, :geography)
-          choose "Country"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_select(t("form.label.activity.recipient_country"))
+      scenario "if there are no other benefitting countries the intended_beneficiaries step will be omitted" do
+        visit activity_step_path(activity, :geography)
+        choose "Country"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_select(t("form.label.activity.recipient_country"))
 
-          select "Bolivia"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-          choose "No"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_current_path(activity_step_path(activity, :gdi))
-        end
-        scenario "the user has the option of selecting other intended beneficiaries based on a reduced list depending on the region of the country selected" do
-          visit activity_step_path(activity, :geography)
-          choose "Country"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_select(t("form.label.activity.recipient_country"))
-
-          select "Bolivia"
-          click_button t("form.button.activity.submit")
-          expect(activity.reload.recipient_region).to eq("489") # South America
-
-          expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-          choose "Yes"
-          click_button t("form.button.activity.submit")
-
-          expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
-          expect(page).to have_content("Argentina")
-          expect(page).to have_content("Venezuela")
-          check "Argentina"
-          check "Colombia"
-          check "Peru"
-          click_button t("form.button.activity.submit")
-          activity.reload
-          expect(activity.intended_beneficiaries).to eq(["AR", "CO", "PE"])
-          expect(page).to have_current_path(activity_step_path(activity, :gdi))
-        end
-
-        scenario "the user will not be able to select more than 10 intended beneficiaries" do
-          visit activity_step_path(activity, :geography)
-          choose "Country"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_select(t("form.label.activity.recipient_country"))
-
-          select "Burundi"
-          click_button t("form.button.activity.submit")
-          expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-          choose "Yes"
-          click_button t("form.button.activity.submit")
-
-          expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
-          check "Comoros"
-          check "Eritrea"
-          check "Ethiopia"
-          check "Kenya"
-          check "Madagascar"
-          check "Mozambique"
-          check "Somalia"
-          check "Sudan"
-          check "Tanzania"
-          check "Uganda"
-          check "Zambia"
-          click_button t("form.button.activity.submit")
-
-          expect(page).to have_content t("activerecord.errors.models.activity.attributes.intended_beneficiaries.too_long")
-          expect(activity.intended_beneficiaries).to be_nil
-        end
+        select "Bolivia"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+        choose "No"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_current_path(activity_step_path(activity, :gdi))
       end
     end
 

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -32,31 +32,61 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
         click_button t("form.button.activity.submit")
         expect(page).to have_current_path(activity_step_path(activity, :gdi))
       end
-    end
-
-    context "if they choose recipient region as geography option" do
-      scenario "it is required that they choose at least one intended beneficiary" do
+      scenario "the user has the option of selecting other intended beneficiaries based on the full list of all countries" do
         visit activity_step_path(activity, :geography)
         choose "Region"
         click_button t("form.button.activity.submit")
         expect(page).to have_select(t("form.label.activity.recipient_region"))
 
-        select "Developing countries, unspecified"
+        select "Africa, regional"
         click_button t("form.button.activity.submit")
-        expect(activity.reload.recipient_region).to eq("998")
+        expect(activity.reload.recipient_region).to eq("298")
+
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+        choose "Yes"
+        click_button t("form.button.activity.submit")
 
         expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
+        expect(page).to have_selector(".govuk-checkboxes__item", count: 143)
         expect(page).to have_content("Afghanistan")
         expect(page).to have_content("Zimbabwe")
-        # Don't select any countries
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.intended_beneficiaries.blank")
-
-        check "Kenya"
-        check "Turkey"
+        check "Gambia"
+        check "Indonesia"
+        check "Yemen"
         click_button t("form.button.activity.submit")
         activity.reload
-        expect(activity.intended_beneficiaries).to eq(["KE", "TR"])
+        expect(activity.intended_beneficiaries).to eq(["GM", "ID", "YE"])
+        expect(page).to have_current_path(activity_step_path(activity, :gdi))
+      end
+
+      scenario "the user will not be able to select more than 10 intended beneficiaries" do
+        visit activity_step_path(activity, :geography)
+        choose "Country"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_select(t("form.label.activity.recipient_country"))
+
+        select "Burundi"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+        choose "Yes"
+        click_button t("form.button.activity.submit")
+
+        expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
+        check "Comoros"
+        check "Eritrea"
+        check "Ethiopia"
+        check "Kenya"
+        check "Madagascar"
+        check "Mozambique"
+        check "Somalia"
+        check "Sudan"
+        check "Tanzania"
+        check "Uganda"
+        check "Zambia"
+        click_button t("form.button.activity.submit")
+
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.intended_beneficiaries.too_long")
+        expect(activity.intended_beneficiaries).to be_nil
       end
     end
   end

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -229,7 +229,15 @@ RSpec.feature "Users can create a fund level activity" do
         # region has the default value already selected
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("form.label.activity.intended_beneficiaries")
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+
+        # Don't select any option
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.requires_additional_benefitting_countries.blank")
+
+        choose "Yes"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
 
         # Don't select any intended beneficiaries
         click_button t("form.button.activity.submit")

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -138,7 +138,15 @@ RSpec.feature "Users can create a programme activity" do
         # region has the default value already selected
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("form.label.activity.intended_beneficiaries")
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+
+        # Don't select any option
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.requires_additional_benefitting_countries.blank")
+
+        choose "Yes"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
 
         # Don't select any intended beneficiaries
         click_button t("form.button.activity.submit")

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -191,7 +191,7 @@ RSpec.feature "Users can edit an activity" do
           select recipient_region, from: "activity[recipient_region]"
           click_button t("form.button.activity.submit")
 
-          expect(page).to have_content t("form.label.activity.intended_beneficiaries")
+          expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
           expect(page).not_to have_content activity.title
         end
 

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -52,8 +52,8 @@ RSpec.feature "Users can provide the geography for an activity" do
         select "Developing countries, unspecified", from: "activity[recipient_region]"
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("form.label.activity.intended_beneficiaries")
-        expect(page).to have_current_path(activity_step_path(activity, :intended_beneficiaries))
+        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+        expect(page).to have_current_path(activity_step_path(activity, :requires_additional_benefitting_countries))
       end
     end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -218,6 +218,16 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.last.code).to eq("3")
       end
     end
+
+    describe "#intended_beneficiaries_checkbox_options" do
+      it "returns a full list of all countries" do
+        options = helper.intended_beneficiaries_checkbox_options
+
+        expect(options.length).to eq 143
+        expect(options.first.name).to eq("Afghanistan")
+        expect(options.last.name).to eq("Zimbabwe")
+      end
+    end
   end
 
   describe "BEIS" do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -189,11 +189,9 @@ module FormHelpers
     select recipient_region, from: "activity[recipient_region]"
     click_button t("form.button.activity.submit")
 
-    if geography == "recipient_country"
-      expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-      choose "Yes"
-      click_button t("form.button.activity.submit")
-    end
+    expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
+    choose "Yes"
+    click_button t("form.button.activity.submit")
 
     expect(page).to have_content t("form.label.activity.intended_beneficiaries")
     check intended_beneficiaries

--- a/vendor/data/codelists/IATI/2_03/activity/intended_beneficiaries.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/intended_beneficiaries.yml
@@ -188,9 +188,6 @@ data:
       name: Morocco
     - code: TN
       name: Tunisia
-  '889': # Oceania
-    - code: '889'
-      name: Oceania, regional
   '1035': # Polynesia
     - code: CK
       name: Cook Islands
@@ -262,9 +259,6 @@ data:
       name: Suriname
     - code: VE
       name: Venezuela
-  '289': # South of Sahara
-    - code: '289'
-      name: South of Sahara, regional
   '1029': # Southern Africa
     - code: BW
       name: Botswana

--- a/vendor/data/codelists/IATI/2_03/activity/recipient_region.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/recipient_region.yml
@@ -10,14 +10,26 @@ data:
     name: North of Sahara, regional
   - code: '289'
     name: South of Sahara, regional
+  - code: '298'
+    name: Africa, regional
+  - code: '389'
+    name: North & Central America, regional
   - code: '489'
     name: South America, regional
+  - code: '498'
+    name: America, regional
   - code: '589'
     name: Middle East, regional
+  - code: '619'
+    name: Central Asia, regional
+  - code: '679'
+    name: South Asia, regional
   - code: '689'
     name: South & Central Asia, regional
   - code: '789'
     name: Far East Asia, regional
+  - code: '798'
+    name: Asia, regional
   - code: '889'
     name: Oceania, regional
   - code: '998'


### PR DESCRIPTION
Trello: https://trello.com/c/M9FaDIxY

## Changes in this PR

A decision has been made with the client that in order to facilitate Q3 reporting we are going to try replicate the behaviour we have seen on the trackers for the geography/intended beneficiaries step. For this we are now making `intended_beneficiaries` an optional step on all cases (included when user selects `recipient_region`) and we will now display a full list of all countries approved by OECD-DAC regardless of the region the user has selected. This is to reflect what we have seen on the trackers where users will select countries from different regions even if they have selected a specific region.

We are keeping the limit to 10 countries as this is the expectation we have set with BEIS.

We are also adding the missing regions back into the service, so now users are able to select any of those.

After Q3 reporting we will re-design this step from scratch, so these changes are just a quick fix to allow a less troubled reporting period this time.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
