### PR TITLE
(1359) Importer stops activities being associated to an incomplete parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,7 @@
 - Forecasted spend form always includes the current financial year
 - Remove `Complete` label from child activities view
 - Refactor helper to standardise the way we load BEIS codes
+- Activity importer ignores incomplete activities when finding a parent
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -376,6 +376,7 @@ module Activities
         parent = Activity.by_roda_identifier(roda_id)
 
         raise I18n.t("importer.errors.activity.parent_not_found") if parent.nil?
+        raise I18n.t("importer.errors.activity.invalid_parent") unless parent.form_steps_completed?
 
         parent.id
       end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -485,6 +485,7 @@ en:
         invalid_flow: The flow code is not valid
         invalid_aid_type: The aid type code is not valid
         invalid_fstc_applies: The free standing technical cooperation column is not valid
+        invalid_parent: The parent activity is not valid
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Activities::ImportFromCsv do
   let(:organisation) { create(:organisation) }
-  let(:parent_activity) { create(:activity) }
+  let(:parent_activity) { create(:fund_activity) }
   let(:existing_activity) do
     create(:activity) do |activity|
       activity.implementing_organisations = [
@@ -286,6 +286,7 @@ RSpec.describe Activities::ImportFromCsv do
       ].join("-")
 
       expect(new_activity.parent).to eq(parent_activity)
+      expect(new_activity.level).to eq("programme")
       expect(new_activity.roda_identifier_compound).to eq(expected_roda_identifier_compound)
       expect(new_activity.transparency_identifier).to eq(new_activity_attributes["Transparency identifier"])
       expect(new_activity.title).to eq(new_activity_attributes["Title"])

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe Activities::ImportFromCsv do
   let(:organisation) { create(:organisation) }
   let(:parent_activity) { create(:fund_activity) }
-  let(:existing_activity) do
+
+  # NB: 'let!' to prevent `to change { Activity.count }` from giving confusing results
+  let!(:existing_activity) do
     create(:activity) do |activity|
       activity.implementing_organisations = [
         create(:implementing_organisation, activity: activity),
@@ -323,6 +325,20 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.beis_id).to eq(new_activity_attributes["BEIS ID"])
       expect(new_activity.uk_dp_named_contact).to eq(new_activity_attributes["UK DP Named Contact (NF)"])
       expect(new_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
+    end
+
+    context "with a parent activity that is incomplete" do
+      it "doesn't allow the new activity to be created" do
+        parent_activity.update!(form_state: "level")
+
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Parent RODA ID")
+        expect(subject.errors.first.column).to eq(:parent_id)
+        expect(subject.errors.first.value).to eq(parent_activity.roda_identifier)
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_parent"))
+      end
     end
 
     it "sets BEIS as the accountable organisation" do


### PR DESCRIPTION
On production, we have several activities in an incomplete state, which meant that `Activity.by_roda_identifier` would return a result, instead of `nil`, so the expected `parent_not_found` was not raised. This would lead to these activities being imported and incorrectly parented to a random activity.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
