### PR TITLE
(1213) developers can import forecasts

### DIFF
--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -1,0 +1,34 @@
+require "csv"
+
+class ImportPlannedDisbursements
+  RODA_ID_KEY = "RODA identifier"
+  FORECAST_COLUMN_HEADER = /FC +(\d{4})\/\d{2} +FY +Q([1-4])/
+
+  def initialize(report:)
+    @report = report
+  end
+
+  def import(forecasts)
+    forecasts.each { |row| import_row(row) }
+  end
+
+  def import_row(row)
+    roda_identifier = row[RODA_ID_KEY]
+    activity = Activity.by_roda_identifier(roda_identifier)
+
+    row.each do |key, value|
+      match = FORECAST_COLUMN_HEADER.match(key)
+      next unless match
+
+      year = match[1].to_i
+      quarter = match[2].to_i
+
+      import_forecast(activity, quarter, year, value)
+    end
+  end
+
+  def import_forecast(activity, quarter, year, value)
+    history = PlannedDisbursementHistory.new(activity, quarter, year, report: @report)
+    history.set_value(value)
+  end
+end

--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -4,13 +4,27 @@ class ImportPlannedDisbursements
   RODA_ID_KEY = "RODA identifier"
   FORECAST_COLUMN_HEADER = /FC +(\d{4})\/\d{2} +FY +Q([1-4])/
 
+  attr_reader :errors
+
   def initialize(report:)
     @report = report
+    @errors = []
   end
 
   def import(forecasts)
-    forecasts.each { |row| import_row(row) }
+    latest_report = Report
+      .where(fund: @report.fund_id, organisation: @report.organisation_id)
+      .in_historical_order
+      .first
+
+    ActiveRecord::Base.transaction do
+      log_report_not_latest_error(latest_report) unless @report == latest_report
+      forecasts.each { |row| import_row(row) }
+      raise ActiveRecord::Rollback unless @errors.empty?
+    end
   end
+
+  private
 
   def import_row(row)
     roda_identifier = row[RODA_ID_KEY]
@@ -30,5 +44,22 @@ class ImportPlannedDisbursements
   def import_forecast(activity, quarter, year, value)
     history = PlannedDisbursementHistory.new(activity, quarter, year, report: @report)
     history.set_value(value)
+  end
+
+  def log_report_not_latest_error(latest_report)
+    organisation = @report.organisation.name
+    fund = @report.fund.roda_identifier
+
+    message = [
+      "The report #{@report.id} (#{organisation}, #{quarter @report} for #{fund},",
+      "#{@report.state}) is not the latest for that organisation and fund.",
+      "The latest is #{latest_report.id}, for #{quarter latest_report} (#{latest_report.state}).",
+    ]
+
+    @errors << message.join(" ")
+  end
+
+  def quarter(report)
+    "Q#{report.financial_quarter} #{report.financial_year}"
   end
 end

--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -28,7 +28,8 @@ class ImportPlannedDisbursements
 
   def import_row(row)
     roda_identifier = row[RODA_ID_KEY]
-    activity = Activity.by_roda_identifier(roda_identifier)
+    activity = lookup_activity(roda_identifier)
+    return unless activity
 
     row.each do |key, value|
       match = FORECAST_COLUMN_HEADER.match(key)
@@ -44,6 +45,14 @@ class ImportPlannedDisbursements
   def import_forecast(activity, quarter, year, value)
     history = PlannedDisbursementHistory.new(activity, quarter, year, report: @report)
     history.set_value(value)
+  end
+
+  def lookup_activity(roda_identifier)
+    activity = Activity.by_roda_identifier(roda_identifier)
+    return activity if activity
+
+    @errors << "The RODA identifier '#{roda_identifier}' was not recognised."
+    nil
   end
 
   def log_report_not_latest_error(latest_report)

--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -38,13 +38,15 @@ class ImportPlannedDisbursements
       year = match[1].to_i
       quarter = match[2].to_i
 
-      import_forecast(activity, quarter, year, value)
+      import_forecast(activity, quarter, year, value, header: key)
     end
   end
 
-  def import_forecast(activity, quarter, year, value)
+  def import_forecast(activity, quarter, year, value, header:)
     history = PlannedDisbursementHistory.new(activity, quarter, year, report: @report)
     history.set_value(value)
+  rescue ConvertFinancialValue::Error
+    @errors << "The forecast for #{header} for activity #{activity.roda_identifier} is not a number."
   end
 
   def lookup_activity(roda_identifier)

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -3,10 +3,11 @@ class PlannedDisbursementHistory
 
   attr_reader :financial_year, :financial_quarter
 
-  def initialize(activity, financial_quarter, financial_year, user: nil)
+  def initialize(activity, financial_quarter, financial_year, report: nil, user: nil)
     @activity = activity
     @financial_quarter = financial_quarter.to_i
     @financial_year = financial_year.to_i
+    @report = report
     @user = user
   end
 
@@ -52,7 +53,7 @@ class PlannedDisbursementHistory
   end
 
   def update_history(latest_entry, value)
-    report = Report.editable_for_activity(@activity)
+    report = @report || Report.editable_for_activity(@activity)
     check_forecast_in_future(report)
 
     if latest_entry&.report_id == report.id

--- a/script/import_forecasts.rb
+++ b/script/import_forecasts.rb
@@ -1,0 +1,62 @@
+require "optparse"
+require_relative "../config/environment"
+
+parser = OptionParser.new { |args|
+  args.on "-f", "--fund FUND"
+  args.on "-o", "--organisation ORGANISATION"
+  args.on "-q", "--quarter QUARTER", Integer
+  args.on "-y", "--year YEAR", Integer
+  args.on "-i", "--input FILE"
+}
+
+options = {}
+parser.parse!(into: options)
+
+fund = Activity.fund.by_roda_identifier(options.fetch(:fund))
+organisation = Organisation.find_by(name: options.fetch(:organisation))
+
+unless fund
+  warn "Could not find fund with RODA identifier '#{options.fetch(:fund)}'"
+  exit 1
+end
+
+unless organisation
+  warn "Could not find organisation with name '#{options.fetch(:organisation)}'"
+  exit 1
+end
+
+report = Report.find_by(
+  fund: fund,
+  organisation: organisation,
+  financial_quarter: options.fetch(:quarter),
+  financial_year: options.fetch(:year)
+)
+
+unless report
+  warn "Could not find report with the given parameters"
+  exit 1
+end
+
+puts "\nRunning import with the following report:\n\n"
+puts "    id:           #{report.id}"
+puts "    description:  #{report.description}"
+puts "    fund:         #{report.fund.roda_identifier}"
+puts "    organisation: #{report.organisation.name}"
+puts "    quarter:      Q#{report.financial_quarter} #{report.financial_year}"
+puts "    state:        #{report.state}"
+
+puts "\nIs this correct? [y/n]"
+confirmation = gets
+exit unless confirmation.strip == "y"
+
+importer = ImportPlannedDisbursements.new(report: report)
+rows = CSV.parse(File.read(options.fetch(:input)), headers: true)
+
+importer.import(rows)
+
+if importer.errors.empty?
+  exit 0
+else
+  importer.errors.each { |message| warn message }
+  exit 1
+end

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -79,4 +79,25 @@ RSpec.describe ImportPlannedDisbursements do
       expect(forecast_values).to eq([])
     end
   end
+
+  context "when the data includes an unknown RODA identifier" do
+    before do
+      importer.import([
+        {
+          "RODA identifier" => "not-really-an-id",
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+        },
+      ])
+    end
+
+    it "reports an error" do
+      expect(importer.errors).to eq([
+        "The RODA identifier 'not-really-an-id' was not recognised.",
+      ])
+    end
+
+    it "does not import any forecasts" do
+      expect(forecast_values).to eq([])
+    end
+  end
 end

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ImportPlannedDisbursements do
 
     it "reports an error" do
       expect(importer.errors).to eq([
-        "The RODA identifier 'not-really-an-id' was not recognised.",
+        "Line 2: The RODA identifier 'not-really-an-id' was not recognised.",
       ])
     end
 
@@ -113,7 +113,7 @@ RSpec.describe ImportPlannedDisbursements do
 
     it "reports an error" do
       expect(importer.errors).to eq([
-        "The forecast for FC 2020/21 FY Q3 (Oct, Nov, Dec) for activity #{project.roda_identifier} is not a number.",
+        "Line 2: The forecast for FC 2020/21 FY Q3 (Oct, Nov, Dec) for activity #{project.roda_identifier} is not a number.",
       ])
     end
 
@@ -143,7 +143,7 @@ RSpec.describe ImportPlannedDisbursements do
 
     it "reports an error" do
       expect(importer.errors).to eq([
-        "The activity #{unrelated_project.roda_identifier} is not related to the report, which belongs to #{fund} and #{organisation}.",
+        "Line 3: The activity #{unrelated_project.roda_identifier} is not related to the report, which belongs to #{fund} and #{organisation}.",
       ])
     end
 

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -100,4 +100,25 @@ RSpec.describe ImportPlannedDisbursements do
       expect(forecast_values).to eq([])
     end
   end
+
+  context "when the data includes a non-numeric forecast" do
+    before do
+      importer.import([
+        {
+          "RODA identifier" => project.roda_identifier,
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "not a number",
+        },
+      ])
+    end
+
+    it "reports an error" do
+      expect(importer.errors).to eq([
+        "The forecast for FC 2020/21 FY Q3 (Oct, Nov, Dec) for activity #{project.roda_identifier} is not a number.",
+      ])
+    end
+
+    it "does not import any forecasts" do
+      expect(forecast_values).to eq([])
+    end
+  end
 end

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -121,4 +121,34 @@ RSpec.describe ImportPlannedDisbursements do
       expect(forecast_values).to eq([])
     end
   end
+
+  context "when the data includes a project unrelated to the report" do
+    let(:unrelated_project) { create(:project_activity) }
+
+    let(:organisation) { project.organisation.name }
+    let(:fund) { project.associated_fund.roda_identifier }
+
+    before do
+      importer.import([
+        {
+          "RODA identifier" => project.roda_identifier,
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+        },
+        {
+          "RODA identifier" => unrelated_project.roda_identifier,
+          "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+        },
+      ])
+    end
+
+    it "reports an error" do
+      expect(importer.errors).to eq([
+        "The activity #{unrelated_project.roda_identifier} is not related to the report, which belongs to #{fund} and #{organisation}.",
+      ])
+    end
+
+    it "does not import any forecasts" do
+      expect(forecast_values).to eq([])
+    end
+  end
 end

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe ImportPlannedDisbursements do
+  let(:project) { create(:project_activity) }
+  let(:reporting_cycle) { ReportingCycle.new(project, 1, 2020) }
+  let(:latest_report) { Report.in_historical_order.first }
+
+  let :importer do
+    ImportPlannedDisbursements.new(report: latest_report)
+  end
+
+  before do
+    2.times { reporting_cycle.tick }
+    Report.in_historical_order.first.update!(state: :in_review)
+  end
+
+  def forecast_values
+    overview = PlannedDisbursementOverview.new(project)
+
+    overview.latest_values.map do |planned_disbursement|
+      [
+        planned_disbursement.financial_quarter,
+        planned_disbursement.financial_year,
+        planned_disbursement.value,
+      ]
+    end
+  end
+
+  describe "importing a row of forecasts" do
+    let :forecast_row do
+      {
+        "RODA identifier" => project.roda_identifier,
+        "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+        "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+        "FC 2021/22 FY Q1 (Apr, May, Jun)" => "984150",
+        "FC 2021/22 FY Q2 (Jul, Aug, Sep)" => "206206",
+      }
+    end
+
+    before do
+      importer.import([forecast_row])
+    end
+
+    it "imports the forecasts" do
+      expect(forecast_values).to eq([
+        [3, 2020, 200_436.0],
+        [4, 2020, 310_793.0],
+        [1, 2021, 984_150.0],
+        [2, 2021, 206_206.0],
+      ])
+    end
+  end
+end

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe PlannedDisbursementHistory do
-  let(:history) { PlannedDisbursementHistory.new(activity, 3, 2020) }
+  let(:edited_report) { nil }
+  let(:history) { PlannedDisbursementHistory.new(activity, 3, 2020, report: edited_report) }
   let(:reporting_cycle) { ReportingCycle.new(activity, 1, 2015) }
 
   def history_entries
@@ -224,6 +225,25 @@ RSpec.describe PlannedDisbursementHistory do
         ["original", 1, 2015, 10],
         ["revised", 2, 2015, 20],
         ["revised", 1, 2016, 30],
+      ])
+    end
+  end
+
+  context "adding data to a specific report" do
+    let(:delivery_partner) { create(:delivery_partner_organisation) }
+    let(:activity) { create(:project_activity, organisation: delivery_partner) }
+    let(:edited_report) { Report.in_historical_order.first }
+
+    before do
+      reporting_cycle.tick
+      Report.update_all(state: :in_review)
+    end
+
+    it "allows data to be added to the given report" do
+      history.set_value(10)
+
+      expect(history_entries).to eq([
+        ["original", 1, 2015, 10],
       ])
     end
   end


### PR DESCRIPTION
## Changes in this PR

This PR adds a script that lets us import forecast data into the Q2 reports using a command-line script and CSV files. The behaviour of the import is described in detail in the commits. We plan to split the input data into one file per fund per delivery partner, so that each file's data can be assigned to a specific report. The interface for specifying which report to use is given in the last commit.

## Screenshots of UI changes

<img width="666" alt="Screenshot 2020-11-30 at 11 26 25" src="https://user-images.githubusercontent.com/9265/100605104-55a72a00-32ff-11eb-914b-5f06ca127791.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
