### PR TITLE
Add local development user seeds

### DIFF
--- a/db/seeds/local_users.rb
+++ b/db/seeds/local_users.rb
@@ -1,0 +1,19 @@
+administrator = User.find_or_create_by(
+  name: "Administrator",
+  email: "roda@dxw.com",
+  identifier: "auth0|5dc53e4b85758e0e95b062f0",
+  role: :administrator
+)
+delivery_partner = User.find_or_create_by(
+  name: "Delivery Partner",
+  email: "roda+dp@dxw.com",
+  identifier: "auth0|5e5e1ee731555a0cb0ab5a75",
+  role: :administrator
+)
+beis = Organisation.find_by(service_owner: true)
+administrator.organisation = beis
+administrator.save
+
+other_organisation = Organisation.where(service_owner: false).first
+delivery_partner.organisation = other_organisation
+delivery_partner.save


### PR DESCRIPTION
## Changes in this PR

A common scenario is for a developer to take a copy of production data
to run it locally.

In this situation rather than running all the database seeds it is
helpful to add the least amount of entities to the data to get the local
environment working.

The only data we really need is the users from the local development
Auth0 tenant.

This change allows a developer to add those users by running the
following command on the Rails console after duplicating the production
database locally:

`load File.join(Rails.root, "db", "seeds", "local_users.rb")`

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
