### PR TITLE
Fix tests in dates

### DIFF
--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -212,10 +212,10 @@ RSpec.feature "Users can create a fund level activity" do
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12
-        fill_in "activity[planned_start_date(1i)]", with: 2010
+        fill_in "activity[planned_start_date(1i)]", with: 2020
         fill_in "activity[planned_end_date(3i)]", with: 1
         fill_in "activity[planned_end_date(2i)]", with: 12
-        fill_in "activity[planned_end_date(1i)]", with: 2010
+        fill_in "activity[planned_end_date(1i)]", with: 2020
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.geography")
 

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -121,10 +121,10 @@ RSpec.feature "Users can create a programme activity" do
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12
-        fill_in "activity[planned_start_date(1i)]", with: 2010
+        fill_in "activity[planned_start_date(1i)]", with: 2020
         fill_in "activity[planned_end_date(3i)]", with: 1
         fill_in "activity[planned_end_date(2i)]", with: 12
-        fill_in "activity[planned_end_date(1i)]", with: 2010
+        fill_in "activity[planned_end_date(1i)]", with: 2020
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.geography")
 


### PR DESCRIPTION
Since the calendar ticked over to 2020-12-01, the dates we enter in the tests are now over 10 years ago and therefore invalid, so any time we run the test suite, the tests will break 🤦 