### PR TITLE
(1314) Remove form steps label from child activities view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,7 @@
 - SDGs on activity details page now shows `Not applicable` when the user selects this option on the form
 - Refactor away `funding organisation` field
 - Forecasted spend form always includes the current financial year
+- Remove `Complete` label from child activities view
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -9,8 +9,6 @@
         = t("table.header.programme.identifier")
       %th.govuk-table__header
         =t("table.header.programme.fund")
-      %th.govuk-table__header
-        =t("summary.label.activity.stage")
 
   %tbody.govuk-table__body
     - programmes.each do |programme|
@@ -18,10 +16,3 @@
         %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
         %td.govuk-table__cell= programme.delivery_partner_identifier
         %td.govuk-table__cell= programme.parent_title
-        %td.govuk-table__cell
-          - if programme.form_steps_completed?
-            %strong.govuk-tag.govuk-tag--green
-              = t("summary.label.activity.form_state.complete")
-          - else
-            %strong.govuk-tag.govuk-tag--yellow
-              = t("summary.label.activity.form_state.incomplete")

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -10,8 +10,6 @@
           = t("table.header.project.identifier")
         %th.govuk-table__header
           =t("table.header.project.programme")
-        %th.govuk-table__header
-          =t("summary.label.activity.stage")
         - if policy(:project).redact_from_iati?
           %th.govuk-table__header
             = t("summary.label.activity.publish_to_iati.label")
@@ -22,13 +20,6 @@
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.delivery_partner_identifier
           %td.govuk-table__cell= project.parent_title
-          %td.govuk-table__cell
-            - if project.form_steps_completed?
-              %strong.govuk-tag.govuk-tag--green
-                = t("summary.label.activity.form_state.complete")
-            - else
-              %strong.govuk-tag.govuk-tag--yellow
-                = t("summary.label.activity.form_state.incomplete")
           - if policy(:project).redact_from_iati?
             %td.govuk-table__cell
               - if project.publish_to_iati?

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -10,8 +10,6 @@
           = t("table.header.third_party_project.identifier")
         %th.govuk-table__header
           =t("table.header.third_party_project.project")
-        %th.govuk-table__header
-          =t("summary.label.activity.stage")
         - if policy(:third_party_project).redact_from_iati?
           %th.govuk-table__header
             = t("summary.label.activity.publish_to_iati.label")
@@ -22,13 +20,6 @@
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
           %td.govuk-table__cell= project.delivery_partner_identifier
           %td.govuk-table__cell= project.parent_title
-          %td.govuk-table__cell
-            - if project.form_steps_completed?
-              %strong.govuk-tag.govuk-tag--green
-                = t("summary.label.activity.form_state.complete")
-            - else
-              %strong.govuk-tag.govuk-tag--yellow
-                = t("summary.label.activity.form_state.incomplete")
           - if policy(:third_party_project).redact_from_iati?
             %td.govuk-table__cell
               - if project.publish_to_iati?

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -36,18 +36,6 @@ RSpec.feature "Users can view an activity" do
         expect(page.find("table.programmes  tbody tr:last-child")[:id]).to have_content(programme_2.id)
       end
 
-      scenario "they see 'Incomplete' next to incomplete programmes" do
-        fund = create(:fund_activity)
-        incomplete_programme = create(:programme_activity, :at_purpose_step, parent: fund)
-
-        visit organisation_activity_children_path(fund.organisation, fund)
-
-        within("##{incomplete_programme.id}") do
-          expect(page).to have_link incomplete_programme.title
-          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
-        end
-      end
-
       scenario "they do not see a Publish to Iati column & status against programmes" do
         fund = create(:fund_activity)
         programme = create(:programme_activity, parent: fund)
@@ -86,18 +74,6 @@ RSpec.feature "Users can view an activity" do
         end
       end
 
-      scenario "they see 'Incomplete' next to incomplete projects" do
-        fund = create(:fund_activity)
-        programme = create(:programme_activity, parent: fund)
-        incomplete_project = create(:project_activity, :at_purpose_step, parent: programme)
-
-        visit organisation_activity_children_path(programme.organisation, programme)
-        within("##{incomplete_project.id}") do
-          expect(page).to have_link incomplete_project.title
-          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
-        end
-      end
-
       scenario "they see a Publish to Iati column & status against projects" do
         fund = create(:fund_activity)
         programme = create(:programme_activity, parent: fund)
@@ -126,18 +102,6 @@ RSpec.feature "Users can view an activity" do
           expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
           expect(page).to have_content third_party_project.delivery_partner_identifier
           expect(page).to have_content third_party_project.parent.title
-        end
-      end
-
-      scenario "they see 'Incomplete' next to incomplete third-party projects" do
-        project = create(:project_activity)
-        incomplete_third_party_project = create(:project_activity, :at_identifier_step, parent: project)
-
-        visit organisation_activity_children_path(user.organisation, project)
-
-        within("##{incomplete_third_party_project.id}") do
-          expect(page).to have_link incomplete_third_party_project.title
-          expect(page).to have_content t("summary.label.activity.form_state.incomplete")
         end
       end
 


### PR DESCRIPTION
Trello: https://trello.com/c/h6QNiHF6

## Changes in this PR

This is an old feature that shows if a user has completed all the form steps of an activity or not, which used to be an indicator of an activity being valid. This is no longer the case and this information has no value for the users anymore, so we are now removing this column from the child activities view. This applies to programmes, projects and third-party projects.

I have also removed the specs related to this feature.

## Screenshots of UI changes

### Before

<img width="1132" alt="Screenshot 2021-01-05 at 11 58 08" src="https://user-images.githubusercontent.com/48016017/103666248-4b1a2900-4f6c-11eb-86fd-41b5dc3279d2.png">

### After

<img width="1132" alt="Screenshot 2021-01-05 at 15 07 26" src="https://user-images.githubusercontent.com/48016017/103666265-51100a00-4f6c-11eb-82f9-150ff3c6c0b5.png">

<img width="1132" alt="Screenshot 2021-01-05 at 15 10 19" src="https://user-images.githubusercontent.com/48016017/103666284-579e8180-4f6c-11eb-8723-24b0f579d388.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
