### PR TITLE
(1100) Add methods to determine if activity is funded by GCRF or Newton

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -325,4 +325,12 @@ class Activity < ApplicationRecord
   def is_project?
     project? || third_party_project?
   end
+
+  def is_gcrf_funded?
+    parent.present? && associated_fund.roda_identifier_fragment == "GCRF"
+  end
+
+  def is_newton_funded?
+    parent.present? && associated_fund.roda_identifier_fragment == "NF"
+  end
 end

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -1,12 +1,14 @@
 beis = Organisation.find_by(service_owner: true)
 
 gcrf_fund_params = FactoryBot.build(:fund_activity,
-  title: "GCRF",
+  roda_identifier_fragment: "GCRF",
+  title: "Global Challenges Research Fund (GCRF)",
   organisation: beis).attributes
 
 gcrf_fund = Activity.find_or_create_by(gcrf_fund_params)
 
 newton_fund_params = FactoryBot.build(:fund_activity,
+  roda_identifier_fragment: "NF",
   title: "Newton Fund",
   organisation: beis).attributes
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -54,6 +54,24 @@ FactoryBot.define do
       association :organisation, factory: :beis_organisation
       association :extending_organisation, factory: :beis_organisation
       association :reporting_organisation, factory: :beis_organisation
+
+      trait :gcrf do
+        roda_identifier_fragment { "GCRF" }
+        title { "Global Challenges Research Fund (GCRF)" }
+
+        initialize_with do
+          Activity.find_or_initialize_by(roda_identifier_fragment: "GCRF")
+        end
+      end
+
+      trait :newton do
+        roda_identifier_fragment { "NF" }
+        title { "Newton Fund" }
+
+        initialize_with do
+          Activity.find_or_initialize_by(roda_identifier_fragment: "NF")
+        end
+      end
     end
 
     factory :programme_activity do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1177,4 +1177,60 @@ RSpec.describe Activity, type: :model do
       expect(project.comment_for_report(report_id: report.id)).to be_nil
     end
   end
+
+  describe "#is_gcrf_funded?" do
+    it "returns true if activity is associated with the GCRF fund" do
+      fund = build(:fund_activity, :gcrf)
+      programme = build(:programme_activity, parent: fund)
+
+      expect(programme.is_gcrf_funded?).to be_truthy
+    end
+
+    it "returns false if activity is not associated with the GCRF fund" do
+      fund = build(:fund_activity)
+      programme = build(:programme_activity, parent: fund)
+
+      expect(programme.is_gcrf_funded?).to be_falsey
+    end
+
+    it "returns false if activity does not yet have a level" do
+      programme = build(:programme_activity, :level_form_state)
+
+      expect(programme.is_gcrf_funded?).to be_falsey
+    end
+
+    it "returns false if activity is a fund" do
+      fund = build(:fund_activity)
+
+      expect(fund.is_gcrf_funded?).to be_falsey
+    end
+  end
+
+  describe "#is_newton_funded?" do
+    it "returns true if activity is associated with the Newton fund" do
+      fund = build(:fund_activity, :newton)
+      programme = build(:programme_activity, parent: fund)
+
+      expect(programme.is_newton_funded?).to be_truthy
+    end
+
+    it "returns false if activity is not associated with the Newton fund" do
+      fund = build(:fund_activity)
+      programme = build(:programme_activity, parent: fund)
+
+      expect(programme.is_newton_funded?).to be_falsey
+    end
+
+    it "returns false if activity does not yet have a level" do
+      programme = build(:programme_activity, :level_form_state)
+
+      expect(programme.is_newton_funded?).to be_falsey
+    end
+
+    it "returns false if activity is a fund" do
+      fund = build(:fund_activity, :newton)
+
+      expect(fund.is_newton_funded?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Adds the following methods on Activity:

- `is_gcrf_funded?`
- `is_newton_funded?`

These assume that GCRF and Newton fund activities have RODA IDs "GCRF" and "NF" respectively, which is how they are set up in production. I've also updated `db/seeds/activity.rb` to reflect this.

Additionally, I've added two new FactoryBot traits to create GCRF and Newton fund activities with the correct attributes to make these methods work, e.g.

- `create(:fund_activity, :gcrf)`
- `create(:fund_activity, :newton)`

**NB: This was extracted out of https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/760 to unblock further work which relied on these methods.**