### PR TITLE
(1250) Add new fields to the activity importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,6 +415,7 @@
 - Allow Channel of delivery code to be imported from CSV and reported in the CSV
 - Allow importer to import the implementing organisation name, reference and sector
 - Add "BEIS ID" (beis_id) to the importer
+- Add "UK DP Named Contact (NF)" (uk_dp_named_contact) to the importer
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,7 @@
 - Add fund pillar question to the Activity form
 - Allow Channel of delivery code to be imported from CSV and reported in the CSV
 - Allow importer to import the implementing organisation name, reference and sector
+- Add "BEIS ID" (beis_id) to the importer
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,7 @@
 - Allow importer to import the implementing organisation name, reference and sector
 - Add "BEIS ID" (beis_id) to the importer
 - Add "UK DP Named Contact (NF)" (uk_dp_named_contact) to the importer
+- Add "NF Partner Country DP" (country_delivery_partners) to the importer
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -232,6 +232,7 @@ module Activities
         objectives: "Aims/Objectives (DP Definition)",
         beis_id: "BEIS ID",
         uk_dp_named_contact: "UK DP Named Contact (NF)",
+        country_delivery_partners: "NF Partner Country DP",
       }
 
       ALLOWED_BLANK_FIELDS = [
@@ -247,6 +248,7 @@ module Activities
         "Implementing organisation reference",
         "BEIS ID",
         "UK DP Named Contact (NF)",
+        "NF Partner Country DP",
       ]
 
       def initialize(row)
@@ -468,6 +470,10 @@ module Activities
 
       def convert_actual_end_date(actual_end_date)
         parse_date(actual_end_date, I18n.t("importer.errors.activity.invalid_actual_end_date"))
+      end
+
+      def convert_country_delivery_partners(delivery_partners)
+        delivery_partners.split("|").map(&:strip).reject(&:blank?)
       end
 
       def parse_date(date, message)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -230,6 +230,7 @@ module Activities
         aid_type: "Aid type",
         fstc_applies: "Free Standing Technical Cooperation",
         objectives: "Aims/Objectives (DP Definition)",
+        beis_id: "BEIS ID",
       }
 
       ALLOWED_BLANK_FIELDS = [
@@ -243,6 +244,7 @@ module Activities
         "DFID policy marker - Nutrition",
         "Channel of delivery code",
         "Implementing organisation reference",
+        "BEIS ID",
       ]
 
       def initialize(row)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -231,6 +231,7 @@ module Activities
         fstc_applies: "Free Standing Technical Cooperation",
         objectives: "Aims/Objectives (DP Definition)",
         beis_id: "BEIS ID",
+        uk_dp_named_contact: "UK DP Named Contact (NF)",
       }
 
       ALLOWED_BLANK_FIELDS = [
@@ -245,6 +246,7 @@ module Activities
         "Channel of delivery code",
         "Implementing organisation reference",
         "BEIS ID",
+        "UK DP Named Contact (NF)",
       ]
 
       def initialize(row)

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Aims/Objectives (DP Definition)" => "Foo bar baz",
       "BEIS ID" => "BEIS_ID_EXAMPLE_01",
       "UK DP Named Contact (NF)" => "Jo Soap",
+      "NF Partner Country DP" => "Association of Example Companies (AEC) | | Board of Sample Organisations (BSO)",
       "Implementing organisation name" => existing_activity.implementing_organisations.first.name,
       "Implementing organisation reference" => existing_activity.implementing_organisations.first.reference,
       "Implementing organisation sector" => existing_activity.implementing_organisations.first.organisation_type,
@@ -174,6 +175,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.implementing_organisations.first.name).to eq(existing_activity_attributes["Implementing organisation name"])
       expect(existing_activity.implementing_organisations.first.reference).to eq(existing_activity_attributes["Implementing organisation reference"])
       expect(existing_activity.implementing_organisations.first.organisation_type).to eq(existing_activity_attributes["Implementing organisation sector"])
+      expect(existing_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
     end
 
     it "ignores any blank columns" do
@@ -284,6 +286,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
       expect(new_activity.beis_id).to eq(new_activity_attributes["BEIS ID"])
       expect(new_activity.uk_dp_named_contact).to eq(new_activity_attributes["UK DP Named Contact (NF)"])
+      expect(new_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
     end
 
     it "creates the associated implementing organisations" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Free Standing Technical Cooperation" => "1",
       "Aims/Objectives (DP Definition)" => "Foo bar baz",
       "BEIS ID" => "BEIS_ID_EXAMPLE_01",
+      "UK DP Named Contact (NF)" => "Jo Soap",
       "Implementing organisation name" => existing_activity.implementing_organisations.first.name,
       "Implementing organisation reference" => existing_activity.implementing_organisations.first.reference,
       "Implementing organisation sector" => existing_activity.implementing_organisations.first.organisation_type,
@@ -167,6 +168,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
       expect(existing_activity.beis_id).to eq(existing_activity_attributes["BEIS ID"])
+      expect(existing_activity.uk_dp_named_contact).to eq(existing_activity_attributes["UK DP Named Contact (NF)"])
 
       expect(existing_activity.implementing_organisations.count).to eql(1)
       expect(existing_activity.implementing_organisations.first.name).to eq(existing_activity_attributes["Implementing organisation name"])
@@ -281,6 +283,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.fstc_applies).to eq(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
       expect(new_activity.beis_id).to eq(new_activity_attributes["BEIS ID"])
+      expect(new_activity.uk_dp_named_contact).to eq(new_activity_attributes["UK DP Named Contact (NF)"])
     end
 
     it "creates the associated implementing organisations" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
       "Aims/Objectives (DP Definition)" => "Foo bar baz",
+      "BEIS ID" => "BEIS_ID_EXAMPLE_01",
       "Implementing organisation name" => existing_activity.implementing_organisations.first.name,
       "Implementing organisation reference" => existing_activity.implementing_organisations.first.reference,
       "Implementing organisation sector" => existing_activity.implementing_organisations.first.organisation_type,
@@ -165,6 +166,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
+      expect(existing_activity.beis_id).to eq(existing_activity_attributes["BEIS ID"])
 
       expect(existing_activity.implementing_organisations.count).to eql(1)
       expect(existing_activity.implementing_organisations.first.name).to eq(existing_activity_attributes["Implementing organisation name"])
@@ -278,6 +280,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
       expect(new_activity.fstc_applies).to eq(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
+      expect(new_activity.beis_id).to eq(new_activity_attributes["BEIS ID"])
     end
 
     it "creates the associated implementing organisations" do


### PR DESCRIPTION
Adds the following fields that were missing from the activity importer:

- BEIS ID (`beis_id`)
- UK DP Named Contact (NF) (`uk_dp_named_contact`)
- NF Partner Country DP (`country_delivery_partners`)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
