### PR TITLE
(1261) Importer can import policy markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,7 @@
 - Separate intended beneficiaries with a pipe
 - Add a field to record the UK delivery partner named contact for project-level activities
 - Validate country codes against all valid-country codes in the importer
+- Importer can import policy markers
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -412,14 +412,4 @@ class Staff::ActivityFormsController < Staff::BaseController
     # This allows us to pre-select a specific radio button on collaboration_type form step (value "Bilateral" in this case)
     @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
   end
-
-  def policy_markers_iati_codes_to_enum(code)
-    case code
-    when "0" then "not_targeted"
-    when "1" then "significant_objective"
-    when "2" then "principal_objective"
-    when "3" then "principal_objective_and_in_support"
-    when "1000" then "not_assessed"
-    end
-  end
 end

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -25,4 +25,8 @@ module ActivityHelper
   def sdg_options
     I18n.t("form.label.activity.sdg_options")
   end
+
+  def policy_markers_iati_codes_to_enum(code)
+    Activity::POLICY_MARKER_CODES.key(code.to_i)
+  end
 end

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -168,11 +168,30 @@ module Activities
         actual_end_date: "Actual end date",
         sector: "Sector",
         collaboration_type: "Collaboration type (Bi/Multi Marker)",
+        policy_marker_gender: "DFID policy marker - Gender",
+        policy_marker_climate_change_adaptation: "DFID policy marker - Climate Change - Adaptation",
+        policy_marker_climate_change_mitigation: "DFID policy marker - Climate Change - Mitigation",
+        policy_marker_biodiversity: "DFID policy marker - Biodiversity",
+        policy_marker_desertification: "DFID policy marker - Desertification",
+        policy_marker_disability: "DFID policy marker - Disability",
+        policy_marker_disaster_risk_reduction: "DFID policy marker - Disaster Risk Reduction",
+        policy_marker_nutrition: "DFID policy marker - Nutrition",
         flow: "Flow",
         aid_type: "Aid type",
         fstc_applies: "Free Standing Technical Cooperation",
         objectives: "Aims/Objectives (DP Definition)",
       }
+
+      ALLOWED_BLANK_FIELDS = [
+        "DFID policy marker - Gender",
+        "DFID policy marker - Climate Change - Adaptation",
+        "DFID policy marker - Climate Change - Mitigation",
+        "DFID policy marker - Biodiversity",
+        "DFID policy marker - Desertification",
+        "DFID policy marker - Disability",
+        "DFID policy marker - Disaster Risk Reduction",
+        "DFID policy marker - Nutrition",
+      ]
 
       def initialize(row)
         @row = row
@@ -190,7 +209,7 @@ module Activities
 
       def convert_to_attributes
         attributes = FIELDS.each_with_object({}) { |(attr_name, column_name), attrs|
-          attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if @row[column_name].present?
+          attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if field_should_be_converted?(column_name)
         }
 
         attributes[:geography] = infer_geography(attributes)
@@ -200,6 +219,10 @@ module Activities
         attributes[:sector_category] = get_sector_category(attributes[:sector])
 
         attributes
+      end
+
+      def field_should_be_converted?(column_name)
+        ALLOWED_BLANK_FIELDS.include?(column_name) || @row[column_name].present?
       end
 
       def convert_to_attribute(attr_name, value)
@@ -237,6 +260,20 @@ module Activities
           I18n.t("importer.errors.activity.invalid_gdi"),
         )
       end
+
+      def convert_policy_marker(policy_marker)
+        return "not_assessed" if policy_marker.blank?
+
+        policy_markers_iati_codes_to_enum(policy_marker)
+      end
+      alias convert_policy_marker_gender convert_policy_marker
+      alias convert_policy_marker_climate_change_adaptation convert_policy_marker
+      alias convert_policy_marker_climate_change_mitigation convert_policy_marker
+      alias convert_policy_marker_biodiversity convert_policy_marker
+      alias convert_policy_marker_desertification convert_policy_marker
+      alias convert_policy_marker_disability convert_policy_marker
+      alias convert_policy_marker_disaster_risk_reduction convert_policy_marker
+      alias convert_policy_marker_nutrition convert_policy_marker
 
       def convert_sustainable_development_goal(goal)
         raise I18n.t("importer.errors.activity.invalid_sdg_goal") unless sdg_options.keys.map(&:to_s).include?(goal.to_s)

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Activities::ImportFromCsv do
       "Actual end date" => "05/01/2020",
       "Sector" => "11220",
       "Collaboration type (Bi/Multi Marker)" => "1",
+      "DFID policy marker - Gender" => "0",
+      "DFID policy marker - Climate Change - Adaptation" => "2",
+      "DFID policy marker - Climate Change - Mitigation" => "1",
+      "DFID policy marker - Biodiversity" => "2",
+      "DFID policy marker - Desertification" => "1000",
+      "DFID policy marker - Disability" => "",
+      "DFID policy marker - Disaster Risk Reduction" => "0",
+      "DFID policy marker - Nutrition" => "",
       "Flow" => "10",
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
@@ -128,6 +136,14 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.sector).to eq(existing_activity_attributes["Sector"])
       expect(existing_activity.sector_category).to eq("112")
       expect(existing_activity.collaboration_type).to eq(existing_activity_attributes["Collaboration type (Bi/Multi Marker)"])
+      expect(existing_activity.policy_marker_gender).to eq("not_targeted")
+      expect(existing_activity.policy_marker_climate_change_adaptation).to eq("principal_objective")
+      expect(existing_activity.policy_marker_climate_change_mitigation).to eq("significant_objective")
+      expect(existing_activity.policy_marker_biodiversity).to eq("principal_objective")
+      expect(existing_activity.policy_marker_desertification).to eq("not_assessed")
+      expect(existing_activity.policy_marker_disability).to eq("not_assessed")
+      expect(existing_activity.policy_marker_disaster_risk_reduction).to eq("not_targeted")
+      expect(existing_activity.policy_marker_nutrition).to eq("not_assessed")
       expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)


### PR DESCRIPTION
This adds the policy marker fields for import. We want to treat blank fields as “not_assessed”, but the way the convertor works at the moment, we skip any blank fields. 

I’ve got round this by adding a constant called `ALLOWED_BLANK_FIELDS`. Rather than just checking a field is present before converting it, we additionally check is a field is in the `ALLOWED_BLANK_FIELDS` constant too. This way we can convert any fields that are left blank to read as `not_assessed`