### PR TITLE
(1055) calculate variance by report history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,6 +401,7 @@
 ## [unreleased]
 
 - Show only the financial quarter and value for forecasts on the activity page
+- Use the latest versions of forecasts from the report history to calculate variance
 - Add a new activity status: "Paused"
 - Update importer date format to be MM/DD/YYYY
 - Separate intended beneficiaries with a pipe

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -308,10 +308,6 @@ class Activity < ApplicationRecord
     !ingested? && is_project?
   end
 
-  def forecasted_total_for_date_range(range:)
-    planned_disbursements.where(period_start_date: range).sum(:value)
-  end
-
   def comment_for_report(report_id:)
     comments.find_by(report_id: report_id)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -297,7 +297,7 @@ class Activity < ApplicationRecord
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    @forecasted_total_for_report_financial_quarter ||= forecasted_total_for_date_range(range: report.created_at.all_quarter)
+    @forecasted_total_for_report_financial_quarter ||= PlannedDisbursementOverview.new(self).value_for_report(report)
   end
 
   def variance_for_report_financial_quarter(report:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -297,7 +297,7 @@ class Activity < ApplicationRecord
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    @forecasted_total_for_report_financial_quarter ||= PlannedDisbursementOverview.new(self).value_for_report(report)
+    @forecasted_total_for_report_financial_quarter ||= PlannedDisbursementOverview.new(self).snapshot(report).value_for_report_quarter
   end
 
   def variance_for_report_financial_quarter(report:)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -77,15 +77,14 @@ class Report < ApplicationRecord
   end
 
   def next_four_financial_quarters
-    case current_financial_quarter
-    when 1
-      ["Q2 #{current_financial_year}", "Q3 #{current_financial_year}", "Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}"]
-    when 2
-      ["Q3 #{current_financial_year}", "Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}"]
-    when 3
-      ["Q4 #{current_financial_year}", "Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}", "Q3 #{current_financial_year + 1}"]
-    when 4
-      ["Q1 #{current_financial_year + 1}", "Q2 #{current_financial_year + 1}", "Q3 #{current_financial_year + 1}", "Q4 #{current_financial_year + 1}"]
+    quarter, year = current_financial_quarter, current_financial_year
+
+    (0..3).map do |increment|
+      next_quarter = quarter + increment
+      [
+        (next_quarter % 4) + 1,
+        next_quarter >= 4 ? year + 1 : year,
+      ]
     end
   end
 

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -214,11 +214,6 @@ class ActivityPresenter < SimpleDelegator
     "%.2f" % super
   end
 
-  def forecasted_total_for_date_range(range:)
-    return if super.blank?
-    "%.2f" % super
-  end
-
   def variance_for_report_financial_quarter(report:)
     return if super.blank?
     "%.2f" % super

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -15,23 +15,4 @@ class ReportPresenter < SimpleDelegator
     return nil if financial_quarter.nil? || financial_year.nil?
     "Q#{financial_quarter} #{financial_year}-#{financial_year + 1}"
   end
-
-  def quarters_to_date_ranges
-    next_four_financial_quarters.map! do |quarter|
-      quarter = quarter.match(/(\d) (\d{4})/)
-      quarter_num, year = quarter[1].to_i, quarter[2].to_i
-      quarter_month = case quarter_num
-                      when 1
-                        "April"
-                      when 2
-                        "July"
-                      when 3
-                        "October"
-                      when 4
-                        "January"
-      end
-      year = quarter_num == 4 ? year + 1 : year
-      Date.parse("1 #{quarter_month} #{year}").all_quarter
-    end
-  end
 end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -106,12 +106,19 @@ class ExportActivityToCsv
       "Variance",
       "Comment",
       "Link to activity in RODA",
-    ].concat(report_presenter.next_four_financial_quarters).to_csv
+    ].concat(next_four_financial_quarters).to_csv
   end
 
   def next_four_quarter_forecasts
-    quarter_date_ranges = report_presenter.quarters_to_date_ranges
-    quarter_date_ranges.map { |range| activity_presenter.forecasted_total_for_date_range(range: range) }
+    report_presenter.next_four_financial_quarters.map do |quarter, year|
+      overview = PlannedDisbursementOverview.new(activity_presenter)
+      value = overview.value_for_report(report_presenter, financial_quarter: quarter, financial_year: year)
+      "%.2f" % value
+    end
+  end
+
+  private def next_four_financial_quarters
+    report_presenter.next_four_financial_quarters.map { |quarter, year| "Q#{quarter} #{year}" }
   end
 
   private def activity_presenter

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -112,7 +112,7 @@ class ExportActivityToCsv
   def next_four_quarter_forecasts
     report_presenter.next_four_financial_quarters.map do |quarter, year|
       overview = PlannedDisbursementOverview.new(activity_presenter)
-      value = overview.value_for_report(report_presenter, financial_quarter: quarter, financial_year: year)
+      value = overview.snapshot(report_presenter).value_for(financial_quarter: quarter, financial_year: year)
       "%.2f" % value
     end
   end

--- a/app/services/planned_disbursement_overview.rb
+++ b/app/services/planned_disbursement_overview.rb
@@ -27,10 +27,10 @@ class PlannedDisbursementOverview
     latest_values.merge(Report.historically_up_to(report))
   end
 
-  def value_for_report(report)
+  def value_for_report(report, financial_quarter: report.financial_quarter, financial_year: report.financial_year)
     forecasts_for_report_quarter = values_at_report(report).where(
-      financial_quarter: report.financial_quarter,
-      financial_year: report.financial_year
+      financial_quarter: financial_quarter,
+      financial_year: financial_year
     )
     PlannedDisbursement.from(forecasts_for_report_quarter).sum(:value)
   end
@@ -52,7 +52,7 @@ class PlannedDisbursementOverview
   def historical_entries
     PlannedDisbursement
       .select(LATEST_ENTRY_PER_QUARTER)
-      .where(parent_activity: @activity)
+      .where(parent_activity_id: @activity.id)
       .order(financial_year: :asc, financial_quarter: :asc)
   end
 end

--- a/app/services/planned_disbursement_overview.rb
+++ b/app/services/planned_disbursement_overview.rb
@@ -27,6 +27,14 @@ class PlannedDisbursementOverview
     latest_values.merge(Report.historically_up_to(report))
   end
 
+  def value_for_report(report)
+    forecasts_for_report_quarter = values_at_report(report).where(
+      financial_quarter: report.financial_quarter,
+      financial_year: report.financial_year
+    )
+    PlannedDisbursement.from(forecasts_for_report_quarter).sum(:value)
+  end
+
   private
 
   def record_history?

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -150,16 +150,20 @@ RSpec.feature "Users can view reports" do
       end
 
       scenario "the report shows the total forecasted and actual spend and the variance" do
-        quarter_one_2019 = Date.parse("2019-4-1")
         quarter_two_2019 = Date.parse("2019-7-1")
 
         activity = create(:project_activity, organisation: delivery_partner_user.organisation)
+        reporting_cycle = ReportingCycle.new(activity, 4, 2018)
+        forecast = PlannedDisbursementHistory.new(activity, 1, 2019)
 
-        report = create(:report, :active, organisation: delivery_partner_user.organisation, fund: activity.associated_fund, financial_quarter: 1, financial_year: 2019, created_at: quarter_one_2019)
+        reporting_cycle.tick
+        forecast.set_value(1000)
+
+        reporting_cycle.tick
+        report = Report.for_activity(activity).in_historical_order.first
         report_presenter = ReportPresenter.new(report)
 
-        _forecasted_value = create(:planned_disbursement, parent_activity: activity, period_start_date: quarter_one_2019, value: 1000)
-        _actual_value = create(:transaction, parent_activity: activity, report: report, date: quarter_one_2019, value: 1100)
+        _actual_value = create(:transaction, parent_activity: activity, report: report, date: report.created_at, value: 1100)
 
         travel_to quarter_two_2019 do
           visit reports_path

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1155,35 +1155,66 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "#forecasted_total_for_report_financial_quarter" do
-    it "returns the total of all the activity's planned disbursements scoped to a report's financial quarter only" do
-      project = create(:project_activity, :with_report)
-      report = Report.for_activity(project).first
+    let(:project) { create(:project_activity) }
 
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
+    it "returns the activity's planned disbursement value for a report's financial quarter" do
+      forecast = PlannedDisbursementHistory.new(project, 3, 2020)
+      reporting_cycle = ReportingCycle.new(project, 2, 2020)
+
+      reporting_cycle.tick
+      forecast.set_value(1000.0)
+
+      reporting_cycle.tick
+      report = Report.for_activity(project).find_by(financial_quarter: 3)
+
+      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(1000.00)
+    end
+
+    it "does not include totals for any planned disbursements outside the report's date range" do
+      q3_forecast = PlannedDisbursementHistory.new(project, 3, 2020)
+      q4_forecast = PlannedDisbursementHistory.new(project, 4, 2020)
+      reporting_cycle = ReportingCycle.new(project, 2, 2020)
+
+      reporting_cycle.tick
+      q3_forecast.set_value(2000.0)
+      q4_forecast.set_value(1000.0)
+
+      reporting_cycle.tick
+      report = Report.for_activity(project).find_by(financial_quarter: 3)
 
       expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(2000.00)
     end
 
-    it "does not include totals for any planned disbursements outside the report's date range" do
-      project = create(:project_activity, :with_report)
-      report = Report.for_activity(project).first
+    it "only counts the latest revision value for a planned disbursement" do
+      forecast = PlannedDisbursementHistory.new(project, 3, 2020)
+      reporting_cycle = ReportingCycle.new(project, 1, 2020)
 
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 6.months.ago)
-      create(:planned_disbursement, parent_activity: project, value: 1000.00, period_start_date: 4.months.ago)
+      reporting_cycle.tick
+      forecast.set_value(3000.0)
 
-      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(0)
+      reporting_cycle.tick
+      forecast.set_value(4000.0)
+
+      reporting_cycle.tick
+      report = Report.for_activity(project).find_by(financial_quarter: 3)
+
+      expect(project.forecasted_total_for_report_financial_quarter(report: report)).to eq(4000.00)
     end
   end
 
   describe "#variance_for_report_financial_quarter" do
+    let(:project) { create(:project_activity) }
+    let(:reporting_cycle) { ReportingCycle.new(project, 2, 2020) }
+    let(:forecast) { PlannedDisbursementHistory.new(project, 3, 2020) }
+
     it "returns the variance between #actual_total_for_report_financial_quarter and #forecasted_total_for_report_financial_quarter" do
-      project = create(:project_activity, :with_report)
-      report = Report.for_activity(project).first
+      reporting_cycle.tick
+      forecast.set_value(1500)
+      reporting_cycle.tick
+
+      report = Report.for_activity(project).find_by(financial_quarter: 3)
       create(:transaction, parent_activity: project, value: 100, report: report, date: Date.today)
       create(:transaction, parent_activity: project, value: 200, report: report, date: Date.today)
-      create(:planned_disbursement, parent_activity: project, value: 1500, report: report, period_start_date: Date.today)
 
       expect(project.variance_for_report_financial_quarter(report: report)).to eq(-1200)
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1220,17 +1220,6 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#forecasted_total_for_date_range" do
-    it "returns the total of all the activity's planned disbursements scoped to a date range" do
-      project = create(:project_activity, :with_report)
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200, period_start_date: Date.parse("13 April 2020"))
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1000, period_start_date: Date.parse("20 November 2020"))
-
-      expect(project.forecasted_total_for_date_range(range: Date.parse("1 April 2020")..Date.parse("30 June 2020"))).to eq 200
-      expect(project.forecasted_total_for_date_range(range: Date.parse("1 October 2020")..Date.parse("31 December 2020"))).to eq 1000
-    end
-  end
-
   describe "#comment_for_report" do
     it "returns the comment associated to this activity and a particular report" do
       project = create(:project_activity, :with_report)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Report, type: :model do
         travel_to(Date.parse("1 April 2020")) do
           report = create(:report)
 
-          expect(report.next_four_financial_quarters).to eq ["Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021"]
+          expect(report.next_four_financial_quarters).to eq [[2, 2020], [3, 2020], [4, 2020], [1, 2021]]
         end
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe Report, type: :model do
         travel_to(Date.parse("1 July 2020")) do
           report = create(:report)
 
-          expect(report.next_four_financial_quarters).to eq ["Q3 2020", "Q4 2020", "Q1 2021", "Q2 2021"]
+          expect(report.next_four_financial_quarters).to eq [[3, 2020], [4, 2020], [1, 2021], [2, 2021]]
         end
       end
     end
@@ -182,7 +182,7 @@ RSpec.describe Report, type: :model do
         travel_to(Date.parse("1 October 2020")) do
           report = create(:report)
 
-          expect(report.next_four_financial_quarters).to eq ["Q4 2020", "Q1 2021", "Q2 2021", "Q3 2021"]
+          expect(report.next_four_financial_quarters).to eq [[4, 2020], [1, 2021], [2, 2021], [3, 2021]]
         end
       end
     end
@@ -192,7 +192,7 @@ RSpec.describe Report, type: :model do
         travel_to(Date.parse("1 January 2021")) do
           report = create(:report)
 
-          expect(report.next_four_financial_quarters).to eq ["Q1 2021", "Q2 2021", "Q3 2021", "Q4 2021"]
+          expect(report.next_four_financial_quarters).to eq [[1, 2021], [2, 2021], [3, 2021], [4, 2021]]
         end
       end
     end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -566,21 +566,6 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#forecasted_total_for_date_range" do
-    it "returns the planned disbursement total for a date range as a formatted number" do
-      project = create(:project_activity, :with_report)
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, value: 200.20, period_start_date: Date.today)
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: 3.months.ago)
-
-      expect(described_class.new(project).forecasted_total_for_date_range(range: Date.today.all_quarter))
-        .to eq "200.20"
-      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.ago.all_quarter))
-        .to eq "1500.00"
-      expect(described_class.new(project).forecasted_total_for_date_range(range: 3.months.from_now.all_quarter))
-        .to eq "0.00"
-    end
-  end
-
   describe "#variance_for_report_financial_quarter" do
     it "returns the variance per report as a formatted number" do
       project = create(:project_activity)

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -551,10 +551,15 @@ RSpec.describe ActivityPresenter do
 
   describe "#forecasted_total_for_report_financial_quarter" do
     it "returns the planned disbursement total per report as a formatted number" do
-      project = create(:project_activity, :with_report)
-      report = Report.for_activity(project).first
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, report: report, value: 200.20, period_start_date: Date.today)
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, value: 1500.00)
+      project = create(:project_activity)
+      reporting_cycle = ReportingCycle.new(project, 3, 2020)
+      forecast = PlannedDisbursementHistory.new(project, 4, 2020)
+
+      reporting_cycle.tick
+      forecast.set_value(200.20)
+
+      reporting_cycle.tick
+      report = Report.for_activity(project).in_historical_order.first
 
       expect(described_class.new(project).forecasted_total_for_report_financial_quarter(report: report))
         .to eq "200.20"
@@ -578,10 +583,16 @@ RSpec.describe ActivityPresenter do
 
   describe "#variance_for_report_financial_quarter" do
     it "returns the variance per report as a formatted number" do
-      project = create(:project_activity, :with_report)
-      report = Report.for_activity(project).first
-      _transaction = create(:transaction, parent_activity: project, report: report, value: 200, date: Date.today)
-      _disbursement = create(:planned_disbursement, parent_activity: project, value: 1500, period_start_date: Date.today)
+      project = create(:project_activity)
+      reporting_cycle = ReportingCycle.new(project, 3, 2019)
+      forecast = PlannedDisbursementHistory.new(project, 4, 2019)
+
+      reporting_cycle.tick
+      forecast.set_value(1500)
+
+      reporting_cycle.tick
+      report = Report.for_activity(project).in_historical_order.first
+      _transaction = create(:transaction, parent_activity: project, report: report, value: 200, date: report.created_at)
 
       expect(described_class.new(project).variance_for_report_financial_quarter(report: report))
         .to eq "-1300.00"

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -34,18 +34,4 @@ RSpec.describe ReportPresenter do
       expect(result).to be_nil
     end
   end
-
-  describe "#quarters_to_date_ranges" do
-    it "returns a date range for each quarter it is passed" do
-      travel_to(Date.parse("20 January 2021")) do
-        report = create(:report)
-        expect(described_class.new(report).quarters_to_date_ranges).to eq [
-          Date.parse("1 April 2021").all_quarter,
-          Date.parse("1 July 2021").all_quarter,
-          Date.parse("1 October 2021").all_quarter,
-          Date.parse("1 January 2022").all_quarter,
-        ]
-      end
-    end
-  end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -73,9 +73,14 @@ RSpec.describe ExportActivityToCsv do
   end
 
   describe "#next_four_quarter_forecasts" do
-    it "gets the forecasted total for the date ranges of the next four quarters" do
-      _disbursement_1 = create(:planned_disbursement, parent_activity: project, period_start_date: 3.months.from_now, value: 1000)
-      _disbursement_2 = create(:planned_disbursement, parent_activity: project, period_start_date: 9.months.from_now, value: 500)
+    it "gets the forecasted total for the next four quarters" do
+      quarters = report.next_four_financial_quarters
+      q1_forecast = PlannedDisbursementHistory.new(project, *quarters[0])
+      q3_forecast = PlannedDisbursementHistory.new(project, *quarters[2])
+
+      q1_forecast.set_value(1000)
+      q3_forecast.set_value(500)
+
       totals = ExportActivityToCsv.new(activity: project, report: report).next_four_quarter_forecasts
 
       expect(totals).to eq ["1000.00", "0.00", "500.00", "0.00"]

--- a/spec/services/planned_disbursement_overview_spec.rb
+++ b/spec/services/planned_disbursement_overview_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PlannedDisbursementOverview do
     end
 
     it "does not support requesting values at a specific report" do
-      expect { overview.values_at_report(Report.new) }.to raise_error(TypeError)
+      expect { overview.snapshot(Report.new).all_quarters }.to raise_error(TypeError)
     end
   end
 
@@ -99,13 +99,13 @@ RSpec.describe PlannedDisbursementOverview do
 
     shared_examples_for "forecast report history" do
       it "returns the forecast values for all quarters" do
-        forecasts = forecast_values(overview.values_at_report(report))
+        forecasts = forecast_values(overview.snapshot(report).all_quarters)
         expect(forecasts).to eq(expected_values)
       end
 
       it "returns the forecast value for a particular quarter" do
         expected_values.each do |quarter, year, amount|
-          value = overview.value_for_report(report, financial_quarter: quarter, financial_year: year)
+          value = overview.snapshot(report).value_for(financial_quarter: quarter, financial_year: year)
           expect(value).to eq(amount)
         end
       end
@@ -157,13 +157,13 @@ RSpec.describe PlannedDisbursementOverview do
 
       expected_values.each do |quarter, year, amount|
         report = Report.for_activity(activity).find_by(financial_year: year, financial_quarter: quarter)
-        expect(overview.value_for_report(report)).to eq(amount)
+        expect(overview.snapshot(report).value_for_report_quarter).to eq(amount)
       end
     end
 
     it "returns a zero forecast value for a report whose quarter has no forecast" do
       report = Report.for_activity(activity).find_by(financial_year: 2016, financial_quarter: 2)
-      expect(overview.value_for_report(report)).to eq(0)
+      expect(overview.snapshot(report).value_for_report_quarter).to eq(0)
     end
 
     context "when the first report is a historic one with no financial quarter" do

--- a/spec/services/planned_disbursement_overview_spec.rb
+++ b/spec/services/planned_disbursement_overview_spec.rb
@@ -97,32 +97,52 @@ RSpec.describe PlannedDisbursementOverview do
       ])
     end
 
-    it "returns the values as of the first report" do
-      report = Report.for_activity(activity).find_by(financial_quarter: 4, financial_year: 2015)
-      forecasts = forecast_values(overview.values_at_report(report))
+    shared_examples_for "forecast report history" do
+      it "returns the forecast values for all quarters" do
+        forecasts = forecast_values(overview.values_at_report(report))
+        expect(forecasts).to eq(expected_values)
+      end
 
-      expect(forecasts).to eq([
-        [1, 2017, 10],
-        [4, 2017, 20],
-        [1, 2018, 30],
-        [3, 2018, 40],
-        [4, 2018, 50],
-      ])
+      it "returns the forecast value for a particular quarter" do
+        expected_values.each do |quarter, year, amount|
+          value = overview.value_for_report(report, financial_quarter: quarter, financial_year: year)
+          expect(value).to eq(amount)
+        end
+      end
     end
 
-    it "returns the values as of a specific report" do
-      report = Report.for_activity(activity).find_by(financial_quarter: 1, financial_year: 2016)
-      forecasts = forecast_values(overview.values_at_report(report))
+    context "for the first report" do
+      let(:report) { Report.for_activity(activity).find_by(financial_quarter: 4, financial_year: 2015) }
 
-      expect(forecasts).to eq([
-        [1, 2017, 10],
-        [2, 2017, 60],
-        [4, 2017, 70],
-        [1, 2018, 30],
-        [2, 2018, 80],
-        [3, 2018, 90],
-        [4, 2018, 50],
-      ])
+      let(:expected_values) {
+        [
+          [1, 2017, 10],
+          [4, 2017, 20],
+          [1, 2018, 30],
+          [3, 2018, 40],
+          [4, 2018, 50],
+        ]
+      }
+
+      it_should_behave_like "forecast report history"
+    end
+
+    context "for a specific report" do
+      let(:report) { Report.for_activity(activity).find_by(financial_quarter: 1, financial_year: 2016) }
+
+      let(:expected_values) {
+        [
+          [1, 2017, 10],
+          [2, 2017, 60],
+          [4, 2017, 70],
+          [1, 2018, 30],
+          [2, 2018, 80],
+          [3, 2018, 90],
+          [4, 2018, 50],
+        ]
+      }
+
+      it_should_behave_like "forecast report history"
     end
 
     it "can return the forecast value for the quarter of a report" do
@@ -149,21 +169,21 @@ RSpec.describe PlannedDisbursementOverview do
     context "when the first report is a historic one with no financial quarter" do
       let(:report) { Report.for_activity(activity).find_by(financial_quarter: 4, financial_year: 2015) }
 
-      before do
-        Report.where(id: report.id).update_all(financial_quarter: nil, financial_year: nil)
-      end
-
-      it "returns the values as of the first report" do
-        forecasts = forecast_values(overview.values_at_report(report))
-
-        expect(forecasts).to eq([
+      let(:expected_values) {
+        [
           [1, 2017, 10],
           [4, 2017, 20],
           [1, 2018, 30],
           [3, 2018, 40],
           [4, 2018, 50],
-        ])
+        ]
+      }
+
+      before do
+        Report.where(id: report.id).update_all(financial_quarter: nil, financial_year: nil)
       end
+
+      it_should_behave_like "forecast report history"
     end
 
     context "when there are two reports for the same financial quarter" do
@@ -195,33 +215,41 @@ RSpec.describe PlannedDisbursementOverview do
         ])
       end
 
-      it "returns the values as of the latest report" do
-        forecasts = forecast_values(overview.values_at_report(reports[0]))
+      context "for the latest report" do
+        let(:report) { reports[0] }
 
-        expect(forecasts).to eq([
-          [1, 2017, 10],
-          [2, 2017, 60],
-          [3, 2017, 100],
-          [4, 2017, 70],
-          [1, 2018, 110],
-          [2, 2018, 120],
-          [3, 2018, 130],
-          [4, 2018, 140],
-        ])
+        let(:expected_values) {
+          [
+            [1, 2017, 10],
+            [2, 2017, 60],
+            [3, 2017, 100],
+            [4, 2017, 70],
+            [1, 2018, 110],
+            [2, 2018, 120],
+            [3, 2018, 130],
+            [4, 2018, 140],
+          ]
+        }
+
+        it_should_behave_like "forecast report history"
       end
 
-      it "returns the values as of the penultimate report" do
-        forecasts = forecast_values(overview.values_at_report(reports[1]))
+      context "for the penultimate report" do
+        let(:report) { reports[1] }
 
-        expect(forecasts).to eq([
-          [1, 2017, 10],
-          [2, 2017, 60],
-          [4, 2017, 70],
-          [1, 2018, 30],
-          [2, 2018, 80],
-          [3, 2018, 90],
-          [4, 2018, 50],
-        ])
+        let(:expected_values) {
+          [
+            [1, 2017, 10],
+            [2, 2017, 60],
+            [4, 2017, 70],
+            [1, 2018, 30],
+            [2, 2018, 80],
+            [3, 2018, 90],
+            [4, 2018, 50],
+          ]
+        }
+
+        it_should_behave_like "forecast report history"
       end
     end
 

--- a/spec/services/planned_disbursement_overview_spec.rb
+++ b/spec/services/planned_disbursement_overview_spec.rb
@@ -125,6 +125,27 @@ RSpec.describe PlannedDisbursementOverview do
       ])
     end
 
+    it "can return the forecast value for the quarter of a report" do
+      6.times { reporting_cycle.tick }
+
+      expected_values = [
+        [1, 2017, 10],
+        [2, 2017, 60],
+        [3, 2017, 100],
+        [4, 2017, 70],
+      ]
+
+      expected_values.each do |quarter, year, amount|
+        report = Report.for_activity(activity).find_by(financial_year: year, financial_quarter: quarter)
+        expect(overview.value_for_report(report)).to eq(amount)
+      end
+    end
+
+    it "returns a zero forecast value for a report whose quarter has no forecast" do
+      report = Report.for_activity(activity).find_by(financial_year: 2016, financial_quarter: 2)
+      expect(overview.value_for_report(report)).to eq(0)
+    end
+
     context "when the first report is a historic one with no financial quarter" do
       let(:report) { Report.for_activity(activity).find_by(financial_quarter: 4, financial_year: 2015) }
 

--- a/spec/support/reporting_cycle.rb
+++ b/spec/support/reporting_cycle.rb
@@ -4,7 +4,6 @@ class ReportingCycle
     @financial_quarter = financial_quarter
     @financial_year = financial_year
     @report = nil
-    @time = Time.now
   end
 
   def tick
@@ -21,9 +20,8 @@ class ReportingCycle
 
   def create_report
     @report = Report.new(fund: @activity.associated_fund, organisation: @activity.organisation)
-    @time += 1.second
 
-    @report.created_at = @time
+    @report.created_at = FinancialPeriod.start_date_from_quarter_and_year(@financial_quarter.to_s, @financial_year.to_s)
     @report.financial_quarter = @financial_quarter
     @report.financial_year = @financial_year
     @report.state = :active


### PR DESCRIPTION
## Changes in this PR

This PR changes how `Activity#forecasted_total_for_report_financial_quarter` and therefore `Activity#variance_for_report_financial_quarter` work. Previously they were summing all the `planned_disbursements` values for the given activity and date range, by generating a date range from the given `Report`'s `created_at` field, and then calling `Activity#forecasted_total_for_date_range` with that date range.

Now, we use the `Report`'s `financial_{quarter,year}` fields, not `created_at`, to determine which forecasts we're interested in, and we use the version of that forecast that was current at the time of the given report. As we're now storing multiple versions of a forecast for a given activity and quarter, we need to grab the latest version as of the given report, not sum the value over all stored versions.

My main questions here are about whether these changes in terms of how we model time are OK. Assuming that `created_at` (the time a record is written) is the same as the logical time period it relates to makes me nervous, and makes things harder to test, so I'm happy to get rid of that, but I'm less certain about the move from date-based to quarter-based operation here.

I'm also not sure what this means for `Activity#forecasted_total_for_date_range` -- should this still exist? Should its functionality be changed?

#### Update

I discussed the above questions with @mec who helped me understand how `Activity#forecasted_total_for_date_range` is used in the CSV export code. This PR now also includes updates so that all date-based forecast logic is replaced with quarter-based logic that understands how forecasts are versioned. This affects how variances are calculated, and the "next four quarters" forecast functionality in the CSV export.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
