### PR TITLE
(1366) Users can delete a transaction added by mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,8 @@
 
 ## [unreleased]
 
+- Allow users to delete their transactions
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-28...HEAD
 [release-28]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...release-28
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -52,6 +52,18 @@ class Staff::TransactionsController < Staff::BaseController
     end
   end
 
+  def destroy
+    @transaction = Transaction.find(id)
+    authorize @transaction
+
+    @transaction.create_activity key: "transaction.destroy", owner: current_user, parameters: {activity_id: activity.id}
+    @transaction.destroy
+
+    flash[:notice] = t("action.transaction.destroy.success")
+
+    redirect_to organisation_activity_path(activity.organisation, activity)
+  end
+
   private
 
   def transaction_params

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -16,6 +16,14 @@ class TransactionPolicy < ApplicationPolicy
   end
 
   def update?
+    can_update_or_delete?
+  end
+
+  def destroy?
+    can_update_or_delete?
+  end
+
+  private def can_update_or_delete?
     return false if record.parent_activity.level.nil?
     return true if beis_user? && record.parent_activity.programme?
 
@@ -23,10 +31,6 @@ class TransactionPolicy < ApplicationPolicy
       return true if editable_report_for_organisation_and_fund == record.report
     end
 
-    false
-  end
-
-  def destroy?
     false
   end
 

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -19,4 +19,5 @@
 
 - if action_name == "new"
   = link_to t("form.link.activity.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"
-
+- if action_name == "edit"
+  = link_to t("default.button.delete"), activity_transaction_path(@activity, @transaction), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this transaction?" }

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -16,3 +16,7 @@
   = f.govuk_text_field :receiving_organisation_reference
 
 = f.govuk_submit t("default.button.submit")
+
+- if action_name == "new"
+  = link_to t("form.link.activity.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"
+

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -6,6 +6,8 @@ en:
         success: Transaction successfully created
       update:
         success: Transaction sucessfully updated
+      destroy:
+        success: Transaction sucessfully deleted
       download:
         button: Download CSV template
       upload:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     end
 
     concern :transactionable do
-      resources :transactions, only: [:new, :create, :show, :edit, :update]
+      resources :transactions
     end
 
     concern :budgetable do

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -257,6 +257,20 @@ RSpec.feature "Users can create a transaction" do
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.date.blank")
       end
     end
+
+    scenario "they can cancel their transaction" do
+      activity = create(:programme_activity, :with_report, organisation: user.organisation)
+
+      visit activities_path
+
+      click_on(activity.title)
+
+      click_on(t("page_content.transactions.button.create"))
+
+      click_on(t("form.link.activity.back"))
+
+      expect(page).to have_content(activity.title)
+    end
   end
 
   context "when they are a government delivery partner organisation user" do

--- a/spec/features/staff/users_can_delete_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_delete_a_transaction_spec.rb
@@ -1,0 +1,55 @@
+RSpec.feature "Users can delete a transaction" do
+  let(:delivery_partner_user) { create(:delivery_partner_user) }
+  let(:beis_user) { create(:beis_user) }
+
+  let!(:activity) { create(:programme_activity, organisation: delivery_partner_user.organisation) }
+  let!(:report) { create(:report, :active, organisation: delivery_partner_user.organisation, fund: activity.associated_fund) }
+  let!(:transaction) { create(:transaction, parent_activity: activity, report: report) }
+
+  context "when the user belongs to BEIS" do
+    before { authenticate!(user: beis_user) }
+
+    scenario "deleting a transaction on a programme" do
+      PublicActivity.with_tracking do
+        visit organisation_activity_path(activity.organisation, activity)
+
+        within("##{transaction.id}") do
+          click_on(t("default.link.edit"))
+        end
+
+        expect { click_on t("default.button.delete") }.to change { Transaction.count }.by(-1)
+
+        expect(page).to have_content(t("action.transaction.destroy.success"))
+
+        auditable_event = PublicActivity::Activity.last
+        expect(auditable_event.key).to eq "transaction.destroy"
+        expect(auditable_event.owner_id).to eq beis_user.id
+        expect(auditable_event.trackable_id).to eq transaction.id
+        expect(auditable_event.parameters).to eq({activity_id: activity.id})
+      end
+    end
+  end
+
+  context "when signed in as a delivery partner" do
+    before { authenticate!(user: delivery_partner_user) }
+
+    scenario "deleting a transaction on a programme" do
+      PublicActivity.with_tracking do
+        visit organisation_activity_path(activity.organisation, activity)
+
+        within("##{transaction.id}") do
+          click_on(t("default.link.edit"))
+        end
+
+        expect { click_on t("default.button.delete") }.to change { Transaction.count }.by(-1)
+
+        expect(page).to have_content(t("action.transaction.destroy.success"))
+
+        auditable_event = PublicActivity::Activity.last
+        expect(auditable_event.key).to eq "transaction.destroy"
+        expect(auditable_event.owner_id).to eq delivery_partner_user.id
+        expect(auditable_event.trackable_id).to eq transaction.id
+      end
+    end
+  end
+end

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe TransactionPolicy do
       it { is_expected.to permit_action(:create) }
       it { is_expected.to permit_action(:edit) }
       it { is_expected.to permit_action(:update) }
-
-      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to permit_action(:destroy) }
     end
 
     context "when the activity is a project" do
@@ -175,8 +174,7 @@ RSpec.describe TransactionPolicy do
               it { is_expected.to permit_action(:create) }
               it { is_expected.to permit_action(:edit) }
               it { is_expected.to permit_action(:update) }
-
-              it { is_expected.to forbid_action(:destroy) }
+              it { is_expected.to permit_action(:destroy) }
             end
           end
         end


### PR DESCRIPTION
## Changes in this PR

This allows BEIS and Delivery Partner users to delete transactions, which may have been added by mistake. It also adds a "Cancel" button to allow users to go back if they have accidentally tried to add a transaction.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/109774/104159716-be49f200-53e7-11eb-9aba-b1ce248df8d0.png)

![image](https://user-images.githubusercontent.com/109774/104159762-d02b9500-53e7-11eb-8db6-ed116d685599.png)

### After

![image](https://user-images.githubusercontent.com/109774/104159808-e76a8280-53e7-11eb-8174-838bb78a4420.png)

![image](https://user-images.githubusercontent.com/109774/104159788-df124780-53e7-11eb-867b-d49995693156.png)