### PR TITLE
Fix display of previous actuals in the report CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,6 +470,7 @@
 ## [unreleased]
 
 - Allow users to delete their transactions
+- Fix display of previous actuals in the report CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-28...HEAD
 [release-28]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...release-28

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -357,7 +357,7 @@ class Activity < ApplicationRecord
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    @actual_total_for_report_financial_quarter ||= transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
+    transactions.where(report: report, date: report.created_at.all_quarter).sum(:value)
   end
 
   def forecasted_total_for_report_financial_quarter(report:)

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -72,18 +72,24 @@ RSpec.describe ExportActivityToCsv do
 
   describe "#previous_quarter_actuals" do
     it "gets the actuals for the previous quarter" do
-      fund = report.fund
-      organisation = report.organisation
-      report.approved!
+      activity = create(:project_activity)
+      organisation = activity.organisation
+      fund = activity.associated_fund
 
-      travel_to_quarter(4, 2019) do
-        previous_report = Report.create(fund: fund, organisation: organisation, state: :active)
-        create(:transaction, report: previous_report, parent_activity: project, value: 9876.54)
+      travel_to_quarter(1, 2019) do
+        previous_report = Report.new(fund: fund, organisation: organisation, state: :active)
+        create(:transaction, report: previous_report, parent_activity: activity, value: 666.66)
+        previous_report.approved!
       end
 
-      actuals = ExportActivityToCsv.new(activity: project, report: report).previous_quarter_actuals
+      travel_to_quarter(2, 2019) do
+        current_report = Report.new(fund: fund, organisation: organisation, state: :active)
+        create(:transaction, report: current_report, parent_activity: activity, value: 10000.00)
 
-      expect(actuals).to eq "9876.54"
+        exporter = ExportActivityToCsv.new(activity: activity, report: current_report)
+
+        expect(exporter.call).to include "666.66"
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

During Q3 reporting we realised that the report CSV was showing the wrong values for the previous quarter’s actuals. It was showing the same values as for the current quarter. (The values were not overwritten, it was only a computation/display bug.)

The reason was that the service object was memoising all the actuals values for the current report, so when the code attempted to calculate the actuals for the previous report, it was using the already computed values.

The reason the spec didn’t catch this is that it was not set up with a full real-life scenario.

We have now enriched the spec’s setup to replicate the conditions under which the bug occurs.

None of the other methods which memoise values are being called for a different report, so we didn’t see a reason to preemptively change them.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
