### PR TITLE
(1347) Include current financial year in the list of the “next ten years”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,7 @@
 
 - SDGs on activity details page now shows `Not applicable` when the user selects this option on the form
 - Refactor away `funding organisation` field
+- Forecasted spend form always includes the current financial year
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/lib/financial_period.rb
+++ b/lib/financial_period.rb
@@ -33,7 +33,7 @@ module FinancialPeriod
   end
 
   def self.next_ten_years
-    this_year = Date.today.year
+    this_year = current_financial_year.to_i
     tenth_year = this_year + 9
     (this_year..tenth_year).step.to_a
   end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -21,17 +21,31 @@ RSpec.describe "Users can create a planned disbursement" do
       expect(page).to have_content t("action.planned_disbursement.create.success")
     end
 
-    scenario "the current financial quarter and year are pre selected" do
-      project = create(:project_activity, :with_report, organisation: user.organisation)
-      first_quarter_2019_2020 = "2019-04-01".to_date
+    context "when we are in the first quarter" do
+      scenario "the current financial quarter and year are pre selected" do
+        travel_to_quarter(1, 2019) do
+          project = create(:project_activity, :with_report, organisation: user.organisation)
+          visit activities_path
+          click_on project.title
+          click_on t("page_content.planned_disbursements.button.create")
 
-      travel_to first_quarter_2019_2020 do
-        visit activities_path
-        click_on project.title
-        click_on t("page_content.planned_disbursements.button.create")
+          expect(page).to have_checked_field "Q1"
+          expect(page).to have_select "Financial year", selected: "2019-2020"
+        end
+      end
+    end
 
-        expect(page).to have_checked_field "Q1"
-        expect(page).to have_select "Financial year", selected: "2019-2020"
+    context "when we are in the fourth quarter" do
+      scenario "the current financial quarter and year are pre selected" do
+        travel_to_quarter(4, 2019) do
+          project = create(:project_activity, :with_report, organisation: user.organisation)
+          visit activities_path
+          click_on project.title
+          click_on t("page_content.planned_disbursements.button.create")
+
+          expect(page).to have_checked_field "Q4"
+          expect(page).to have_select "Financial year", selected: "2019-2020"
+        end
       end
     end
 

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -107,26 +107,23 @@ RSpec.describe "Users can create a planned disbursement" do
     end
 
     scenario "they receive an error message if the forecast is not in the future" do
-      start_of_third_quarter = Date.parse("2020-10-01")
-      travel_to start_of_third_quarter
+      travel_to_quarter(3, 2020) do
+        project = create(:project_activity, :with_report, organisation: user.organisation)
+        visit activities_path
+        click_on project.title
 
-      project = create(:project_activity, :with_report, organisation: user.organisation)
-      visit activities_path
-      click_on project.title
+        click_on t("page_content.planned_disbursements.button.create")
 
-      click_on t("page_content.planned_disbursements.button.create")
+        report = Report.editable_for_activity(project)
+        year = report.financial_year
 
-      report = Report.editable_for_activity(project)
-      year = report.financial_year
+        fill_in_planned_disbursement_form(
+          financial_quarter: "Q1",
+          financial_year: "#{year}-#{year + 1}"
+        )
 
-      fill_in_planned_disbursement_form(
-        financial_quarter: "Q1",
-        financial_year: "#{year}-#{year + 1}"
-      )
-
-      expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.financial_quarter.in_the_past")
-
-      travel_back
+        expect(page).to have_content t("activerecord.errors.models.planned_disbursement.attributes.financial_quarter.in_the_past")
+      end
     end
 
     scenario "they receive an error message if the value is not a valid number" do

--- a/spec/lib/financial_period_spec.rb
+++ b/spec/lib/financial_period_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe FinancialPeriod do
     end
   end
 
-  describe "#current_year" do
+  describe "#current_financial_year" do
     context "when it is the first, second or third financial quarter" do
       it "returns the current four digit year as a string" do
         dates = ["2019-05-03", "2019-08-15", "2019-10-03"]
@@ -97,6 +97,17 @@ RSpec.describe FinancialPeriod do
       it "returns the previous four digit year as a string" do
         travel_to Date.parse("2020-02-09") do
           expect(FinancialPeriod.current_financial_year).to eql "2019"
+        end
+      end
+    end
+  end
+
+  describe "#next_ten_years" do
+    it "returns the list of the next ten financial years including the current financial year" do
+      dates = ["2019-05-03", "2019-08-15", "2019-10-03", "2020-02-09"]
+      dates.each do |date|
+        travel_to Date.parse(date) do
+          expect(FinancialPeriod.next_ten_years).to eql [2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028]
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR

- Forecasted spend form always includes the current financial year

## Screenshots of UI changes

### Before
<img width="785" alt="Screenshot 2021-01-04 at 12 30 00" src="https://user-images.githubusercontent.com/579522/103566017-39c41480-4eb9-11eb-9d6e-602e707c2a9e.png">

### After
<img width="755" alt="Screenshot 2021-01-04 at 18 17 56" src="https://user-images.githubusercontent.com/579522/103566054-42b4e600-4eb9-11eb-9207-a254f8f96747.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
