### PR TITLE
(1379) Fix: Users can change the extending organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,6 +465,7 @@
 - Infer the value of FSTC applies from aid type, where possible
 - Require UK Delivery partner named contact for all projects and third-party projects
 - Fix a brittle spec
+- Fix users can change the extending organisation on a level B (programme) activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/controllers/staff/extending_organisations_controller.rb
+++ b/app/controllers/staff/extending_organisations_controller.rb
@@ -14,7 +14,7 @@ class Staff::ExtendingOrganisationsController < Staff::BaseController
 
     if @activity.valid?(:update_extending_organisation)
       set_implementing_organisation
-      @activity.save
+      @activity.save(context: :update_extending_organisation)
       flash[:notice] = t("action.#{@activity.level}.update.success")
       redirect_to organisation_activity_details_path(@activity.organisation, @activity)
     else

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Users can manage the extending organisation" do
         expect(implementing_organisation.reference).to eq(delivery_partner.iati_reference)
       end
 
-      scenario "they can change the extending organistion" do
+      scenario "they can change the extending organistion when the activity is valid" do
         delivery_partner = create(:delivery_partner_organisation)
         programme.update(extending_organisation: delivery_partner)
         another_delivery_partner = create(:delivery_partner_organisation)
@@ -49,6 +49,26 @@ RSpec.feature "Users can manage the extending organisation" do
 
         expect(page).to have_content("success")
         expect(page).to have_content another_delivery_partner.name
+        expect(programme.reload.extending_organisation_id).to eql another_delivery_partner.id
+      end
+
+      scenario "they can change the extending organistion when the activity is invalid i.e. not yet complete" do
+        delivery_partner = create(:delivery_partner_organisation)
+        invalid_programme = create(:programme_activity)
+        invalid_programme.update(extending_organisation: delivery_partner)
+        invalid_programme.title = nil
+        invalid_programme.save(context: :update_extending_organisation)
+        another_delivery_partner = create(:delivery_partner_organisation)
+
+        visit organisation_activity_path(invalid_programme.organisation, invalid_programme)
+        click_on t("tabs.activity.details")
+        click_on t("page_content.activity.extending_organisation.button.edit")
+
+        choose another_delivery_partner.name
+        click_on t("default.button.submit")
+
+        expect(page).to have_content another_delivery_partner.name
+        expect(invalid_programme.reload.extending_organisation_id).to eql another_delivery_partner.id
       end
 
       scenario "when the extending organisation is changed, the implementing organisation is changed" do


### PR DESCRIPTION
## Changes in this PR
Whilst looking at if this was even possible I noticed it was broken.

The reason is that the activity model is not valid by default without
all required attributes. We often see activities being completed over
time and so cannot always rely on the object being valid.

It turns out we even have a validation context that was used for these
reasons to test the validity but it was no called on the `save` so the
save never completed.

This was compounded by the fact the UI gives the impression that the
save was completed when it had not.

The fix is to simply validation in the `update_extending_organisation`
context which will only validate the extending organisation attribute
and not the entire Activity object.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
