### PR TITLE
(1055) show forecast quarter and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,9 @@
 - Add missing fields to the activity importer
 - Allow forecasts to be edited, preserving their history
 
-## [unreleased]
+## [unreleased]
+
+- Show only the financial quarter and value for forecasts on the activity page
 
 - Add a new activity status: "Paused"
 - Update importer date format to be MM/DD/YYYY

--- a/app/presenters/planned_disbursement_presenter.rb
+++ b/app/presenters/planned_disbursement_presenter.rb
@@ -1,27 +1,7 @@
 class PlannedDisbursementPresenter < SimpleDelegator
-  def planned_disbursement_type
-    return if super.blank?
-    I18n.t("table.body.planned_disbursement.planned_disbursement_type_options.#{super}")
-  end
-
-  def period_start_date
-    return if super.blank?
-    I18n.l(super)
-  end
-
-  def period_end_date
-    return if super.blank?
-    I18n.l(super)
-  end
-
   def financial_quarter_and_year
     return nil if financial_quarter.nil? || financial_year.nil?
     "Q#{financial_quarter} #{financial_year}-#{financial_year + 1}"
-  end
-
-  def currency
-    return if super.blank?
-    I18n.t("generic.default_currency.#{super.downcase}")
   end
 
   def value

--- a/app/views/staff/shared/planned_disbursements/_table.html.haml
+++ b/app/views/staff/shared/planned_disbursements/_table.html.haml
@@ -3,28 +3,16 @@
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header
-          =t("table.header.planned_disbursement.period_start_date")
-        %th.govuk-table__header
-          =t("table.header.planned_disbursement.period_end_date")
-        %th.govuk-table__header
-          =t("table.header.planned_disbursement.currency")
+          =t("table.header.planned_disbursement.financial_quarter")
         %th.govuk-table__header
           =t("table.header.planned_disbursement.value")
         %th.govuk-table__header
-          =t("table.header.planned_disbursement.providing_organisation")
-        %th.govuk-table__header
-          =t("table.header.planned_disbursement.receiving_organisation")
-          %th.govuk-table__header
 
     %tbody.govuk-table__body
       - planned_disbursements.each do |planned_disbursement|
         %tr.govuk-table__row{id: planned_disbursement.id}
-          %td.govuk-table__cell= planned_disbursement.period_start_date
-          %td.govuk-table__cell= planned_disbursement.period_end_date
-          %td.govuk-table__cell= planned_disbursement.currency
+          %td.govuk-table__cell= planned_disbursement.financial_quarter_and_year
           %td.govuk-table__cell= planned_disbursement.value
-          %td.govuk-table__cell= planned_disbursement.providing_organisation_name
-          %td.govuk-table__cell= planned_disbursement.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(planned_disbursement).edit?
               = a11y_action_link(t('default.link.edit'),

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -19,13 +19,14 @@ en:
   table:
     header:
       planned_disbursement:
+        financial_quarter: Financial quarter
         planned_disbursement_type: Type
         period_start_date: Start date
         period_end_date: End date
         currency: Currency
         providing_organisation: Provider
         receiving_organisation: Receiver
-        value: Forecasted spend amount
+        value: Amount
     body:
       planned_disbursement:
         planned_disbursement_type_options:

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -20,12 +20,6 @@ en:
     header:
       planned_disbursement:
         financial_quarter: Financial quarter
-        planned_disbursement_type: Type
-        period_start_date: Start date
-        period_end_date: End date
-        currency: Currency
-        providing_organisation: Provider
-        receiving_organisation: Receiver
         value: Amount
     body:
       planned_disbursement:

--- a/spec/presenters/planned_disbursement_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_presenter_spec.rb
@@ -3,35 +3,9 @@ require "rails_helper"
 RSpec.describe PlannedDisbursementPresenter do
   let(:planned_disbursement) { build_stubbed(:planned_disbursement) }
 
-  describe "#planned_disbursement_type" do
-    it "returns the I18n string for the planned_disbursement_type" do
-      expect(described_class.new(planned_disbursement).planned_disbursement_type).to eq("Original")
-    end
-  end
-
-  describe "#period_start_date" do
-    it "returns a human readable date" do
-      planned_disbursement.period_start_date = "2020-06-25"
-      expect(described_class.new(planned_disbursement).period_start_date).to eq("25 Jun 2020")
-    end
-  end
-
-  describe "#period_end_date" do
-    it "returns a human readable date" do
-      planned_disbursement.period_end_date = "2020-10-20"
-      expect(described_class.new(planned_disbursement).period_end_date).to eq("20 Oct 2020")
-    end
-  end
-
   describe "#value" do
     it "returns the value to two decimal places with a currency symbol" do
       expect(described_class.new(planned_disbursement).value).to eq("£100,000.00")
-    end
-  end
-
-  describe "#currency" do
-    it "returns the I18n string for the currency" do
-      expect(described_class.new(planned_disbursement).currency).to eq("Pound Sterling")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

This simplifies the view of forecasts, to show the quarter rather than start and end dates, the value, and no other columns.

## Screenshots of UI changes

### Before

<img width="1097" alt="Screenshot 2020-11-25 at 15 41 57" src="https://user-images.githubusercontent.com/9265/100251689-f203b200-2f36-11eb-8376-33137dc6332e.png">


### After

<img width="1097" alt="Screenshot 2020-11-25 at 15 42 17" src="https://user-images.githubusercontent.com/9265/100251707-f6c86600-2f36-11eb-8f3a-4d438a533209.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
