### PR TITLE
(1202) Add a Rake task to run the CSV importer

### DIFF
--- a/lib/tasks/import_activities.rake
+++ b/lib/tasks/import_activities.rake
@@ -1,0 +1,38 @@
+require "csv"
+
+desc "Imports Activities from a CSV file"
+namespace :activities do
+  task import: :environment do
+    path = ENV["CSV"]
+    organisation_id = ENV["ORGANISATION_ID"]
+
+    abort "You must specify a CSV (e.g. `rake activites:import CSV=path/to/file.csv ORGANISATION_ID=8c3b69ec-1e9c-49ae-8e04-7c5d3826b253`)" if path.nil?
+    abort "You must specify an organisation ID (e.g. `rake activites:import CSV=path/to/file.csv ORGANISATION_ID=8c3b69ec-1e9c-49ae-8e04-7c5d3826b253`)" if organisation_id.nil?
+
+    organisation = Organisation.find(organisation_id)
+
+    file = File.open(path, encoding: "bom|utf-8")
+    csv = CSV.parse(file.read, headers: true)
+
+    importer = Activities::ImportFromCsv.new(organisation: organisation)
+    importer.import(csv)
+
+    if importer.errors.empty?
+      puts "Successfully created #{pluralize(importer.created.count, "activity")} and updated #{pluralize(importer.updated.count, "activity")}"
+    else
+      # Output errors
+      puts "There were #{pluralize(importer.errors.count, "error")} when importing"
+      importer.errors.each do |error|
+        puts "At row #{error.csv_row}: #{error.message}"
+      end
+    end
+  rescue Errno::ENOENT
+    abort "Cannot find the file at #{path}"
+  rescue ActiveRecord::RecordNotFound
+    abort "Can't find an organisation with the ID '#{organisation_id}'"
+  end
+
+  def pluralize(count, string)
+    count.to_s + " " + string.pluralize(count)
+  end
+end

--- a/spec/lib/tasks/import_activities_spec.rb
+++ b/spec/lib/tasks/import_activities_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+describe "rake activities:import", type: :task do
+  let(:organisation) { create(:organisation) }
+
+  it "returns an error if the organisation is blank" do
+    ClimateControl.modify CSV: "/foo/bar/baz" do
+      expect {
+        task.execute
+      }.to raise_error(SystemExit, /You must specify an organisation ID/)
+    end
+  end
+
+  it "returns an error if the CSV is blank" do
+    ClimateControl.modify ORGANISATION_ID: organisation.id do
+      expect {
+        task.execute
+      }.to raise_error(SystemExit, /You must specify a CSV/)
+    end
+  end
+
+  it "returns an error if the CSV cannot be found" do
+    ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
+      expect {
+        task.execute
+      }.to raise_error(SystemExit, "Cannot find the file at /foo/bar/baz")
+    end
+  end
+
+  it "returns an error if the organisation cannot be found" do
+    ClimateControl.modify ORGANISATION_ID: "124", CSV: "/foo/bar/baz" do
+      expect {
+        task.execute
+      }.to raise_error(SystemExit, "Can't find an organisation with the ID '124'")
+    end
+  end
+
+  context "with the correct environment variables" do
+    let(:csv) do
+      <<~CSV
+        foo,bar,baz
+        1,2,3
+      CSV
+    end
+
+    around do |example|
+      ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
+        example.run
+      end
+    end
+
+    before do
+      allow(File).to receive(:open).and_return(StringIO.new(csv))
+      allow(Activities::ImportFromCsv).to receive(:new).with(organisation: organisation) { importer }
+      allow(importer).to receive(:import).with(CSV.parse(csv, headers: true))
+    end
+
+    context "When there are no errors from the importer" do
+      let(:importer) do
+        double(:importer, errors: [], created: build_list(:activity, 3), updated: build_list(:activity, 2))
+      end
+
+      it "outputs the number of activities imported and updated" do
+        expect { task.execute }.to output(/Successfully created 3 activities and updated 2 activities/).to_stdout
+      end
+    end
+
+    context "When there are errors from the importer" do
+      let(:errors) do
+        [
+          Activities::ImportFromCsv::Error.new(1, 3, "Foo", "Blah"),
+          Activities::ImportFromCsv::Error.new(2, 4, "Bar", "Blah"),
+        ]
+      end
+
+      let(:importer) do
+        double(:importer, errors: errors, created: [], updated: [])
+      end
+
+      it "outputs the number of errors" do
+        expect { task.execute }.to output(/There were 2 errors when importing/).to_stdout
+      end
+
+      it "outputs the specific errors" do
+        expect { task.execute }.to output(/At row 3: Blah\nAt row 4: Blah/).to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/invalid_activities_spec.rb
+++ b/spec/lib/tasks/invalid_activities_spec.rb
@@ -1,14 +1,13 @@
 require "rails_helper"
 require "csv"
-Rails.application.load_tasks
 
-describe "invalid_activities.rake" do
+describe "rake invalid_activities" do
   it "creates a csv file on tmp folder with a list of invalid activities in RODA" do
     activities = create_list(:project_activity, 5)
     activities.first.update_columns(gdi: nil, collaboration_type: nil)
     activities.last.update_columns(title: nil, programme_status: nil)
 
-    run_task(task_name: "invalid_activities")
+    task.execute
     invalid_activities_from_csv = CSV.read("tmp/invalid_activities.csv")
 
     expect(invalid_activities_from_csv.count).to eql(2)
@@ -18,8 +17,4 @@ describe "invalid_activities.rake" do
     expect(invalid_activities_from_csv.first).to include(activities.first.level)
     expect(invalid_activities_from_csv.first).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(activities.first.organisation, activities.first.id, host: ENV["DOMAIN"]))
   end
-end
-
-def run_task(task_name:)
-  Rake::Task[task_name].invoke
 end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([existing_activity_attributes]) }.to_not change { existing_activity }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
 
       expect(subject.errors.first.csv_row).to eq(2)
@@ -48,6 +51,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([existing_activity_attributes]) }.to_not change { existing_activity }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.column).to eq(:roda_identifier_fragment)
@@ -60,6 +66,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([existing_activity_attributes]) }.to_not change { existing_activity }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.column).to eq(:parent_id)
@@ -71,6 +80,8 @@ RSpec.describe Activities::ImportFromCsv do
       subject.import([existing_activity_attributes])
 
       expect(subject.errors.count).to eq(0)
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(1)
 
       expect(existing_activity.reload.title).to eq(existing_activity_attributes["Title"])
       expect(existing_activity.description).to eq(existing_activity_attributes["Description"])
@@ -98,6 +109,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import(activities) }.to_not change { existing_activity }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(3)
       expect(subject.errors.first.column).to eq(:roda_id)
@@ -120,6 +134,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import(activities) }.to_not change { existing_activity }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(3)
       expect(subject.errors.first.column).to eq(:recipient_region)
@@ -134,6 +151,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([existing_activity_attributes]) }.to_not change { Activity.count }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.column).to eq(:roda_id)
@@ -144,6 +164,9 @@ RSpec.describe Activities::ImportFromCsv do
     it "creates the activity" do
       rows = [new_activity_attributes]
       expect { subject.import(rows) }.to change { Activity.count }.by(1)
+
+      expect(subject.created.count).to eq(1)
+      expect(subject.updated.count).to eq(0)
 
       expect(subject.errors.count).to eq(0)
 
@@ -168,6 +191,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.column).to eq(:recipient_region)
@@ -179,6 +205,9 @@ RSpec.describe Activities::ImportFromCsv do
       new_activity_attributes["Parent RODA ID"] = "111111"
 
       expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
@@ -192,6 +221,9 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.column).to eq(:roda_identifier_fragment)
@@ -204,6 +236,9 @@ RSpec.describe Activities::ImportFromCsv do
     it "creates and imports activities" do
       rows = [existing_activity_attributes, new_activity_attributes]
       expect { subject.import(rows) }.to change { Activity.count }.by(1)
+
+      expect(subject.created.count).to eq(1)
+      expect(subject.updated.count).to eq(1)
 
       expect(subject.errors.count).to eq(0)
     end

--- a/spec/support/rake_helpers.rb
+++ b/spec/support/rake_helpers.rb
@@ -1,0 +1,38 @@
+require "rake"
+
+module TaskExampleGroup
+  extend ActiveSupport::Concern
+
+  included do
+    def silent_warnings
+      old_stderr = $stderr
+      $stderr = StringIO.new
+      yield
+    ensure
+      $stderr = old_stderr
+    end
+
+    let(:task_name) { self.class.top_level_description.sub(/\Arake /, "") }
+    let(:tasks) { Rake::Task }
+
+    # Make the Rake task available as `task` in your examples:
+    subject(:task) { tasks[task_name] }
+
+    # Silence any errors that get sent to stderr when the task gets run
+    around(:example) do |example|
+      silent_warnings { example.run }
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{/spec/lib/tasks/}) do |metadata|
+    metadata[:type] = :task
+  end
+
+  config.include TaskExampleGroup, type: :task
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+end


### PR DESCRIPTION
This adds a Rake task to run an Activity import with the command:

```
rake activites:import CSV=path/to/file.csv ORGANISATION_ID=8c3b69ec-1e9c-49ae-8e04-7c5d3826b253
```

This parses the CSV from the path and runs the importer. If the import is successful, the number of added / updated Activities is presented to the user. If there are any errors, these are played back to the user.

I've kept the tests pretty light touch, and only testing the code that gets introduced in the Rake task, as we don't want a whole bunch of CSV files clogging up the test suite, and we'd only be repeating ourselves anyway, as the everything is already tested in the `ImportFromCsv` class.