### PR TITLE
(1246) Ensure tests run in a random order each time

### DIFF
--- a/config/spring.rb
+++ b/config/spring.rb
@@ -6,3 +6,11 @@ Spring.watch(
   "tmp/restart.txt",
   "tmp/caching-dev.txt"
 )
+
+Spring.after_fork do
+  if Rails.env.test?
+    RSpec.configure do |config|
+      config.seed = srand % 0xFFFF unless ARGV.any? { |arg| arg =~ /seed/ }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,12 +108,12 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-  #
-  #   # Seed global randomization in this process using the `--seed` CLI option.
-  #   # Setting this allows you to use `--seed` to deterministically reproduce
-  #   # test failures related to randomization by passing the same `--seed` value
-  #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 
   # Prevent --bisect from locking up
   config.bisect_runner = :shell


### PR DESCRIPTION
I recently noticed that my tests were always using the same seed, instead of running in a different order each time, as per the RSpec configuration.

This fix ensures the seed is always regenerated every time, unless the `--seed` switch is passed.

Source: https://github.com/rails/spring/issues/113