### PR TITLE
(1295) Require UK named contact for all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,7 @@
 - IATI status is calculated on the fly from the programme status
 - Do not allow a user's email address to be changed after creation
 - Infer the value of FSTC applies from aid type, where possible
+- Require UK Delivery partner named contact for all projects and third-party projects
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -88,7 +88,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     when :oda_eligibility_lead
       skip_step unless @activity.is_project?
     when :uk_dp_named_contact
-      skip_step unless @activity.is_project? && @activity.is_newton_funded?
+      skip_step unless @activity.is_project?
     when :fstc_applies
       skip_step if can_infer_fstc?(@activity.aid_type)
       assign_default_fstc_applies_value_if_aid_type_c01

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -87,7 +87,7 @@ class Activity < ApplicationRecord
   validates :gcrf_challenge_area, presence: true, on: :gcrf_challenge_area_step, if: :is_gcrf_funded?
   validates :oda_eligibility, presence: true, on: :oda_eligibility_step
   validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :is_project?
-  validates :uk_dp_named_contact, presence: true, on: :uk_dp_named_contact_step, if: :is_project? && :is_newton_funded?
+  validates :uk_dp_named_contact, presence: true, on: :uk_dp_named_contact_step, if: :is_project?
 
   validates :delivery_partner_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :roda_identifier_compound, uniqueness: true, allow_nil: true

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -88,7 +88,7 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("summary.label.activity.sector"))
 
-  - if @activity.is_project? && @activity.is_newton_funded?
+  - if @activity.is_project?
     .govuk-summary-list__row.uk_dp_named_contact
       %dt.govuk-summary-list__key
         = t("summary.label.activity.uk_dp_named_contact")

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -377,21 +377,18 @@ RSpec.feature "Users can edit an activity" do
         end
       end
 
-      context "when the project is Newton-funded" do
-        let(:activity) { create(:project_activity, organisation: user.organisation, parent: create(:programme_activity, parent: create(:fund_activity, :newton))) }
+      it "shows a link to edit the UK DP named contact" do
+        activity = create(:project_activity, organisation: user.organisation)
+        # Report needs to exist so the activity is editable
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
-        it "shows a link to edit the UK DP named contact" do
-          # Report needs to exist so the activity is editable
-          _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
-          visit organisation_activity_details_path(activity.organisation, activity)
-
-          within(".uk_dp_named_contact") do
-            click_on(t("default.link.edit"))
-            expect(page).to have_current_path(
-              activity_step_path(activity, :uk_dp_named_contact)
-            )
-          end
+        within(".uk_dp_named_contact") do
+          click_on(t("default.link.edit"))
+          expect(page).to have_current_path(
+            activity_step_path(activity, :uk_dp_named_contact)
+          )
         end
       end
 
@@ -676,7 +673,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     click_on t("tabs.activity.details")
   end
 
-  if activity.is_project? && activity.is_newton_funded?
+  if activity.is_project?
     within(".uk_dp_named_contact") do
       click_on(t("default.link.edit"))
       expect(page).to have_current_path(

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -703,31 +703,13 @@ RSpec.describe Activity, type: :model do
       end
 
       context "when the activity is a project" do
-        context "and it is Newton-funded" do
-          subject { build(:project_activity, parent: build(:programme_activity, parent: build(:fund_activity, :newton))) }
-
-          it { should validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
-        end
-
-        context "and it is not Newton-funded" do
-          subject { build(:project_activity) }
-
-          it { should_not validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
-        end
+        subject { build(:project_activity) }
+        it { should validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
       end
 
       context "when the activity is a third party project" do
-        context "and it is Newton-funded" do
-          subject { build(:third_party_project_activity, parent: build(:programme_activity, parent: build(:fund_activity, :newton))) }
-
-          it { should validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
-        end
-
-        context "and it is not Newton-funded" do
-          subject { build(:third_party_project_activity) }
-
-          it { should_not validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
-        end
+        subject { build(:third_party_project_activity) }
+        it { should validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
       end
     end
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -317,7 +317,7 @@ module FormHelpers
       click_button t("form.button.activity.submit")
     end
 
-    if (level == "project" || level == "third_party_project") && parent.is_newton_funded?
+    if level == "project" || level == "third_party_project"
       expect(page).to have_content t("form.label.activity.uk_dp_named_contact")
       fill_in "activity[uk_dp_named_contact]", with: uk_dp_named_contact
       click_button t("form.button.activity.submit")
@@ -396,7 +396,7 @@ module FormHelpers
     expect(page).to have_content fund_pillar if associated_fund_is_newton?(parent)
     expect(page).to have_content oda_eligibility
     expect(page).to have_content oda_eligibility_lead if level == "project" || level == "third_party_project"
-    if (level == "project" || level == "third_party_project") && parent.is_newton_funded?
+    if level == "project" || level == "third_party_project"
       expect(page).to have_content uk_dp_named_contact
     end
     expect(page).to have_content localise_date_from_input_fields(


### PR DESCRIPTION
## Changes in this PR

- Require UK Delivery partner named contact for all projects and third-party projects

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
