### PR TITLE
Show error when cell contains invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,6 +442,7 @@
 - Activity importer sets `form_state` to "complete" to ensure correct behaviour
 - Organisation name must be unique
 - Show error message when the user tries to enter an invalid date on the `dates` step. Covers `planned_start_date`, `planned_end_date`, `actual_start_date`, `actual_end_date`
+- Catch encoding errors when uploading Transactions with invalid characters
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...HEAD
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -153,6 +153,12 @@ class ImportTransactions
       value = __send__(converter, value) if respond_to?(converter)
 
       value
+    rescue Encoding::CompatibilityError
+      @errors[attr_name] = [
+        original_value.force_encoding("UTF-8"),
+        I18n.t("importer.errors.transaction.invalid_characters"),
+      ]
+      nil
     rescue => error
       @errors[attr_name] = [original_value, error.message]
       nil

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -94,3 +94,4 @@ en:
         non_numeric_value: The value must be numeric
         unauthorised: You are not authorised to report against this activity
         unknown_identifier: Identifier is not recognised
+        invalid_characters: This cell contains invalid characters

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -106,6 +106,32 @@ RSpec.feature "users can upload transactions" do
     end
   end
 
+  scenario "uploading a set of transactions with encoding errors" do
+    ids = [project, sibling_project].map(&:roda_identifier)
+
+    upload_csv <<~CSV
+      Activity RODA Identifier | Date       | Value  | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Disbursement Channel | Description
+      #{ids[0]}                | 2020-04-01 | �20    | Example University          | 80                          |                                       | 4                    |
+      #{ids[1]}                | 2020-04-02 | �30    | Example Foundation          | 60                          |                                       | 4                    |
+    CSV
+
+    expect(Transaction.count).to eq(0)
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[1]", text: "Value")
+      expect(page).to have_xpath("td[2]", text: "2")
+      expect(page).to have_xpath("td[3]", text: "�20")
+      expect(page).to have_xpath("td[4]", text: I18n.t("importer.errors.transaction.invalid_characters"))
+    end
+
+    within "//tbody/tr[2]" do
+      expect(page).to have_xpath("td[1]", text: "Value")
+      expect(page).to have_xpath("td[2]", text: "3")
+      expect(page).to have_xpath("td[3]", text: "�30")
+      expect(page).to have_xpath("td[4]", text: I18n.t("importer.errors.transaction.invalid_characters"))
+    end
+  end
+
   def upload_csv(content)
     file = Tempfile.new("transactions.csv")
     file.write(content.gsub(/ *\| */, ","))


### PR DESCRIPTION
At the moment, if a cell contains an invalid (i.e. non-UTF-8) character, we get a 500 error, because the template code attempts to show the value of the cell, and this raises an `Encoding::CompatibilityError`. We can get around this by catching that specific error and forcing the encoding of the cell. We can also display a slightly more friendly error back to the user. The wording is up for debate - it can proably be improved!

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/109774/102761504-e6a57a00-436e-11eb-8cc0-f867d6caa6b2.png)
