### PR TITLE
Mark all "historic" reports as approved

### DIFF
--- a/db/data/20201125123809_approve_historic_reports.rb
+++ b/db/data/20201125123809_approve_historic_reports.rb
@@ -1,0 +1,10 @@
+class ApproveHistoricReports < ActiveRecord::Migration[6.0]
+  def up
+    historic_imports = Report.where(financial_quarter: nil).or(Report.where(financial_year: nil))
+    historic_imports.update_all(state: "approved")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We have a set of reports with no financial quarter; these represent the
sets of "historic" data we imported for an organisation during
onboarding, before they began using RODA. They are considered to predate
all quarterly reports, for the purposes of recording the history of our
data.

New data entered via RODA should _never_ be assigned to these reports.
Many objects like transactions and forecasts are automatically linked to
the current "editable" (active or awaiting_changes) report for that
organisation, and having these "historic" reports in an editable state
allows data entered via RODA to be linked to them.

By marking them as approved, we prevent the RODA service linking new
data to them, so we can only add data to them by explicitly choosing to
do so via an ingest process.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
