### PR TITLE
(1044) Activity status options and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,8 @@
 
 ## [unreleased]
 
+- Add a new activity status: "Paused"
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23
 [release-22]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-21...release-22

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -157,7 +157,7 @@ module Activities
         sdg_3: "SDG 3",
         covid19_related: "Covid-19 related research",
         oda_eligibility: "ODA Eligibility",
-        programme_status: "Programme Status",
+        programme_status: "Activity Status",
         call_open_date: "Call open date",
         call_close_date: "Call close date",
         total_applications: "Total applications",

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -72,7 +72,7 @@ class ExportActivityToCsv
       "Recipient region",
       "Recipient country",
       "Intended beneficiaries",
-      "Programme status",
+      "Activity status",
       "Planned start date",
       "Actual start date",
       "Planned end date",

--- a/app/services/programme_to_iati_status.rb
+++ b/app/services/programme_to_iati_status.rb
@@ -11,6 +11,7 @@ class ProgrammeToIatiStatus
     "09" => "4",
     "10" => "5",
     "11" => "5",
+    "12" => "6",
   }.freeze
 
   def programme_status_to_iati_status(programme_status)

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -702,6 +702,7 @@ en:
       '09': Completed
       '10': Stopped
       '11': Cancelled
+      '12': Paused
     requires_additional_benefitting_countries:
       'true': 'Yes'
       'false': 'No'

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -138,8 +138,8 @@ en:
         actual_end_date: For example, 2 2 2020
         actual_start_date: For example, 11 1 2020
         aid_type: Where an activity is not G01 or E01 we would expect most of our activity to be classified as D02 but there will be cases where C01 is more appropriate.
-        call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
-        call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Programme Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
+        call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Activity Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
+        call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Activity Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         delivery_partner_identifier: This could be the reference you use in your internal systems
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -426,7 +426,7 @@ en:
         invalid_sdg_goal: The sustainable development goal is invalid
         invalid_covid19_related: The COVID 19 Related option is invalid
         invalid_oda_eligibility: The ODA Eligibility option is invalid
-        invalid_programme_status: The Programme status option is invalid
+        invalid_programme_status: The Activity status option is invalid
         invalid_call_open_date: The Call Open Date option is in an invalid format
         invalid_call_close_date: The Call Close Date option is in an invalid format
         invalid_actual_start_date: The Actual start date is in an invalid format

--- a/spec/lib/programme_to_iati_status_spec.rb
+++ b/spec/lib/programme_to_iati_status_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe "#programme_status_to_iati_status" do
 
       status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("11")
       expect(status).to eq "5"
+
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("12")
+      expect(status).to eq "6"
     end
   end
 end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
       "ODA Eligibility" => "never_eligible",
-      "Programme Status" => "01",
+      "Activity Status" => "01",
       "Call open date" => "2020-01-02",
       "Call close date" => "2020-01-02",
       "Total applications" => "12",
@@ -394,8 +394,8 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_oda_eligibility"))
     end
 
-    it "has an error if the Programme Status option is invalid" do
-      new_activity_attributes["Programme Status"] = "99331"
+    it "has an error if the Activity Status option is invalid" do
+      new_activity_attributes["Activity Status"] = "99331"
 
       expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
@@ -404,7 +404,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(1)
       expect(subject.errors.first.csv_row).to eq(2)
-      expect(subject.errors.first.csv_column).to eq("Programme Status")
+      expect(subject.errors.first.csv_column).to eq("Activity Status")
       expect(subject.errors.first.column).to eq(:programme_status)
       expect(subject.errors.first.value).to eq("99331")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_programme_status"))

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ExportActivityToCsv do
           "Recipient region",
           "Recipient country",
           "Intended beneficiaries",
-          "Programme status",
+          "Activity status",
           "Planned start date",
           "Actual start date",
           "Planned end date",

--- a/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
@@ -37,6 +37,9 @@ data:
   - code: '11'
     name: Cancelled
     description: Activity has been cancelled or indefinitely postponed after an activity has started
+  - code: '12'
+    name: Paused
+    description: Activity has been temporarily suspended. No spend should take place while this status is in use
 metadata:
   url: ''
   name: Programme Status

--- a/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/programme_status.yml
@@ -18,7 +18,7 @@ data:
     description: The call/activity is open for applications
   - code: '05'
     name: Review
-    description: The application period has ended and the activity is in the peer review stage. The panek neetubg has not yet happened
+    description: The application period has ended and the activity is in the peer review stage. The panel meeting has not yet happened
   - code: '06'
     name: Decided
     description: Awards have been made (i.e. panel meeting has occurred) but have not begun
@@ -27,7 +27,7 @@ data:
     description: Awards/activity active, contracted and actual spend is occurring
   - code: '08'
     name: Finalisation
-    description: Physical activity is complete or the final disbursement has been made, but the activity remains open pending financia sign off or M&E
+    description: Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&E
   - code: '09'
     name: Completed
     description: All awards have completed and there is no more financial spend or forecast spend from UK. Can only be applied after ALL final payments on the activity, including final reconciliation, have been made


### PR DESCRIPTION
## Changes in this PR

- Add a new activity status: "Paused"
- Fix typos in the hint text
- Ensure we're using "Activity status" and not "Programme status" across any user-facing pages

## Screenshots of UI changes

### Before

### After
<img width="803" alt="Screenshot 2020-11-26 at 13 38 44" src="https://user-images.githubusercontent.com/579522/100357592-cb07b780-2fec-11eb-9746-fa8a9d02e286.png">
<img width="692" alt="Screenshot 2020-11-26 at 13 40 03" src="https://user-images.githubusercontent.com/579522/100357686-ec68a380-2fec-11eb-82ea-d24194bf4e55.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
