### PR TITLE
(1335) Handle forecasted spend errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,6 +448,7 @@
 
 - Transaction importer sets Description automatically from report and project attributes
 - Transaction importer doesn't process Disbursement channel
+- Show error messages when the user tries to enter invalid values for a forecasted spend. Covers financial quarter being in the past and forecast value an invalid number
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...HEAD
 [release-26]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...release-26

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -15,7 +15,16 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     authorize @activity
 
     history = history_for_create
-    history.set_value(planned_disbursement_params[:value])
+
+    begin
+      history.set_value(planned_disbursement_params[:value])
+    rescue PlannedDisbursementHistory::SequenceError
+      @planned_disbursement = PlannedDisbursement.new(planned_disbursement_params)
+      @planned_disbursement.parent_activity = @activity
+      @planned_disbursement.errors.add(:financial_quarter, :in_the_past)
+      render :new
+      return
+    end
 
     flash[:notice] = t("action.planned_disbursement.create.success")
     redirect_to organisation_activity_path(@activity.organisation, @activity)

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -43,3 +43,5 @@ en:
             value:
               inclusion: Value must be between 0.01 and 99,999,999,999.00
               not_a_number: "Value must be a valid number"
+            financial_quarter:
+              in_the_past: The forecast must be for a future financial quarter

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -109,6 +109,25 @@ RSpec.describe "Users can create a planned disbursement" do
 
       expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.financial_quarter.in_the_past")
     end
+
+    scenario "they receive an error message if the value is not a valid number" do
+      project = create(:project_activity, :with_report, organisation: user.organisation)
+      visit activities_path
+      click_on project.title
+
+      click_on t("page_content.planned_disbursements.button.create")
+
+      report = Report.editable_for_activity(project)
+      year = report.financial_year
+
+      fill_in_planned_disbursement_form(
+        financial_quarter: "Q#{report.financial_quarter}",
+        financial_year: "#{year + 1}-#{year + 2}",
+        value: ""
+      )
+
+      expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.value.not_a_number")
+    end
   end
 
   context "when signed in as a beis user" do

--- a/spec/features/staff/users_can_edit_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_edit_a_planned_disbursement_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Users can edit a planned disbursement" do
-  context "when signed in as a deivery partner" do
+  context "when signed in as a delivery partner" do
     let(:user) { create(:delivery_partner_user) }
 
     before { authenticate!(user: user) }
@@ -49,6 +49,24 @@ RSpec.describe "Users can edit a planned disbursement" do
 
       expect(page).not_to have_link t("default.link.edit"),
         href: edit_activity_planned_disbursements_path(activity, planned_disbursement.financial_year, planned_disbursement.financial_quarter)
+    end
+
+    scenario "they receive an error message if the value is not a valid number" do
+      organisation = user.organisation
+      project = create(:project_activity, organisation: user.organisation)
+      editable_report = create(:report, state: :active, organisation: project.organisation, fund: project.associated_fund)
+      planned_disbursement = create(:planned_disbursement, parent_activity: project, report: editable_report, financial_year: editable_report.financial_year + 1)
+
+      visit organisation_activity_path(organisation, project)
+
+      within "##{planned_disbursement.id}" do
+        click_on "Edit"
+      end
+
+      fill_in "Forecasted spend amount", with: ""
+      click_button "Submit"
+
+      expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.value.not_a_number")
     end
 
     scenario "the action is recorded with public_activity" do


### PR DESCRIPTION
## Changes in this PR

- Show error messages when the user tries to enter invalid values for a forecasted spend. Covers financial quarter being in the past and forecast value being an invalid number.

## Screenshots of UI changes

### Before

Server error

### After
<img width="816" alt="Screenshot 2020-12-21 at 19 30 28" src="https://user-images.githubusercontent.com/579522/102814835-30b84b00-43c3-11eb-8bcd-192f2e20f89a.png">
<img width="814" alt="Screenshot 2020-12-21 at 19 30 50" src="https://user-images.githubusercontent.com/579522/102814844-331aa500-43c3-11eb-9fa5-e1d70198a3e0.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
