### PR TITLE
(1090) Organisation names must be unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,6 +440,7 @@
 - Activity importer sets BEIS as the funding and accountable organisation
 - Activity importer infers `status` from `programme_status`
 - Activity importer sets `form_state` to "complete" to ensure correct behaviour
+- Organisation name must be unique
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,7 +5,10 @@ class Organisation < ApplicationRecord
   has_many :users
   has_many :funds
 
-  validates_presence_of :name, :organisation_type, :language_code, :default_currency
+  validates_presence_of :organisation_type, :language_code, :default_currency
+  validates :name,
+    presence: true,
+    uniqueness: {case_sensitive: false}
   validates :iati_reference,
     uniqueness: {case_sensitive: false},
     presence: true,

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :organisation do
-    name { Faker::Company.name }
+    sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
     iati_reference { "GB-GOV-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     organisation_type { "10" }
     default_currency { "GBP" }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Organisation, type: :model do
     it { should validate_presence_of(:iati_reference) }
 
     it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
+    it { should validate_uniqueness_of(:name).ignoring_case_sensitivity }
 
     describe "sanitation" do
       it { should strip_attribute(:iati_reference) }


### PR DESCRIPTION
Trello: https://trello.com/c/gfrNbdqZ

## Changes in this PR

To prevent BEIS users from accidentally duplicate an organisation, we are now introducing validation on the Organisation model to make the name field unique, regardless of case sensitivity.

## Screenshots of UI changes

### After

<img width="1018" alt="Screenshot 2020-12-17 at 08 46 18" src="https://user-images.githubusercontent.com/48016017/102468085-ff4d2180-4048-11eb-9307-df32c36dea98.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
