### PR TITLE
(1311) Fix bug on `programme_status` translation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,6 +433,8 @@
 
 ## [unreleased]
 
+- Fix bug on option `stopped` for `programme_status`
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24

--- a/config/locales/codelists/BEIS/activity.en.yml
+++ b/config/locales/codelists/BEIS/activity.en.yml
@@ -17,6 +17,6 @@ en:
       spend_in_progress: Spend in progress
       finalisation: Finalisation
       completed: Completed
-      stoped: Stopped
+      stopped: Stopped
       cancelled: Cancelled
       paused: Paused


### PR DESCRIPTION
Trello: https://trello.com/c/qg4g3Xyd

## Changes in this PR

One of the options for programme status (`Stopped`) was not displaying correctly on the activity details page. We were getting an error that the translation was missing from the file. This was caused by a typo on the key for this option.

## Screenshots of UI changes

### Before

<img width="1276" alt="Screenshot 2020-12-15 at 10 16 17" src="https://user-images.githubusercontent.com/48016017/102203707-d3069900-3ec0-11eb-904f-af6a6494ac5a.png">

### After

<img width="1276" alt="Screenshot 2020-12-15 at 10 24 16" src="https://user-images.githubusercontent.com/48016017/102203739-dbf76a80-3ec0-11eb-8633-e1f2de75f67f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
