### PR TITLE
(1370) Separate BEIS from other organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,8 @@
 
 ## [unreleased]
 
+- On the user administration page, BEIS now appears as a separate organisation to avoid users being assigned to this org by accident
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...HEAD
 [release-29]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-28...release-29
 [release-28]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-27...release-28

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -12,7 +12,8 @@ class Staff::UsersController < Staff::BaseController
   def new
     @user = User.new
     authorize @user
-    @organisations = policy_scope(Organisation)
+    @service_owner = service_owner
+    @delivery_partners = delivery_partners
   end
 
   def create
@@ -39,13 +40,15 @@ class Staff::UsersController < Staff::BaseController
   def edit
     @user = User.find(id)
     authorize @user
-    @organisations = policy_scope(Organisation)
+    @service_owner = service_owner
+    @delivery_partners = delivery_partners
   end
 
   def update
     @user = User.find(id)
     authorize @user
-    @organisations = policy_scope(Organisation)
+    @service_owner = service_owner
+    @delivery_partners = delivery_partners
 
     @user.assign_attributes(user_params)
     @user.active = params[:user][:active]
@@ -80,5 +83,13 @@ class Staff::UsersController < Staff::BaseController
 
   def organisation
     Organisation.find(organisation_id)
+  end
+
+  private def service_owner
+    Organisation.find_by(service_owner: true)
+  end
+
+  private def delivery_partners
+    Organisation.delivery_partners
   end
 end

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -9,12 +9,13 @@
       :name,
       legend: { tag: :h2 }
 
-  - if @organisations.any?
-    = f.govuk_collection_radio_buttons :organisation_id,
-        @organisations,
-        :id,
-        :name,
-        legend: { tag: :h2 }
+  - if @service_owner.present?
+    = f.govuk_radio_buttons_fieldset :organisation_id, classes: "user-organisations" do
+      = f.govuk_radio_button :organisation_id, @service_owner.id, label: { text: @service_owner.name }, link_errors: true
+      - if @delivery_partners.any?
+        = f.govuk_radio_divider
+        - @delivery_partners.each do |dp|
+          = f.govuk_radio_button :organisation_id, dp.id, label: { text: dp.name }
   - else
     .govuk-inset-text
       = succeed "." do

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -137,6 +137,13 @@ RSpec.feature "BEIS users can invite new users to the service" do
     # Create a new user
     click_on(t("page_content.users.button.create"))
 
+    # We expect to see BEIS separately on this page
+    within(".user-organisations") do
+      beis_id = Organisation.find_by(service_owner: true).id
+      expect(page).to have_css("input[type='radio'][value='#{beis_id}']:first-child")
+      expect(page).to have_css(".govuk-radios__divider:nth-child(2)")
+    end
+
     # Fill out the form
     expect(page).to have_content(t("page_title.users.new"))
     fill_in "user[name]", with: new_user_name


### PR DESCRIPTION
Trello: https://trello.com/c/iEz6socI

## Changes in this PR

When a user wants to add a new user, they have to select what organisation this user belongs to. There is a radio button list for this, with organisations sorted alphabetically. However, there was no distinction between BEIS and the Delivery Partners on this list. BEIS could appear in the middle of the list, which made easier for users to accidentally assign a new user to BEIS when they don't belong to this organisation. This would give that user higher privileges than they should have. To avoid this, we have now separated BEIS org from the rest of organisations on display, adding a divider in the radio button list.

## Screenshots of UI changes

### Before

<img width="1202" alt="Screenshot 2021-01-12 at 14 39 42" src="https://user-images.githubusercontent.com/48016017/105062435-82abc980-5a72-11eb-8fb1-10a8b36c9c22.png">

### After

<img width="1202" alt="Screenshot 2021-01-19 at 16 20 12" src="https://user-images.githubusercontent.com/48016017/105062480-8b9c9b00-5a72-11eb-8490-d885f05cb86a.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
