### PR TITLE
(1093) Planned end date cannot be earlier than planned start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,7 @@
 ## [unreleased]
 
 - Fix bug on option `stopped` for `programme_status`
+- Validation prevents to add a `planned_end_date` that is earlier than `planned_start_date`
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -96,6 +96,7 @@ class Activity < ApplicationRecord
   validates :actual_start_date, presence: {message: I18n.t("activerecord.errors.models.activity.attributes.dates")}, on: :dates_step, unless: proc { |a| a.planned_start_date.present? }
   validates :planned_start_date, :planned_end_date, :actual_start_date, :actual_end_date, date_within_boundaries: true
   validates :actual_start_date, :actual_end_date, date_not_in_future: true
+  validates :planned_end_date, end_date_after_start_date: true, if: :planned_start_date?
   validates :extending_organisation_id, presence: true, on: :update_extending_organisation
   validates :call_open_date, presence: true, on: :call_dates_step, if: :call_present?
   validates :call_close_date, presence: true, on: :call_dates_step, if: :call_present?

--- a/app/validators/end_date_after_start_date_validator.rb
+++ b/app/validators/end_date_after_start_date_validator.rb
@@ -1,0 +1,13 @@
+class EndDateAfterStartDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value
+
+    unless end_date_after_start_date(record.planned_start_date, record.planned_end_date)
+      record.errors.add :planned_end_date, :not_before_start_date
+    end
+  end
+
+  private def end_date_after_start_date(start_date, end_date)
+    end_date >= start_date
+  end
+end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -409,6 +409,7 @@ en:
               not_in_future: Actual start date must not be in the future
             planned_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+              not_before_start_date: Planned end date must be after planned start date
             planned_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
             gdi:

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -416,6 +416,16 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when planned_end_date is not blank" do
+      let(:activity) { build(:activity) }
+
+      it "does not allow planned_end_date to be earlier than planned_start_date" do
+        activity = build(:activity, planned_start_date: Date.today, planned_end_date: Date.yesterday)
+        expect(activity.valid?).to be_falsey
+        expect(activity.errors[:planned_end_date]).to include "Planned end date must be after planned start date"
+      end
+    end
+
     context "when the actual_start_date is not blank" do
       it "allows todays date" do
         activity = build(:activity, actual_start_date: Date.today)

--- a/spec/validators/end_date_after_start_date_validator_spec.rb
+++ b/spec/validators/end_date_after_start_date_validator_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe EndDateAfterStartDateValidator do
+  subject { build(:activity) }
+
+  context "when the planned start date is the same as the planned end date" do
+    it "is valid" do
+      subject.planned_start_date = Date.today
+      subject.planned_end_date = Date.today
+
+      expect(subject.valid?).to be true
+    end
+  end
+
+  context "when the planned end date is before the planned start date" do
+    it "is not valid" do
+      subject.planned_start_date = Date.tomorrow
+      subject.planned_end_date = Date.today
+
+      expect(subject.valid?).to be false
+    end
+
+    it "adds an error message to the :planned_end_date" do
+      subject.planned_start_date = Date.tomorrow
+      subject.planned_end_date = Date.today
+
+      subject.valid?
+      expect(subject.errors.messages[:planned_end_date]).to include t("activerecord.errors.models.activity.attributes.planned_end_date.not_before_start_date")
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/MYdDqivE

## Changes in this PR

The service currently allows users to enter planned end date which is earlier than planned start date. We need to introduce validation to prevent this from happening, since it is more likely that users will accidentally introduce incorrect information when creating or updating an activity. 

The validator in this PR makes sure that `planned_end_date` is after, or at least the same, than `planned_start_date`

## Screenshots of UI changes

### After

<img width="836" alt="Screenshot 2020-12-15 at 16 58 40" src="https://user-images.githubusercontent.com/48016017/102340286-40ccc680-3f8e-11eb-9b4c-a33ee36be984.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
