### PR TITLE
Cache against dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/docker-save
-          key: docker-save-${{ hashFiles('Dockerfile') }}
+          key: docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock', 'package-lock.json') }}
       - name: Load cached Docker image
         run: docker load -i /tmp/docker-save/snapshot.tar || true
         if: steps.cache-docker.outputs.cache-hit == 'true'

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
 --require rails_helper
+--format documentation


### PR DESCRIPTION
This adds the Gemfile.lock and package-lock.json files to calculate the validity of the cache. At the moment, the cache is only refreshed if the Dockerfile changes, meaning that if a Ruby / JS dependency changes, we have to run the whole bundle install again when building the container. 

Now when a new dependency is added / updated (usually on Dependabot PRs), we do a fresh build of the container and upload the cache. This shaves a good 3 - 4 minutes off subsequent builds.