### PR TITLE
(1268) Import can create an activity implementing organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,6 +413,7 @@
 - Users can add `gcrf_challenge_area` for GCRF-funded activities
 - Add fund pillar question to the Activity form
 - Allow Channel of delivery code to be imported from CSV and reported in the CSV
+- Allow importer to import the implementing organisation name, reference and sector
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -107,6 +107,7 @@ class Activity < ApplicationRecord
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
   has_many :implementing_organisations
+  validates_associated :implementing_organisations
   belongs_to :reporting_organisation, foreign_key: "reporting_organisation_id", class_name: "Organisation"
 
   has_many :budgets, foreign_key: "parent_activity_id"

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -106,7 +106,7 @@ class Activity < ApplicationRecord
   has_many :child_activities, foreign_key: "parent_id", class_name: "Activity"
   belongs_to :organisation
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
-  has_many :implementing_organisations
+  has_many :implementing_organisations, dependent: :destroy
   validates_associated :implementing_organisations
   belongs_to :reporting_organisation, foreign_key: "reporting_organisation_id", class_name: "Organisation"
 

--- a/app/models/implementing_organisation.rb
+++ b/app/models/implementing_organisation.rb
@@ -1,7 +1,17 @@
 class ImplementingOrganisation < ApplicationRecord
-  validates_presence_of :name, :organisation_type
+  validates :name, presence: true
+  validates :organisation_type, presence: true, inclusion: {in: ->(_) { valid_organisation_types }, allow_blank: true}
 
-  strip_attributes only: [:reference]
+  strip_attributes only: [:name, :reference]
 
   belongs_to :activity
+
+  private
+
+  class << self
+    private def valid_organisation_types
+      yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/organisation/organisation_type.yml"))
+      yaml["data"].map { |d| d["code"] }
+    end
+  end
 end

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -85,9 +85,9 @@ module Activities
       def update
         return unless @activity && @errors.empty?
 
-        attributes = @converter.to_h
+        @activity.assign_attributes(@converter.to_h)
 
-        return if @activity.update(attributes)
+        return if @activity.save
 
         @activity.errors.each do |attr_name, message|
           @errors[attr_name] ||= [@converter.raw(attr_name), message]

--- a/config/initializers/active_support_deprecation_fix.rb
+++ b/config/initializers/active_support_deprecation_fix.rb
@@ -1,0 +1,11 @@
+module ActiveSupport
+  class Deprecated
+    class DeprecatedConstantProxy < Module
+      # Remove "SourceAnnotationExtractor is deprecated" warnings that were
+      # interfering with pry's tab complete
+      #
+      # REMOVE AFTER Rails 6.0.4 RELEASE (https://github.com/rails/rails/pull/37468)
+      delegate :hash, :instance_methods, :name, :respond_to?, to: :target
+    end
+  end
+end

--- a/config/locales/models/implementing_organisation.en.yml
+++ b/config/locales/models/implementing_organisation.en.yml
@@ -6,6 +6,16 @@ en:
         success: Implementing organisation successfully created
       update:
         success: Implementing organisation successfully updated
+  activerecord:
+    errors:
+      models:
+        implementing_organisation:
+          attributes:
+            name:
+              blank: Implementing organisation name can't be blank
+            organisation_type:
+              blank: Implementing organisation sector can't be blank
+              inclusion: Implementing organisation sector must be included in the IATI codelist
   form:
     label:
       implementing_organisation:

--- a/doc/activity-csv-importer.md
+++ b/doc/activity-csv-importer.md
@@ -1,0 +1,23 @@
+# Activity CSV Importer
+
+We need to import legacy data for delivery partners, so they don't have to
+manually re-key it into RODA.
+
+## Implementing Organisations
+
+These are currently stored on a one-to-many association between `Activity` and `ImplementingOrganisation`.
+
+### Handling multiple implementing organisations
+
+Whilst there can be more than one implementing organisation stored against an
+activity, this is quite rare. Additionally, the CSV can only reference one
+implementing organisation per activity.
+
+Therefore, the decision was made that in the case when the CSV references an
+activity that already exists with more than one implementing organisation,
+running the import will result in *one* being updated with the new information
+and the remaining implementing organisations being removed.
+
+We note that an alternative solution would need to be found once the end-user
+can run this process. This seems fine for now whilst the importer can only be
+run by a developer in the console.

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -138,6 +138,7 @@ FactoryBot.define do
 
         after(:create) do |project_activity, evaluator|
           create_list(:implementing_organisation, evaluator.implementing_organisations_count, activity: project_activity)
+          project_activity.reload
         end
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -940,7 +940,7 @@ RSpec.describe Activity, type: :model do
     it "returns true when there is one or more implementing organisationg" do
       activity = create(:project_activity_with_implementing_organisations)
 
-      expect(activity.has_implementing_organisations?).to be true
+      expect(activity.reload.has_implementing_organisations?).to be true
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -940,7 +940,7 @@ RSpec.describe Activity, type: :model do
     it "returns true when there is one or more implementing organisationg" do
       activity = create(:project_activity_with_implementing_organisations)
 
-      expect(activity.reload.has_implementing_organisations?).to be true
+      expect(activity.has_implementing_organisations?).to be true
     end
   end
 

--- a/spec/models/implementing_organisation_spec.rb
+++ b/spec/models/implementing_organisation_spec.rb
@@ -4,9 +4,16 @@ RSpec.describe ImplementingOrganisation, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:organisation_type) }
+
+    describe ".organisation_type" do
+      it { is_expected.to allow_value("80").for(:organisation_type) }
+      it { is_expected.not_to allow_value("").for(:organisation_type) }
+      it { is_expected.not_to allow_value("invalid").for(:organisation_type) }
+    end
   end
 
   describe "sanitation" do
+    it { should strip_attribute(:name) }
     it { should strip_attribute(:reference) }
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -716,5 +716,22 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.errors.count).to eq(0)
     end
+
+    context "with existing implementing organisation" do
+      let(:existing_activity) do
+        create(:project_activity_with_implementing_organisations, implementing_organisations_count: 3)
+      end
+
+      it "leaves only one associated implementing organisation and updates it" do
+        rows = [existing_activity_attributes]
+
+        expect { subject.import(rows) }.to change { ImplementingOrganisation.count }.by(-2)
+
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(1)
+
+        expect(subject.errors.count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -3,7 +3,13 @@ require "rails_helper"
 RSpec.describe Activities::ImportFromCsv do
   let(:organisation) { create(:organisation) }
   let(:parent_activity) { create(:activity) }
-  let(:existing_activity) { create(:activity) }
+  let(:existing_activity) do
+    create(:activity) do |activity|
+      activity.implementing_organisations = [
+        create(:implementing_organisation, activity: activity),
+      ]
+    end
+  end
   let(:existing_activity_attributes) do
     {
       "RODA ID" => existing_activity.roda_identifier_compound,
@@ -49,6 +55,9 @@ RSpec.describe Activities::ImportFromCsv do
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
       "Aims/Objectives (DP Definition)" => "Foo bar baz",
+      "Implementing organisation name" => existing_activity.implementing_organisations.first.name,
+      "Implementing organisation reference" => existing_activity.implementing_organisations.first.reference,
+      "Implementing organisation sector" => existing_activity.implementing_organisations.first.organisation_type,
     }
   end
   let(:new_activity_attributes) do
@@ -156,6 +165,11 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
+
+      expect(existing_activity.implementing_organisations.count).to eql(1)
+      expect(existing_activity.implementing_organisations.first.name).to eq(existing_activity_attributes["Implementing organisation name"])
+      expect(existing_activity.implementing_organisations.first.reference).to eq(existing_activity_attributes["Implementing organisation reference"])
+      expect(existing_activity.implementing_organisations.first.organisation_type).to eq(existing_activity_attributes["Implementing organisation sector"])
     end
 
     it "ignores any blank columns" do
@@ -264,6 +278,17 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
       expect(new_activity.fstc_applies).to eq(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
+    end
+
+    it "creates the associated implementing organisations" do
+      rows = [new_activity_attributes]
+      expect { subject.import(rows) }.to change { ImplementingOrganisation.count }.by(1)
+
+      new_activity = Activity.order(:created_at).last
+
+      expect(new_activity.implementing_organisations.first.name).to eq(new_activity_attributes["Implementing organisation name"])
+      expect(new_activity.implementing_organisations.first.reference).to eq(new_activity_attributes["Implementing organisation reference"])
+      expect(new_activity.implementing_organisations.first.organisation_type).to eq(new_activity_attributes["Implementing organisation sector"])
     end
 
     it "sets the geography to recipient country and infers the region if the region is not specified" do
@@ -632,6 +657,46 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.value).to eq("%^$!234566")
       expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.roda_identifier_fragment.invalid_characters"))
     end
+
+    context "implementing organisation" do
+      it "has an error if the name is empty" do
+        new_activity_attributes["Implementing organisation name"] = ""
+
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_column).to eq("Implementing organisation name")
+        expect(subject.errors.first.column).to eq("implementing_organisation_name")
+        expect(subject.errors.first.value).to eq("")
+        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.implementing_organisation.attributes.name.blank"))
+      end
+
+      it "has an error if the sector is empty" do
+        new_activity_attributes["Implementing organisation sector"] = ""
+
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_column).to eq("Implementing organisation sector")
+        expect(subject.errors.first.column).to eq("implementing_organisation_organisation_type")
+        expect(subject.errors.first.value).to eq("")
+        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.implementing_organisation.attributes.organisation_type.blank"))
+      end
+
+      it "has an error if the sector is not in the organisation-type codelist" do
+        new_activity_attributes["Implementing organisation sector"] = "9999"
+
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.implementing_organisation.attributes.organisation_type.inclusion"))
+      end
+    end
   end
 
   context "when updating and importing" do
@@ -641,6 +706,13 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(subject.created.count).to eq(1)
       expect(subject.updated.count).to eq(1)
+
+      expect(subject.errors.count).to eq(0)
+    end
+
+    it "creates and imports implementing organisations" do
+      rows = [existing_activity_attributes, new_activity_attributes]
+      expect { subject.import(rows) }.to change { ImplementingOrganisation.count }.by(1)
 
       expect(subject.errors.count).to eq(0)
     end


### PR DESCRIPTION
Add the implementing organisation fields to `Activities::ImportFromCsv`:

 - Implementing organisation name
 - Implementing organisation reference
 - Implementing organisation sector (aka organisation type)

If all of the above are blank, we don't create an associated `ImplementingOrganisation`. However, if either "Implementing organisation name" or "Implementing organisation sector" are provided, these BOTH need to be present and valid to import the row correctly.

**NB: If an activity has more than one associated `ImplementingOrganisation`, these are all deleted and replaced with a single one when imported, which is by design. Obviously, this will need to work differently once end-users are able to use the importer directly.**

#  Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
