### PR TITLE
(1305) Change Programme Status field to an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,6 +418,7 @@
 - Add "UK DP Named Contact (NF)" (uk_dp_named_contact) to the importer
 - Add "NF Partner Country DP" (country_delivery_partners) to the importer
 - Add link to the support site in the footer
+- Change programme status field to an enum
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...HEAD
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -3,7 +3,7 @@ class Staff::ActivityFormsController < Staff::BaseController
   include DateHelper
   include ActivityHelper
 
-  DEFAULT_PROGRAMME_STATUS_FOR_FUNDS = "07"
+  DEFAULT_PROGRAMME_STATUS_FOR_FUNDS = "spend_in_progress"
 
   FORM_STEPS = [
     :blank,

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -143,6 +143,15 @@ module CodelistHelper
     filtered_list.unshift(not_assessed_option)
   end
 
+  def programme_status_radio_options
+    yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/BEIS/programme_status.yml"))
+
+    Activity.programme_statuses.map do |name, code|
+      status = yaml["data"].find { |d| d["code"] == code }
+      OpenStruct.new(value: name, label: status["name"], description: status["description"])
+    end
+  end
+
   def covid19_related_radio_options
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/BEIS/covid19_related_research.yml"))
     yaml["data"].collect { |item|

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -128,6 +128,21 @@ class Activity < ApplicationRecord
     recipient_country: "Recipient country",
   }
 
+  enum programme_status: {
+    delivery: 1,
+    planned: 2,
+    agreement_in_place: 3,
+    open_for_applications: 4,
+    review: 5,
+    decided: 6,
+    spend_in_progress: 7,
+    finalisation: 8,
+    completed: 9,
+    stopped: 10,
+    cancelled: 11,
+    paused: 12,
+  }
+
   enum policy_marker_gender: POLICY_MARKER_CODES, _prefix: :gender
 
   enum policy_marker_climate_change_adaptation: POLICY_MARKER_CODES, _prefix: :climate_change_adaptation

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -15,7 +15,7 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def covid19_related
-    I18n.t("covid19_related.#{super}")
+    I18n.t("activity.covid19_related.#{super}")
   end
 
   def sector

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -393,11 +393,11 @@ module Activities
       end
 
       def convert_programme_status(programme_status)
-        validate_from_codelist(
-          programme_status,
-          :programme_status,
-          I18n.t("importer.errors.activity.invalid_programme_status"),
-        )
+        status = Activity.programme_statuses.key(programme_status.to_i)
+
+        raise I18n.t("importer.errors.activity.invalid_programme_status") if status.nil?
+
+        status
       end
 
       def convert_sector(sector)

--- a/app/services/programme_to_iati_status.rb
+++ b/app/services/programme_to_iati_status.rb
@@ -1,17 +1,17 @@
 class ProgrammeToIatiStatus
   STATUS_MAPPING = {
-    "01" => "2",
-    "02" => "1",
-    "03" => "1",
-    "04" => "1",
-    "05" => "1",
-    "06" => "1",
-    "07" => "2",
-    "08" => "3",
-    "09" => "4",
-    "10" => "5",
-    "11" => "5",
-    "12" => "6",
+    "delivery" => "2",
+    "planned" => "1",
+    "agreement_in_place" => "1",
+    "open_for_applications" => "1",
+    "review" => "1",
+    "decided" => "1",
+    "spend_in_progress" => "2",
+    "finalisation" => "3",
+    "completed" => "4",
+    "stopped" => "5",
+    "cancelled" => "5",
+    "paused" => "6",
   }.freeze
 
   def programme_status_to_iati_status(programme_status)

--- a/app/views/staff/activity_forms/programme_status.html.haml
+++ b/app/views/staff/activity_forms/programme_status.html.haml
@@ -1,8 +1,8 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :programme_status, value: nil
   = f.govuk_collection_radio_buttons :programme_status,
-    yaml_to_objects_with_description(entity: "activity", type: "programme_status"),
-    :code,
-    :name,
+    programme_status_radio_options,
+    :value,
+    :label,
     :description,
     legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.programme_status", level: t("page_content.activity.level.#{f.object.level}")) }

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -18,33 +18,33 @@ en:
       h01: Development awareness
       h02: Refugees in donor countries
     call_present:
-      'true': 'Yes'
-      'false': 'No'
+      "true": "Yes"
+      "false": "No"
     collaboration_type:
-      '1': Bilateral
-      '2': Multilateral (inflows)
-      '3': Bilateral, core contributions to NGOs and other private bodies / PPPs
-      '4': Multilateral outflows
-      '6': Private Sector Outflows
-      '7': Bilateral, ex-post reporting on NGOs’ activities funded through core contributions
-      '8': Bilateral, triangular co-operation
+      "1": Bilateral
+      "2": Multilateral (inflows)
+      "3": Bilateral, core contributions to NGOs and other private bodies / PPPs
+      "4": Multilateral outflows
+      "6": Private Sector Outflows
+      "7": Bilateral, ex-post reporting on NGOs’ activities funded through core contributions
+      "8": Bilateral, triangular co-operation
     flow:
-      '10': ODA
-      '20': OOF
-      '21': Non-export credit OOF
-      '22': Officially supported export credits
-      '30': Private grants
-      '35': Private market
-      '36': Private Foreign Direct Investment
-      '37': Other Private flows at market terms
-      '40': Non flow
-      '50': Other flows
+      "10": ODA
+      "20": OOF
+      "21": Non-export credit OOF
+      "22": Officially supported export credits
+      "30": Private grants
+      "35": Private market
+      "36": Private Foreign Direct Investment
+      "37": Other Private flows at market terms
+      "40": Non flow
+      "50": Other flows
     gdi:
-      '1': Yes - China
-      '2': Yes - India
-      '3': Yes - China and India
-      '4': GDI not applicable
-      '5': No - This activity benefits China or India but GDI does not apply
+      "1": Yes - China
+      "2": Yes - India
+      "3": Yes - China and India
+      "4": GDI not applicable
+      "5": No - This activity benefits China or India but GDI does not apply
     geography:
       recipient_country: Country
       recipient_region: Region
@@ -216,7 +216,7 @@ en:
       NG: Nigeria
       NI: Nicaragua
       NL: Netherlands (the)
-      'NO': Norway
+      "NO": Norway
       NP: Nepal
       NR: Nauru
       NU: Niue
@@ -301,32 +301,32 @@ en:
       ZM: Zambia
       ZW: Zimbabwe
     recipient_region:
-      '88': States Ex-Yugoslavia unspecified
-      '89': Europe, regional
-      '189': North of Sahara, regional
-      '289': South of Sahara, regional
-      '298': Africa, regional
-      '380': West Indies, regional
-      '389': North & Central America, regional
-      '489': South America, regional
-      '498': America, regional
-      '589': Middle East, regional
-      '619': Central Asia, regional
-      '679': South Asia, regional
-      '689': South & Central Asia, regional
-      '789': Far East Asia, regional
-      '798': Asia, regional
-      '889': Oceania, regional
-      '998': Developing countries, unspecified
-      '1027': Eastern Africa, regional
-      '1028': Middle Africa, regional
-      '1029': Southern Africa, regional
-      '1030': Western Africa, regional
-      '1031': Caribbean, regional
-      '1032': Central America, regional
-      '1033': Melanesia, regional
-      '1034': Micronesia, regional
-      '1035': Polynesia, regional
+      "88": States Ex-Yugoslavia unspecified
+      "89": Europe, regional
+      "189": North of Sahara, regional
+      "289": South of Sahara, regional
+      "298": Africa, regional
+      "380": West Indies, regional
+      "389": North & Central America, regional
+      "489": South America, regional
+      "498": America, regional
+      "589": Middle East, regional
+      "619": Central Asia, regional
+      "679": South Asia, regional
+      "689": South & Central Asia, regional
+      "789": Far East Asia, regional
+      "798": Asia, regional
+      "889": Oceania, regional
+      "998": Developing countries, unspecified
+      "1027": Eastern Africa, regional
+      "1028": Middle Africa, regional
+      "1029": Southern Africa, regional
+      "1030": Western Africa, regional
+      "1031": Caribbean, regional
+      "1032": Central America, regional
+      "1033": Melanesia, regional
+      "1034": Micronesia, regional
+      "1035": Polynesia, regional
     policy_markers:
       not_targeted: Not targeted
       significant_objective: Significant objective
@@ -334,393 +334,380 @@ en:
       principal_objective_and_in_support: Principal objective AND in support of an action programme
       not_assessed: Not assessed
     sector:
-      '11110': Education policy and administrative management
-      '11120': Education facilities and training
-      '11130': Teacher training
-      '11182': Educational research
-      '11220': Primary education
-      '11230': Basic life skills for youth and adults
-      '11231': Basic life skills for youth
-      '11232': Primary education equivalent for adults
-      '11240': Early childhood education
-      '11250': School feeding
-      '11320': Secondary education
-      '11321': Lower secondary education
-      '11322': Upper secondary education
-      '11330': Vocational training
-      '11420': Higher education
-      '11430': Advanced technical and managerial training
-      '12110': Health policy and administrative management
-      '12181': Medical education/training
-      '12182': Medical research
-      '12191': Medical services
-      '12220': Basic health care
-      '12230': Basic health infrastructure
-      '12240': Basic nutrition
-      '12250': Infectious disease control
-      '12261': Health education
-      '12262': Malaria control
-      '12263': Tuberculosis control
-      '12281': Health personnel development
-      '12310': NCDs control, general
-      '12320': Tobacco use control
-      '12330': Control of harmful use of alcohol and drugs
-      '12340': Promotion of mental health and well-being
-      '12350': Other prevention and treatment of NCDs
-      '12382': Research for prevention and control of NCDs
-      '13010': Population policy and administrative management
-      '13020': Reproductive health care
-      '13030': Family planning
-      '13040': STD control including HIV/AIDS
-      '13081': Personnel development for population and reproductive health
-      '14010': Water sector policy and administrative management
-      '14015': Water resources conservation (including data collection)
-      '14020': Water supply and sanitation - large systems
-      '14021': Water supply - large systems
-      '14022': Sanitation - large systems
-      '14030': Basic drinking water supply and basic sanitation
-      '14031': Basic drinking water supply
-      '14032': Basic sanitation
-      '14040': River basins development
-      '14050': Waste management/disposal
-      '14081': Education and training in water supply and sanitation
-      '15110': Public sector policy and administrative management
-      '15111': Public finance management (PFM)
-      '15112': Decentralisation and support to subnational government
-      '15113': Anti-corruption organisations and institutions
-      '15114': Domestic revenue mobilisation
-      '15116': Tax collection
-      '15117': Budget planning
-      '15118': National audit
-      '15119': Debt and aid management
-      '15120': Public sector financial management
-      '15121': Foreign affairs
-      '15122': Diplomatic missions
-      '15123': Administration of developing countries' foreign aid
-      '15124': General personnel services
-      '15125': Public Procurement
-      '15126': Other general public services
-      '15127': National monitoring and evaluation
-      '15128': Local government finance
-      '15129': Other central transfers to institutions
-      '15130': Legal and judicial development
-      '15131': Justice, law and order policy, planning and administration
-      '15132': Police
-      '15133': Fire and rescue services
-      '15134': Judicial affairs
-      '15135': Ombudsman
-      '15136': Immigration
-      '15137': Prisons
-      '15140': Government administration
-      '15142': Macroeconomic policy
-      '15143': Meteorological services
-      '15144': National standards development
-      '15150': Democratic participation and civil society
-      '15151': Elections
-      '15152': Legislatures and political parties
-      '15153': Media and free flow of information
-      '15154': Executive office
-      '15155': Tax policy and administration support
-      '15156': Other non-tax revenue mobilisation
-      '15160': Human rights
-      '15161': Elections
-      '15162': Human rights
-      '15163': Free flow of information
-      '15164': Women's equality organisations and institutions
-      '15170': Women's equality organisations and institutions
-      '15180': Ending violence against women and girls
-      '15185': Local government administration
-      '15190': Facilitation of orderly, safe, regular and responsible migration and mobility
-      '15210': Security system management and reform
-      '15220': Civilian peace-building, conflict prevention and resolution
-      '15230': Participation in international peacekeeping operations
-      '15240': Reintegration and SALW control
-      '15250': Removal of land mines and explosive remnants of war
-      '15261': Child soldiers (prevention and demobilisation)
-      '16010': Social Protection
-      '16011': Social protection and welfare services policy, planning and administration
-      '16012': Social security (excl pensions)
-      '16013': General pensions
-      '16014': Civil service pensions
-      '16015': Social services (incl youth development and women+ children)
-      '16020': Employment creation
-      '16030': Housing policy and administrative management
-      '16040': Low-cost housing
-      '16050': Multisector aid for basic social services
-      '16061': Culture and recreation
-      '16062': Statistical capacity building
-      '16063': Narcotics control
-      '16064': Social mitigation of HIV/AIDS
-      '16065': Recreation and sport
-      '16066': Culture
-      '16070': Labour Rights
-      '16080': Social Dialogue
-      '21010': Transport policy and administrative management
-      '21011': Transport policy, planning and administration
-      '21012': Public transport services
-      '21013': Transport regulation
-      '21020': Road transport
-      '21021': Feeder road construction
-      '21022': Feeder road maintenance
-      '21023': National road construction
-      '21024': National road maintenance
-      '21030': Rail transport
-      '21040': Water transport
-      '21050': Air transport
-      '21061': Storage
-      '21081': Education and training in transport and storage
-      '22010': Communications policy and administrative management
-      '22011': Communications policy, planning and administration
-      '22012': Postal services
-      '22013': Information services
-      '22020': Telecommunications
-      '22030': Radio/television/print media
-      '22040': Information and communication technology (ICT)
-      '23010': Energy policy and administrative management
-      '23020': Power generation/non-renewable sources
-      '23030': Power generation/renewable sources
-      '23040': Electrical transmission/ distribution
-      '23050': Gas distribution
-      '23061': Oil-fired power plants
-      '23062': Gas-fired power plants
-      '23063': Coal-fired power plants
-      '23064': Nuclear power plants
-      '23065': Hydro-electric power plants
-      '23066': Geothermal energy
-      '23067': Solar energy
-      '23068': Wind power
-      '23069': Ocean power
-      '23070': Biomass
-      '23081': Energy education/training
-      '23082': Energy research
-      '23110': Energy policy and administrative management
-      '23111': Energy sector policy, planning and administration
-      '23112': Energy regulation
-      '23181': Energy education/training
-      '23182': Energy research
-      '23183': Energy conservation and demand-side efficiency
-      '23210': Energy generation, renewable sources - multiple technologies
-      '23220': Hydro-electric power plants
-      '23230': Solar energy
-      '23240': Wind energy
-      '23250': Marine energy
-      '23260': Geothermal energy
-      '23270': Biofuel-fired power plants
-      '23310': Energy generation, non-renewable sources, unspecified
-      '23320': Coal-fired electric power plants
-      '23330': Oil-fired electric power plants
-      '23340': Natural gas-fired electric power plants
-      '23350': Fossil fuel electric power plants with carbon capture and storage (CCS)
-      '23360': Non-renewable waste-fired electric power plants
-      '23410': Hybrid energy electric power plants
-      '23510': Nuclear energy electric power plants
-      '23610': Heat plants
-      '23620': District heating and cooling
-      '23630': Electric power transmission and distribution
-      '23640': Gas distribution
-      '24010': Financial policy and administrative management
-      '24020': Monetary institutions
-      '24030': Formal sector financial intermediaries
-      '24040': Informal/semi-formal financial intermediaries
-      '24050': Remittance facilitation, promotion and optimisation
-      '24081': Education/training in banking and financial services
-      '25010': Business Policy and Administration
-      '25020': Privatisation
-      '25030': Business development services
-      '25040': Responsible Business Conduct
-      '31110': Agricultural policy and administrative management
-      '31120': Agricultural development
-      '31130': Agricultural land resources
-      '31140': Agricultural water resources
-      '31150': Agricultural inputs
-      '31161': Food crop production
-      '31162': Industrial crops/export crops
-      '31163': Livestock
-      '31164': Agrarian reform
-      '31165': Agricultural alternative development
-      '31166': Agricultural extension
-      '31181': Agricultural education/training
-      '31182': Agricultural research
-      '31191': Agricultural services
-      '31192': Plant and post-harvest protection and pest control
-      '31193': Agricultural financial services
-      '31194': Agricultural co-operatives
-      '31195': Livestock/veterinary services
-      '31210': Forestry policy and administrative management
-      '31220': Forestry development
-      '31261': Fuelwood/charcoal
-      '31281': Forestry education/training
-      '31282': Forestry research
-      '31291': Forestry services
-      '31310': Fishing policy and administrative management
-      '31320': Fishery development
-      '31381': Fishery education/training
-      '31382': Fishery research
-      '31391': Fishery services
-      '32110': Industrial policy and administrative management
-      '32120': Industrial development
-      '32130': Small and medium-sized enterprises (SME) development
-      '32140': Cottage industries and handicraft
-      '32161': Agro-industries
-      '32162': Forest industries
-      '32163': Textiles, leather and substitutes
-      '32164': Chemicals
-      '32165': Fertilizer plants
-      '32166': Cement/lime/plaster
-      '32167': Energy manufacturing
-      '32168': Pharmaceutical production
-      '32169': Basic metal industries
-      '32170': Non-ferrous metal industries
-      '32171': Engineering
-      '32172': Transport equipment industry
-      '32182': Technological research and development
-      '32210': Mineral/mining policy and administrative management
-      '32220': Mineral prospection and exploration
-      '32261': Coal
-      '32262': Oil and gas
-      '32263': Ferrous metals
-      '32264': Nonferrous metals
-      '32265': Precious metals/materials
-      '32266': Industrial minerals
-      '32267': Fertilizer minerals
-      '32268': Offshore minerals
-      '32310': Construction policy and administrative management
-      '33110': Trade policy and administrative management
-      '33120': Trade facilitation
-      '33130': Regional trade agreements (RTAs)
-      '33140': Multilateral trade negotiations
-      '33150': Trade-related adjustment
-      '33181': Trade education/training
-      '33210': Tourism policy and administrative management
-      '41010': Environmental policy and administrative management
-      '41020': Biosphere protection
-      '41030': Bio-diversity
-      '41040': Site preservation
-      '41050': Flood prevention/control
-      '41081': Environmental education/training
-      '41082': Environmental research
-      '43010': Multisector aid
-      '43030': Urban development and management
-      '43031': Urban land policy and management
-      '43032': Urban development
-      '43040': Rural development
-      '43041': Rural land policy and management
-      '43042': Rural development
-      '43050': Non-agricultural alternative development
-      '43060': Disaster Risk Reduction
-      '43071': Food security policy and administrative management
-      '43072': Household food security programmes
-      '43073': Food safety and quality
-      '43081': Multisector education/training
-      '43082': Research/scientific institutions
-      '51010': General budget support-related aid
-      '52010': Food assistance
-      '53030': Import support (capital goods)
-      '53040': Import support (commodities)
-      '60010': Action relating to debt
-      '60020': Debt forgiveness
-      '60030': Relief of multilateral debt
-      '60040': Rescheduling and refinancing
-      '60061': Debt for development swap
-      '60062': Other debt swap
-      '60063': Debt buy-back
-      '72010': Material relief assistance and services
-      '72040': Emergency food assistance
-      '72050': Relief co-ordination and support services
-      '73010': Immediate post-emergency reconstruction and rehabilitation
-      '74010': Disaster prevention and preparedness
-      '74020': Multi-hazard response preparedness
-      '91010': Administrative costs (non-sector allocable)
-      '92010': Support to national NGOs
-      '92020': Support to international NGOs
-      '92030': Support to local and regional NGOs
-      '93010': Refugees/asylum seekers in donor countries (non-sector allocable)
-      '93011': Refugees/asylum seekers in donor countries - food and shelter
-      '93012': Refugees/asylum seekers in donor countries - training
-      '93013': Refugees/asylum seekers in donor countries - health
-      '93014': Refugees/asylum seekers in donor countries - other temporary sustenance
-      '93015': Refugees/asylum seekers in donor countries - voluntary repatriation
-      '93016': Refugees/asylum seekers in donor countries - transport
-      '93017': Refugees/asylum seekers in donor countries - rescue at sea
-      '93018': Refugees/asylum seekers in donor countries - administrative costs
-      '99810': Sectors not specified
-      '99820': Promotion of development awareness (non-sector allocable)
+      "11110": Education policy and administrative management
+      "11120": Education facilities and training
+      "11130": Teacher training
+      "11182": Educational research
+      "11220": Primary education
+      "11230": Basic life skills for youth and adults
+      "11231": Basic life skills for youth
+      "11232": Primary education equivalent for adults
+      "11240": Early childhood education
+      "11250": School feeding
+      "11320": Secondary education
+      "11321": Lower secondary education
+      "11322": Upper secondary education
+      "11330": Vocational training
+      "11420": Higher education
+      "11430": Advanced technical and managerial training
+      "12110": Health policy and administrative management
+      "12181": Medical education/training
+      "12182": Medical research
+      "12191": Medical services
+      "12220": Basic health care
+      "12230": Basic health infrastructure
+      "12240": Basic nutrition
+      "12250": Infectious disease control
+      "12261": Health education
+      "12262": Malaria control
+      "12263": Tuberculosis control
+      "12281": Health personnel development
+      "12310": NCDs control, general
+      "12320": Tobacco use control
+      "12330": Control of harmful use of alcohol and drugs
+      "12340": Promotion of mental health and well-being
+      "12350": Other prevention and treatment of NCDs
+      "12382": Research for prevention and control of NCDs
+      "13010": Population policy and administrative management
+      "13020": Reproductive health care
+      "13030": Family planning
+      "13040": STD control including HIV/AIDS
+      "13081": Personnel development for population and reproductive health
+      "14010": Water sector policy and administrative management
+      "14015": Water resources conservation (including data collection)
+      "14020": Water supply and sanitation - large systems
+      "14021": Water supply - large systems
+      "14022": Sanitation - large systems
+      "14030": Basic drinking water supply and basic sanitation
+      "14031": Basic drinking water supply
+      "14032": Basic sanitation
+      "14040": River basins development
+      "14050": Waste management/disposal
+      "14081": Education and training in water supply and sanitation
+      "15110": Public sector policy and administrative management
+      "15111": Public finance management (PFM)
+      "15112": Decentralisation and support to subnational government
+      "15113": Anti-corruption organisations and institutions
+      "15114": Domestic revenue mobilisation
+      "15116": Tax collection
+      "15117": Budget planning
+      "15118": National audit
+      "15119": Debt and aid management
+      "15120": Public sector financial management
+      "15121": Foreign affairs
+      "15122": Diplomatic missions
+      "15123": Administration of developing countries' foreign aid
+      "15124": General personnel services
+      "15125": Public Procurement
+      "15126": Other general public services
+      "15127": National monitoring and evaluation
+      "15128": Local government finance
+      "15129": Other central transfers to institutions
+      "15130": Legal and judicial development
+      "15131": Justice, law and order policy, planning and administration
+      "15132": Police
+      "15133": Fire and rescue services
+      "15134": Judicial affairs
+      "15135": Ombudsman
+      "15136": Immigration
+      "15137": Prisons
+      "15140": Government administration
+      "15142": Macroeconomic policy
+      "15143": Meteorological services
+      "15144": National standards development
+      "15150": Democratic participation and civil society
+      "15151": Elections
+      "15152": Legislatures and political parties
+      "15153": Media and free flow of information
+      "15154": Executive office
+      "15155": Tax policy and administration support
+      "15156": Other non-tax revenue mobilisation
+      "15160": Human rights
+      "15161": Elections
+      "15162": Human rights
+      "15163": Free flow of information
+      "15164": Women's equality organisations and institutions
+      "15170": Women's equality organisations and institutions
+      "15180": Ending violence against women and girls
+      "15185": Local government administration
+      "15190": Facilitation of orderly, safe, regular and responsible migration and mobility
+      "15210": Security system management and reform
+      "15220": Civilian peace-building, conflict prevention and resolution
+      "15230": Participation in international peacekeeping operations
+      "15240": Reintegration and SALW control
+      "15250": Removal of land mines and explosive remnants of war
+      "15261": Child soldiers (prevention and demobilisation)
+      "16010": Social Protection
+      "16011": Social protection and welfare services policy, planning and administration
+      "16012": Social security (excl pensions)
+      "16013": General pensions
+      "16014": Civil service pensions
+      "16015": Social services (incl youth development and women+ children)
+      "16020": Employment creation
+      "16030": Housing policy and administrative management
+      "16040": Low-cost housing
+      "16050": Multisector aid for basic social services
+      "16061": Culture and recreation
+      "16062": Statistical capacity building
+      "16063": Narcotics control
+      "16064": Social mitigation of HIV/AIDS
+      "16065": Recreation and sport
+      "16066": Culture
+      "16070": Labour Rights
+      "16080": Social Dialogue
+      "21010": Transport policy and administrative management
+      "21011": Transport policy, planning and administration
+      "21012": Public transport services
+      "21013": Transport regulation
+      "21020": Road transport
+      "21021": Feeder road construction
+      "21022": Feeder road maintenance
+      "21023": National road construction
+      "21024": National road maintenance
+      "21030": Rail transport
+      "21040": Water transport
+      "21050": Air transport
+      "21061": Storage
+      "21081": Education and training in transport and storage
+      "22010": Communications policy and administrative management
+      "22011": Communications policy, planning and administration
+      "22012": Postal services
+      "22013": Information services
+      "22020": Telecommunications
+      "22030": Radio/television/print media
+      "22040": Information and communication technology (ICT)
+      "23010": Energy policy and administrative management
+      "23020": Power generation/non-renewable sources
+      "23030": Power generation/renewable sources
+      "23040": Electrical transmission/ distribution
+      "23050": Gas distribution
+      "23061": Oil-fired power plants
+      "23062": Gas-fired power plants
+      "23063": Coal-fired power plants
+      "23064": Nuclear power plants
+      "23065": Hydro-electric power plants
+      "23066": Geothermal energy
+      "23067": Solar energy
+      "23068": Wind power
+      "23069": Ocean power
+      "23070": Biomass
+      "23081": Energy education/training
+      "23082": Energy research
+      "23110": Energy policy and administrative management
+      "23111": Energy sector policy, planning and administration
+      "23112": Energy regulation
+      "23181": Energy education/training
+      "23182": Energy research
+      "23183": Energy conservation and demand-side efficiency
+      "23210": Energy generation, renewable sources - multiple technologies
+      "23220": Hydro-electric power plants
+      "23230": Solar energy
+      "23240": Wind energy
+      "23250": Marine energy
+      "23260": Geothermal energy
+      "23270": Biofuel-fired power plants
+      "23310": Energy generation, non-renewable sources, unspecified
+      "23320": Coal-fired electric power plants
+      "23330": Oil-fired electric power plants
+      "23340": Natural gas-fired electric power plants
+      "23350": Fossil fuel electric power plants with carbon capture and storage (CCS)
+      "23360": Non-renewable waste-fired electric power plants
+      "23410": Hybrid energy electric power plants
+      "23510": Nuclear energy electric power plants
+      "23610": Heat plants
+      "23620": District heating and cooling
+      "23630": Electric power transmission and distribution
+      "23640": Gas distribution
+      "24010": Financial policy and administrative management
+      "24020": Monetary institutions
+      "24030": Formal sector financial intermediaries
+      "24040": Informal/semi-formal financial intermediaries
+      "24050": Remittance facilitation, promotion and optimisation
+      "24081": Education/training in banking and financial services
+      "25010": Business Policy and Administration
+      "25020": Privatisation
+      "25030": Business development services
+      "25040": Responsible Business Conduct
+      "31110": Agricultural policy and administrative management
+      "31120": Agricultural development
+      "31130": Agricultural land resources
+      "31140": Agricultural water resources
+      "31150": Agricultural inputs
+      "31161": Food crop production
+      "31162": Industrial crops/export crops
+      "31163": Livestock
+      "31164": Agrarian reform
+      "31165": Agricultural alternative development
+      "31166": Agricultural extension
+      "31181": Agricultural education/training
+      "31182": Agricultural research
+      "31191": Agricultural services
+      "31192": Plant and post-harvest protection and pest control
+      "31193": Agricultural financial services
+      "31194": Agricultural co-operatives
+      "31195": Livestock/veterinary services
+      "31210": Forestry policy and administrative management
+      "31220": Forestry development
+      "31261": Fuelwood/charcoal
+      "31281": Forestry education/training
+      "31282": Forestry research
+      "31291": Forestry services
+      "31310": Fishing policy and administrative management
+      "31320": Fishery development
+      "31381": Fishery education/training
+      "31382": Fishery research
+      "31391": Fishery services
+      "32110": Industrial policy and administrative management
+      "32120": Industrial development
+      "32130": Small and medium-sized enterprises (SME) development
+      "32140": Cottage industries and handicraft
+      "32161": Agro-industries
+      "32162": Forest industries
+      "32163": Textiles, leather and substitutes
+      "32164": Chemicals
+      "32165": Fertilizer plants
+      "32166": Cement/lime/plaster
+      "32167": Energy manufacturing
+      "32168": Pharmaceutical production
+      "32169": Basic metal industries
+      "32170": Non-ferrous metal industries
+      "32171": Engineering
+      "32172": Transport equipment industry
+      "32182": Technological research and development
+      "32210": Mineral/mining policy and administrative management
+      "32220": Mineral prospection and exploration
+      "32261": Coal
+      "32262": Oil and gas
+      "32263": Ferrous metals
+      "32264": Nonferrous metals
+      "32265": Precious metals/materials
+      "32266": Industrial minerals
+      "32267": Fertilizer minerals
+      "32268": Offshore minerals
+      "32310": Construction policy and administrative management
+      "33110": Trade policy and administrative management
+      "33120": Trade facilitation
+      "33130": Regional trade agreements (RTAs)
+      "33140": Multilateral trade negotiations
+      "33150": Trade-related adjustment
+      "33181": Trade education/training
+      "33210": Tourism policy and administrative management
+      "41010": Environmental policy and administrative management
+      "41020": Biosphere protection
+      "41030": Bio-diversity
+      "41040": Site preservation
+      "41050": Flood prevention/control
+      "41081": Environmental education/training
+      "41082": Environmental research
+      "43010": Multisector aid
+      "43030": Urban development and management
+      "43031": Urban land policy and management
+      "43032": Urban development
+      "43040": Rural development
+      "43041": Rural land policy and management
+      "43042": Rural development
+      "43050": Non-agricultural alternative development
+      "43060": Disaster Risk Reduction
+      "43071": Food security policy and administrative management
+      "43072": Household food security programmes
+      "43073": Food safety and quality
+      "43081": Multisector education/training
+      "43082": Research/scientific institutions
+      "51010": General budget support-related aid
+      "52010": Food assistance
+      "53030": Import support (capital goods)
+      "53040": Import support (commodities)
+      "60010": Action relating to debt
+      "60020": Debt forgiveness
+      "60030": Relief of multilateral debt
+      "60040": Rescheduling and refinancing
+      "60061": Debt for development swap
+      "60062": Other debt swap
+      "60063": Debt buy-back
+      "72010": Material relief assistance and services
+      "72040": Emergency food assistance
+      "72050": Relief co-ordination and support services
+      "73010": Immediate post-emergency reconstruction and rehabilitation
+      "74010": Disaster prevention and preparedness
+      "74020": Multi-hazard response preparedness
+      "91010": Administrative costs (non-sector allocable)
+      "92010": Support to national NGOs
+      "92020": Support to international NGOs
+      "92030": Support to local and regional NGOs
+      "93010": Refugees/asylum seekers in donor countries (non-sector allocable)
+      "93011": Refugees/asylum seekers in donor countries - food and shelter
+      "93012": Refugees/asylum seekers in donor countries - training
+      "93013": Refugees/asylum seekers in donor countries - health
+      "93014": Refugees/asylum seekers in donor countries - other temporary sustenance
+      "93015": Refugees/asylum seekers in donor countries - voluntary repatriation
+      "93016": Refugees/asylum seekers in donor countries - transport
+      "93017": Refugees/asylum seekers in donor countries - rescue at sea
+      "93018": Refugees/asylum seekers in donor countries - administrative costs
+      "99810": Sectors not specified
+      "99820": Promotion of development awareness (non-sector allocable)
     sector_category:
-      '111': Education, Level Unspecified
-      '112': Basic Education
-      '113': Secondary Education
-      '114': Post-Secondary Education
-      '121': Health, General
-      '122': Basic Health
-      '123': Non-communicable diseases (NCDs)
-      '130': Population Policies/Programmes & Reproductive Health
-      '140': Water Supply & Sanitation
-      '151': Government & Civil Society-general
-      '152': Conflict, Peace & Security
-      '160': Other Social Infrastructure & Services
-      '210': Transport & Storage
-      '220': Communications
-      '230': ENERGY GENERATION AND SUPPLY
-      '231': Energy Policy
-      '232': Energy generation, renewable sources
-      '233': Energy generation, non-renewable sources
-      '234': Hybrid energy plants
-      '235': Nuclear energy plants
-      '236': Energy distribution
-      '240': Banking & Financial Services
-      '250': Business & Other Services
-      '311': Agriculture
-      '312': Forestry
-      '313': Fishing
-      '321': Industry
-      '322': Mineral Resources & Mining
-      '323': Construction
-      '331': Trade Policies & Regulations
-      '332': Tourism
-      '410': General Environment Protection
-      '430': Other Multisector
-      '510': General Budget Support
-      '520': Developmental Food Aid/Food Security Assistance
-      '530': Other Commodity Assistance
-      '600': Action Relating to Debt
-      '720': Emergency Response
-      '730': Reconstruction Relief & Rehabilitation
-      '740': Disaster Prevention & Preparedness
-      '910': Administrative Costs of Donors
-      '920': SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
-      '930': Refugees in Donor Countries
-      '998': Unallocated / Unspecified
-    programme_status:
-      '01': Delivery
-      '02': Planned
-      '03': Agreement in place
-      '04': Call/Activity open
-      '05': Review
-      '06': Decided
-      '07': Spend in progress
-      '08': Finalisation
-      '09': Completed
-      '10': Stopped
-      '11': Cancelled
-      '12': Paused
+      "111": Education, Level Unspecified
+      "112": Basic Education
+      "113": Secondary Education
+      "114": Post-Secondary Education
+      "121": Health, General
+      "122": Basic Health
+      "123": Non-communicable diseases (NCDs)
+      "130": Population Policies/Programmes & Reproductive Health
+      "140": Water Supply & Sanitation
+      "151": Government & Civil Society-general
+      "152": Conflict, Peace & Security
+      "160": Other Social Infrastructure & Services
+      "210": Transport & Storage
+      "220": Communications
+      "230": ENERGY GENERATION AND SUPPLY
+      "231": Energy Policy
+      "232": Energy generation, renewable sources
+      "233": Energy generation, non-renewable sources
+      "234": Hybrid energy plants
+      "235": Nuclear energy plants
+      "236": Energy distribution
+      "240": Banking & Financial Services
+      "250": Business & Other Services
+      "311": Agriculture
+      "312": Forestry
+      "313": Fishing
+      "321": Industry
+      "322": Mineral Resources & Mining
+      "323": Construction
+      "331": Trade Policies & Regulations
+      "332": Tourism
+      "410": General Environment Protection
+      "430": Other Multisector
+      "510": General Budget Support
+      "520": Developmental Food Aid/Food Security Assistance
+      "530": Other Commodity Assistance
+      "600": Action Relating to Debt
+      "720": Emergency Response
+      "730": Reconstruction Relief & Rehabilitation
+      "740": Disaster Prevention & Preparedness
+      "910": Administrative Costs of Donors
+      "920": SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
+      "930": Refugees in Donor Countries
+      "998": Unallocated / Unspecified
     requires_additional_benefitting_countries:
-      'true': 'Yes'
-      'false': 'No'
+      "true": "Yes"
+      "false": "No"
     status:
-      '1': Pipeline/identification
-      '2': Implementation
-      '3': Completion
-      '4': Post-completion
-      '5': Cancelled
-      '6': Suspended
+      "1": Pipeline/identification
+      "2": Implementation
+      "3": Completion
+      "4": Post-completion
+      "5": Cancelled
+      "6": Suspended
     oda_eligibility:
       never_eligible: No - was never eligible
       eligible: Eligible
       no_longer_eligible: No longer eligible
     tied_status:
-      '5': Untied
+      "5": Untied
     finance:
-      '110': Standard grant
+      "110": Standard grant
   generic:
     default_currency:
       aed: UAE Dirham
@@ -936,7 +923,7 @@ en:
       et: Estonian
       eu: Basque
       fa: Persian
-      'false': Norwegian
+      "false": Norwegian
       ff: Fulah
       fi: Finnish
       fj: Fijian
@@ -1076,40 +1063,39 @@ en:
       zh: Chinese
       zu: Zulu
     organisation_type:
-      '10': Government
-      '11': Local Government
-      '15': Other Public Sector
-      '21': International NGO
-      '22': National NGO
-      '23': Regional NGO
-      '24': Partner Country based NGO
-      '30': Public Private Partnership
-      '40': Multilateral
-      '60': Foundation
-      '70': Private Sector
-      '71': Private Sector in Provider Country
-      '72': Private Sector in Aid Recipient Country
-      '73': Private Sector in Third Country
-      '80': Academic, Training and Research
-      '90': Other
+      "10": Government
+      "11": Local Government
+      "15": Other Public Sector
+      "21": International NGO
+      "22": National NGO
+      "23": Regional NGO
+      "24": Partner Country based NGO
+      "30": Public Private Partnership
+      "40": Multilateral
+      "60": Foundation
+      "70": Private Sector
+      "71": Private Sector in Provider Country
+      "72": Private Sector in Aid Recipient Country
+      "73": Private Sector in Third Country
+      "80": Academic, Training and Research
+      "90": Other
   transaction:
     disbursement_channel:
-      '1': Money is disbursed through central Ministry of Finance or Treasury
-      '2': Money is disbursed directly to the implementing institution and managed through a separate bank account
-      '3': 'Aid in kind: Donors utilise third party agencies, e.g. NGOs or management companies'
-      '4': 'Aid in kind: Donors manage funds themselves'
+      "1": Money is disbursed through central Ministry of Finance or Treasury
+      "2": Money is disbursed directly to the implementing institution and managed through a separate bank account
+      "3": "Aid in kind: Donors utilise third party agencies, e.g. NGOs or management companies"
+      "4": "Aid in kind: Donors manage funds themselves"
     transaction_type:
-      '1': Incoming Funds
-      '10': Credit Guarantee
-      '11': Incoming Commitment
-      '12': Outgoing Pledge
-      '13': Incoming Pledge
-      '2': Outgoing Commitment
-      '3': Disbursement
-      '4': Expenditure
-      '5': Interest Payment
-      '6': Loan Repayment
-      '7': Reimbursement
-      '8': Purchase of Equity
-      '9': Sale of Equity
-
+      "1": Incoming Funds
+      "10": Credit Guarantee
+      "11": Incoming Commitment
+      "12": Outgoing Pledge
+      "13": Incoming Pledge
+      "2": Outgoing Commitment
+      "3": Disbursement
+      "4": Expenditure
+      "5": Interest Payment
+      "6": Loan Repayment
+      "7": Reimbursement
+      "8": Purchase of Equity
+      "9": Sale of Equity

--- a/config/locales/codelists/BEIS/activity.en.yml
+++ b/config/locales/codelists/BEIS/activity.en.yml
@@ -7,3 +7,16 @@ en:
       "2": Existing activity adapted to fully focus on COVID-19
       "3": New activity that will somewhat focus on COVID-19
       "4": Existing activity adapted to somewhat focus on COVID-19
+    programme_status:
+      delivery: Delivery
+      planned: Planned
+      agreement_in_place: Agreement in place
+      open_for_applications: Call/Activity open
+      review: Review
+      decided: Decided
+      spend_in_progress: Spend in progress
+      finalisation: Finalisation
+      completed: Completed
+      stoped: Stopped
+      cancelled: Cancelled
+      paused: Paused

--- a/config/locales/codelists/BEIS/activity.en.yml
+++ b/config/locales/codelists/BEIS/activity.en.yml
@@ -1,8 +1,9 @@
 ---
 en:
-  covid19_related:
-    "0": Not related
-    "1": New activity full focus on COVID-19
-    "2": Existing activity adapted to fully focus on COVID-19
-    "3": New activity that will somewhat focus on COVID-19
-    "4": Existing activity adapted to somewhat focus on COVID-19
+  activity:
+    covid19_related:
+      "0": Not related
+      "1": New activity full focus on COVID-19
+      "2": Existing activity adapted to fully focus on COVID-19
+      "3": New activity that will somewhat focus on COVID-19
+      "4": Existing activity adapted to somewhat focus on COVID-19

--- a/db/migrate/20201208093803_change_activity_programme_status_to_enum.rb
+++ b/db/migrate/20201208093803_change_activity_programme_status_to_enum.rb
@@ -1,0 +1,27 @@
+class ChangeActivityProgrammeStatusToEnum < ActiveRecord::Migration[6.0]
+  def up
+    add_column :activities, :programme_status_integer, :integer
+
+    Activity.find_each do |activity|
+      programme_status = Integer(activity.programme_status_before_type_cast, exception: false)
+      activity.update_column(:programme_status_integer, programme_status)
+    end
+
+    remove_column :activities, :programme_status, :string
+    rename_column :activities, :programme_status_integer, :programme_status
+  end
+
+  def down
+    add_column :activities, :programme_status_string, :string
+
+    Activity.find_each do |activity|
+      next if activity.programme_status.nil?
+
+      programme_status = "%02d" % activity.programme_status_before_type_cast
+      activity.update_column(:programme_status_string, programme_status)
+    end
+
+    remove_column :activities, :programme_status, :string
+    rename_column :activities, :programme_status_string, :programme_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_114052) do
+ActiveRecord::Schema.define(version: 2020_12_08_093803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 2020_11_30_114052) do
     t.boolean "publish_to_iati", default: true
     t.uuid "parent_id"
     t.string "transparency_identifier"
-    t.string "programme_status"
     t.boolean "call_present"
     t.date "call_open_date"
     t.date "call_close_date"
@@ -85,6 +84,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_114052) do
     t.string "country_delivery_partners", array: true
     t.integer "gcrf_challenge_area"
     t.integer "fund_pillar"
+    t.integer "programme_status"
     t.string "channel_of_delivery_code"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }
-    programme_status { "07" }
+    programme_status { 7 }
     planned_start_date { Date.today }
     planned_end_date { Date.tomorrow }
     actual_start_date { Date.yesterday }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Users can create a fund level activity" do
       click_on(t("page_content.organisation.button.create_activity"))
       fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
       activity = Activity.find_by(delivery_partner_identifier: identifier)
-      expect(activity.programme_status).to eq("07")
+      expect(activity.programme_status).to eq("spend_in_progress")
     end
 
     scenario "the iati status gets set based on the default programme status value" do

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Users can create a programme activity" do
         click_button t("form.button.activity.submit")
         expect(page).to have_content "can't be blank"
 
-        choose("activity[programme_status]", option: "07")
+        choose("activity[programme_status]", option: "spend_in_progress")
         click_button t("form.button.activity.submit")
 
         if parent.roda_identifier_compound.include?("NF")

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -408,19 +408,19 @@ RSpec.feature "Users can edit an activity" do
       let(:activity) { create(:project_activity, organisation: user.organisation) }
 
       it "saves the value and shows an update success message" do
-        activity.update_columns(title: nil, programme_status: "Replace me")
+        activity.update_columns(title: nil, collaboration_type: "Replace me")
         _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
         visit organisation_activity_details_path(activity.organisation, activity)
 
-        within(".programme_status") do
+        within(".collaboration_type") do
           click_on(t("default.link.edit"))
         end
-        choose "Spend in progress"
+        choose "Bilateral"
         click_button t("form.button.activity.submit")
 
         expect(page).to have_content(t("action.project.update.success"))
-        expect(activity.reload.programme_status).to eql("07")
+        expect(activity.reload.collaboration_type).to eql("1")
       end
     end
   end

--- a/spec/lib/programme_to_iati_status_spec.rb
+++ b/spec/lib/programme_to_iati_status_spec.rb
@@ -3,40 +3,40 @@ require "rails_helper"
 RSpec.describe "#programme_status_to_iati_status" do
   context "when the user sets the programme status for an activity" do
     it "sets the correct IATI status automatically" do
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("01")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("delivery")
       expect(status).to eq "2"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("02")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("planned")
       expect(status).to eq "1"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("03")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("agreement_in_place")
       expect(status).to eq "1"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("04")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("open_for_applications")
       expect(status).to eq "1"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("05")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("review")
       expect(status).to eq "1"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("06")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("decided")
       expect(status).to eq "1"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("07")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("spend_in_progress")
       expect(status).to eq "2"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("08")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("finalisation")
       expect(status).to eq "3"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("09")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("completed")
       expect(status).to eq "4"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("10")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("stopped")
       expect(status).to eq "5"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("11")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("cancelled")
       expect(status).to eq "5"
 
-      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("12")
+      status = ProgrammeToIatiStatus.new.programme_status_to_iati_status("paused")
       expect(status).to eq "6"
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe ActivityPresenter do
   describe "#programme_status" do
     context "when the programme status exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, programme_status: "07")
+        activity = build(:activity, programme_status: "spend_in_progress")
         result = described_class.new(activity).programme_status
         expect(result).to eql("Spend in progress")
       end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Activities::ImportFromCsv do
       "ODA Eligibility" => "never_eligible",
       "ODA Eligibility Lead" => "Bruce Wayne",
       "Newton Fund Pillar" => "1",
-      "Activity Status" => "01",
+      "Activity Status" => "1",
       "Call open date" => "02/01/2020",
       "Call close date" => "02/01/2020",
       "Total applications" => "12",
@@ -144,7 +144,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.covid19_related).to eq(0)
       expect(existing_activity.oda_eligibility).to eq("never_eligible")
       expect(existing_activity.oda_eligibility_lead).to eq(existing_activity_attributes["ODA Eligibility Lead"])
-      expect(existing_activity.programme_status).to eq("01")
+      expect(existing_activity.programme_status).to eq("delivery")
       expect(existing_activity.call_open_date).to eq(DateTime.parse(existing_activity_attributes["Call open date"]))
       expect(existing_activity.call_close_date).to eq(DateTime.parse(existing_activity_attributes["Call close date"]))
       expect(existing_activity.planned_start_date).to eq(DateTime.parse(existing_activity_attributes["Planned start date"]))
@@ -267,7 +267,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.covid19_related).to eq(0)
       expect(new_activity.oda_eligibility).to eq("never_eligible")
       expect(new_activity.oda_eligibility_lead).to eq(new_activity_attributes["ODA Eligibility Lead"])
-      expect(new_activity.programme_status).to eq("01")
+      expect(new_activity.programme_status).to eq("delivery")
       expect(new_activity.fund_pillar).to eq(new_activity_attributes["Newton Fund Pillar"].to_i)
       expect(new_activity.call_open_date).to eq(DateTime.parse(new_activity_attributes["Call open date"]))
       expect(new_activity.call_close_date).to eq(DateTime.parse(new_activity_attributes["Call close date"]))

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -17,7 +17,7 @@ module FormHelpers
     call_close_date_year: "2019",
     total_applications: "12",
     total_awards: "5",
-    programme_status: "07",
+    programme_status: "spend_in_progress",
     country_delivery_partners: "National Council for the State Funding Agencies (CONFAP)",
     planned_start_date_day: "1",
     planned_start_date_month: "1",

--- a/vendor/data/codelists/BEIS/programme_status.yml
+++ b/vendor/data/codelists/BEIS/programme_status.yml
@@ -1,46 +1,42 @@
 ---
-attributes:
-  category-codelist:
-  name: ProgrammeStatus
-  complete: '1'
 data:
-  - code: '01'
+  - code: 1
     name: Delivery
     description: Activities related to delivery of ODA activities only
-  - code: '02'
+  - code: 2
     name: Planned
     description: Scoping negotiations and/or workshops have begun but no formal commitment has been made between the UK Delivery Partner. Scoping activity. Financial allocation has been made
-  - code: '03'
+  - code: 3
     name: Agreement in place
     description: A formal agreement to fund the activity has been made, or is at outline stage. For activities in outline stage, please only progress to 'Call/Activity open' if a full call is initiated
-  - code: '04'
+  - code: 4
     name: Call/Activity open
     description: The call/activity is open for applications
-  - code: '05'
+  - code: 5
     name: Review
     description: The application period has ended and the activity is in the peer review stage. The panel meeting has not yet happened
-  - code: '06'
+  - code: 6
     name: Decided
     description: Awards have been made (i.e. panel meeting has occurred) but have not begun
-  - code: '07'
+  - code: 7
     name: Spend in progress
     description: Awards/activity active, contracted and actual spend is occurring
-  - code: '08'
+  - code: 8
     name: Finalisation
     description: Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&E
-  - code: '09'
+  - code: 9
     name: Completed
     description: All awards have completed and there is no more financial spend or forecast spend from UK. Can only be applied after ALL final payments on the activity, including final reconciliation, have been made
-  - code: '10'
+  - code: 10
     name: Stopped
     description: Activity has been cancelled or indefinitely postponed before an activity started
-  - code: '11'
+  - code: 11
     name: Cancelled
     description: Activity has been cancelled or indefinitely postponed after an activity has started
-  - code: '12'
+  - code: 12
     name: Paused
     description: Activity has been temporarily suspended. No spend should take place while this status is in use
 metadata:
-  url: ''
+  url: ""
   name: Programme Status
   description: A description of the status of the activity


### PR DESCRIPTION
This updates the Programme Status field to be an enum, rather than a string. I've also tweaked the codelists to be in the BEIS folders, as these codes are actually BEIS, not IATI.

I've dispensed with my usual mantra of making sure all the tests pass for each commit, as there are quite a few changes here, and I wanted to make sure I explained everything I'd done, instead of lumping everything in as one commit, which would make it tricky to explain everything in a neat and tidy narrative.