### PR TITLE
(1313) Refactor away `funding organisation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -455,9 +455,10 @@
 ## [unreleased]
 
 - SDGs on activity details page now shows `Not applicable` when the user selects this option on the form
+- Refactor away `funding organisation` field
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
-[release-26]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27
+[release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27
 [release-26]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-25...release-26
 [release-25]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-24...release-25
 [release-24]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-23...release-24

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -209,12 +209,6 @@ class Activity < ApplicationRecord
     organisation.default_currency
   end
 
-  def has_funding_organisation?
-    funding_organisation_reference.present? &&
-      funding_organisation_name.present? &&
-      funding_organisation_type.present?
-  end
-
   def has_accountable_organisation?
     accountable_organisation_reference.present? &&
       accountable_organisation_name.present? &&

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -239,7 +239,16 @@ class Activity < ApplicationRecord
   end
 
   def providing_organisation
-    return organisation if third_party_project? && !organisation.is_government?
+    third_party_project? && !organisation.is_government? ? organisation : service_owner
+  end
+
+  def funding_organisation
+    return nil if fund?
+
+    service_owner
+  end
+
+  def service_owner
     Organisation.find_by(service_owner: true)
   end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -129,9 +129,6 @@ module Activities
         @activity.reporting_organisation = @organisation
 
         beis = Organisation.find_by(service_owner: true)
-        @activity.funding_organisation_name = beis.name
-        @activity.funding_organisation_reference = beis.iati_reference
-        @activity.funding_organisation_type = beis.organisation_type
         @activity.accountable_organisation_name = beis.name
         @activity.accountable_organisation_reference = beis.iati_reference
         @activity.accountable_organisation_type = beis.organisation_type

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -96,7 +96,6 @@ class ExportActivityToCsv
       "Tied status" => -> { activity_presenter.tied_status_with_code },
 
       # Additional headers specific to export CSV =============================
-      "Funding organisation name" => -> { activity_presenter.funding_organisation_name },
       forecast_header => -> { activity_presenter.forecasted_total_for_report_financial_quarter(report: report) },
       actuals_header => -> { activity_presenter.actual_total_for_report_financial_quarter(report: report) },
       "Variance" => -> { activity_presenter.variance_for_report_financial_quarter(report: report) },

--- a/app/services/update_activity_as_fund.rb
+++ b/app/services/update_activity_as_fund.rb
@@ -11,10 +11,6 @@ class UpdateActivityAsFund
     activity.form_state = "parent"
     activity.level = :fund
 
-    activity.funding_organisation_name = "HM Treasury"
-    activity.funding_organisation_reference = "GB-GOV-2"
-    activity.funding_organisation_type = "10"
-
     activity.accountable_organisation_name = "Department for Business, Energy and Industrial Strategy"
     activity.accountable_organisation_reference = "GB-GOV-13"
     activity.accountable_organisation_type = "10"

--- a/app/services/update_activity_as_programme.rb
+++ b/app/services/update_activity_as_programme.rb
@@ -18,10 +18,6 @@ class UpdateActivityAsProgramme
     activity.form_state = "parent"
     activity.level = :programme
 
-    activity.funding_organisation_name = service_owner.name
-    activity.funding_organisation_reference = service_owner.iati_reference
-    activity.funding_organisation_type = service_owner.organisation_type
-
     activity.accountable_organisation_name = service_owner.name
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type

--- a/app/services/update_activity_as_project.rb
+++ b/app/services/update_activity_as_project.rb
@@ -19,10 +19,6 @@ class UpdateActivityAsProject
     activity.form_state = "parent"
     activity.level = :project
 
-    activity.funding_organisation_name = service_owner.name
-    activity.funding_organisation_reference = service_owner.iati_reference
-    activity.funding_organisation_type = service_owner.organisation_type
-
     activity.accountable_organisation_name = service_owner.name
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type

--- a/app/services/update_activity_as_third_party_project.rb
+++ b/app/services/update_activity_as_third_party_project.rb
@@ -19,10 +19,6 @@ class UpdateActivityAsThirdPartyProject
     activity.form_state = "parent"
     activity.level = :third_party_project
 
-    activity.funding_organisation_name = service_owner.name
-    activity.funding_organisation_reference = service_owner.iati_reference
-    activity.funding_organisation_type = service_owner.organisation_type
-
     activity.accountable_organisation_name = service_owner.name
     activity.accountable_organisation_reference = service_owner.iati_reference
     activity.accountable_organisation_type = service_owner.organisation_type

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -9,9 +9,9 @@
   - unless activity.fund?
     %description{"type" => "2"}
       %narrative= activity.objectives
-  - if activity.has_funding_organisation?
-    %participating-org{"ref" => activity.funding_organisation_reference, "type" => activity.funding_organisation_type, "role" => 1}
-      %narrative= activity.funding_organisation_name
+  - if activity.funding_organisation.present?
+    %participating-org{"ref" => activity.funding_organisation.iati_reference, "type" => activity.funding_organisation.organisation_type, "role" => 1}
+      %narrative= activity.funding_organisation.name
   - if activity.has_accountable_organisation?
     %participating-org{"ref" => activity.accountable_organisation_reference, "type" => activity.accountable_organisation_type, "role" => 2}
       %narrative= activity.accountable_organisation_name

--- a/db/migrate/20210105131930_remove_funding_organisation_fields.rb
+++ b/db/migrate/20210105131930_remove_funding_organisation_fields.rb
@@ -1,0 +1,13 @@
+class RemoveFundingOrganisationFields < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :activities, :funding_organisation_name, :string
+    remove_column :activities, :funding_organisation_reference, :string
+    remove_column :activities, :funding_organisation_type, :string
+  end
+
+  def down
+    add_column :activities, :funding_organisation_name, :string, default: "Department for Business, Energy and Industrial Strategy"
+    add_column :activities, :funding_organisation_reference, :string, default: "GB-GOV-13"
+    add_column :activities, :funding_organisation_type, :string, default: "10"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_093803) do
+ActiveRecord::Schema.define(version: 2021_01_05_131930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,9 +34,6 @@ ActiveRecord::Schema.define(version: 2020_12_08_093803) do
     t.string "aid_type"
     t.string "form_state"
     t.string "level"
-    t.string "funding_organisation_name"
-    t.string "funding_organisation_reference"
-    t.string "funding_organisation_type"
     t.string "accountable_organisation_name"
     t.string "accountable_organisation_reference"
     t.string "accountable_organisation_type"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -47,9 +47,6 @@ FactoryBot.define do
 
     factory :fund_activity do
       level { :fund }
-      funding_organisation_name { "HM Treasury" }
-      funding_organisation_reference { "GB-GOV-2" }
-      funding_organisation_type { "10" }
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
@@ -83,9 +80,6 @@ FactoryBot.define do
       objectives { Faker::Lorem.paragraph }
       country_delivery_partners { ["National Council for the State Funding Agencies (CONFAP)"] }
       collaboration_type { "1" }
-      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
-      funding_organisation_reference { "GB-GOV-13" }
-      funding_organisation_type { "10" }
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
@@ -121,9 +115,6 @@ FactoryBot.define do
       policy_marker_disability { "not_assessed" }
       policy_marker_disaster_risk_reduction { "not_assessed" }
       policy_marker_nutrition { "not_assessed" }
-      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
-      funding_organisation_reference { "GB-GOV-13" }
-      funding_organisation_type { "10" }
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }
@@ -169,9 +160,6 @@ FactoryBot.define do
       policy_marker_disability { "not_assessed" }
       policy_marker_disaster_risk_reduction { "not_assessed" }
       policy_marker_nutrition { "not_assessed" }
-      funding_organisation_name { "Department for Business, Energy and Industrial Strategy" }
-      funding_organisation_reference { "GB-GOV-13" }
-      funding_organisation_type { "10" }
       accountable_organisation_name { "Department for Business, Energy and Industrial Strategy" }
       accountable_organisation_reference { "GB-GOV-13" }
       accountable_organisation_type { "10" }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -51,20 +51,6 @@ RSpec.feature "Users can create a fund level activity" do
       expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.flow
     end
 
-    scenario "the activity has the appropriate funding organisation defaults" do
-      identifier = "a-fund-has-a-funding-organisation"
-
-      visit activities_path
-      click_on(t("page_content.organisation.button.create_activity"))
-
-      fill_in_activity_form(delivery_partner_identifier: identifier, level: "fund")
-
-      activity = Activity.find_by(delivery_partner_identifier: identifier)
-      expect(activity.funding_organisation_name).to eq("HM Treasury")
-      expect(activity.funding_organisation_reference).to eq("GB-GOV-2")
-      expect(activity.funding_organisation_type).to eq("10")
-    end
-
     scenario "the activity has the appropriate accountable organisation defaults" do
       identifier = "a-fund-has-an-accountable-organisation"
 

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -257,23 +257,6 @@ RSpec.feature "Users can create a programme activity" do
       end
     end
 
-    scenario "the activity has the appropriate funding organisation defaults" do
-      fund = create(:activity, level: :fund, organisation: user.organisation)
-      identifier = "a-programme-has-a-funding-organisation"
-
-      visit activities_path
-      click_on fund.title
-      click_on t("tabs.activity.children")
-      click_on(t("page_content.organisation.button.create_activity"))
-
-      fill_in_activity_form(delivery_partner_identifier: identifier, level: "programme", parent: fund)
-
-      activity = Activity.find_by(delivery_partner_identifier: identifier)
-      expect(activity.funding_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(activity.funding_organisation_reference).to eq("GB-GOV-13")
-      expect(activity.funding_organisation_type).to eq("10")
-    end
-
     scenario "the activity has the appropriate accountable organisation defaults" do
       fund = create(:activity, level: :fund, organisation: user.organisation)
       identifier = "a-fund-has-an-accountable-organisation"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -736,14 +736,6 @@ RSpec.describe Activity, type: :model do
       it { should validate_presence_of(:extending_organisation_id).on(:update_extending_organisation) }
     end
 
-    context "when the form state is blank" do
-      it "allows updates to be made to other fields set on creation" do
-        blank_activity = create(:activity, funding_organisation_name: "old", form_state: :blank)
-        blank_activity.funding_organisation_name = "new"
-        expect(blank_activity.valid?).to eq(true)
-      end
-    end
-
     context "when the activity is neither a fund nor a programme" do
       context "when call_present is blank" do
         subject(:activity) { build(:project_activity, call_present: nil) }
@@ -900,20 +892,6 @@ RSpec.describe Activity, type: :model do
       activity = build(:activity, form_state: nil)
 
       expect(activity.form_steps_completed?).to be_falsey
-    end
-  end
-
-  describe "#has_funding_organisation?" do
-    it "returns true if all funding_organisation fields are present" do
-      activity = build(:fund_activity)
-
-      expect(activity.has_funding_organisation?).to be true
-    end
-
-    it "returns false if all funding_organisation fields are not present" do
-      activity = build(:activity)
-
-      expect(activity.has_funding_organisation?).to be false
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -987,6 +987,30 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    describe "#funding_organisation" do
+      let!(:beis) { create(:beis_organisation) }
+
+      it "returns BEIS if the activity is a programme" do
+        project = build(:programme_activity)
+        expect(project.funding_organisation).to eql beis
+      end
+
+      it "returns BEIS if the activity is a project" do
+        project = build(:project_activity)
+        expect(project.funding_organisation).to eql beis
+      end
+
+      it "returns BEIS if the activity is a third party project" do
+        project = build(:third_party_project_activity)
+        expect(project.funding_organisation).to eql beis
+      end
+
+      it "returns nil if the activity is a fund" do
+        fund = build(:fund_activity)
+        expect(fund.funding_organisation).to be_nil
+      end
+    end
+
     context "when the activity is a third-party project" do
       context "when the activity organisation is a government type" do
         it "returns BEIS" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -324,18 +324,6 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
     end
 
-    it "sets BEIS as the funding organisation" do
-      beis = create(:beis_organisation)
-
-      subject.import([new_activity_attributes])
-
-      new_activity = Activity.order(:created_at).last
-
-      expect(new_activity.funding_organisation_name).to eq beis.name
-      expect(new_activity.funding_organisation_reference).to eq beis.iati_reference
-      expect(new_activity.funding_organisation_type).to eq beis.organisation_type
-    end
-
     it "sets BEIS as the accountable organisation" do
       beis = create(:beis_organisation)
 

--- a/spec/services/update_activity_as_fund_spec.rb
+++ b/spec/services/update_activity_as_fund_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe UpdateActivityAsFund do
       expect(result.level).to eq("fund")
     end
 
-    it "sets the funding organisation details to HMT" do
-      expect(result.funding_organisation_name).to eq("HM Treasury")
-      expect(result.funding_organisation_reference).to eq("GB-GOV-2")
-      expect(result.funding_organisation_type).to eq("10")
-    end
-
     it "sets the accountable organisation details to the service owner" do
       expect(result.accountable_organisation_name).to eq beis.name
       expect(result.accountable_organisation_reference).to eq beis.iati_reference

--- a/spec/services/update_activity_as_project_spec.rb
+++ b/spec/services/update_activity_as_project_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe UpdateActivityAsProject do
       expect(result.level).to eq("project")
     end
 
-    it "sets the funding organisation details to the service owner" do
-      expect(result.funding_organisation_name).to eq beis.name
-      expect(result.funding_organisation_reference).to eq beis.iati_reference
-      expect(result.funding_organisation_type).to eq beis.organisation_type
-    end
-
     it "sets the accountable organisation details to the service owner" do
       expect(result.accountable_organisation_name).to eq beis.name
       expect(result.accountable_organisation_reference).to eq beis.iati_reference

--- a/spec/services/update_activity_as_third_party_project_spec.rb
+++ b/spec/services/update_activity_as_third_party_project_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe UpdateActivityAsThirdPartyProject do
       expect(result.level).to eq("third_party_project")
     end
 
-    it "sets the funding organisation details to service_owner" do
-      expect(result.funding_organisation_name).to eq beis.name
-      expect(result.funding_organisation_reference).to eq beis.iati_reference
-      expect(result.funding_organisation_type).to eq beis.organisation_type
-    end
-
     it "sets the accountable organisation details to the service owner" do
       expect(result.accountable_organisation_name).to eq beis.name
       expect(result.accountable_organisation_reference).to eq beis.iati_reference

--- a/spec/services/update_programme_activity_spec.rb
+++ b/spec/services/update_programme_activity_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe UpdateActivityAsProgramme do
       expect(result.level).to eq("programme")
     end
 
-    it "sets the funding organisation details to service_owner" do
-      expect(result.funding_organisation_name).to eq beis.name
-      expect(result.funding_organisation_reference).to eq beis.iati_reference
-      expect(result.funding_organisation_type).to eq beis.organisation_type
-    end
-
     it "sets the accountable organisation details to the service owner" do
       expect(result.accountable_organisation_name).to eq beis.name
       expect(result.accountable_organisation_reference).to eq beis.iati_reference

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -18,11 +18,15 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/reporting-org/narrative").text).to eq(activity.reporting_organisation.name)
   end
 
-  it "contains the funding organisation XML" do
+  it "has the relevant funding organisation XML" do
     visit organisation_activity_path(organisation, activity, format: :xml)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation_reference)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation_type)
-    expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation_name)
+    if activity.funding_organisation.present?
+      expect(xml.at("iati-activity/participating-org[@role = '1']/@ref").text).to eq(activity.funding_organisation.iati_reference)
+      expect(xml.at("iati-activity/participating-org[@role = '1']/@type").text).to eq(activity.funding_organisation.organisation_type)
+      expect(xml.at("iati-activity/participating-org[@role = '1']/narrative").text).to eq(activity.funding_organisation.name)
+    else
+      expect(xml.at("iati-activity/participating-org[@role = '1']")).to be_nil
+    end
   end
 
   it "contains the accountable organisation XML" do


### PR DESCRIPTION
This PR removes the `funding_organisation_*` fields, because all Activities are funded by BEIS, and all level A funds are not reported to IATI anyway. Now we just return the Service Owner (which in our case will always be BEIS)