### PR TITLE
(1098) CSV template now shows activity title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,6 +427,7 @@
 - Column order of CSV report file matches data migration template
 - Add missing columns to the CSV report file
 - Add a transaction form has been simplified
+- CSV template uses `activity.title` for activity name
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...HEAD
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -52,7 +52,7 @@ class Staff::TransactionUploadsController < Staff::BaseController
 
   private def csv_row(activity)
     [
-      activity.description,
+      activity.title,
       activity.delivery_partner_identifier,
       activity.roda_identifier,
     ]

--- a/spec/features/staff/users_can_upload_transactions.rb
+++ b/spec/features/staff/users_can_upload_transactions.rb
@@ -26,7 +26,7 @@ RSpec.feature "users can upload transactions" do
 
     expect(rows).to eq([
       {
-        "Activity Name" => project.description,
+        "Activity Name" => project.title,
         "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,
         "Activity RODA Identifier" => project.roda_identifier,
         "Date" => nil,
@@ -38,7 +38,7 @@ RSpec.feature "users can upload transactions" do
         "Description" => nil,
       },
       {
-        "Activity Name" => sibling_project.description,
+        "Activity Name" => sibling_project.title,
         "Activity Delivery Partner Identifier" => sibling_project.delivery_partner_identifier,
         "Activity RODA Identifier" => sibling_project.roda_identifier,
         "Date" => nil,


### PR DESCRIPTION
Trello: https://trello.com/c/V0k57Ky5

## Changes in this PR

On the CSV report, we were showing the activity description for the column `activity name`. The activity title would be more appropiate in this case. The activity title is only shown here to help guide users, we do not use this column from the template during import.

Specs have been modified accordingly.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
