### PR TITLE
Update planned disbursement usage

### DIFF
--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -18,7 +18,7 @@ class Staff::ActivitiesController < Staff::BaseController
 
     @transactions = policy_scope(Transaction).where(parent_activity: @activity).order("date DESC")
     @budgets = policy_scope(Budget).where(parent_activity: @activity).order("period_start_date DESC")
-    @planned_disbursements = policy_scope(PlannedDisbursement).where(parent_activity: @activity).order("period_start_date DESC")
+    @planned_disbursements = policy_scope(@activity.latest_planned_disbursements)
 
     respond_to do |format|
       format.html do

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -9,7 +9,7 @@ class Staff::ActivityFinancialsController < Staff::BaseController
 
     @transactions = policy_scope(Transaction).where(parent_activity: @activity).order("date DESC")
     @budgets = policy_scope(Budget).where(parent_activity: @activity).order("period_start_date DESC")
-    @planned_disbursements = PlannedDisbursementOverview.new(@activity).latest_values
+    @planned_disbursements = policy_scope(@activity.latest_planned_disbursements)
 
     @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
     @budget_presenters = @budgets.includes(:parent_activity).map { |budget| BudgetPresenter.new(budget) }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -112,7 +112,6 @@ class Activity < ApplicationRecord
 
   has_many :budgets, foreign_key: "parent_activity_id"
   has_many :transactions, foreign_key: "parent_activity_id"
-  has_many :planned_disbursements, foreign_key: "parent_activity_id"
 
   has_many :comments
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -326,6 +326,10 @@ class Activity < ApplicationRecord
     @variance_for_report_financial_quarter ||= actual_total_for_report_financial_quarter(report: report) - forecasted_total_for_report_financial_quarter(report: report)
   end
 
+  def latest_planned_disbursements
+    PlannedDisbursementOverview.new(self).latest_values
+  end
+
   def requires_call_dates?
     !ingested? && is_project?
   end

--- a/app/views/staff/organisations/show.xml.haml
+++ b/app/views/staff/organisations/show.xml.haml
@@ -2,5 +2,5 @@
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
-    = render partial: "staff/shared/xml/activity", locals: { activity: activity, transactions: activity.transactions, budgets: activity.budgets, planned_disbursements: activity.planned_disbursements }
+    = render partial: "staff/shared/xml/activity", locals: { activity: activity, transactions: activity.transactions, budgets: activity.budgets, planned_disbursements: activity.latest_planned_disbursements }
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -785,7 +785,6 @@ RSpec.describe Activity, type: :model do
     it { should belong_to(:reporting_organisation).with_foreign_key("reporting_organisation_id") }
     it { should have_many(:budgets) }
     it { should have_many(:transactions) }
-    it { should have_many(:planned_disbursements) }
   end
 
   describe "#parent_activities" do


### PR DESCRIPTION
The intent of this PR is to amend all places in the application that display planned disbursements so that they only display the latest value for each quarter, rather than all the records linked to an activity. Some of those records will represent old historical data that has been superseded by newer entries.

I have amended the instances of this that I have found but I would like to know if there are others I've missed. I have removed the `Activity#planned_disbursements` association to discourage people from accidentally rendering all the historical records -- we should use `Activity#latest_planned_disbursements` instead.