### PR TITLE
(1203) Add missing fields to the activity importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,7 @@
 - `Intended_beneficiaries` is now optional in all cases
 - Store the BEIS ID and export it to the report CSV file
 - Add field to record the ODA eligibility lead
+- Add missing fields to the activity importer
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...HEAD
 [release-22]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...release-22

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -36,7 +36,7 @@ class Activity < ApplicationRecord
     :collaboration_type_step,
     :flow_step,
     :sustainable_development_goals_step,
-    :aid_type,
+    :aid_type_step,
     :fstc_applies_step,
     :policy_markers_step,
     :covid19_related_step,

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -113,6 +113,7 @@ module Activities
         :sustainable_development_goals_step,
         :covid19_related_step,
         :oda_eligibility_step,
+        :programme_status_step,
       ]
 
       attr_reader :errors, :activity
@@ -170,6 +171,7 @@ module Activities
         sdg_3: "SDG 3",
         covid19_related: "Covid-19 related research",
         oda_eligibility: "ODA Eligibility",
+        programme_status: "Programme Status",
       }
 
       def initialize(row)
@@ -276,6 +278,14 @@ module Activities
           oda_eligibility,
           :oda_eligibility,
           I18n.t("importer.errors.activity.invalid_oda_eligibility"),
+        )
+      end
+
+      def convert_programme_status(programme_status)
+        validate_from_codelist(
+          programme_status,
+          :programme_status,
+          I18n.t("importer.errors.activity.invalid_programme_status"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -121,6 +121,7 @@ module Activities
         :collaboration_type_step,
         :flow_step,
         :aid_type_step,
+        :fstc_applies_step,
       ]
 
       attr_reader :errors, :activity
@@ -191,6 +192,7 @@ module Activities
         collaboration_type: "Collaboration type (Bi/Multi Marker)",
         flow: "Flow",
         aid_type: "Aid type",
+        fstc_applies: "Free Standing Technical Cooperation",
       }
 
       def initialize(row)
@@ -340,6 +342,12 @@ module Activities
           :aid_type,
           I18n.t("importer.errors.activity.invalid_aid_type"),
         )
+      end
+
+      def convert_fstc_applies(fstc_applies)
+        raise I18n.t("importer.errors.activity.invalid_fstc_applies") unless ["1", "0"].include?(fstc_applies)
+
+        fstc_applies
       end
 
       def convert_call_open_date(call_open_date)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -119,6 +119,7 @@ module Activities
         :sector_category_step,
         :sector_step,
         :collaboration_type_step,
+        :flow_step,
       ]
 
       attr_reader :errors, :activity
@@ -187,6 +188,7 @@ module Activities
         actual_end_date: "Actual end date",
         sector: "Sector",
         collaboration_type: "Collaboration type (Bi/Multi Marker)",
+        flow: "Flow",
       }
 
       def initialize(row)
@@ -319,6 +321,14 @@ module Activities
           collaboration_type,
           :collaboration_type,
           I18n.t("importer.errors.activity.invalid_collaboration_type"),
+        )
+      end
+
+      def convert_flow(flow)
+        validate_from_codelist(
+          flow,
+          :flow,
+          I18n.t("importer.errors.activity.invalid_flow"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -118,6 +118,7 @@ module Activities
         :call_dates_step,
         :sector_category_step,
         :sector_step,
+        :collaboration_type_step,
       ]
 
       attr_reader :errors, :activity
@@ -185,6 +186,7 @@ module Activities
         actual_start_date: "Actual start date",
         actual_end_date: "Actual end date",
         sector: "Sector",
+        collaboration_type: "Collaboration type (Bi/Multi Marker)",
       }
 
       def initialize(row)
@@ -309,6 +311,14 @@ module Activities
           sector,
           :sector,
           I18n.t("importer.errors.activity.invalid_sector"),
+        )
+      end
+
+      def convert_collaboration_type(collaboration_type)
+        validate_from_codelist(
+          collaboration_type,
+          :collaboration_type,
+          I18n.t("importer.errors.activity.invalid_collaboration_type"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -149,6 +149,7 @@ module Activities
         title: "Title",
         description: "Description",
         recipient_region: "Recipient Region",
+        recipient_country: "Recipient Country",
         delivery_partner_identifier: "Delivery partner identifier",
         roda_identifier_fragment: "RODA ID Fragment",
         parent_id: "Parent RODA ID",
@@ -192,6 +193,14 @@ module Activities
           region,
           :recipient_region,
           I18n.t("importer.errors.activity.invalid_region"),
+        )
+      end
+
+      def convert_recipient_country(country)
+        validate_from_codelist(
+          country,
+          :recipient_country,
+          I18n.t("importer.errors.activity.invalid_country"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -111,6 +111,7 @@ module Activities
         :intended_beneficiaries_step,
         :gdi_step,
         :sustainable_development_goals_step,
+        :covid19_related_step,
       ]
 
       attr_reader :errors, :activity
@@ -166,6 +167,7 @@ module Activities
         sdg_1: "SDG 1",
         sdg_2: "SDG 2",
         sdg_3: "SDG 3",
+        covid19_related: "Covid-19 related research",
       }
 
       def initialize(row)
@@ -257,6 +259,14 @@ module Activities
         raise I18n.t("importer.errors.activity.parent_not_found") if parent.nil?
 
         parent.id
+      end
+
+      def convert_covid19_related(covid19_related)
+        codelist = covid19_related_radio_options.map(&:code).map(&:to_s)
+
+        raise I18n.t("importer.errors.activity.invalid_covid19_related") unless codelist.include?(covid19_related.to_s)
+
+        covid19_related
       end
 
       def infer_geography(attributes)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -167,6 +167,7 @@ module Activities
         flow: "Flow",
         aid_type: "Aid type",
         fstc_applies: "Free Standing Technical Cooperation",
+        objectives: "Aims/Objectives (DP Definition)",
       }
 
       def initialize(row)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -145,6 +145,7 @@ module Activities
       attr_reader :errors
 
       FIELDS = {
+        transparency_identifier: "Transparency identifier",
         title: "Title",
         description: "Description",
         recipient_region: "Recipient Region",

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -112,6 +112,7 @@ module Activities
         :gdi_step,
         :sustainable_development_goals_step,
         :covid19_related_step,
+        :oda_eligibility_step,
       ]
 
       attr_reader :errors, :activity
@@ -168,6 +169,7 @@ module Activities
         sdg_2: "SDG 2",
         sdg_3: "SDG 3",
         covid19_related: "Covid-19 related research",
+        oda_eligibility: "ODA Eligibility",
       }
 
       def initialize(row)
@@ -267,6 +269,14 @@ module Activities
         raise I18n.t("importer.errors.activity.invalid_covid19_related") unless codelist.include?(covid19_related.to_s)
 
         covid19_related
+      end
+
+      def convert_oda_eligibility(oda_eligibility)
+        validate_from_codelist(
+          oda_eligibility,
+          :oda_eligibility,
+          I18n.t("importer.errors.activity.invalid_oda_eligibility"),
+        )
       end
 
       def infer_geography(attributes)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -178,6 +178,10 @@ module Activities
         call_close_date: "Call close date",
         total_applications: "Total applications",
         total_awards: "Total awards",
+        planned_start_date: "Planned start date",
+        planned_end_date: "Planned end date",
+        actual_start_date: "Actual start date",
+        actual_end_date: "Actual end date",
       }
 
       def initialize(row)
@@ -302,6 +306,22 @@ module Activities
 
       def convert_call_close_date(call_close_date)
         parse_date(call_close_date, I18n.t("importer.errors.activity.invalid_call_close_date"))
+      end
+
+      def convert_planned_start_date(planned_start_date)
+        parse_date(planned_start_date, I18n.t("importer.errors.activity.invalid_planned_start_date"))
+      end
+
+      def convert_planned_end_date(planned_end_date)
+        parse_date(planned_end_date, I18n.t("importer.errors.activity.invalid_planned_end_date"))
+      end
+
+      def convert_actual_start_date(actual_start_date)
+        parse_date(actual_start_date, I18n.t("importer.errors.activity.invalid_actual_start_date"))
+      end
+
+      def convert_actual_end_date(actual_end_date)
+        parse_date(actual_end_date, I18n.t("importer.errors.activity.invalid_actual_end_date"))
       end
 
       def parse_date(date, message)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -120,6 +120,7 @@ module Activities
         :sector_step,
         :collaboration_type_step,
         :flow_step,
+        :aid_type_step,
       ]
 
       attr_reader :errors, :activity
@@ -189,6 +190,7 @@ module Activities
         sector: "Sector",
         collaboration_type: "Collaboration type (Bi/Multi Marker)",
         flow: "Flow",
+        aid_type: "Aid type",
       }
 
       def initialize(row)
@@ -329,6 +331,14 @@ module Activities
           flow,
           :flow,
           I18n.t("importer.errors.activity.invalid_flow"),
+        )
+      end
+
+      def convert_aid_type(aid_type)
+        validate_from_codelist(
+          aid_type,
+          :aid_type,
+          I18n.t("importer.errors.activity.invalid_aid_type"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -114,6 +114,8 @@ module Activities
         :covid19_related_step,
         :oda_eligibility_step,
         :programme_status_step,
+        :call_present_step,
+        :call_dates_step,
       ]
 
       attr_reader :errors, :activity
@@ -172,6 +174,10 @@ module Activities
         covid19_related: "Covid-19 related research",
         oda_eligibility: "ODA Eligibility",
         programme_status: "Programme Status",
+        call_open_date: "Call open date",
+        call_close_date: "Call close date",
+        total_applications: "Total applications",
+        total_awards: "Total awards",
       }
 
       def initialize(row)
@@ -196,6 +202,7 @@ module Activities
         attributes[:geography] = infer_geography(attributes)
         attributes[:requires_additional_benefitting_countries] = (@row["Recipient Country"] && @row["Intended Beneficiaries"]).present?
         attributes[:recipient_region] ||= inferred_region
+        attributes[:call_present] = (@row["Call open date"] && @row["Call close date"]).present?
 
         attributes
       end
@@ -287,6 +294,22 @@ module Activities
           :programme_status,
           I18n.t("importer.errors.activity.invalid_programme_status"),
         )
+      end
+
+      def convert_call_open_date(call_open_date)
+        parse_date(call_open_date, I18n.t("importer.errors.activity.invalid_call_open_date"))
+      end
+
+      def convert_call_close_date(call_close_date)
+        parse_date(call_close_date, I18n.t("importer.errors.activity.invalid_call_close_date"))
+      end
+
+      def parse_date(date, message)
+        return if date.blank?
+
+        Date.strptime(date, "%Y-%m-%d").to_datetime
+      rescue ArgumentError
+        raise message
       end
 
       def infer_geography(attributes)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -109,6 +109,7 @@ module Activities
         :country_step,
         :requires_additional_benefitting_countries_step,
         :intended_beneficiaries_step,
+        :gdi_step,
       ]
 
       attr_reader :errors, :activity
@@ -159,6 +160,7 @@ module Activities
         delivery_partner_identifier: "Delivery partner identifier",
         roda_identifier_fragment: "RODA ID Fragment",
         parent_id: "Parent RODA ID",
+        gdi: "GDI",
       }
 
       def initialize(row)
@@ -213,6 +215,14 @@ module Activities
           country,
           :recipient_country,
           I18n.t("importer.errors.activity.invalid_country"),
+        )
+      end
+
+      def convert_gdi(gdi)
+        validate_from_codelist(
+          gdi,
+          :gdi,
+          I18n.t("importer.errors.activity.invalid_gdi"),
         )
       end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -110,6 +110,7 @@ module Activities
         :requires_additional_benefitting_countries_step,
         :intended_beneficiaries_step,
         :gdi_step,
+        :sustainable_development_goals_step,
       ]
 
       attr_reader :errors, :activity
@@ -146,6 +147,7 @@ module Activities
     end
 
     class Converter
+      include ActivityHelper
       include CodelistHelper
 
       attr_reader :errors
@@ -161,6 +163,9 @@ module Activities
         roda_identifier_fragment: "RODA ID Fragment",
         parent_id: "Parent RODA ID",
         gdi: "GDI",
+        sdg_1: "SDG 1",
+        sdg_2: "SDG 2",
+        sdg_3: "SDG 3",
       }
 
       def initialize(row)
@@ -225,6 +230,15 @@ module Activities
           I18n.t("importer.errors.activity.invalid_gdi"),
         )
       end
+
+      def convert_sustainable_development_goal(goal)
+        raise I18n.t("importer.errors.activity.invalid_sdg_goal") unless sdg_options.keys.map(&:to_s).include?(goal.to_s)
+
+        goal
+      end
+      alias convert_sdg_1 convert_sustainable_development_goal
+      alias convert_sdg_2 convert_sustainable_development_goal
+      alias convert_sdg_3 convert_sustainable_development_goal
 
       def convert_intended_beneficiaries(intended_beneficiaries)
         codelist = load_yaml(entity: :activity, type: :intended_beneficiaries)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -4,6 +4,10 @@ module Activities
       def csv_row
         row + 2
       end
+
+      def csv_column
+        Converter::FIELDS[column] || column.to_s
+      end
     }
 
     attr_reader :errors, :created, :updated

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -104,6 +104,9 @@ module Activities
         :parent_step,
         :identifier_step,
         :roda_identifier_step,
+        :geography_step,
+        :region_step,
+        :country_step,
       ]
 
       attr_reader :errors, :activity
@@ -170,9 +173,13 @@ module Activities
       end
 
       def convert_to_attributes
-        FIELDS.each_with_object({}) do |(attr_name, column_name), attrs|
+        attributes = FIELDS.each_with_object({}) { |(attr_name, column_name), attrs|
           attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if @row[column_name].present?
-        end
+        }
+
+        attributes[:geography] = infer_geography(attributes)
+
+        attributes
       end
 
       def convert_to_attribute(attr_name, value)
@@ -210,6 +217,10 @@ module Activities
         raise I18n.t("importer.errors.activity.parent_not_found") if parent.nil?
 
         parent.id
+      end
+
+      def infer_geography(attributes)
+        attributes[:recipient_region].present? ? :recipient_region : :recipient_country
       end
 
       def validate_from_codelist(code, entity, message)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -99,31 +99,6 @@ module Activities
     end
 
     class ActivityCreator
-      IMPORT_VALIDATION_STEPS = [
-        :level_step,
-        :parent_step,
-        :identifier_step,
-        :roda_identifier_step,
-        :geography_step,
-        :region_step,
-        :country_step,
-        :requires_additional_benefitting_countries_step,
-        :intended_beneficiaries_step,
-        :gdi_step,
-        :sustainable_development_goals_step,
-        :covid19_related_step,
-        :oda_eligibility_step,
-        :programme_status_step,
-        :call_present_step,
-        :call_dates_step,
-        :sector_category_step,
-        :sector_step,
-        :collaboration_type_step,
-        :flow_step,
-        :aid_type_step,
-        :fstc_applies_step,
-      ]
-
       attr_reader :errors, :activity
 
       def initialize(organisation, row)
@@ -144,8 +119,7 @@ module Activities
         @activity.level = calculate_level
         @activity.cache_roda_identifier
 
-        # TODO: This will eventually need to validate against all contexts (Activity::VALIDATION_STEPS)
-        return if @activity.save(context: IMPORT_VALIDATION_STEPS)
+        return if @activity.save(context: Activity::VALIDATION_STEPS)
 
         @activity.errors.each do |attr_name, message|
           @errors[attr_name] ||= [@converter.raw(attr_name), message]

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -421,6 +421,7 @@ en:
         not_found: Cannot be found
         invalid_region: The region cannot be found
         invalid_country: The country code cannot be found
+        invalid_intended_beneficiaries: The intended beneficiaries are invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -427,6 +427,8 @@ en:
         invalid_covid19_related: The COVID 19 Related option is invalid
         invalid_oda_eligibility: The ODA Eligibility option is invalid
         invalid_programme_status: The Programme status option is invalid
+        invalid_call_open_date: The Call Open Date option is in an invalid format
+        invalid_call_close_date: The Call Close Date option is in an invalid format
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -420,6 +420,7 @@ en:
       activity:
         not_found: Cannot be found
         invalid_region: The region cannot be found
+        invalid_country: The country code cannot be found
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -435,6 +435,7 @@ en:
         invalid_planned_end_date: The Planned end date is in an invalid format
         invalid_sector: The sector code is not valid
         invalid_collaboration_type: The collaboration type code is not valid
+        invalid_flow: The flow code is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -437,6 +437,7 @@ en:
         invalid_collaboration_type: The collaboration type code is not valid
         invalid_flow: The flow code is not valid
         invalid_aid_type: The aid type code is not valid
+        invalid_fstc_applies: The free standing technical cooperation column is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -433,6 +433,7 @@ en:
         invalid_actual_end_date: The Actual end date is in an invalid format
         invalid_planned_start_date: The Planned start date is in an invalid format
         invalid_planned_end_date: The Planned end date is in an invalid format
+        invalid_sector: The sector code is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -436,6 +436,7 @@ en:
         invalid_sector: The sector code is not valid
         invalid_collaboration_type: The collaboration type code is not valid
         invalid_flow: The flow code is not valid
+        invalid_aid_type: The aid type code is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -423,6 +423,7 @@ en:
         invalid_country: The country code cannot be found
         invalid_intended_beneficiaries: The intended beneficiaries are invalid
         invalid_gdi: The GDI code is invalid
+        invalid_sdg_goal: The sustainable development goal is invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -424,6 +424,7 @@ en:
         invalid_intended_beneficiaries: The intended beneficiaries are invalid
         invalid_gdi: The GDI code is invalid
         invalid_sdg_goal: The sustainable development goal is invalid
+        invalid_covid19_related: The COVID 19 Related option is invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -425,6 +425,7 @@ en:
         invalid_gdi: The GDI code is invalid
         invalid_sdg_goal: The sustainable development goal is invalid
         invalid_covid19_related: The COVID 19 Related option is invalid
+        invalid_oda_eligibility: The ODA Eligibility option is invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -422,6 +422,7 @@ en:
         invalid_region: The region cannot be found
         invalid_country: The country code cannot be found
         invalid_intended_beneficiaries: The intended beneficiaries are invalid
+        invalid_gdi: The GDI code is invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -429,6 +429,10 @@ en:
         invalid_programme_status: The Programme status option is invalid
         invalid_call_open_date: The Call Open Date option is in an invalid format
         invalid_call_close_date: The Call Close Date option is in an invalid format
+        invalid_actual_start_date: The Actual start date is in an invalid format
+        invalid_actual_end_date: The Actual end date is in an invalid format
+        invalid_planned_start_date: The Planned start date is in an invalid format
+        invalid_planned_end_date: The Planned end date is in an invalid format
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -426,6 +426,7 @@ en:
         invalid_sdg_goal: The sustainable development goal is invalid
         invalid_covid19_related: The COVID 19 Related option is invalid
         invalid_oda_eligibility: The ODA Eligibility option is invalid
+        invalid_programme_status: The Programme status option is invalid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -434,6 +434,7 @@ en:
         invalid_planned_start_date: The Planned start date is in an invalid format
         invalid_planned_end_date: The Planned end date is in an invalid format
         invalid_sector: The sector code is not valid
+        invalid_collaboration_type: The collaboration type code is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/lib/tasks/import_activities.rake
+++ b/lib/tasks/import_activities.rake
@@ -23,7 +23,7 @@ namespace :activities do
       # Output errors
       puts "There were #{pluralize(importer.errors.count, "error")} when importing"
       importer.errors.each do |error|
-        puts "At row #{error.csv_row}: #{error.message}"
+        puts "At row #{error.csv_row}, column `#{error.csv_column}`: #{error.message}"
       end
     end
   rescue Errno::ENOENT

--- a/spec/lib/tasks/import_activities_spec.rb
+++ b/spec/lib/tasks/import_activities_spec.rb
@@ -64,8 +64,8 @@ describe "rake activities:import", type: :task do
     context "When there are errors from the importer" do
       let(:errors) do
         [
-          Activities::ImportFromCsv::Error.new(1, 3, "Foo", "Blah"),
-          Activities::ImportFromCsv::Error.new(2, 4, "Bar", "Blah"),
+          Activities::ImportFromCsv::Error.new(1, :title, "Foo", "Blah"),
+          Activities::ImportFromCsv::Error.new(2, :description, "Bar", "Blah"),
         ]
       end
 
@@ -81,7 +81,7 @@ describe "rake activities:import", type: :task do
 
       it "outputs the specific errors" do
         ClimateControl.modify ORGANISATION_ID: organisation.id, CSV: "/foo/bar/baz" do
-          expect { task.execute }.to output(/At row 3: Blah\nAt row 4: Blah/).to_stdout
+          expect { task.execute }.to output(/At row 3, column `Title`: Blah\nAt row 4, column `Description`: Blah/).to_stdout
         end
       end
     end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Title" => "Here is a title",
       "Description" => "Some description goes here...",
       "Recipient Region" => "789",
+      "Recipient Country" => "LR",
       "Delivery partner identifier" => "1234567890",
     }
   end
@@ -25,6 +26,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Title" => "Here is a title",
       "Description" => "Some description goes here...",
       "Recipient Region" => "789",
+      "Recipient Country" => "LR",
       "Delivery partner identifier" => "98765432",
     }
   end
@@ -89,6 +91,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.title).to eq(existing_activity_attributes["Title"])
       expect(existing_activity.description).to eq(existing_activity_attributes["Description"])
       expect(existing_activity.recipient_region).to eq(existing_activity_attributes["Recipient Region"])
+      expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
     end
 
@@ -187,6 +190,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.description).to eq(new_activity_attributes["Description"])
       expect(new_activity.roda_identifier_fragment).to eq(new_activity_attributes["RODA ID Fragment"])
       expect(new_activity.recipient_region).to eq(new_activity_attributes["Recipient Region"])
+      expect(new_activity.recipient_country).to eq(new_activity_attributes["Recipient Country"])
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
     end
 
@@ -203,6 +207,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:recipient_region)
       expect(subject.errors.first.value).to eq("111111")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_region"))
+    end
+
+    it "has an error if a country does not exist" do
+      new_activity_attributes["Recipient Country"] = "BBBBBB"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:recipient_country)
+      expect(subject.errors.first.value).to eq("BBBBBB")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_country"))
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Recipient Country" => "KH",
       "Intended Beneficiaries" => "KH;KP;ID",
       "Delivery partner identifier" => "1234567890",
+      "GDI" => "1",
     }
   end
   let(:new_activity_attributes) do
@@ -30,6 +31,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Recipient Country" => "KH",
       "Intended Beneficiaries" => "KH;KP;ID",
       "Delivery partner identifier" => "98765432",
+      "GDI" => "1",
     }
   end
 
@@ -95,6 +97,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.recipient_region).to eq(existing_activity_attributes["Recipient Region"])
       expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
+      expect(existing_activity.gdi).to eq("1")
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
     end
 
@@ -195,6 +198,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.recipient_region).to eq(new_activity_attributes["Recipient Region"])
       expect(new_activity.recipient_country).to eq(new_activity_attributes["Recipient Country"])
       expect(new_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
+      expect(new_activity.gdi).to eq("1")
       expect(new_activity.geography).to eq("recipient_region")
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
     end
@@ -253,6 +257,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:intended_beneficiaries)
       expect(subject.errors.first.value).to eq("ffsdfdsfsfds")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_intended_beneficiaries"))
+    end
+
+    it "has an error if the GDI is invalid" do
+      new_activity_attributes["GDI"] = "2222222"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:gdi)
+      expect(subject.errors.first.value).to eq("2222222")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_gdi"))
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -191,7 +191,18 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.roda_identifier_fragment).to eq(new_activity_attributes["RODA ID Fragment"])
       expect(new_activity.recipient_region).to eq(new_activity_attributes["Recipient Region"])
       expect(new_activity.recipient_country).to eq(new_activity_attributes["Recipient Country"])
+      expect(new_activity.geography).to eq("recipient_region")
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
+    end
+
+    it "sets the geography to recipient country if the region is not specified" do
+      new_activity_attributes["Recipient Region"] = ""
+
+      subject.import([new_activity_attributes])
+
+      new_activity = Activity.order(:created_at).last
+
+      expect(new_activity.geography).to eq("recipient_country")
     end
 
     it "has an error if a region does not exist" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -40,39 +40,12 @@ RSpec.describe Activities::ImportFromCsv do
     }
   end
   let(:new_activity_attributes) do
-    {
+    existing_activity_attributes.merge({
       "RODA ID" => "",
-      "Transparency identifier" => "3232332323",
       "RODA ID Fragment" => "234566",
       "Parent RODA ID" => parent_activity.roda_identifier_fragment,
-      "Title" => "Here is a title",
-      "Description" => "Some description goes here...",
-      "Recipient Region" => "789",
-      "Recipient Country" => "KH",
-      "Intended Beneficiaries" => "KH;KP;ID",
-      "Delivery partner identifier" => "98765432",
-      "GDI" => "1",
-      "SDG 1" => "1",
-      "SDG 2" => "2",
-      "SDG 3" => "3",
-      "Covid-19 related research" => "0",
-      "ODA Eligibility" => "never_eligible",
-      "Programme Status" => "01",
-      "Call open date" => "2020-01-02",
-      "Call close date" => "2020-01-02",
-      "Total applications" => "12",
-      "Total awards" => "12",
-      "Planned start date" => "2020-01-02",
-      "Actual start date" => "2020-01-03",
-      "Planned end date" => "2020-01-04",
-      "Actual end date" => "2020-01-05",
-      "Sector" => "11220",
-      "Collaboration type (Bi/Multi Marker)" => "1",
-      "Flow" => "10",
-      "Aid type" => "B03",
-      "Free Standing Technical Cooperation" => "1",
-      "Aims/Objectives (DP Definition)" => "Foo bar baz",
-    }
+      "Transparency identifier" => "23232332323",
+    })
   end
 
   subject { described_class.new(organisation: organisation) }

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Actual end date" => "2020-01-05",
       "Sector" => "11220",
       "Collaboration type (Bi/Multi Marker)" => "1",
+      "Flow" => "10",
     }
   end
   let(:new_activity_attributes) do
@@ -64,6 +65,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Actual end date" => "2020-01-05",
       "Sector" => "11220",
       "Collaboration type (Bi/Multi Marker)" => "1",
+      "Flow" => "10",
     }
   end
 
@@ -144,6 +146,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.sector).to eq(existing_activity_attributes["Sector"])
       expect(existing_activity.sector_category).to eq("112")
       expect(existing_activity.collaboration_type).to eq(existing_activity_attributes["Collaboration type (Bi/Multi Marker)"])
+      expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
     end
 
     it "ignores any blank columns" do
@@ -259,6 +262,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.sector).to eq(new_activity_attributes["Sector"])
       expect(new_activity.sector_category).to eq("112")
       expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
+      expect(new_activity.flow).to eq(new_activity_attributes["Flow"])
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -435,6 +439,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:collaboration_type)
       expect(subject.errors.first.value).to eq("99")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_collaboration_type"))
+    end
+
+    it "has an error if the Flow option is invalid" do
+      new_activity_attributes["Flow"] = "1"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:flow)
+      expect(subject.errors.first.value).to eq("1")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_flow"))
     end
 
     {

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Sector" => "11220",
       "Collaboration type (Bi/Multi Marker)" => "1",
       "Flow" => "10",
+      "Aid type" => "B03",
     }
   end
   let(:new_activity_attributes) do
@@ -66,6 +67,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Sector" => "11220",
       "Collaboration type (Bi/Multi Marker)" => "1",
       "Flow" => "10",
+      "Aid type" => "B03",
     }
   end
 
@@ -147,6 +149,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.sector_category).to eq("112")
       expect(existing_activity.collaboration_type).to eq(existing_activity_attributes["Collaboration type (Bi/Multi Marker)"])
       expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
+      expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
     end
 
     it "ignores any blank columns" do
@@ -263,6 +266,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.sector_category).to eq("112")
       expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
       expect(new_activity.flow).to eq(new_activity_attributes["Flow"])
+      expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -454,6 +458,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:flow)
       expect(subject.errors.first.value).to eq("1")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_flow"))
+    end
+
+    it "has an error if the Aid Type option is invalid" do
+      new_activity_attributes["Aid type"] = "1"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:aid_type)
+      expect(subject.errors.first.value).to eq("1")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_aid_type"))
     end
 
     {

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Collaboration type (Bi/Multi Marker)" => "1",
       "Flow" => "10",
       "Aid type" => "B03",
+      "Free Standing Technical Cooperation" => "1",
     }
   end
   let(:new_activity_attributes) do
@@ -68,6 +69,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Collaboration type (Bi/Multi Marker)" => "1",
       "Flow" => "10",
       "Aid type" => "B03",
+      "Free Standing Technical Cooperation" => "1",
     }
   end
 
@@ -150,6 +152,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.collaboration_type).to eq(existing_activity_attributes["Collaboration type (Bi/Multi Marker)"])
       expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
+      expect(existing_activity.fstc_applies).to eq(true)
     end
 
     it "ignores any blank columns" do
@@ -267,6 +270,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
       expect(new_activity.flow).to eq(new_activity_attributes["Flow"])
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
+      expect(new_activity.fstc_applies).to eq(true)
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -473,6 +477,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:aid_type)
       expect(subject.errors.first.value).to eq("1")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_aid_type"))
+    end
+
+    it "has an error if the Free Standing Technical Cooperation option is invalid" do
+      new_activity_attributes["Free Standing Technical Cooperation"] = "x"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:fstc_applies)
+      expect(subject.errors.first.value).to eq("x")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_fstc_applies"))
     end
 
     {

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 2" => "2",
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
+      "ODA Eligibility" => "never_eligible",
     }
   end
   let(:new_activity_attributes) do
@@ -40,6 +41,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 2" => "2",
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
+      "ODA Eligibility" => "never_eligible",
     }
   end
 
@@ -108,6 +110,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.gdi).to eq("1")
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.covid19_related).to eq(0)
+      expect(existing_activity.oda_eligibility).to eq("never_eligible")
     end
 
     it "ignores any blank columns" do
@@ -211,6 +214,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.geography).to eq("recipient_region")
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
       expect(new_activity.covid19_related).to eq(0)
+      expect(new_activity.oda_eligibility).to eq("never_eligible")
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -314,6 +318,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:covid19_related)
       expect(subject.errors.first.value).to eq("9999999")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_covid19_related"))
+    end
+
+    it "has an error if the ODA Eligibility option is invalid" do
+      new_activity_attributes["ODA Eligibility"] = "some_invalid_string"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:oda_eligibility)
+      expect(subject.errors.first.value).to eq("some_invalid_string")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_oda_eligibility"))
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Activities::ImportFromCsv do
   let(:existing_activity_attributes) do
     {
       "RODA ID" => existing_activity.roda_identifier_compound,
+      "Transparency identifier" => "13232332323",
       "RODA ID Fragment" => "",
       "Parent RODA ID" => "",
       "Title" => "Here is a title",
@@ -18,6 +19,7 @@ RSpec.describe Activities::ImportFromCsv do
   let(:new_activity_attributes) do
     {
       "RODA ID" => "",
+      "Transparency identifier" => "3232332323",
       "RODA ID Fragment" => "234566",
       "Parent RODA ID" => parent_activity.roda_identifier_fragment,
       "Title" => "Here is a title",
@@ -83,7 +85,8 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.created.count).to eq(0)
       expect(subject.updated.count).to eq(1)
 
-      expect(existing_activity.reload.title).to eq(existing_activity_attributes["Title"])
+      expect(existing_activity.reload.transparency_identifier).to eq(existing_activity_attributes["Transparency identifier"])
+      expect(existing_activity.title).to eq(existing_activity_attributes["Title"])
       expect(existing_activity.description).to eq(existing_activity_attributes["Description"])
       expect(existing_activity.recipient_region).to eq(existing_activity_attributes["Recipient Region"])
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
@@ -179,6 +182,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(new_activity.parent).to eq(parent_activity)
       expect(new_activity.roda_identifier_compound).to eq(expected_roda_identifier_compound)
+      expect(new_activity.transparency_identifier).to eq(new_activity_attributes["Transparency identifier"])
       expect(new_activity.title).to eq(new_activity_attributes["Title"])
       expect(new_activity.description).to eq(new_activity_attributes["Description"])
       expect(new_activity.roda_identifier_fragment).to eq(new_activity_attributes["RODA ID Fragment"])

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Planned end date" => "2020-01-04",
       "Actual end date" => "2020-01-05",
       "Sector" => "11220",
+      "Collaboration type (Bi/Multi Marker)" => "1",
     }
   end
   let(:new_activity_attributes) do
@@ -62,6 +63,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Planned end date" => "2020-01-04",
       "Actual end date" => "2020-01-05",
       "Sector" => "11220",
+      "Collaboration type (Bi/Multi Marker)" => "1",
     }
   end
 
@@ -141,6 +143,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.call_present).to eq(true)
       expect(existing_activity.sector).to eq(existing_activity_attributes["Sector"])
       expect(existing_activity.sector_category).to eq("112")
+      expect(existing_activity.collaboration_type).to eq(existing_activity_attributes["Collaboration type (Bi/Multi Marker)"])
     end
 
     it "ignores any blank columns" do
@@ -255,6 +258,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.actual_end_date).to eq(DateTime.parse(new_activity_attributes["Actual end date"]))
       expect(new_activity.sector).to eq(new_activity_attributes["Sector"])
       expect(new_activity.sector_category).to eq("112")
+      expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -416,6 +420,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:sector)
       expect(subject.errors.first.value).to eq("53453453453453")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_sector"))
+    end
+
+    it "has an error if the Collaboration type option is invalid" do
+      new_activity_attributes["Collaboration type (Bi/Multi Marker)"] = "99"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:collaboration_type)
+      expect(subject.errors.first.value).to eq("99")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_collaboration_type"))
     end
 
     {

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 1" => "1",
       "SDG 2" => "2",
       "SDG 3" => "3",
+      "Covid-19 related research" => "0",
     }
   end
   let(:new_activity_attributes) do
@@ -38,6 +39,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 1" => "1",
       "SDG 2" => "2",
       "SDG 3" => "3",
+      "Covid-19 related research" => "0",
     }
   end
 
@@ -105,6 +107,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
       expect(existing_activity.gdi).to eq("1")
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
+      expect(existing_activity.covid19_related).to eq(0)
     end
 
     it "ignores any blank columns" do
@@ -207,6 +210,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.gdi).to eq("1")
       expect(new_activity.geography).to eq("recipient_region")
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
+      expect(new_activity.covid19_related).to eq(0)
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -295,6 +299,21 @@ RSpec.describe Activities::ImportFromCsv do
         expect(subject.errors.first.value).to eq("9999999")
         expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_sdg_goal"))
       end
+    end
+
+    it "has an error if the Covid-19 related option is invalid" do
+      new_activity_attributes["Covid-19 related research"] = "9999999"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:covid19_related)
+      expect(subject.errors.first.value).to eq("9999999")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_covid19_related"))
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
       "ODA Eligibility" => "never_eligible",
+      "Programme Status" => "01",
     }
   end
   let(:new_activity_attributes) do
@@ -42,6 +43,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
       "ODA Eligibility" => "never_eligible",
+      "Programme Status" => "01",
     }
   end
 
@@ -111,6 +113,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.covid19_related).to eq(0)
       expect(existing_activity.oda_eligibility).to eq("never_eligible")
+      expect(existing_activity.programme_status).to eq("01")
     end
 
     it "ignores any blank columns" do
@@ -215,6 +218,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.delivery_partner_identifier).to eq(new_activity_attributes["Delivery partner identifier"])
       expect(new_activity.covid19_related).to eq(0)
       expect(new_activity.oda_eligibility).to eq("never_eligible")
+      expect(new_activity.programme_status).to eq("01")
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -333,6 +337,21 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:oda_eligibility)
       expect(subject.errors.first.value).to eq("some_invalid_string")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_oda_eligibility"))
+    end
+
+    it "has an error if the Programme Status option is invalid" do
+      new_activity_attributes["Programme Status"] = "99331"
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.column).to eq(:programme_status)
+      expect(subject.errors.first.value).to eq("99331")
+      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_programme_status"))
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Activities::ImportFromCsv do
       "Call close date" => "2020-01-02",
       "Total applications" => "12",
       "Total awards" => "12",
+      "Planned start date" => "2020-01-02",
+      "Actual start date" => "2020-01-03",
+      "Planned end date" => "2020-01-04",
+      "Actual end date" => "2020-01-05",
     }
   end
   let(:new_activity_attributes) do
@@ -52,6 +56,10 @@ RSpec.describe Activities::ImportFromCsv do
       "Call close date" => "2020-01-02",
       "Total applications" => "12",
       "Total awards" => "12",
+      "Planned start date" => "2020-01-02",
+      "Actual start date" => "2020-01-03",
+      "Planned end date" => "2020-01-04",
+      "Actual end date" => "2020-01-05",
     }
   end
 
@@ -124,6 +132,11 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.programme_status).to eq("01")
       expect(existing_activity.call_open_date).to eq(DateTime.parse(existing_activity_attributes["Call open date"]))
       expect(existing_activity.call_close_date).to eq(DateTime.parse(existing_activity_attributes["Call close date"]))
+      expect(existing_activity.planned_start_date).to eq(DateTime.parse(existing_activity_attributes["Planned start date"]))
+      expect(existing_activity.planned_end_date).to eq(DateTime.parse(existing_activity_attributes["Planned end date"]))
+      expect(existing_activity.actual_start_date).to eq(DateTime.parse(existing_activity_attributes["Actual start date"]))
+      expect(existing_activity.actual_end_date).to eq(DateTime.parse(existing_activity_attributes["Actual end date"]))
+
       expect(existing_activity.call_present).to eq(true)
     end
 
@@ -233,6 +246,10 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.call_open_date).to eq(DateTime.parse(new_activity_attributes["Call open date"]))
       expect(new_activity.call_close_date).to eq(DateTime.parse(new_activity_attributes["Call close date"]))
       expect(new_activity.call_present).to eq(true)
+      expect(new_activity.planned_start_date).to eq(DateTime.parse(new_activity_attributes["Planned start date"]))
+      expect(new_activity.planned_end_date).to eq(DateTime.parse(new_activity_attributes["Planned end date"]))
+      expect(new_activity.actual_start_date).to eq(DateTime.parse(new_activity_attributes["Actual start date"]))
+      expect(new_activity.actual_end_date).to eq(DateTime.parse(new_activity_attributes["Actual end date"]))
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -381,19 +398,28 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_programme_status"))
     end
 
-    it "has an error if the Call Open Date is invalid" do
-      new_activity_attributes["Call open date"] = "01/01/2020"
+    {
+      "Call open date" => :call_open_date,
+      "Call close date" => :call_close_date,
+      "Planned start date" => :planned_start_date,
+      "Planned end date" => :planned_end_date,
+      "Actual start date" => :actual_start_date,
+      "Actual end date" => :actual_end_date,
+    }.each do |attr_name, column_name|
+      it "has an error if any the #{attr_name} is invalid" do
+        new_activity_attributes[attr_name] = "01/01/2020"
 
-      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
-      expect(subject.created.count).to eq(0)
-      expect(subject.updated.count).to eq(0)
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(0)
 
-      expect(subject.errors.count).to eq(1)
-      expect(subject.errors.first.csv_row).to eq(2)
-      expect(subject.errors.first.column).to eq(:call_open_date)
-      expect(subject.errors.first.value).to eq("01/01/2020")
-      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_call_open_date"))
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.column).to eq(column_name)
+        expect(subject.errors.first.value).to eq("01/01/2020")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_#{column_name}"))
+      end
     end
 
     it "has an error if the parent activity cannot be found" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Flow" => "10",
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
+      "Aims/Objectives (DP Definition)" => "Foo bar baz",
     }
   end
   let(:new_activity_attributes) do
@@ -70,6 +71,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Flow" => "10",
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
+      "Aims/Objectives (DP Definition)" => "Foo bar baz",
     }
   end
 
@@ -153,6 +155,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
+      expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
     end
 
     it "ignores any blank columns" do
@@ -271,6 +274,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.flow).to eq(new_activity_attributes["Flow"])
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
       expect(new_activity.fstc_applies).to eq(true)
+      expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.count).to eq(1)
 
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("roda_id")
       expect(subject.errors.first.column).to eq(:roda_id)
       expect(subject.errors.first.value).to eq("FAKE RODA ID")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
@@ -77,6 +78,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("RODA ID Fragment")
       expect(subject.errors.first.column).to eq(:roda_identifier_fragment)
       expect(subject.errors.first.value).to eq("13344")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_update.fragment_present"))
@@ -92,6 +94,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Parent RODA ID")
       expect(subject.errors.first.column).to eq(:parent_id)
       expect(subject.errors.first.value).to eq(parent_activity.roda_identifier_fragment)
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_update.parent_present"))
@@ -156,6 +159,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(3)
+      expect(subject.errors.first.csv_column).to eq("roda_id")
       expect(subject.errors.first.column).to eq(:roda_id)
       expect(subject.errors.first.value).to eq("FAKE RODA ID")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
@@ -181,6 +185,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(3)
+      expect(subject.errors.first.csv_column).to eq("Recipient Region")
       expect(subject.errors.first.column).to eq(:recipient_region)
       expect(subject.errors.first.value).to eq("111111")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_region"))
@@ -198,6 +203,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("roda_id")
       expect(subject.errors.first.column).to eq(:roda_id)
       expect(subject.errors.first.value).to eq("")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_create"))
@@ -284,6 +290,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Recipient Region")
       expect(subject.errors.first.column).to eq(:recipient_region)
       expect(subject.errors.first.value).to eq("111111")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_region"))
@@ -299,6 +306,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Recipient Country")
       expect(subject.errors.first.column).to eq(:recipient_country)
       expect(subject.errors.first.value).to eq("BBBBBB")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_country"))
@@ -314,6 +322,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Intended Beneficiaries")
       expect(subject.errors.first.column).to eq(:intended_beneficiaries)
       expect(subject.errors.first.value).to eq("ffsdfdsfsfds")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_intended_beneficiaries"))
@@ -329,6 +338,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("GDI")
       expect(subject.errors.first.column).to eq(:gdi)
       expect(subject.errors.first.value).to eq("2222222")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_gdi"))
@@ -345,6 +355,7 @@ RSpec.describe Activities::ImportFromCsv do
 
         expect(subject.errors.count).to eq(1)
         expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("SDG #{i}")
         expect(subject.errors.first.column).to eq("sdg_#{i}".to_sym)
         expect(subject.errors.first.value).to eq("9999999")
         expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_sdg_goal"))
@@ -361,6 +372,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Covid-19 related research")
       expect(subject.errors.first.column).to eq(:covid19_related)
       expect(subject.errors.first.value).to eq("9999999")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_covid19_related"))
@@ -376,6 +388,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("ODA Eligibility")
       expect(subject.errors.first.column).to eq(:oda_eligibility)
       expect(subject.errors.first.value).to eq("some_invalid_string")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_oda_eligibility"))
@@ -391,6 +404,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Programme Status")
       expect(subject.errors.first.column).to eq(:programme_status)
       expect(subject.errors.first.value).to eq("99331")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_programme_status"))
@@ -406,6 +420,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Sector")
       expect(subject.errors.first.column).to eq(:sector)
       expect(subject.errors.first.value).to eq("53453453453453")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_sector"))
@@ -421,6 +436,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Collaboration type (Bi/Multi Marker)")
       expect(subject.errors.first.column).to eq(:collaboration_type)
       expect(subject.errors.first.value).to eq("99")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_collaboration_type"))
@@ -436,6 +452,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Flow")
       expect(subject.errors.first.column).to eq(:flow)
       expect(subject.errors.first.value).to eq("1")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_flow"))
@@ -451,6 +468,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Aid type")
       expect(subject.errors.first.column).to eq(:aid_type)
       expect(subject.errors.first.value).to eq("1")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_aid_type"))
@@ -466,6 +484,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Free Standing Technical Cooperation")
       expect(subject.errors.first.column).to eq(:fstc_applies)
       expect(subject.errors.first.value).to eq("x")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_fstc_applies"))
@@ -489,6 +508,7 @@ RSpec.describe Activities::ImportFromCsv do
 
         expect(subject.errors.count).to eq(1)
         expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq(attr_name)
         expect(subject.errors.first.column).to eq(column_name)
         expect(subject.errors.first.value).to eq("01/01/2020")
         expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_#{column_name}"))
@@ -505,6 +525,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Parent RODA ID")
       expect(subject.errors.first.column).to eq(:parent_id)
       expect(subject.errors.first.value).to eq("111111")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.parent_not_found"))
@@ -520,6 +541,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("RODA ID Fragment")
       expect(subject.errors.first.column).to eq(:roda_identifier_fragment)
       expect(subject.errors.first.value).to eq("%^$!234566")
       expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.roda_identifier_fragment.invalid_characters"))


### PR DESCRIPTION
This adds the remaining missing fields to the activity importer. I've added each field (or group of fields) on a commit by 
commit basis, so there's a lot of commits, but should hopefully make things easier to follow.  