### PR TITLE
Refactor/enforce report constraints

### DIFF
--- a/db/data/20201124145240_link_forecasts_to_reports.rb
+++ b/db/data/20201124145240_link_forecasts_to_reports.rb
@@ -1,0 +1,40 @@
+class LinkForecastsToReports < ActiveRecord::Migration[6.0]
+  def up
+    level_a_or_b_forecasts.update_all(report_id: nil)
+
+    level_c_or_d_forecasts.where(report_id: nil).each do |planned_disbursement|
+      reports = historic_reports_for_activity(planned_disbursement.parent_activity)
+
+      if reports.count == 1
+        planned_disbursement.update!(report: reports.first)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def level_a_or_b_forecasts
+    PlannedDisbursement
+      .includes(:parent_activity)
+      .where(activities: {level: %w[fund programme]})
+  end
+
+  def level_c_or_d_forecasts
+    PlannedDisbursement
+      .includes(:parent_activity)
+      .where(activities: {level: %w[project third_party_project]})
+  end
+
+  def historic_reports_for_activity(activity)
+    Report.where(
+      fund_id: activity.associated_fund.id,
+      organisation_id: activity.organisation_id,
+      financial_quarter: nil,
+      financial_year: nil,
+    )
+  end
+end

--- a/db/migrate/20201124155809_enforce_one_historic_report_per_series.rb
+++ b/db/migrate/20201124155809_enforce_one_historic_report_per_series.rb
@@ -1,0 +1,10 @@
+class EnforceOneHistoricReportPerSeries < ActiveRecord::Migration[6.0]
+  def change
+    change_table :reports do |t|
+      t.index [:fund_id, :organisation_id],
+        where: "financial_quarter IS NULL OR financial_year IS NULL",
+        unique: true,
+        name: "enforce_one_historic_report_per_series"
+    end
+  end
+end

--- a/db/migrate/20201124160000_enforce_one_editable_report_per_series.rb
+++ b/db/migrate/20201124160000_enforce_one_editable_report_per_series.rb
@@ -1,0 +1,10 @@
+class EnforceOneEditableReportPerSeries < ActiveRecord::Migration[6.0]
+  def change
+    change_table :reports do |t|
+      t.index [:fund_id, :organisation_id],
+        where: "state IN ('active', 'awaiting_changes')",
+        unique: true,
+        name: "enforce_one_editable_report_per_series"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_155809) do
+ActiveRecord::Schema.define(version: 2020_11_24_160000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_155809) do
     t.date "deadline"
     t.integer "financial_quarter"
     t.integer "financial_year"
+    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text = ANY ((ARRAY['active'::character varying, 'awaiting_changes'::character varying])::text[]))"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_150002) do
+ActiveRecord::Schema.define(version: 2020_11_24_155809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_150002) do
     t.date "deadline"
     t.integer "financial_quarter"
     t.integer "financial_year"
+    t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"
     t.index ["state"], name: "index_reports_on_state"

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Users can manage the implementing organisations" do
     scenario "they can edit an implementing organisation" do
       other_public_sector_organisation = ImplementingOrganisation.new(name: "Other public sector organisation", organisation_type: "70", reference: "GB-COH-123456")
       project.implementing_organisations << other_public_sector_organisation
-      _report = create(:report, state: :active, organisation: project.organisation, fund: project.associated_fund)
+      Report.for_activity(project).first.update!(state: :active)
 
       visit organisation_activity_details_path(project.organisation, project)
 


### PR DESCRIPTION
## Changes in this PR

This PR includes a data migration on the `planned_disbursements` table and two new indexes on the `reports` table. These are described in full in the commit messages; the overall intent is to make sure data in production aligns with assumptions made by the `PlannedDisbursementHistory` and `PlannedDisbursementOverview` services. We do this either by correcting existing data or by putting indexes in place that ensure we cannot create data that breaks these assumptions.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
