### PR TITLE
Fix time sensitive specs

### DIFF
--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "BEIS users can edit a report" do
   context "Logged in as a BEIS user" do
     let(:beis_user) { create(:beis_user) }
+    before { travel_to DateTime.parse("2021-01-01") }
+    after { travel_back }
 
     scenario "they can edit a Report to set the deadline" do
       user = create(:beis_user)

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe "Users can create a planned disbursement" do
     end
 
     scenario "they receive an error message if the forecast is not in the future" do
+      start_of_third_quarter = Date.parse("2020-10-01")
+      travel_to start_of_third_quarter
+
       project = create(:project_activity, :with_report, organisation: user.organisation)
       visit activities_path
       click_on project.title
@@ -108,6 +111,8 @@ RSpec.describe "Users can create a planned disbursement" do
       )
 
       expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.financial_quarter.in_the_past")
+
+      travel_back
     end
 
     scenario "they receive an error message if the value is not a valid number" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1303,6 +1303,13 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "#variance_for_report_financial_quarter" do
+    before do
+      start_of_third_quarter = Date.parse("2020-10-01")
+      travel_to start_of_third_quarter
+    end
+
+    after { travel_back }
+
     let(:project) { create(:project_activity) }
     let(:reporting_cycle) { ReportingCycle.new(project, 2, 2020) }
     let(:forecast) { PlannedDisbursementHistory.new(project, 3, 2020) }


### PR DESCRIPTION
A couple of specs have started failing because we're now in another financial quarter, I've fixed these by using Rails's built in `travel_to` functionality to travel to a date where the tests will pass.

@CristinaRO also pointed out another test that will fail in the [Trello card](https://trello.com/c/rbYJza9l/1342-some-specs-are-written-in-a-time-brittle-way?menu=filter&filter=email), so I've fixed that too.