### PR TITLE
Users can delete a forecast added by mistake

### DIFF
--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -63,6 +63,17 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     redirect_to organisation_activity_path(@activity.organisation, @activity)
   end
 
+  def destroy
+    @activity = Activity.find(params["activity_id"])
+    history = history_for_update
+    authorize history.latest_entry
+
+    history.clear!
+
+    flash[:notice] = t("action.planned_disbursement.destroy.success")
+    redirect_to organisation_activity_path(@activity.organisation, @activity)
+  end
+
   private def history_for_create
     PlannedDisbursementHistory.new(
       @activity,

--- a/app/policies/planned_disbursement_policy.rb
+++ b/app/policies/planned_disbursement_policy.rb
@@ -16,6 +16,14 @@ class PlannedDisbursementPolicy < ApplicationPolicy
   end
 
   def update?
+    can_update_or_destroy?
+  end
+
+  def destroy?
+    can_update_or_destroy?
+  end
+
+  private def can_update_or_destroy?
     return false if record.parent_activity.level.nil?
     return true if beis_user? && record.parent_activity.programme?
 
@@ -23,10 +31,6 @@ class PlannedDisbursementPolicy < ApplicationPolicy
       return true if editable_report_for_organisation_and_fund.present?
     end
 
-    false
-  end
-
-  def destroy?
     false
   end
 

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -24,6 +24,10 @@ class PlannedDisbursementHistory
     end
   end
 
+  def clear!
+    entries.destroy_all
+  end
+
   def all_entries
     entries.to_a.reverse
   end

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -25,7 +25,10 @@ class PlannedDisbursementHistory
   end
 
   def clear!
-    entries.destroy_all
+    entries.each do |entry|
+      entry.create_activity(key: "planned_disbursement.destroy", owner: @user, parameters: {associated_activity_id: @activity.id})
+      entry.destroy
+    end
   end
 
   def all_entries

--- a/app/views/staff/planned_disbursements/edit.html.haml
+++ b/app/views/staff/planned_disbursements/edit.html.haml
@@ -10,3 +10,5 @@
         = f.govuk_error_summary
         = f.govuk_text_field :value, width: 20
         = f.govuk_submit t("default.button.submit")
+        = link_to t("default.button.delete"), destroy_activity_planned_disbursements_path(@planned_disbursement.parent_activity, @planned_disbursement.financial_year, @planned_disbursement.financial_quarter), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this forecast and all its associated history?" }
+

--- a/app/views/staff/planned_disbursements/new.html.haml
+++ b/app/views/staff/planned_disbursements/new.html.haml
@@ -8,3 +8,4 @@
 
       = form_with model: @planned_disbursement, url: activity_planned_disbursements_path(@activity) do |f|
         = render partial: "form", locals: { f: f }
+        = link_to t("form.link.activity.back"), organisation_activity_financials_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -14,6 +14,7 @@ en:
       download_as_xml: Download as XML
       menu: Menu
       submit: Submit
+      delete: Delete
     link:
       add: Add
       back: Back
@@ -41,7 +42,7 @@ en:
         invalid: "%{attribute} is invalid"
         less_than: "%{attribute} must be less than %{count}"
         less_than_or_equal_to: "%{attribute} must be less than or equal to %{count}"
-        model_invalid: 'Validation failed: %{errors}'
+        model_invalid: "Validation failed: %{errors}"
         not_a_number: "%{attribute} is not a number"
         not_an_integer: "%{attribute} must be an integer"
         odd: "%{attribute} must be odd"

--- a/config/locales/models/planned_disbursement.en.yml
+++ b/config/locales/models/planned_disbursement.en.yml
@@ -6,6 +6,8 @@ en:
         success: Forecasted spend successfully created
       update:
         success: Forecasted spend successfully updated
+      destroy:
+        success: Forecasted spend successfully deleted
   form:
     label:
       planned_disbursement:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
           constraints year: /\d{4}/, quarter: /[1-4]/ do
             get ":year/:quarter", to: "planned_disbursements#edit", as: "edit"
             patch ":year/:quarter", to: "planned_disbursements#update", as: "update"
+            delete ":year/:quarter", to: "planned_disbursements#destroy", as: "destroy"
           end
         end
       end

--- a/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_create_a_planned_disbursement_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe "Users can create a planned disbursement" do
       expect(page).to have_content t("action.planned_disbursement.create.success")
     end
 
+    scenario "they can go back if they try to add a planned disbursement in error" do
+      project = create(:project_activity, :with_report, organisation: user.organisation)
+      visit activities_path
+      click_on project.title
+
+      click_on t("page_content.planned_disbursements.button.create")
+
+      click_on t("form.link.activity.back")
+
+      expect(page).to have_title t("document_title.activity.financials", name: project.title)
+    end
+
     context "when we are in the first quarter" do
       scenario "the current financial quarter and year are pre selected" do
         travel_to_quarter(1, 2019) do

--- a/spec/features/staff/users_can_delete_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_delete_a_planned_disbursement_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "Users can delete a planned disbursement" do
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+
+    before { authenticate!(user: user) }
+
+    scenario "the history is deleted" do
+      PublicActivity.with_tracking do
+        organisation = user.organisation
+        project = create(:project_activity, organisation: user.organisation)
+        editable_report = create(:report, state: :active, organisation: project.organisation, fund: project.associated_fund)
+        planned_disbursement = create(:planned_disbursement, parent_activity: project, report: editable_report, financial_year: editable_report.financial_year + 1)
+
+        visit organisation_activity_path(organisation, project)
+
+        within "##{planned_disbursement.id}" do
+          click_on "Edit"
+        end
+
+        expect {
+          click_on t("default.button.delete")
+        }.to change {
+          PlannedDisbursement.count
+        }.by(-1)
+
+        expect(page).to have_title t("document_title.activity.financials", name: project.title)
+        expect(page).to have_content t("action.planned_disbursement.destroy.success")
+
+        expect(page).to_not have_selector "##{planned_disbursement.id}"
+
+        auditable_event = PublicActivity::Activity.find_by(trackable_id: planned_disbursement.id, parameters: {associated_activity_id: project.id})
+        expect(auditable_event).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe PlannedDisbursementPolicy do
       it { is_expected.to permit_action(:create) }
       it { is_expected.to permit_action(:edit) }
       it { is_expected.to permit_action(:update) }
-
-      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to permit_action(:destroy) }
     end
 
     context "when the activity is a project" do
@@ -163,7 +162,7 @@ RSpec.describe PlannedDisbursementPolicy do
 
               it { is_expected.to permit_action(:edit) }
               it { is_expected.to permit_action(:update) }
-              it { is_expected.to forbid_action(:destroy) }
+              it { is_expected.to permit_action(:destroy) }
             end
 
             context "when the report is the one in which the planned disbursement was created" do
@@ -175,8 +174,7 @@ RSpec.describe PlannedDisbursementPolicy do
               it { is_expected.to permit_action(:create) }
               it { is_expected.to permit_action(:edit) }
               it { is_expected.to permit_action(:update) }
-
-              it { is_expected.to forbid_action(:destroy) }
+              it { is_expected.to permit_action(:destroy) }
             end
           end
         end

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -94,6 +94,35 @@ RSpec.describe PlannedDisbursementHistory do
         ["original", nil, nil, 10],
       ])
     end
+
+    context "when deleting a report" do
+      it "deletes the original planned disbursement when there is only one entry" do
+        history.set_value(10)
+
+        history.clear!
+
+        expect(history_entries).to eq([])
+      end
+
+      it "deletes the original and revised entries when a forecast has been revised" do
+        history.set_value(10)
+        history.set_value(5)
+
+        history.clear!
+
+        expect(history_entries).to eq([])
+      end
+
+      it "deletes the original and revised entries when a forecast has been revised multiple times" do
+        history.set_value(10)
+        history.set_value(5)
+        history.set_value(7)
+
+        history.clear!
+
+        expect(history_entries).to eq([])
+      end
+    end
   end
 
   context "for a level C activity, owned by a delivery partner" do

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -122,6 +122,28 @@ RSpec.describe PlannedDisbursementHistory do
 
         expect(history_entries).to eq([])
       end
+
+      it "creates a public activity record for each deleted entry" do
+        PublicActivity.with_tracking do
+          history.set_value(10)
+          history.set_value(5)
+
+          old_entries = history.all_entries
+
+          expect { history.clear! }.to change { PublicActivity::Activity.where(key: "planned_disbursement.destroy").count }.by(2)
+
+          activities = PublicActivity::Activity.where(key: "planned_disbursement.destroy").order(created_at: :desc)
+
+          first_activity = activities.first
+          second_activity = activities.second
+
+          expect(first_activity.trackable_id).to eq(old_entries.first.id)
+          expect(first_activity.parameters).to eq({associated_activity_id: activity.id})
+
+          expect(second_activity.trackable_id).to eq(old_entries.last.id)
+          expect(second_activity.parameters).to eq({associated_activity_id: activity.id})
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

This allows users to delete forecasts that may have been added by mistake. After a bit of back and forth and discussion, we decided that when a user wants to "delete" a forecast, it'll be because they've erroneously created one, either for the wrong reporting period, or the wrong activity, rather than they've just entered the wrong amount. With this in mind, I decided that the expected behaviour would be to delete all the Planned Disbursements for that activity / period, and remove all history. We did discuss just setting the latest value to zero, which would behave as if the forecast was deleted, but this would still keep the erroneously created value as the "original", which may not be the intent.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/109774/104296754-f7529700-54b9-11eb-871e-9cd5ed62a413.png)

![image](https://user-images.githubusercontent.com/109774/104296825-0afdfd80-54ba-11eb-9076-5b1708fc105b.png)

### After

![image](https://user-images.githubusercontent.com/109774/104296792-00dbff00-54ba-11eb-9ead-2fa0e39fb397.png)

![image](https://user-images.githubusercontent.com/109774/104296861-13eecf00-54ba-11eb-96cb-6b15a233a618.png)