### PR TITLE
(1048) Show error message when user enters invalid dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,7 @@
 - Activity importer infers `status` from `programme_status`
 - Activity importer sets `form_state` to "complete" to ensure correct behaviour
 - Organisation name must be unique
+- Show error message when the user tries to enter an invalid date on the `dates` step. Covers `planned_start_date`, `planned_end_date`, `actual_start_date`, `actual_end_date`
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,4 +1,6 @@
 module DateHelper
+  class InvalidDateError < StandardError; end
+
   def format_date(params)
     date_parts = params.values_at(:day, :month, :year)
     return unless date_parts.all?(&:present?)
@@ -7,5 +9,17 @@ module DateHelper
     Date.new(year, month, day)
   rescue ArgumentError
     nil
+  end
+
+  def validated_date(params)
+    date_parts = params.values_at(:day, :month, :year)
+    return if date_parts.all?(&:blank?)
+
+    raise InvalidDateError unless date_parts.all?(&:present?)
+
+    day, month, year = date_parts.map(&:to_i)
+    Date.new(year, month, day)
+  rescue ArgumentError
+    raise InvalidDateError
   end
 end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -401,17 +401,21 @@ en:
             actual_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Actual end date must not be in the future
+              invalid: Please enter a valid date
             country_delivery_partners:
               blank: Enter at least one country delivery partner
             dates: Enter an actual start date or a planned start date for the activity
             actual_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Actual start date must not be in the future
+              invalid: Please enter a valid date
             planned_end_date:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_before_start_date: Planned end date must be after planned start date
+              invalid: Please enter a valid date
             planned_start_date:
               between: Date must be between %{min} years ago and %{max} years in the future
+              invalid: Please enter a valid date
             gdi:
               blank: Select an option for GDI
             intended_beneficiaries:

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -208,7 +208,8 @@ RSpec.feature "Users can create a fund level activity" do
         fill_in "activity[planned_end_date(1i)]", with: 2010
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.dates")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_start_date.invalid")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_end_date.invalid")
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -128,7 +128,8 @@ RSpec.feature "Users can create a programme activity" do
         fill_in "activity[planned_end_date(1i)]", with: 2010
         click_button t("form.button.activity.submit")
 
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.dates")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_start_date.invalid")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_end_date.invalid")
 
         fill_in "activity[planned_start_date(3i)]", with: 1
         fill_in "activity[planned_start_date(2i)]", with: 12

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -53,6 +53,49 @@ RSpec.feature "Users can create a project" do
         expect(activity.transparency_identifier).to eql("GB-GOV-13-#{programme.parent.roda_identifier_fragment}-#{programme.roda_identifier_fragment}-#{activity.roda_identifier_fragment}")
       end
 
+      scenario "the activity date shows an error message if an invalid date is entered" do
+        programme = create(:programme_activity, extending_organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
+
+        visit organisation_activity_children_path(programme.organisation, programme)
+
+        click_on(t("page_content.organisation.button.create_activity"))
+        visit activities_path
+        click_on(t("page_content.organisation.button.create_activity"))
+
+        choose custom_capitalisation(t("page_content.activity.level.project"))
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("form.legend.activity.parent", parent_level: t("page_content.activity.level.programme", level: "programme"), level: t("page_content.activity.level.programme"))
+        expect(page).to have_content t("form.hint.activity.parent", parent_level: t("page_content.activity.level.programme"), level: t("page_content.activity.level.project"))
+        choose programme.title
+        click_button t("form.button.activity.submit")
+        fill_in "activity[delivery_partner_identifier]", with: "no-country-selected"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[roda_identifier_fragment]", with: "roda-identifier"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[title]", with: "My title"
+        fill_in "activity[description]", with: "My description"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[objectives]", with: Faker::Lorem.paragraph
+        click_button t("form.button.activity.submit")
+        choose "Basic Education"
+        click_button t("form.button.activity.submit")
+        choose "School feeding"
+        click_button t("form.button.activity.submit")
+        choose "No"
+        click_button t("form.button.activity.submit")
+        choose "Delivery"
+        click_button t("form.button.activity.submit")
+        fill_in "activity[planned_start_date(3i)]", with: "01"
+        fill_in "activity[planned_start_date(2i)]", with: "12"
+        fill_in "activity[planned_start_date(1i)]", with: "2020"
+        fill_in "activity[planned_end_date(3i)]", with: "01"
+        fill_in "activity[planned_end_date(2i)]", with: "15"
+        fill_in "activity[planned_end_date(1i)]", with: "2021"
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_end_date.invalid")
+      end
+
       scenario "project creation is tracked with public_activity" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -386,6 +386,22 @@ RSpec.feature "Users can edit an activity" do
           end
         end
       end
+
+      it "shows an error message when the user enters an invalid date" do
+        activity = create(:project_activity, organisation: user.organisation, planned_start_date: Date.parse("2020-01-01"), actual_start_date: nil)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within(".planned_start_date") do
+          click_on(t("default.link.edit"))
+        end
+
+        fill_in "activity[planned_start_date(2i)]", with: "15"
+
+        click_button t("form.button.activity.submit")
+        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_start_date.invalid")
+      end
     end
 
     context "when the activity is a third-party project" do

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -27,4 +27,36 @@ RSpec.describe DateHelper, type: :helper do
       expect(helper.format_date(params)).to eq(nil)
     end
   end
+
+  describe "#validated_date" do
+    it "returns a Date object from params" do
+      params = {day: "1", month: "2", year: "2020"}
+      expect(helper.validated_date(params)).to eq(Date.new(2020, 2, 1))
+    end
+
+    it "returns nil when passed nil" do
+      params = {}
+      expect(helper.validated_date(params)).to eq(nil)
+    end
+
+    it "raises an error when the date params are incomplete" do
+      params = {day: "", month: "", year: "2019"}
+      expect { helper.validated_date(params) }.to raise_error(DateHelper::InvalidDateError)
+    end
+
+    it "raises an error when there are some nil date params" do
+      params = {day: nil, month: "10", year: "2019"}
+      expect { helper.validated_date(params) }.to raise_error(DateHelper::InvalidDateError)
+    end
+
+    it "raises an error when given an invalid date" do
+      params = {day: "40", month: "13", year: "2020"}
+      expect { helper.validated_date(params) }.to raise_error(DateHelper::InvalidDateError)
+    end
+
+    it "raises an error when given a zero parameter" do
+      params = {day: "10", month: "0", year: "2020"}
+      expect { helper.validated_date(params) }.to raise_error(DateHelper::InvalidDateError)
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- Show error message when the user tries to enter an invalid date on the `dates` step. Covers `planned_start_date`, `planned_end_date`, `actual_start_date`, `actual_end_date`

We are not able to reflect to the user what it was that they typed in. We are already swimming against Rails a bit, so it would take more effort and possibly make a more brittle feature if we tried to do that.

## Screenshots of UI changes

### Before

No feedback was given to the user.

### After
<img width="496" alt="Screenshot 2020-12-17 at 22 35 44" src="https://user-images.githubusercontent.com/579522/102551993-55a57900-40b8-11eb-81da-c4a98a99dacd.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
