### PR TITLE
Restrict all potentially concurrent report states to one per series

### DIFF
--- a/db/migrate/20201127105312_restrict_report_states.rb
+++ b/db/migrate/20201127105312_restrict_report_states.rb
@@ -1,0 +1,12 @@
+class RestrictReportStates < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :reports,
+      column: [:fund_id, :organisation_id],
+      name: "enforce_one_editable_report_per_series"
+
+    add_index :reports, [:fund_id, :organisation_id],
+      where: "state NOT IN ('inactive', 'approved')",
+      unique: true,
+      name: "enforce_one_editable_report_per_series"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_172731) do
+ActiveRecord::Schema.define(version: 2020_11_27_105312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2020_11_25_172731) do
     t.date "deadline"
     t.integer "financial_quarter"
     t.integer "financial_year"
-    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text = ANY ((ARRAY['active'::character varying, 'awaiting_changes'::character varying])::text[]))"
+    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> ALL ((ARRAY['inactive'::character varying, 'approved'::character varying])::text[]))"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"


### PR DESCRIPTION
The state machine that reports operate looks like this:

                                     +-- awaiting_changes <--+
                                     |                       |
                                     |                       |
                                     V                       |
    inactive ------> active ------> submitted ------> in_review
                                                             |
                                                             |
                                                             V
                                                         approved

During the `active` and `awaiting_changes` states, the delivery partner
is allowed to change the report's contents -- these states are
"editable".

We added an index to allow only one report to exist in this state at a
time, for each set of reports scoped by (fund_id, organisation_id). The
purpose of this is to ensure the report sequence represents a totally
ordered history, because you can't have two editable reports open
concurrently that partner-entered data could be assigned to.

The problem is that this doesn't fully ensure the history is totally
ordered. For example, it allows the following sequence of state
transitions to occur on a pair of reports in the same series:

    Report 1            | Report 2
    --------------------+--------------------
    inactive            | inactive
    active              |
    submitted           |
                        | active
                        | submitted
    awaiting_changes    |
                        | approved

When Report 1 is active, new data is assigned to it. It is then
submitted, which allows Report 2 to enter an editable state -- the
current index only covers `active` and `awaiting_changes`. New data is
then assigned to Report 2.

Once Report 2 is submitted, it is possible under the current index for
Report 1 to go into awaiting changes, and therefore have more data
assigned to it. We've now broken the total ordering of report data by
adding data to Report 1, after we've added some to Report 2. Once we
start adding data in Report 2, it should be _impossible_ to further
change Report 1.

So, once a report enters the loop of states where it could become
editable again -- the states `active`, `submitted`, `in_review`, and
`awaiting_changes` -- we must not allow any other report to enter those
states, until the first report becomes `approved` and will never be
editable again.

The safest way to do that is to change the index condition so that any
state that's _not_ `inactive` or `approved` is covered by the uniqueness
rule. This does allow BEIS to create a new `inactive` report while the
current one is in the review cycle; they just can't activate it until
that review is concluded.

This constraint is currently obeyed in production and so this migration
should run successfully:

    > Report.where.not(state: %w[inactive approved]).count
    => 13
    > Report.where.not(state: %w[inactive approved]).map { |r| [r.fund_id, r.organisation_id] }.uniq.size
    => 13

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
