### PR TITLE
(1299) Actuals/transactions summary similar to forecast summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,7 @@
 - Add "NF Partner Country DP" (country_delivery_partners) to the importer
 - Add link to the support site in the footer
 - Change programme status field to an enum
+- Simplify actuals/transactions display on an activity's financials page
 
 ## [unreleased]
 

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -23,4 +23,10 @@ class TransactionPresenter < SimpleDelegator
     return if super.blank?
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
+
+  def financial_quarter_and_year
+    return nil if date.blank?
+    financial_year = FinancialPeriod.year_from_date(to_model.date).to_i
+    "Q#{FinancialPeriod.quarter_from_date(to_model.date)} #{financial_year}-#{financial_year + 1}"
+  end
 end

--- a/app/views/staff/shared/transactions/_table.html.haml
+++ b/app/views/staff/shared/transactions/_table.html.haml
@@ -3,17 +3,9 @@
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th.govuk-table__header
-          = t("table.header.transaction.transaction_type")
-        %th.govuk-table__header
-          = t("table.header.transaction.date")
-        %th.govuk-table__header
-          = t("table.header.transaction.currency")
+          = t("table.header.transaction.financial_quarter")
         %th.govuk-table__header
           = t("table.header.transaction.value")
-        %th.govuk-table__header
-          = t("table.header.transaction.disbursement_channel")
-        %th.govuk-table__header
-          = t("table.header.transaction.providing_organisation")
         %th.govuk-table__header
           = t("table.header.transaction.receiving_organisation")
         %th.govuk-table__header
@@ -21,12 +13,8 @@
     %tbody.govuk-table__body
       - transactions.each do |transaction|
         %tr.govuk-table__row{id: transaction.id}
-          %td.govuk-table__cell= transaction.transaction_type
-          %td.govuk-table__cell= transaction.date
-          %td.govuk-table__cell= transaction.currency
+          %td.govuk-table__cell= transaction.financial_quarter_and_year
           %td.govuk-table__cell= transaction.value
-          %td.govuk-table__cell= transaction.disbursement_channel
-          %td.govuk-table__cell= transaction.providing_organisation_name
           %td.govuk-table__cell= transaction.receiving_organisation_name
           %td.govuk-table__cell
             - if policy(transaction).edit?

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -46,12 +46,8 @@ en:
   table:
     header:
       transaction:
-        transaction_type: Type
-        date: Date
-        currency: Currency
+        financial_quarter: Financial quarter
         value: Transaction amount
-        disbursement_channel: Disbursement channel
-        providing_organisation: Provide
         receiving_organisation: Receiver
   page_content:
     transactions:

--- a/spec/features/staff/users_can_view_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_view_planned_disbursements_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Users can view planned disbursements" do
     let(:user) { create(:delivery_partner_user) }
     before { authenticate!(user: user) }
 
-    scenario "they can view planned disburesment on projects" do
+    scenario "they can view planned disbursements on projects" do
       project = create(:project_activity, organisation: user.organisation)
       planned_disbursement = create(:planned_disbursement, parent_activity: project)
 
@@ -28,7 +28,7 @@ RSpec.describe "Users can view planned disbursements" do
     let(:beis_user) { create(:beis_user) }
     before { authenticate!(user: beis_user) }
 
-    scenario "they can view planned disburesment on projects" do
+    scenario "they can view planned disbursements on projects" do
       project = create(:project_activity, organisation: beis_user.organisation)
       planned_disbursement = create(:planned_disbursement, parent_activity: project)
 

--- a/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_transactions_on_an_activity_page_spec.rb
@@ -30,12 +30,8 @@ RSpec.feature "Users can view transactions on an activity page" do
 
         click_link activity.title
 
-        expect(page).to have_content(transaction_presenter.transaction_type)
-        expect(page).to have_content(transaction_presenter.date)
-        expect(page).to have_content(transaction_presenter.currency)
+        expect(page).to have_content(transaction_presenter.financial_quarter_and_year)
         expect(page).to have_content(transaction_presenter.value)
-        expect(page).to have_content(transaction_presenter.disbursement_channel)
-        expect(page).to have_content(transaction_presenter.providing_organisation_name)
         expect(page).to have_content(transaction_presenter.receiving_organisation_name)
       end
 
@@ -70,12 +66,8 @@ RSpec.feature "Users can view transactions on an activity page" do
         click_on t("tabs.activity.children")
         click_link project_activity.title
 
-        expect(page).to have_content(transaction_presenter.transaction_type)
-        expect(page).to have_content(transaction_presenter.date)
-        expect(page).to have_content(transaction_presenter.currency)
+        expect(page).to have_content(transaction_presenter.financial_quarter_and_year)
         expect(page).to have_content(transaction_presenter.value)
-        expect(page).to have_content(transaction_presenter.disbursement_channel)
-        expect(page).to have_content(transaction_presenter.providing_organisation_name)
         expect(page).to have_content(transaction_presenter.receiving_organisation_name)
       end
 

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PlannedDisbursement, type: :model do
     context "when the activity belongs to a delivery partner organisation" do
       before { activity.update(organisation: build_stubbed(:delivery_partner_organisation)) }
 
-      it "should validate the prescence of report" do
+      it "should validate the presence of report" do
         transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
         expect(transaction.valid?).to be false
       end
@@ -21,7 +21,7 @@ RSpec.describe PlannedDisbursement, type: :model do
     context "when the activity belongs to BEIS" do
       before { activity.update(organisation: build_stubbed(:beis_organisation)) }
 
-      it "should not validate the prescence of report" do
+      it "should not validate the presence of report" do
         transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
         expect(transaction.valid?).to be true
       end

--- a/spec/presenters/planned_disbursement_presenter_spec.rb
+++ b/spec/presenters/planned_disbursement_presenter_spec.rb
@@ -8,4 +8,20 @@ RSpec.describe PlannedDisbursementPresenter do
       expect(described_class.new(planned_disbursement).value).to eq("£100,000.00")
     end
   end
+
+  describe "#financial_quarter_and_year" do
+    it "returns the formatted financial quarter and year e.g. Q1 2020-2021" do
+      planned_disbursement = build(:planned_disbursement, financial_quarter: 1, financial_year: 2020)
+      result = described_class.new(planned_disbursement).financial_quarter_and_year
+
+      expect(result).to eql "Q1 2020-2021"
+    end
+
+    it "returns nil when the planned_disbursement has no financial quarter or year" do
+      planned_disbursement = build(:planned_disbursement, financial_quarter: nil, financial_year: nil)
+      result = described_class.new(planned_disbursement).financial_quarter_and_year
+
+      expect(result).to be_nil
+    end
+  end
 end

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -33,4 +33,20 @@ RSpec.describe TransactionPresenter do
       expect(described_class.new(transaction).value).to eq("£110.01")
     end
   end
+
+  describe "#financial_quarter_and_year" do
+    it "returns the formatted financial quarter and year e.g. Q1 2020-2021 for the date" do
+      transaction.date = Date.new(2020, 6, 1)
+      result = described_class.new(transaction).financial_quarter_and_year
+
+      expect(result).to eql "Q1 2020-2021"
+    end
+
+    it "returns nil when the transaction has no date" do
+      transaction.date = nil
+      result = described_class.new(transaction).financial_quarter_and_year
+
+      expect(result).to be_nil
+    end
+  end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -441,16 +441,8 @@ module FormHelpers
 
     if expectations
       within ".transactions" do
-        expect(page).to have_content(transaction_type)
-        expect(page).to have_content localise_date_from_input_fields(
-          year: date_year,
-          month: date_month,
-          day: date_day
-        )
+        expect(page).to have_content financial_quarter_and_year_from_date_input_fields(year: date_year, month: date_month, day: date_day)
         expect(page).to have_content(ActionController::Base.helpers.number_to_currency(value, unit: "£"))
-        expect(page).to have_content(disbursement_channel)
-        expect(page).to have_content(currency)
-        expect(page).to have_content(providing_organisation.name)
         expect(page).to have_content(receiving_organisation.name)
       end
     end
@@ -482,6 +474,11 @@ module FormHelpers
 
   def localise_date_from_input_fields(year:, month:, day:)
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
+  end
+
+  def financial_quarter_and_year_from_date_input_fields(year:, month:, day:)
+    date = Date.parse("#{year}-#{month}-#{day}")
+    TransactionPresenter.new(Transaction.new(date: date)).financial_quarter_and_year
   end
 
   private def activity_level(level)


### PR DESCRIPTION
## Changes in this PR

Display changes to the Financials tab of an activity:
- Remove currency, transaction type, disbursement channel, and providing organisation name from the transactions table
- Replace transaction date with the financial quarter and year computed from the date

Incidental changes:
- Add missing spec for the method that displays the financial quarter and year of forecasts

## Screenshots of UI changes

### Before
![Screenshot 2020-12-08 at 19 39 38](https://user-images.githubusercontent.com/579522/101533612-f6e05100-398d-11eb-8737-3b99f6c13bfa.png)

### After
![Screenshot 2020-12-08 at 19 42 31](https://user-images.githubusercontent.com/579522/101533627-fc3d9b80-398d-11eb-882a-fe4d6bc16057.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
