### PR TITLE
(1316) Lock bundler version to 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,6 +420,10 @@
 - Add link to the support site in the footer
 - Change programme status field to an enum
 
+## [unreleased]
+
+- Lock bundler version for Docker to 2.1.4
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...HEAD
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24
 [release-23]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-22...release-23

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
 RUN gem update --system 3.0.3
 RUN gem update rake 13.0.1
-RUN gem install bundler
+RUN gem install bundler -v 2.1.4
 
 RUN bundle config set frozen 'true'
 


### PR DESCRIPTION
## Changes in this PR

- Bundler version used by Docker locked to 2.1.4

Travis builds started failing on 10 Dec 2020.

The failure occurs when installing the gem `libv8`: `Failed to build gem native extension.`

This coincided with bundler version 2.2.0 becoming the default, instead of 2.1.4.

Our Dockerfile didn’t specify a version.

I propose to resolve this in the first instance by locking bundler to 2.1.4, known to work with libv8.


## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
