### PR TITLE
(1157) Transaction uploader expects dates in `dd/mm/yyyy` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,6 +449,7 @@
 - Transaction importer sets Description automatically from report and project attributes
 - Transaction importer doesn't process Disbursement channel
 - Show error messages when the user tries to enter invalid values for a forecasted spend. Covers financial quarter being in the past and forecast value an invalid number
+- Transaction importer expects dates in `dd/mm/yyyy` format
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...HEAD
 [release-26]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...release-26

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -166,7 +166,7 @@ class ImportTransactions
 
     def convert_date(date)
       return nil unless date.present?
-      Date.iso8601(date)
+      Date.strptime(date, "%d/%m/%Y")
     rescue ArgumentError
       raise I18n.t("importer.errors.transaction.invalid_date")
     end

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -59,8 +59,8 @@ RSpec.feature "users can upload transactions" do
 
     upload_csv <<~CSV
       Activity RODA Identifier | Date       | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 2020-04-01 | 20    | Example University          | 80                          |
-      #{ids[1]}                | 2020-04-02 | 30    | Example Foundation          | 60                          |
+      #{ids[0]}                | 1/4/2020   | 20    | Example University          | 80                          |
+      #{ids[1]}                | 2/4/2020   | 30    | Example Foundation          | 60                          |
     CSV
 
     expect(Transaction.count).to eq(2)
@@ -73,8 +73,8 @@ RSpec.feature "users can upload transactions" do
 
     upload_csv <<~CSV
       Activity RODA Identifier | Date       | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 2020-04-01 | 0     | Example University          | 80                          |
-      #{ids[1]}                | 2020-04-02 | 30    | Example Foundation          | 61                          |
+      #{ids[0]}                | 1/4/2020   | 0     | Example University          | 80                          |
+      #{ids[1]}                | 2/4/2020   | 30    | Example Foundation          | 61                          |
     CSV
 
     expect(Transaction.count).to eq(0)
@@ -100,8 +100,8 @@ RSpec.feature "users can upload transactions" do
 
     upload_csv <<~CSV
       Activity RODA Identifier | Date       | Value  | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 2020-04-01 | �20    | Example University          | 80                          |
-      #{ids[1]}                | 2020-04-02 | �30    | Example Foundation          | 60                          |
+      #{ids[0]}                | 1/4/2020   | �20    | Example University          | 80                          |
+      #{ids[1]}                | 2/4/2020   | �30    | Example Foundation          | 60                          |
     CSV
 
     expect(Transaction.count).to eq(0)

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe ImportTransactions do
           ImportTransactions::Error.new(0, "Date", "99/4/2020", t("importer.errors.transaction.invalid_date")),
         ])
       end
+
+      context "two-digit date" do
+        let :transaction_row do
+          super().merge("Date" => "21/10/15")
+        end
+
+        it "returns an error" do
+          expect(importer.errors).to eq([
+            ImportTransactions::Error.new(0, "Date", "21/10/15", t("activerecord.errors.models.transaction.attributes.date.between", min: 10, max: 25)),
+          ])
+        end
+      end
     end
 
     context "with additional formatting in the Value field" do

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ImportTransactions do
     let :transaction_row do
       {
         "Activity RODA Identifier" => project.roda_identifier,
-        "Date" => "2020-09-08",
+        "Date" => "8/9/2020",
         "Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
@@ -137,9 +137,9 @@ RSpec.describe ImportTransactions do
       end
     end
 
-    context "when the Date is not an existing date" do
+    context "when the Date is invalid" do
       let :transaction_row do
-        super().merge("Date" => "2020-04-31")
+        super().merge("Date" => "99/4/2020")
       end
 
       it "does not import any transactions" do
@@ -148,7 +148,7 @@ RSpec.describe ImportTransactions do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportTransactions::Error.new(0, "Date", "2020-04-31", t("importer.errors.transaction.invalid_date")),
+          ImportTransactions::Error.new(0, "Date", "99/4/2020", t("importer.errors.transaction.invalid_date")),
         ])
       end
     end
@@ -289,7 +289,7 @@ RSpec.describe ImportTransactions do
     let :first_transaction_row do
       {
         "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Date" => "2020-09-08",
+        "Date" => "8/9/2020",
         "Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
@@ -299,7 +299,7 @@ RSpec.describe ImportTransactions do
     let :second_transaction_row do
       {
         "Activity RODA Identifier" => project.roda_identifier,
-        "Date" => "2020-09-10",
+        "Date" => "10/9/2020",
         "Value" => "150.00",
         "Receiving Organisation Name" => "Example Corporation",
         "Receiving Organisation Type" => "70",
@@ -309,7 +309,7 @@ RSpec.describe ImportTransactions do
     let :third_transaction_row do
       {
         "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Date" => "2019-12-25",
+        "Date" => "25/12/2019",
         "Value" => "£5,000",
         "Receiving Organisation Name" => "Example Foundation",
         "Receiving Organisation Type" => "60",
@@ -369,7 +369,7 @@ RSpec.describe ImportTransactions do
       end
 
       let :third_transaction_row do
-        super().merge("Date" => 6.months.from_now.iso8601, "Value" => "0")
+        super().merge("Date" => 6.months.from_now.strftime("%-d/%-m/%Y"), "Value" => "0")
       end
 
       it "does not import any transactions" do


### PR DESCRIPTION
## Changes in this PR

Update `ImportTransactions` so it expects dates in the `dd/mm/yyyy` format that
Excel uses when exporting a CSV.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
