### PR TITLE
Link level C/D forecasts to reports

### DIFF
--- a/db/data/20201209164802_link_project_forecasts_to_reports.rb
+++ b/db/data/20201209164802_link_project_forecasts_to_reports.rb
@@ -1,0 +1,28 @@
+class LinkProjectForecastsToReports < ActiveRecord::Migration[6.0]
+  def up
+    level_c_or_d_forecasts.where(report_id: nil).each do |planned_disbursement|
+      reports = historic_reports_for_activity(planned_disbursement.parent_activity)
+
+      if reports.count == 1
+        pds = PlannedDisbursement.where(id: planned_disbursement.id)
+        pds.update_all(report_id: reports.first.id)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def level_c_or_d_forecasts
+    PlannedDisbursement
+      .joins(:parent_activity)
+      .where(activities: {level: %w[project third_party_project]})
+  end
+
+  def historic_reports_for_activity(activity)
+    Report.for_activity(activity).where(financial_quarter: nil, financial_year: nil)
+  end
+end


### PR DESCRIPTION
In the most recent deployment, part of the logic of the data migration
`20201124145240_link_forecasts_to_reports` failed to run, specifically
this section:

    level_c_or_d_forecasts.where(report_id: nil).each do |planned_disbursement|
      reports = historic_reports_for_activity(planned_disbursement.parent_activity)

      if reports.count == 1
        planned_disbursement.update!(report: reports.first)
      end
    end

The problem with this is the call to `update!` did not work, because
this migration ended up in a deployment where the PlannedDisbursement
model gained a new restriction on updates:

    attr_readonly :report_id

This makes the call to `update!` fail silently: it is not an error to
update a read-only column, the request is simply ignored. The main
instance-level alternative is `update_column`, which raises an exception
on read-only columns.

If we do want to actually update this column, we need to use the
relation-level `update_all` method. So this migration repeats the logic
of the partially-failed migration in a way that bypasses the read-only
restriction on `report_id`.