### PR TITLE
(1247) Fix intermittent test failures

### DIFF
--- a/spec/lib/tasks/import_activities_spec.rb
+++ b/spec/lib/tasks/import_activities_spec.rb
@@ -43,12 +43,6 @@ describe "rake activities:import", type: :task do
       CSV
     end
 
-    around do |example|
-      ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
-        example.run
-      end
-    end
-
     before do
       allow(File).to receive(:open).and_return(StringIO.new(csv))
       allow(Activities::ImportFromCsv).to receive(:new).with(organisation: organisation) { importer }
@@ -61,7 +55,9 @@ describe "rake activities:import", type: :task do
       end
 
       it "outputs the number of activities imported and updated" do
-        expect { task.execute }.to output(/Successfully created 3 activities and updated 2 activities/).to_stdout
+        ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
+          expect { task.execute }.to output(/Successfully created 3 activities and updated 2 activities/).to_stdout
+        end
       end
     end
 
@@ -78,11 +74,15 @@ describe "rake activities:import", type: :task do
       end
 
       it "outputs the number of errors" do
-        expect { task.execute }.to output(/There were 2 errors when importing/).to_stdout
+        ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
+          expect { task.execute }.to output(/There were 2 errors when importing/).to_stdout
+        end
       end
 
       it "outputs the specific errors" do
-        expect { task.execute }.to output(/At row 3: Blah\nAt row 4: Blah/).to_stdout
+        ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
+          expect { task.execute }.to output(/At row 3: Blah\nAt row 4: Blah/).to_stdout
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,6 +115,9 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 
+  # Prevent --bisect from locking up
+  config.bisect_runner = :shell
+
   # Don't generate coverage for partial test runs
   SimpleCov.start if config.files_to_run.map { |file| file.split("spec/").last.split("/").first }.uniq.size > 3
 end


### PR DESCRIPTION
Move the `ClimateControl.modify` from the `around` block and inline them into the relevant tests.

I believe this is interfering with hooks that database_cleaner sets up in order to ensure that the database is cleared between test runs, as I found this also fixed things:

```
config.before(:each, type: :task) do
  DatabaseCleaner.strategy = :truncation
end
```

NB: I tried using `--bisect` to find the smallest number of tests needed to recreate the failure and it kept locking up after the first pass. I've fixed this by adding the `shell` bisect runner rather than the default `fork` runner.
