### PR TITLE
(1297) Update transactions to reflect actual disbursements

### DIFF
--- a/db/data/20201209112603_transactions_reflect_actual_disbursements.rb
+++ b/db/data/20201209112603_transactions_reflect_actual_disbursements.rb
@@ -1,0 +1,10 @@
+class TransactionsReflectActualDisbursements < ActiveRecord::Migration[6.0]
+  def up
+    Transaction.where(transaction_type: [2, 11]).delete_all
+    Transaction.where(transaction_type: [4, 10]).update_all(transaction_type: 3)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The definition of actuals/transactions has changed over time and we need
to update production data to reflect this. There are two parts to this
problem:

- Some transactions are included in the data which do not fit our
  definition, and they need to be removed.
- Some transactions are labelled incorrectly, and they need to be
  relabelled to fit our definition.

Any transactions of type 'incoming commitments' (code `11`) and
'outgoing commitments' (code `2`) should be deleted

All transactions in the database should be of type 'disbursement' code
`3`. To achieve this we need to change the type for 'expenditure' (code
`4`) and 'credit guarantee' (code `10`) to code `3`.