### PR TITLE
(1318) export next twelve quarters forecasts

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -77,7 +77,7 @@ class Report < ApplicationRecord
   end
 
   def next_twelve_financial_quarters
-    quarter, year = current_financial_quarter, current_financial_year
+    quarter, year = financial_quarter, financial_year
 
     (1..12).map do
       year += 1 if quarter == 4

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -76,15 +76,14 @@ class Report < ApplicationRecord
     Activity.projects_and_third_party_projects_for_report(self).with_roda_identifier
   end
 
-  def next_four_financial_quarters
+  def next_twelve_financial_quarters
     quarter, year = current_financial_quarter, current_financial_year
 
-    (0..3).map do |increment|
-      next_quarter = quarter + increment
-      [
-        (next_quarter % 4) + 1,
-        next_quarter >= 4 ? year + 1 : year,
-      ]
+    (1..12).map do
+      year += 1 if quarter == 4
+      quarter = (quarter % 4) + 1
+
+      [quarter, year]
     end
   end
 

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -9,23 +9,23 @@ class ExportActivityToCsv
   end
 
   def call
-    columns.values.map(&:call).concat(next_four_quarter_forecasts).to_csv
+    columns.values.map(&:call).concat(next_twelve_quarter_forecasts).to_csv
   end
 
   def headers
-    columns.keys.concat(next_four_financial_quarters).to_csv
+    columns.keys.concat(next_twelve_financial_quarters).to_csv
   end
 
-  def next_four_quarter_forecasts
-    report_presenter.next_four_financial_quarters.map do |quarter, year|
+  def next_twelve_quarter_forecasts
+    report_presenter.next_twelve_financial_quarters.map do |quarter, year|
       overview = PlannedDisbursementOverview.new(activity_presenter)
       value = overview.snapshot(report_presenter).value_for(financial_quarter: quarter, financial_year: year)
       "%.2f" % value
     end
   end
 
-  private def next_four_financial_quarters
-    report_presenter.next_four_financial_quarters.map { |quarter, year| "Q#{quarter} #{year}" }
+  private def next_twelve_financial_quarters
+    report_presenter.next_twelve_financial_quarters.map { |quarter, year| "Q#{quarter} #{year}" }
   end
 
   private def columns

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -157,16 +157,14 @@ RSpec.describe Report, type: :model do
   end
 
   describe "#next_twelve_financial_quarters" do
-    it "returns an array with the next twelve financial quarters" do
-      travel_to(Date.parse("1 April 2020")) do
-        report = create(:report)
+    it "returns an array with the next twelve financial quarters from the date of the report" do
+      report = travel_to(Date.parse("1 April 2020")) { create(:report) }
 
-        expect(report.next_twelve_financial_quarters).to eq [
-          [2, 2020], [3, 2020], [4, 2020], [1, 2021],
-          [2, 2021], [3, 2021], [4, 2021], [1, 2022],
-          [2, 2022], [3, 2022], [4, 2022], [1, 2023],
-        ]
-      end
+      expect(report.next_twelve_financial_quarters).to eq [
+        [2, 2020], [3, 2020], [4, 2020], [1, 2021],
+        [2, 2021], [3, 2021], [4, 2021], [1, 2022],
+        [2, 2022], [3, 2022], [4, 2022], [1, 2023],
+      ]
     end
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -156,44 +156,16 @@ RSpec.describe Report, type: :model do
     end
   end
 
-  describe "#next_four_financial_quarters" do
-    context "when in Q1 2020" do
-      it "returns an array with the next four financial quarters" do
-        travel_to(Date.parse("1 April 2020")) do
-          report = create(:report)
+  describe "#next_twelve_financial_quarters" do
+    it "returns an array with the next twelve financial quarters" do
+      travel_to(Date.parse("1 April 2020")) do
+        report = create(:report)
 
-          expect(report.next_four_financial_quarters).to eq [[2, 2020], [3, 2020], [4, 2020], [1, 2021]]
-        end
-      end
-    end
-
-    context "when in Q2 2020" do
-      it "returns an array with the next four financial quarters" do
-        travel_to(Date.parse("1 July 2020")) do
-          report = create(:report)
-
-          expect(report.next_four_financial_quarters).to eq [[3, 2020], [4, 2020], [1, 2021], [2, 2021]]
-        end
-      end
-    end
-
-    context "when in Q3 2020" do
-      it "returns an array with the next four financial quarters" do
-        travel_to(Date.parse("1 October 2020")) do
-          report = create(:report)
-
-          expect(report.next_four_financial_quarters).to eq [[4, 2020], [1, 2021], [2, 2021], [3, 2021]]
-        end
-      end
-    end
-
-    context "when in Q4 2020" do
-      it "returns an array with the next four financial quarters" do
-        travel_to(Date.parse("1 January 2021")) do
-          report = create(:report)
-
-          expect(report.next_four_financial_quarters).to eq [[1, 2021], [2, 2021], [3, 2021], [4, 2021]]
-        end
+        expect(report.next_twelve_financial_quarters).to eq [
+          [2, 2020], [3, 2020], [4, 2020], [1, 2021],
+          [2, 2021], [3, 2021], [4, 2021], [1, 2022],
+          [2, 2022], [3, 2022], [4, 2022], [1, 2023],
+        ]
       end
     end
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -2,25 +2,23 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe ExportActivityToCsv do
-  let(:project) { create(:project_activity, :with_report) }
+  let(:project) { travel_to(Date.parse("1 April 2020")) { create(:project_activity, :with_report) } }
   let(:report) { Report.for_activity(project).first }
   let!(:comment) { create(:comment, report: report, activity: project) }
 
   describe "#call" do
     it "creates a CSV line which contains all columns in order, followed by forecasts for the next twelve financial quarters" do
-      travel_to(Date.parse("1 April 2020")) do
-        export_service = ExportActivityToCsv.new(activity: project, report: report)
+      export_service = ExportActivityToCsv.new(activity: project, report: report)
 
-        allow(export_service).to receive(:columns).and_return(
-          "Header A" => -> { "Value A" },
-          "Header B" => -> { "Value B" },
-          "Header C" => -> { "Value C" },
-        )
+      allow(export_service).to receive(:columns).and_return(
+        "Header A" => -> { "Value A" },
+        "Header B" => -> { "Value B" },
+        "Header C" => -> { "Value C" },
+      )
 
-        result = export_service.call
+      result = export_service.call
 
-        expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00\n")
-      end
+      expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00\n")
     end
 
     it "includes the BEIS id if there is one" do
@@ -56,53 +54,45 @@ RSpec.describe ExportActivityToCsv do
 
   describe "#headers" do
     it "generates a CSV header row for all columns in order, followed by the next twelve financial quarters" do
-      travel_to(Date.parse("1 April 2020")) do
-        export_service = ExportActivityToCsv.new(activity: project, report: report)
+      export_service = ExportActivityToCsv.new(activity: project, report: report)
 
-        allow(export_service).to receive(:columns).and_return(
-          "Header A" => -> { "Value A" },
-          "Header B" => -> { "Value B" },
-          "Header C" => -> { "Value C" },
-        )
+      allow(export_service).to receive(:columns).and_return(
+        "Header A" => -> { "Value A" },
+        "Header B" => -> { "Value B" },
+        "Header C" => -> { "Value C" },
+      )
 
-        headers = export_service.headers
+      headers = export_service.headers
 
-        expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021,Q2 2021,Q3 2021,Q4 2021,Q1 2022,Q2 2022,Q3 2022,Q4 2022,Q1 2023\n")
-      end
+      expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021,Q2 2021,Q3 2021,Q4 2021,Q1 2022,Q2 2022,Q3 2022,Q4 2022,Q1 2023\n")
     end
 
     it "uses the current report financial quarter to generate the actuals total column" do
-      travel_to(Date.parse("1 April 2020")) do
-        report = Report.new
+      report = travel_to(Date.parse("1 April 2020")) { Report.new }
 
-        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+      headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
-        expect(headers).to include "Q1 2020-2021 actuals"
-      end
+      expect(headers).to include "Q1 2020-2021 actuals"
     end
 
     it "uses the current report financial quarter to generate the forecast total column" do
-      travel_to(Date.parse("1 April 2020")) do
-        report = Report.new
+      report = travel_to(Date.parse("1 April 2020")) { Report.new }
 
-        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+      headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
-        expect(headers).to include "Q1 2020-2021 forecast"
-      end
+      expect(headers).to include "Q1 2020-2021 forecast"
     end
 
     it "includes the next twelve financial quarters as headers" do
-      travel_to(Date.parse("1 April 2020")) do
-        report = Report.new
+      report = travel_to(Date.parse("1 April 2020")) { Report.new }
 
-        headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+      headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
-        expect(headers).to include [
-          "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
-          "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
-          "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",
-        ].to_csv
-      end
+      expect(headers).to include [
+        "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
+        "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
+        "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",
+      ].to_csv
     end
   end
 end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ExportActivityToCsv do
   let!(:comment) { create(:comment, report: report, activity: project) }
 
   describe "#call" do
-    it "creates a CSV line which contains all columns in order, followed by forecasts for the next four financial quarters" do
+    it "creates a CSV line which contains all columns in order, followed by forecasts for the next twelve financial quarters" do
       travel_to(Date.parse("1 April 2020")) do
         export_service = ExportActivityToCsv.new(activity: project, report: report)
 
@@ -19,7 +19,7 @@ RSpec.describe ExportActivityToCsv do
 
         result = export_service.call
 
-        expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00\n")
+        expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00\n")
       end
     end
 
@@ -33,23 +33,29 @@ RSpec.describe ExportActivityToCsv do
     end
   end
 
-  describe "#next_four_quarter_forecasts" do
-    it "gets the forecasted total for the next four quarters" do
-      quarters = report.next_four_financial_quarters
+  describe "#next_twelve_quarter_forecasts" do
+    it "gets the forecasted total for the next twelve quarters" do
+      quarters = report.next_twelve_financial_quarters
       q1_forecast = PlannedDisbursementHistory.new(project, *quarters[0])
       q3_forecast = PlannedDisbursementHistory.new(project, *quarters[2])
+      q11_forecast = PlannedDisbursementHistory.new(project, *quarters[10])
 
       q1_forecast.set_value(1000)
       q3_forecast.set_value(500)
+      q11_forecast.set_value(300)
 
-      totals = ExportActivityToCsv.new(activity: project, report: report).next_four_quarter_forecasts
+      totals = ExportActivityToCsv.new(activity: project, report: report).next_twelve_quarter_forecasts
 
-      expect(totals).to eq ["1000.00", "0.00", "500.00", "0.00"]
+      expect(totals).to eq [
+        "1000.00", "0.00", "500.00", "0.00",
+        "0.00", "0.00", "0.00", "0.00",
+        "0.00", "0.00", "300.00", "0.00",
+      ]
     end
   end
 
   describe "#headers" do
-    it "generates a CSV header row for all columns in order, followed by the next four financial quarters" do
+    it "generates a CSV header row for all columns in order, followed by the next twelve financial quarters" do
       travel_to(Date.parse("1 April 2020")) do
         export_service = ExportActivityToCsv.new(activity: project, report: report)
 
@@ -61,7 +67,7 @@ RSpec.describe ExportActivityToCsv do
 
         headers = export_service.headers
 
-        expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021\n")
+        expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021,Q2 2021,Q3 2021,Q4 2021,Q1 2022,Q2 2022,Q3 2022,Q4 2022,Q1 2023\n")
       end
     end
 
@@ -85,13 +91,17 @@ RSpec.describe ExportActivityToCsv do
       end
     end
 
-    it "includes the next four financial quarters as headers" do
+    it "includes the next twelve financial quarters as headers" do
       travel_to(Date.parse("1 April 2020")) do
         report = Report.new
 
         headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
-        expect(headers).to include ["Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021"].to_csv
+        expect(headers).to include [
+          "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
+          "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
+          "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",
+        ].to_csv
       end
     end
   end


### PR DESCRIPTION
The changes are covered by the commit messages, but to summarise them: we are changing the forecast data included in exported activity CSV.

Before this change, the export includes forecasts for the _four_ quarters following _today's date_.

After this change the export includes forecasts for the _twelve_ quarters following _the date of the report_.