### PR TITLE
(1140) Automatically fill in FSTC question where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -462,6 +462,7 @@
 - Activity importer ignores incomplete activities when finding a parent
 - IATI status is calculated on the fly from the programme status
 - Do not allow a user's email address to be changed after creation
+- Infer the value of FSTC applies from aid type, where possible
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -14,6 +14,11 @@ module CodelistHelper
     "E01",
     "G01",
   ]
+  FSTC_FROM_AID_TYPE_CODE = {
+    "D02" => true,
+    "E01" => true,
+    "G01" => false,
+  }
 
   ALLOWED_POLICY_MARKERS_SIGNIFICANCES = [
     "0",
@@ -134,6 +139,14 @@ module CodelistHelper
     )
 
     options.select { |a| ALLOWED_AID_TYPE_CODES.include?(a.code) }
+  end
+
+  def fstc_from_aid_type(aid_type_code)
+    FSTC_FROM_AID_TYPE_CODE[aid_type_code]
+  end
+
+  def can_infer_fstc?(aid_type_code)
+    FSTC_FROM_AID_TYPE_CODE.key?(aid_type_code)
   end
 
   def policy_markers_select_options

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -320,7 +320,7 @@
       - unless activity_presenter.fstc_applies.to_s.blank?
         = t("summary.label.activity.fstc_applies.#{activity_presenter.fstc_applies}")
     %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fstc_applies)
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fstc_applies) && !can_infer_fstc?(@activity.aid_type)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:fstc_applies)}"), activity_step_path(activity_presenter, :fstc_applies), t("summary.label.activity.fstc_applies"))
 
   - if activity_presenter.project? || activity_presenter.third_party_project?

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -147,6 +147,38 @@ RSpec.feature "Users can create a project" do
           expect(activity.country_delivery_partners).to be_empty
         end
       end
+
+      context "when the aid type is one of 'D02', 'E01', 'G01'" do
+        it "skips the FSTC applies step and infers it from the aid type" do
+          programme = create(:programme_activity, extending_organisation: user.organisation)
+          _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
+
+          visit organisation_activity_children_path(programme.organisation, programme)
+          click_on(t("page_content.organisation.button.create_activity"))
+
+          # Test is done in this method:
+          fill_in_activity_form(level: "project", parent: programme, aid_type: "D02")
+
+          expect(page).to have_content t("action.project.create.success")
+          expect(programme.child_activities.last.fstc_applies).to eql true
+        end
+      end
+
+      context "when the aid type is 'C01'" do
+        it "pre-selects Yes for the FSTC applies step but lets the user choose" do
+          programme = create(:programme_activity, extending_organisation: user.organisation)
+          _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
+
+          visit organisation_activity_children_path(programme.organisation, programme)
+          click_on(t("page_content.organisation.button.create_activity"))
+
+          # Test is done in this method:
+          fill_in_activity_form(level: "project", parent: programme, aid_type: "C01", fstc_applies: false)
+
+          expect(page).to have_content t("action.project.create.success")
+          expect(programme.child_activities.last.fstc_applies).to eql false
+        end
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -144,6 +144,14 @@ RSpec.feature "Users can edit an activity" do
           assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
         end
 
+        it "does not show an edit link for FSTC applies if it can be inferred from the aid type" do
+          activity = create(:fund_activity, organisation: user.organisation, aid_type: "D02", fstc_applies: true)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          assert_all_edit_links_go_to_the_correct_form_step(activity: activity)
+        end
+
         it "does not show an edit link for the transparency identifier" do
           activity = create(:fund_activity, organisation: user.organisation)
 
@@ -613,14 +621,20 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
 
-  within(".fstc_applies") do
-    click_on(t("default.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :fstc_applies)
-    )
+  if activity.aid_type.in?(["D02", "E01", "G01"])
+    within(".fstc_applies") do
+      expect(page).to_not have_link(t("default.link.edit"))
+    end
+  else
+    within(".fstc_applies") do
+      click_on(t("default.link.edit"))
+      expect(page).to have_current_path(
+        activity_step_path(activity, :fstc_applies)
+      )
+    end
+    click_on(t("default.link.back"))
+    click_on t("tabs.activity.details")
   end
-  click_on(t("default.link.back"))
-  click_on t("tabs.activity.details")
 
   within(".covid19_related") do
     click_on(t("default.link.edit"))

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -229,6 +229,46 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.last.name).to eq("Zimbabwe")
       end
     end
+
+    describe "#fstc_from_aid_type" do
+      it "returns nil if the aid type is not set" do
+        expect(helper.fstc_from_aid_type(nil)).to be_nil
+      end
+
+      it "returns true for D02" do
+        expect(helper.fstc_from_aid_type("D02")).to eql true
+      end
+
+      it "returns true for E01" do
+        expect(helper.fstc_from_aid_type("E01")).to eql true
+      end
+
+      it "returns false for G01" do
+        expect(helper.fstc_from_aid_type("G01")).to eql false
+      end
+
+      it "returns nil for any other aid type" do
+        expect(helper.fstc_from_aid_type("B02")).to be_nil
+      end
+    end
+
+    describe "#can_infer_fstc?" do
+      it "returns false if the aid type is not set" do
+        expect(helper.can_infer_fstc?(nil)).to eql false
+      end
+
+      it "returns true for aid types 'D02', 'E01', 'G01'" do
+        %w[D02 E01 G01].each do |at|
+          expect(helper.can_infer_fstc?(at)).to eql true
+        end
+      end
+
+      it "returns false for any other aid type" do
+        (CodelistHelper::ALLOWED_AID_TYPE_CODES - %w[D02 E01 G01]).each do |at|
+          expect(helper.can_infer_fstc?(at)).to eql false
+        end
+      end
+    end
   end
 
   describe "BEIS" do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -248,10 +248,18 @@ module FormHelpers
     choose("activity[aid_type]", option: aid_type)
     click_button t("form.button.activity.submit")
 
-    expect(page).to have_content t("form.legend.activity.fstc_applies")
-    expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
-    choose("activity[fstc_applies]", option: fstc_applies)
-    click_button t("form.button.activity.submit")
+    if aid_type.in?(["B02", "B03", "D01"])
+      expect(page).to have_content t("form.legend.activity.fstc_applies")
+      expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
+      choose("activity[fstc_applies]", option: fstc_applies)
+      click_button t("form.button.activity.submit")
+    elsif aid_type == "C01"
+      expect(page).to have_content t("form.legend.activity.fstc_applies")
+      expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
+      expect(find_field("activity-fstc-applies-true-field")).to be_checked
+      choose("activity[fstc_applies]", option: fstc_applies)
+      click_button t("form.button.activity.submit")
+    end
 
     if level == "project" || level == "third_party_project"
       expect(page).to have_content t("page_title.activity_form.show.policy_markers")
@@ -348,6 +356,17 @@ module FormHelpers
     expect(page).to have_content gdi
     expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
+
+    within(".govuk-summary-list__row.fstc_applies") do
+      if aid_type.in?(["B02", "B03", "C01", "D01"])
+        expect(page).to have_content t("summary.label.activity.fstc_applies.#{fstc_applies}")
+      elsif aid_type.in?(["D02", "E01"])
+        expect(page).to have_content "Yes"
+      elsif aid_type == "G01"
+        expect(page).to have_content "No"
+      end
+    end
+
     if level == "project" || level == "third_party_project"
       within(".policy_marker_gender") do
         expect(page).to have_content policy_marker_gender


### PR DESCRIPTION
## Changes in this PR

- Infer the answer to the "FSTC applies" question from the value of the aid type, where possible
- Do not link to edit FSTC if it is inferred from aid type

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
