### PR TITLE
Importer handles no implementing organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -429,6 +429,7 @@
 - Add a transaction form has been simplified
 - CSV template uses `activity.title` for activity name
 - Updated version of sector codelist added to RODA
+- Activity importer handles missing implementing organisations
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...HEAD
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -89,7 +89,9 @@ module Activities
         @activity.assign_attributes(@converter.to_h)
 
         implementing_organisation_builder = ImplementingOrganisationBuilder.new(@activity, row)
-        @activity.implementing_organisations = [implementing_organisation_builder.build]
+        implementing_organisation = implementing_organisation_builder.build
+
+        @activity.implementing_organisations = [implementing_organisation] if implementing_organisation.valid?
 
         return if @activity.save
 
@@ -131,7 +133,10 @@ module Activities
         @activity.cache_roda_identifier
 
         implementing_organisation_builder = ImplementingOrganisationBuilder.new(@activity, row)
-        @activity.implementing_organisations = [implementing_organisation_builder.build]
+        if row["Implementing organisation name"].present? || row["Implementing organisation sector"].present?
+          implementing_organisation = implementing_organisation_builder.build
+          @activity.implementing_organisations = [implementing_organisation]
+        end
 
         return if @activity.save(context: Activity::VALIDATION_STEPS)
 
@@ -139,7 +144,7 @@ module Activities
           @errors[attr_name] ||= [@converter.raw(attr_name), message]
         end
 
-        implementing_organisation_builder.add_errors(@errors)
+        implementing_organisation_builder.add_errors(@errors) if @activity.implementing_organisations.any?
       end
 
       def calculate_level

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_update.parent_present"))
     end
 
+    it "does not fail when the acitvity and import row has no implementing organiation" do
+      existing_activity_attributes["Implementing organisation name"] = nil
+      existing_activity_attributes["Implementing organisation reference"] = nil
+      existing_activity_attributes["Implementing organisation sector"] = nil
+      existing_activity.update(implementing_organisations: [])
+
+      subject.import([existing_activity_attributes])
+
+      expect(subject.errors.count).to eq(0)
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(1)
+    end
+
     it "updates an existing activity" do
       subject.import([existing_activity_attributes])
 
@@ -233,6 +246,19 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:roda_id)
       expect(subject.errors.first.value).to eq("")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_create"))
+    end
+
+    it "does not fail when the row has no implementing organiation" do
+      new_activity_attributes["Implementing organisation name"] = nil
+      new_activity_attributes["Implementing organisation reference"] = nil
+      new_activity_attributes["Implementing organisation sector"] = nil
+      rows = [new_activity_attributes]
+
+      expect { subject.import(rows) }.to change { Activity.count }.by(1)
+
+      expect(subject.created.count).to eq(1)
+      expect(subject.updated.count).to eq(0)
+      expect(subject.errors.count).to eq(0)
     end
 
     it "creates the activity" do


### PR DESCRIPTION
## Changes in this PR

I'll be honest and say I am struggling to follow how the
ImplementingOrganisationBuilder is working, but I do know that when
trying to import real data to production we have some issues.

I've written the tests to reproduce the issues and get around them,
although I feel like there is probably a better approach than this, with
time in short supply to get these imports done I think this potential
work-around is good enough.

I believe the issues are:

When the importer is creating an activity it assumes the import row will
have the details to make an implementing organisation and this is not
always the case.

When the importer is updating an existing activity it assumes the
activity has an existing implementing organisation or that the import
row has the details to create one, again this is not always the case.

When updating an activity we only add the result of trying to build an
implementing organisation if it is valid, for an implementing
organisation to be valid it will need the activity_id, name and type.

We cannot use this approach for creating new activities because the
activity will not have an id until it is saved.

It looks like we create a new activity and implementing organisation at the
same time and the implementing organisation will only become valid once
the new activity is saved and able to give the implementing organisation
its `activity_id`. Because these two things happen at the point the
activity is saved, it may be we are trying to save an invalid
implementing organisation, there is no way to know until the entire
activity is saved.

The fix here is if  Implementing organisation name or type is present
in the row we have to assume the user is trying to set an implementing
organisation for this row, and if one of the values is missing we need to tell them
with an error.

But if neither is present, we don't want to try and create an implementing
organisation at all.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
