### PR TITLE
Fix spec that would fail for the wrong reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,6 +464,7 @@
 - Do not allow a user's email address to be changed after creation
 - Infer the value of FSTC applies from aid type, where possible
 - Require UK Delivery partner named contact for all projects and third-party projects
+- Fix a brittle spec
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...HEAD
 [release-27]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-26...release-27

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -22,8 +22,8 @@ RSpec.feature "Users can view budgets on an activity page" do
       scenario "budgets are shown in period date order, newest first" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         budget_1 = create(:budget, parent_activity: fund_activity, period_start_date: Date.today, period_end_date: Date.tomorrow)
-        budget_2 = create(:budget, parent_activity: fund_activity, period_start_date: 1.year.ago, period_end_date: Date.yesterday)
-        budget_3 = create(:budget, parent_activity: fund_activity, period_start_date: 2.years.ago, period_end_date: 1.year.ago)
+        budget_2 = create(:budget, parent_activity: fund_activity, period_start_date: 11.months.ago, period_end_date: Date.yesterday)
+        budget_3 = create(:budget, parent_activity: fund_activity, period_start_date: 23.months.ago, period_end_date: 12.months.ago)
 
         visit activities_path
 


### PR DESCRIPTION
## Changes in this PR

The spec is exercising the ordering of the budgets, so the period of time that the budgets are for isn’t relevant.

The spec would fail when there was a leap year involved, because the validator intentionally checks for 365 days, not the variable duration of “a year”. (This was a choice, well documented in the commit message 6a9d56e44.)

Remove the brittle spec arrangement and replace with a time period that would always be less than 365 days.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
