### PR TITLE
Ignore Ruby files when running Shellcheck

### DIFF
--- a/lib/tasks/shellcheck.rake
+++ b/lib/tasks/shellcheck.rake
@@ -1,6 +1,6 @@
 desc "Lint with ShellCheck"
 task shellcheck: :environment do
-  files = Dir.glob(["**/*.{sh,ksh,bash}", "script/*"]).reject { |path|
+  files = Dir.glob(["**/*.{sh,ksh,bash}", "script/*[^.rb]"]).reject { |path|
     Dir.exist?(path)
   }
 


### PR DESCRIPTION
Currently, import_forecasts.rb is causing Shellcheck to fail when run via `script/test`. I've updated the Rake task to ignore any Ruby files that are in the `script` directory.