### PR TITLE
(1087) Prevent admnistrators from changing an email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,7 @@
 - Refactor helper to standardise the way we load BEIS codes
 - Activity importer ignores incomplete activities when finding a parent
 - IATI status is calculated on the fly from the programme status
+- Do not allow a user's email address to be changed after creation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   belongs_to :organisation
   validates_presence_of :name, :email
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
+  validates :email, with: :email_cannot_be_changed_after_create, on: :update
 
   enum role: {
     administrator: "administrator",
@@ -25,5 +26,13 @@ class User < ApplicationRecord
 
   def delivery_partner?
     !service_owner?
+  end
+
+  private
+
+  def email_cannot_be_changed_after_create
+    if email_changed?
+      errors.add(:email, :cannot_be_changed)
+    end
   end
 end

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -2,7 +2,7 @@
   = f.govuk_error_summary
 
   = f.govuk_text_field :name
-  = f.govuk_email_field :email
+  = f.govuk_email_field :email, disabled: (action_name == "edit")
   = f.govuk_collection_radio_buttons :role,
       list_of_user_roles,
       :id,

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -3,7 +3,7 @@ en:
   action:
     user:
       create:
-        failed: 'The service failed to create the new user. The error received was: %{error}'
+        failed: "The service failed to create the new user. The error received was: %{error}"
         success: User successfully created
       update:
         failed: The service is experiencing issues updating users and the team has been alerted to the problem.
@@ -28,10 +28,10 @@ en:
     user:
       active:
         active: Activate
-        'false': 'No'
+        "false": "No"
         inactive: Deactivate
         label: Activate user
-        'true': 'Yes'
+        "true": "Yes"
   table:
     header:
       user:
@@ -81,3 +81,4 @@ en:
               blank: Enter a full name
             email:
               blank: Enter an email address
+              cannot_be_changed: "cannot be changed once a user has been created"

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -14,12 +14,11 @@ RSpec.feature "BEIS users can editing other users" do
     target_user = create(:administrator, name: "Old Name", email: "old@example.com")
 
     updated_name = "New Name"
-    updated_email = "new@example.com"
 
     stub_auth0_update_user_request(
       auth0_identifier: target_user.identifier,
-      email: updated_email,
-      name: updated_name
+      name: updated_name,
+      email: target_user.email,
     )
 
     # Navigate from the landing page
@@ -36,14 +35,12 @@ RSpec.feature "BEIS users can editing other users" do
 
     # Fill out the form
     fill_in "user[name]", with: updated_name
-    fill_in "user[email]", with: updated_email
 
     # Submit the form
     click_button t("form.button.user.submit")
 
     # Verify the user was updated
     expect(page).to have_content(updated_name)
-    expect(page).to have_content(updated_email)
   end
 
   scenario "the role can be changed" do
@@ -98,12 +95,11 @@ RSpec.feature "BEIS users can editing other users" do
     target_user = create(:administrator, name: "Old Name", email: "old@example.com")
 
     updated_name = "New Name"
-    updated_email = "new@example.com"
 
     stub_auth0_update_user_request(
       auth0_identifier: target_user.identifier,
-      email: updated_email,
-      name: updated_name
+      name: updated_name,
+      email: target_user.email,
     )
 
     PublicActivity.with_tracking do
@@ -114,7 +110,6 @@ RSpec.feature "BEIS users can editing other users" do
       find("tr", text: target_user.name).click_link("Edit")
 
       fill_in "user[name]", with: updated_name
-      fill_in "user[email]", with: updated_email
 
       click_button t("form.button.user.submit")
 

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -7,6 +7,21 @@ RSpec.feature "BEIS users can editing other users" do
     stub_auth0_token_request
   end
 
+  scenario "the email address is disabled" do
+    user = create(:beis_user)
+    authenticate!(user: user)
+
+    target_user = create(:administrator, name: "Old Name", email: "old@example.com")
+
+    visit organisation_path(user.organisation)
+    click_on(t("page_title.users.index"))
+
+    find("tr", text: target_user.name).click_link("Edit")
+
+    email_field = find("input[name='user[email]']")
+    expect(email_field).to be_disabled
+  end
+
   scenario "the details of the user can be updated" do
     user = create(:beis_user)
     authenticate!(user: user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe User, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:email) }
+
+    it "should not allow an email to be changed" do
+      user = create(:administrator, email: "old@example.com")
+
+      user.email = "new@example.com"
+
+      expect(user).to be_invalid
+      expect(user.errors[:email]).to eq([I18n.t("activerecord.errors.models.user.attributes.email.cannot_be_changed")])
+    end
   end
 
   describe "associations" do


### PR DESCRIPTION
When carrying out user testing, we found out that if an administrator created an account with the wrong email address and the email address was subsequently changed, the new user would not recieve a confirmation email for them to activate their account. 

We did initially consider sending a new confirmation email if an email is changed, but on further investigation / discussion, we discovered that Auth0 does not allow a user's email to be changed, and in any case, we should treat the email of a user as the primary identifier. 

With this in mind, I've changed the system to not allow emails to be changed, both via a validation, and by disabling the email field on the edit page. If a user has been created with the wrong email address, they should be deactivated. We don't currently allow deletion of users, though if the system gets clogged up with loads of erroneously created deactivated users, we can reconsider and prioritise appropriately.

### Before

![image](https://user-images.githubusercontent.com/109774/103759654-fded9400-500b-11eb-8c04-7f7eb4da9d0f.png)

### After

![image](https://user-images.githubusercontent.com/109774/103759687-06de6580-500c-11eb-8c49-9deeff54b6d3.png)