### PR TITLE
(1248) Codify ODA Eligibility

### DIFF
--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -173,6 +173,15 @@ module CodelistHelper
     }.compact.sort_by(&:code)
   end
 
+  def oda_eligibility_radio_options
+    yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/BEIS/oda_eligibility.yml"))
+
+    Activity.oda_eligibilities.map do |name, code|
+      options = yaml["data"].find { |d| d["code"] == code }
+      OpenStruct.new(value: name, label: options["name"], description: options["description"])
+    end
+  end
+
   def load_yaml(entity:, type:)
     yaml = YAML.safe_load(File.read("#{Rails.root}/vendor/data/codelists/IATI/#{IATI_VERSION}/#{entity}/#{type}.yml"))
     yaml["data"]

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -400,11 +400,11 @@ module Activities
       end
 
       def convert_oda_eligibility(oda_eligibility)
-        validate_from_codelist(
-          oda_eligibility,
-          :oda_eligibility,
-          I18n.t("importer.errors.activity.invalid_oda_eligibility"),
-        )
+        option = Activity.oda_eligibilities.key(oda_eligibility.to_i)
+
+        raise I18n.t("importer.errors.activity.invalid_oda_eligibility") if option.nil?
+
+        option
       end
 
       def convert_programme_status(programme_status)

--- a/app/views/staff/activity_forms/oda_eligibility.html.haml
+++ b/app/views/staff/activity_forms/oda_eligibility.html.haml
@@ -1,8 +1,8 @@
 = render layout: "wrapper" do |f|
   = f.hidden_field :oda_eligibility, value: nil
   = f.govuk_collection_radio_buttons :oda_eligibility,
-    yaml_to_objects_with_description(entity: "activity", type: "oda_eligibility"),
-    :code,
-    :name,
+    oda_eligibility_radio_options,
+    :value,
+    :label,
     :description,
     legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.oda_eligibility") }

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.last.name).to eq("Zimbabwe")
       end
     end
+
+    describe "#oda_eligibility_radio_options" do
+      it "returns the radio options and hints for ODA eligibility" do
+        options = helper.oda_eligibility_radio_options
+
+        expect(options.length).to eq 3
+        expect(options.first.label).to eq("No - was never eligible")
+        expect(options.first.description).to eq("The activity was reported as eligible but was actually never ODA eligible, this applies to past and future spend")
+        expect(options.last.label).to eq("No longer eligible")
+        expect(options.last.description).to eq("The activity used to be ODA eligible but no longer meets the OECD DAC rules for future spend")
+      end
+    end
   end
 
   describe "BEIS" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Activities::ImportFromCsv do
       "SDG 2" => "2",
       "SDG 3" => "3",
       "Covid-19 related research" => "0",
-      "ODA Eligibility" => "never_eligible",
+      "ODA Eligibility" => "0",
       "ODA Eligibility Lead" => "Bruce Wayne",
       "Newton Fund Pillar" => "1",
       "Activity Status" => "1",
@@ -522,7 +522,7 @@ RSpec.describe Activities::ImportFromCsv do
     end
 
     it "has an error if the ODA Eligibility option is invalid" do
-      new_activity_attributes["ODA Eligibility"] = "some_invalid_string"
+      new_activity_attributes["ODA Eligibility"] = "789"
 
       expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
@@ -533,7 +533,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.csv_row).to eq(2)
       expect(subject.errors.first.csv_column).to eq("ODA Eligibility")
       expect(subject.errors.first.column).to eq(:oda_eligibility)
-      expect(subject.errors.first.value).to eq("some_invalid_string")
+      expect(subject.errors.first.value).to eq("789")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_oda_eligibility"))
     end
 

--- a/vendor/data/codelists/BEIS/oda_eligibility.yml
+++ b/vendor/data/codelists/BEIS/oda_eligibility.yml
@@ -1,15 +1,11 @@
 ---
-attributes:
-  category-codelist:
-  name: OdaEligibility
-  complete: '1'
 data:
-  - code: never_eligible
+  - code: 0
     name: No - was never eligible
     description: The activity was reported as eligible but was actually never ODA eligible, this applies to past and future spend
-  - code: eligible
+  - code: 1
     name: Eligible
     description: The activity adheres to the OECD DAC rules for ODA Eligibility
-  - code: no_longer_eligible
+  - code: 2
     name: No longer eligible
     description: The activity used to be ODA eligible but no longer meets the OECD DAC rules for future spend


### PR DESCRIPTION
Trello: https://trello.com/c/hXMGMMGf

## Changes in this PR

For consistency throughout the service, we are now going to codify the options for `oda_eligibility`, using numbers instead of strings. This field is already an enum on the DB, so the changes on this PR are small modifications of the data in the yaml file and how we use this file to display the different options in the UI.

Likewise, we want to be consistent and ask users to provide codes when we can, instead of strings. Until now, `oda_eligibility` on the CSV import work was taken as a string. We are now collecting the numeric values instead. This carries a few changes on the importer tool, along with amendments to the specs.

I believe a DB migration is not needed since we already did one when we changed `oda_eligibility` column in the DB from a string to an integer (enum). We [migrated the existing data](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/db/migrate/20201102105419_change_oda_eligibility_type.rb) back then, so we should be okay about this, but please let me know if you disagree! :-)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
