### PR TITLE
(1305) Fix programme status enum migration

### DIFF
--- a/db/migrate/20201208093803_change_activity_programme_status_to_enum.rb
+++ b/db/migrate/20201208093803_change_activity_programme_status_to_enum.rb
@@ -4,6 +4,8 @@ class ChangeActivityProgrammeStatusToEnum < ActiveRecord::Migration[6.0]
 
     Activity.find_each do |activity|
       programme_status = Integer(activity.programme_status_before_type_cast, exception: false)
+      programme_status = 8 if activity.programme_status_before_type_cast == "08"
+      programme_status = 9 if activity.programme_status_before_type_cast == "09"
       activity.update_column(:programme_status_integer, programme_status)
     end
 


### PR DESCRIPTION
When this migration ran, some of the programme statuses were ending up being `nil` unexpectedly.

This is because calling `Integer` with a zero-prefixed number is treated as octal, so "08" and "09" are invalid, and `exception: false` was causing them to be set to `nil`
