### PR TITLE
Handle zero values in planned disbursement history

### DIFF
--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -21,5 +21,5 @@ class PlannedDisbursement < ApplicationRecord
     :providing_organisation_reference,
     :financial_quarter,
     :financial_year
-  validates :value, inclusion: {in: 0.01..99_999_999_999.00}
+  validates :value, inclusion: {in: 0..99_999_999_999.00}
 end

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -86,6 +86,8 @@ class PlannedDisbursementHistory
   end
 
   def create_original_entry(value, report = nil)
+    return if value == 0
+
     attributes = series_attributes.merge(required_attributes).merge(
       planned_disbursement_type: :original,
       value: value,
@@ -108,8 +110,12 @@ class PlannedDisbursementHistory
   end
 
   def update_entry(entry, value)
-    entry.update!(value: value)
-    entry.create_activity(key: "planned_disbursement.update", owner: @user)
+    if value == 0 && entries.count == 1
+      entry.destroy!
+    else
+      entry.update!(value: value)
+      entry.create_activity(key: "planned_disbursement.update", owner: @user)
+    end
   end
 
   def series_attributes

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe PlannedDisbursementHistory do
       ])
     end
 
+    it "does not create an original entry with a zero value" do
+      history.set_value(0)
+      expect(history_entries).to eq([])
+    end
+
     it "adds a revision when the value is first updated" do
       history.set_value(10)
       history.set_value(20)
@@ -36,6 +41,16 @@ RSpec.describe PlannedDisbursementHistory do
       expect(history_entries).to eq([
         ["original", nil, nil, 10],
         ["revised", nil, nil, 20],
+      ])
+    end
+
+    it "adds a revision with a zero value" do
+      history.set_value(10)
+      history.set_value(0)
+
+      expect(history_entries).to eq([
+        ["original", nil, nil, 10],
+        ["revised", nil, nil, 0],
       ])
     end
 
@@ -47,6 +62,17 @@ RSpec.describe PlannedDisbursementHistory do
       expect(history_entries).to eq([
         ["original", nil, nil, 10],
         ["revised", nil, nil, 30],
+      ])
+    end
+
+    it "modifies the revision with a zero value" do
+      history.set_value(10)
+      history.set_value(20)
+      history.set_value(0)
+
+      expect(history_entries).to eq([
+        ["original", nil, nil, 10],
+        ["revised", nil, nil, 0],
       ])
     end
 
@@ -102,6 +128,11 @@ RSpec.describe PlannedDisbursementHistory do
       ])
     end
 
+    it "does not create an original entry with a zero value" do
+      history.set_value(0)
+      expect(history_entries).to eq([])
+    end
+
     it "edits an original entry when it belongs to the current report" do
       history.set_value(10)
       history.set_value(20)
@@ -109,6 +140,13 @@ RSpec.describe PlannedDisbursementHistory do
       expect(history_entries).to eq([
         ["original", 1, 2015, 20],
       ])
+    end
+
+    it "deletes an original entry with a zero value when it belongs to the current report" do
+      history.set_value(10)
+      history.set_value(0)
+
+      expect(history_entries).to eq([])
     end
 
     it "adds a revision when the original entry is part of an approved report" do
@@ -135,6 +173,18 @@ RSpec.describe PlannedDisbursementHistory do
       ])
     end
 
+    it "adds a revision with a zero value when the original is part of an approved report" do
+      history.set_value(10)
+      reporting_cycle.tick
+
+      history.set_value(0)
+
+      expect(history_entries).to eq([
+        ["original", 1, 2015, 10],
+        ["revised", 2, 2015, 0],
+      ])
+    end
+
     it "edits a revision when it belongs to the current report" do
       history.set_value(10)
       reporting_cycle.tick
@@ -145,6 +195,19 @@ RSpec.describe PlannedDisbursementHistory do
       expect(history_entries).to eq([
         ["original", 1, 2015, 10],
         ["revised", 2, 2015, 30],
+      ])
+    end
+
+    it "edits a revision with a zero value when it belongs to the current report" do
+      history.set_value(10)
+      reporting_cycle.tick
+
+      history.set_value(20)
+      history.set_value(0)
+
+      expect(history_entries).to eq([
+        ["original", 1, 2015, 10],
+        ["revised", 2, 2015, 0],
       ])
     end
 


### PR DESCRIPTION
## Changes in this PR

These changes are required in order to unblock #773, and they also improve how forecast entry works for end users. The commits go into more detail on the implementation, but the gist is:

When we see a value of `0` in an imported CSV, or when the user enters this value on the site, we should interpret this as saying there is no spending planned for that quarter. In general, we don't want to delete history, and so we handle this by storing the `0` so that it supersedes previous historical values. We avoid displaying zero-valued forecasts on the site, so from the user's point of view they're effectively deleted.

There are some exceptions to this behaviour:

- If there are no existing forecast records stored for that activity and quarter, then we ignore the input rather than storing a record with `value = 0`.
- If the activity is level C/D and therefore stores report-based history, and there is only one forecast record in the history for the quarter, and that record belongs to the current report, we delete it.

In all other situations, the `0` is stored as a new revision, so that it overrides previous values without deleting them.

## Screenshots of UI changes

### Before

Suppose we have a few forecasts stored for an activity:

<img width="1096" alt="Screenshot 2020-12-02 at 15 10 10" src="https://user-images.githubusercontent.com/9265/100891187-ec671880-34b0-11eb-839e-7a54e1473925.png">

We go to edit one and set its value to zero:

<img width="665" alt="Screenshot 2020-12-02 at 15 10 30" src="https://user-images.githubusercontent.com/9265/100891192-ed984580-34b0-11eb-88eb-91fa0835935b.png">

This is currently a validation error; planned disbursements are not allowed to have a zero value.

<img width="778" alt="Screenshot 2020-12-02 at 15 10 44" src="https://user-images.githubusercontent.com/9265/100891196-ee30dc00-34b0-11eb-9d29-303bc9c99c81.png">

### After

This is now not an error, and it acts to effectively delete the forecast, without destroying history. Whereas before, if there were any zero values in the database, they would be displayed:

<img width="1095" alt="Screenshot 2020-12-02 at 15 11 29" src="https://user-images.githubusercontent.com/9265/100891255-fdb02500-34b0-11eb-9aad-b6b2d8a05bfe.png">

Now, they no longer appear -- setting a value of zero means you're asserting that no spending is planned in that quarter, and so we stop displaying it.

<img width="1095" alt="Screenshot 2020-12-02 at 15 11 48" src="https://user-images.githubusercontent.com/9265/100891257-fe48bb80-34b0-11eb-9bba-1ddb6c78486a.png">

However, the previous value is not destroyed; we represent the "deletion" by storing `0` as the latest value, superseding the previous one.

<img width="665" alt="Screenshot 2020-12-02 at 15 12 46" src="https://user-images.githubusercontent.com/9265/100891258-fee15200-34b0-11eb-9da5-a1e1acaa7972.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
