### PR TITLE
Move CI to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run tests
         run: script/cibuild
+      - name: Test terraform scripts
+        run: script/terraform_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - id: cache-docker
+        uses: actions/cache@v2
+        with:
+          path: /tmp/docker-save
+          key: docker-save-${{ hashFiles('Dockerfile') }}
+      - name: Load cached Docker image
+        run: docker load -i /tmp/docker-save/snapshot.tar || true
+        if: steps.cache-docker.outputs.cache-hit == 'true'
       - name: Run tests
         run: script/cibuild
       - name: Test terraform scripts
         run: script/terraform_test
+      - name: Prepare Docker cache
+        run: mkdir -p /tmp/docker-save && docker save beis-report-official-development-assistance_test:latest -o /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
+        if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push]
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,19 @@
 language: minimal
 services:
-- docker
+  - docker
 before_install:
-- docker build . --target test --build-arg RAILS_ENV=test -t app/test
-jobs:
-  include:
-  - stage: Test
-    name: Build and test the current version of the application using Docker
-    env:
-    - RAILS_ENV=test
-    script: |
-      set -eu
-      docker network create test
-      docker run -d --name pg --network test -p 5432:5432 postgres:11.6
-      docker run \
-        --network test \
-        -e RAILS_ENV=test \
-        -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
-        -e DATABASE_URL=postgres://postgres@pg:5432/roda_test \
-        -e TRAVIS="$TRAVIS" \
-        -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" \
-        -e TRAVIS_BRANCH="$TRAVIS_BRANCH" \
-        -e TRAVIS_PULL_REQUEST="$TRAVIS_PULL_REQUEST" \
-        -e COVERALLS_SERVICE_NAME=travis-ci \
-        -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" \
-        -e CI=true \
-        --env-file .env.test \
-        app/test /bin/bash -c "set -eu; bundle exec rake; bundle exec brakeman"
-      echo "==== testing terrafrom ===="
-      cd terraform
-      git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-      export PATH="$HOME/.tfenv/bin:$PATH"
-      tfenv install
-      ../install-terraform-provider-for-cf.sh
-      terraform init
-      terraform fmt  -diff -check -recursive
-      terraform validate
-      cd ..
-      echo "==== linting our shell scripts ===="
-      bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
-      set +eu
+  - docker build . --target test --build-arg RAILS_ENV=test -t app/test
 deploy:
-- provider: script
-  script: bash travis-docker-push.sh
-  on:
-    all_branches: true
-    condition: "$TRAVIS_BRANCH =~ ^(develop|master|hotfix)"
-- provider: script
-  script: bash deploy-terraform.sh
-  on:
-    all_branches: true
-    condition: "$TRAVIS_BRANCH =~ ^(develop|master)$"
+  - provider: script
+    script: bash travis-docker-push.sh
+    on:
+      all_branches: true
+      condition: "$TRAVIS_BRANCH =~ ^(develop|master|hotfix)"
+  - provider: script
+    script: bash deploy-terraform.sh
+    on:
+      all_branches: true
+      condition: "$TRAVIS_BRANCH =~ ^(develop|master)$"
 env:
   global:
     secure: mBNvcyOEhYVAbbUJL4sXvwU6RM9LgFLAaEq/B5VKhUSOSKWvcYYInk5qWOldMF79aE8mC7JsOi5D4AC6fvPEEU2aM9N5jcvoNyR5FEKg80ltgK8GE8NwrzqjD3shS2IhFtKdBN1PI/vDxAtIJqefQ8eSy2/FwdpN/aB06QDGjEy5ye2dh/A4YH5fAz1W9lncFI8zr7ZdPC5N7FG6DkNCVju9wfqwzyHCQabuJ3iKvq3dxBaRvJgrIi6I2QVHV9ieWARuI5CHgYQWwm2VPVW5vUhrZ3ZaefD5qJZ4Bp+NzlnDH7frCjuDpPrCiNI6wYrbOxj4LFVDAWl9dMYcZ9BY6DNQjeTtSt9qLCgG6csBsTf9RHR5THz3zreChEyf/+iJvBqyh9XdSNj/ZtEDFAM4z4LTsyQy7VlxyjLoO+oYOONzQP/y4EOmELJ7YPvB6bZmazJ2Rpix91svlBmaxtcx63W0aZa8yqqzJ5n6mPdIIBnMQOlNkofUSapaKJRceMcVqHk/5EqjUG7ETTf8eohrfLqrHP/S344NPNCDMHmTIoWd4QL7K9E0IeAinBUOa8RfN4A3SfXvouOPvfZGqCjmciAsQi2r024EqZ/c39xu1BQDLIm+LZ9ThMBimi2u7yZV7W4ijoY7DRae3mgzqGxnHxEmWhtDMWWnEujfR2BM4oY= # Coveralls.io READ_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,7 @@
 - Fix bug on option `stopped` for `programme_status`
 - Validation prevents to add a `planned_end_date` that is earlier than `planned_start_date`
 - Hint text for `fstc` modified
+- Move CI tests to Github Actions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,8 @@ CMD ["bundle", "exec", "puma"]
 # ------------------------------------------------------------------------------
 FROM web as test
 
-RUN apt-get install -qq -y firefox-esr
+RUN apt-get install -qq -y firefox-esr \
+  shellcheck
 
 ARG gecko_driver_version=0.26.0
 
@@ -113,5 +114,3 @@ RUN tar -xvzf  geckodriver-v$gecko_driver_version-linux64.tar.gz
 RUN rm geckodriver-v$gecko_driver_version-linux64.tar.gz
 RUN chmod +x geckodriver
 RUN mv geckodriver* /usr/local/bin
-
-CMD [ "bundle", "exec", "rake, default" ]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,17 +6,13 @@ services:
       target: test
       args:
         RAILS_ENV: test
-    entrypoint: bundle exec rails db:prepare default
     depends_on:
       - db
     environment:
-      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: postgres://postgres:password@db:5432/roda_test
     env_file:
       - .env.test
-    volumes:
-      - .:/app:cached
-      - .node_modules:/deps/node_modules:cached
   db:
     image: postgres
     volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   test:
     build:
+      cache_from:
+        - beis-report-official-development-assistance_test:latest
       context: .
       target: test
       args:

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,4 +2,5 @@
 
 set -e
 
-docker-compose -f docker-compose.test.yml run -e CI=true --rm test script/test
+docker-compose -f docker-compose.test.yml build
+docker-compose -f docker-compose.test.yml run -e CI=true test script/test

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,4 +3,7 @@
 set -e
 
 docker-compose -f docker-compose.test.yml build
-docker-compose -f docker-compose.test.yml run -e CI=true test script/test
+docker-compose -f docker-compose.test.yml run \
+  -e CI=true \
+  -e COVERALLS_REPO_TOKEN="$COVERALLS_REPO_TOKEN" \
+  test script/test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+docker-compose -f docker-compose.test.yml run -e CI=true --rm test script/test

--- a/script/setup
+++ b/script/setup
@@ -27,7 +27,7 @@ DB_DROP_RESULT=$?
 set -e
 
 if [ -z "$CI" ] && [ "$DB_DROP_RESULT" -ne "0"  ]; then
-  printf "\nDatabase drop failed. Continue anyway? [y/N] "
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
   read -r
 
   case $REPLY in
@@ -49,7 +49,7 @@ DB_DROP_RESULT=$?
 set -e
 
 if [ -z "$CI" ] && [ "$DB_DROP_RESULT" -ne "0" ]; then
-  printf "\nDatabase drop failed. Continue anyway? [y/N] "
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
   read -r
 
   case $REPLY in

--- a/script/terraform_test
+++ b/script/terraform_test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+cd terraform
+git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+export PATH="$HOME/.tfenv/bin:$PATH"
+tfenv install
+../install-terraform-provider-for-cf.sh
+terraform init
+terraform fmt  -diff -check -recursive
+terraform validate


### PR DESCRIPTION
This moves the CI to Github Actions. This should hopefully speed up build times, as well as starting the process of moving away from Travis (and paying them money), as well as keeping the CI closer to the code.

I've made a couple of tiny tweaks to the Docker config, mainly removing volumes from the docker-compose config, and adding a dependency to the test layer of the Dockerfile. This shouldn't have any impact on the project, as I don't think the docker-compose config is being used by anyone locally (shout if it is!).

I've added a couple of secrets to the Github config - namely the Coveralls Token and the AWS config (so we can get the Terraform testing working). 

Next stage is to get the deploy working, but I think it'll be better to do this in a seperate PR, once we're happy with this.