### PR TITLE
Fix spec that wasn't running

### DIFF
--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "users can upload transactions" do
 
     rows = CSV.parse(page.body, headers: true).map(&:to_h)
 
-    expect(rows).to eq([
+    expect(rows).to match_array([
       {
         "Activity Name" => project.title,
         "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,


### PR DESCRIPTION
While I was investigating something else, I noticed that this spec was not named correctly, and actually failing. I've fixed the test to not worry about the order of the array, and also renamed the file, so it runs as part of the main test suite. I think this code is already touched in other specs, so I don't think it'll improve the coverage