### PR TITLE
(1300) Simplify transactions form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,7 @@
 - Lock bundler version for Docker to 2.1.4
 - Column order of CSV report file matches data migration template
 - Add missing columns to the CSV report file
+- Add a transaction form has been simplified
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...HEAD
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -7,7 +7,6 @@ class Staff::TransactionsController < Staff::BaseController
     @activity = activity
     @transaction = Transaction.new
     @transaction.parent_activity = @activity
-    pre_fill_providing_organisation
 
     authorize @transaction
   end
@@ -57,16 +56,8 @@ class Staff::TransactionsController < Staff::BaseController
 
   def transaction_params
     params.require(:transaction).permit(
-      :reference,
-      :description,
-      :transaction_type,
-      :currency,
-      :date,
       :value,
-      :disbursement_channel,
-      :providing_organisation_name,
-      :providing_organisation_reference,
-      :providing_organisation_type,
+      :date,
       :receiving_organisation_name,
       :receiving_organisation_reference,
       :receiving_organisation_type
@@ -83,11 +74,5 @@ class Staff::TransactionsController < Staff::BaseController
 
   def activity
     @activity ||= Activity.find(activity_id)
-  end
-
-  private def pre_fill_providing_organisation
-    @transaction.providing_organisation_name = @activity.providing_organisation.name
-    @transaction.providing_organisation_type = @activity.providing_organisation.organisation_type
-    @transaction.providing_organisation_reference = @activity.providing_organisation.iati_reference
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -7,13 +7,8 @@ class Transaction < ApplicationRecord
   belongs_to :report, optional: true
 
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
-  validates_presence_of :description,
-    :transaction_type,
+  validates_presence_of :value,
     :date,
-    :currency,
-    :value,
-    :providing_organisation_name,
-    :providing_organisation_type,
     :receiving_organisation_name,
     :receiving_organisation_type
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -1,22 +1,7 @@
 class TransactionPresenter < SimpleDelegator
-  def transaction_type
-    return if super.blank?
-    I18n.t("transaction.transaction_type.#{super}")
-  end
-
   def date
     return if super.blank?
     I18n.l(super)
-  end
-
-  def currency
-    return if super.blank?
-    I18n.t("generic.default_currency.#{super.downcase}")
-  end
-
-  def disbursement_channel
-    return if super.blank?
-    I18n.t("transaction.disbursement_channel.#{super}")
   end
 
   def value

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -1,34 +1,8 @@
 = f.govuk_error_summary
-= f.govuk_text_area :description
 
-= f.govuk_collection_select :transaction_type,
-                               yaml_to_objects(entity: "transaction", type: "transaction_type"),
-                               :code,
-                               :name
+= f.govuk_text_field :value, width: 'one-third'
 
 = f.govuk_date_field :date, legend: {  size: "s" }
-
-= f.govuk_collection_select :currency,
-                               currency_select_options,
-                               :code,
-                               :name
-= f.govuk_text_field :value
-
-= f.govuk_collection_select :disbursement_channel,
-                               yaml_to_objects(entity: "transaction", type: "disbursement_channel"),
-                               :code,
-                               :name
-
-= f.govuk_fieldset legend: { text: t("form.legend.transaction.providing_organisation") } do
-  %span.govuk-hint= t("form.hint.transaction.providing_organisation")
-  = f.govuk_text_field :providing_organisation_name
-
-  = f.govuk_collection_select :providing_organisation_type,
-                      yaml_to_objects(entity: "organisation", type: "organisation_type"),
-                      :code,
-                      :name
-
-  = f.govuk_text_field :providing_organisation_reference
 
 = f.govuk_fieldset legend: { text: t("form.legend.transaction.receiving_organisation") } do
   %span.govuk-hint= t("form.hint.transaction.receiving_organisation")

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -30,7 +30,7 @@ en:
         value: Transaction amount
     legend:
       transaction:
-        date: Date transaction was made
+        date: Date of transaction
         providing_organisation: Providing organisation
         receiving_organisation: Receiving organisation
     hint:

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -25,14 +25,10 @@ RSpec.feature "Users can edit a transaction" do
       end
 
       fill_in_transaction_form(
-        description: "This money will be buying some books for students",
-        transaction_type: "Expenditure",
+        value: "2000.51",
         date_day: "1",
         date_month: "1",
         date_year: "2020",
-        value: "2000.51",
-        disbursement_channel: "Aid in kind: Donors manage funds themselves",
-        currency: "US Dollar"
       )
 
       expect(page).to have_content(t("action.transaction.update.success"))
@@ -51,14 +47,10 @@ RSpec.feature "Users can edit a transaction" do
         end
 
         fill_in_transaction_form(
-          description: "This money will be buying some books for students",
-          transaction_type: "Expenditure",
+          value: "2000.51",
           date_day: "1",
           date_month: "1",
           date_year: "2020",
-          value: "2000.51",
-          disbursement_channel: "Aid in kind: Donors manage funds themselves",
-          currency: "US Dollar"
         )
 
         auditable_event = PublicActivity::Activity.find_by(trackable_id: transaction.id)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -4,14 +4,8 @@ RSpec.describe Transaction, type: :model do
   let(:activity) { build(:activity) }
 
   describe "validations" do
-    it { should validate_presence_of(:description) }
-    it { should validate_presence_of(:transaction_type) }
-    it { should validate_presence_of(:date) }
-    it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:value) }
-    it { should_not validate_presence_of(:disbursement_channel) }
-    it { should validate_presence_of(:providing_organisation_name) }
-    it { should validate_presence_of(:providing_organisation_type) }
+    it { should validate_presence_of(:date) }
     it { should validate_presence_of(:receiving_organisation_name) }
     it { should validate_presence_of(:receiving_organisation_type) }
 
@@ -35,7 +29,6 @@ RSpec.describe Transaction, type: :model do
   end
 
   describe "sanitation" do
-    it { should strip_attribute(:providing_organisation_reference) }
     it { should strip_attribute(:receiving_organisation_reference) }
   end
 

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -3,28 +3,10 @@ require "rails_helper"
 RSpec.describe TransactionPresenter do
   let(:transaction) { build_stubbed(:transaction, currency: "GBP") }
 
-  describe "#transaction_type" do
-    it "returns the I18n string for the transaction_type" do
-      expect(described_class.new(transaction).transaction_type).to eq("Incoming Funds")
-    end
-  end
-
   describe "#date" do
     it "returns a human readable date" do
       transaction.date = "2020-06-25"
       expect(described_class.new(transaction).date).to eq("25 Jun 2020")
-    end
-  end
-
-  describe "#currency" do
-    it "returns the I18n string for the currency" do
-      expect(described_class.new(transaction).currency).to eq("Pound Sterling")
-    end
-  end
-
-  describe "#disbursement_channel" do
-    it "returns the I18n string for the disbursement_channel" do
-      expect(described_class.new(transaction).disbursement_channel).to eq("Money is disbursed through central Ministry of Finance or Treasury")
     end
   end
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -410,29 +410,16 @@ module FormHelpers
   end
 
   def fill_in_transaction_form(expectations: true,
-    description: "This money will be purchasing a new school roof",
-    transaction_type: "Outgoing Pledge",
+    value: "1000.01",
     date_year: "2020",
     date_month: "1",
     date_day: "2",
-    value: "1000.01",
-    disbursement_channel: "Money is disbursed through central Ministry of Finance or Treasury",
-    currency: "Pound Sterling",
-    providing_organisation: OpenStruct.new(name: "Example provider", reference: "GB-GOV-1", type: "Government"),
     receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-123", type: "Private Sector"))
-    fill_in "transaction[description]", with: description
-    select transaction_type, from: "transaction[transaction_type]"
+
+    fill_in "transaction[value]", with: value
     fill_in "transaction[date(3i)]", with: date_day
     fill_in "transaction[date(2i)]", with: date_month
     fill_in "transaction[date(1i)]", with: date_year
-    fill_in "transaction[value]", with: value
-    select disbursement_channel, from: "transaction[disbursement_channel]"
-    select currency, from: "transaction[currency]"
-
-    fill_in "transaction[providing_organisation_name]", with: providing_organisation.name
-    select providing_organisation.type, from: "transaction[providing_organisation_type]"
-    fill_in "transaction[providing_organisation_reference]", with: providing_organisation.reference
-
     fill_in "transaction[receiving_organisation_name]", with: receiving_organisation.name
     select receiving_organisation.type, from: "transaction[receiving_organisation_type]"
     fill_in "transaction[receiving_organisation_reference]", with: receiving_organisation.reference


### PR DESCRIPTION
Trello: https://trello.com/c/cPiODeqP

## Changes in this PR

The current flow for reporting a transaction asks users to complete lots of fields, not all of which are needed. We can save users time and effort by streamlining the form.

Our proposed approach is to remove a number of fields that can be autopopulated by RODA in case they are needed. This PR removes the fields that are not necessary in both the `Add a transaction` form and the transaction details page, but retaining them in the data model. 

I have also modified the specs to reflect these changes.

## Screenshots of UI changes

### Before

<img width="606" alt="Screenshot 2020-12-10 at 15 46 03" src="https://user-images.githubusercontent.com/48016017/101794528-df74a580-3afe-11eb-857a-8e5e975b2089.png">

<img width="1121" alt="Screenshot 2020-12-10 at 15 47 14" src="https://user-images.githubusercontent.com/48016017/101794663-03d08200-3aff-11eb-91c5-8e3b8f910a78.png">

### After

<img width="976" alt="Screenshot 2020-12-09 at 16 27 22" src="https://user-images.githubusercontent.com/48016017/101794737-164abb80-3aff-11eb-9a79-31405f34a512.png">

<img width="1285" alt="Screenshot 2020-12-09 at 16 28 18" src="https://user-images.githubusercontent.com/48016017/101794770-1e0a6000-3aff-11eb-88d1-501a0fe06150.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
