### PR TITLE
(1416) Parent step only shows complete parent activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,6 +476,7 @@
 
 - On the user administration page, BEIS now appears as a separate organisation to avoid users being assigned to this org by accident
 - Users can upload activities in bulk from a CSV
+- Make sure only completed parent activities are shown when prompting for a parent activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...HEAD
 [release-29]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-28...release-29

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -46,7 +46,7 @@ module FormHelper
   end
 
   def scoped_parent_activities(activity:, user:)
-    case activity.level.to_sym
+    activities = case activity.level.to_sym
     when :fund
       Activity.none
     when :programme
@@ -59,6 +59,8 @@ module FormHelper
       FindProjectActivities.new(organisation: activity.organisation, user: user)
         .call(eager_load_parent: false)
     end
+
+    activities.where(form_state: "complete")
   end
 
   def create_activity_level_options(user:)

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -341,5 +341,24 @@ RSpec.feature "Users can create a programme activity" do
 
       fill_in_activity_form(level: "programme", parent: newton_fund)
     end
+
+    scenario "only completed parent activities are listed" do
+      funds = create_list(:fund_activity, 2, organisation: user.organisation)
+      incomplete_funds = create_list(:fund_activity, 2, :at_region_step, organisation: user.organisation)
+
+      visit activities_path
+      click_on(t("page_content.organisation.button.create_activity"))
+
+      choose custom_capitalisation(t("page_content.activity.level.programme"))
+      click_button t("form.button.activity.submit")
+
+      funds.each do |fund|
+        expect(page).to have_content(fund.title)
+      end
+
+      incomplete_funds.each do |fund|
+        expect(page).to_not have_content(fund.title)
+      end
+    end
   end
 end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe FormHelper, type: :helper do
   end
 
   describe "#scoped_parent_activities" do
+    let(:activities) { double(ActiveRecord::Relation) }
+
     context "when the activity is a fund" do
       it "returns an empty result" do
         activity = build(:fund_activity)
@@ -30,8 +32,10 @@ RSpec.describe FormHelper, type: :helper do
     context "when the activity is a programme" do
       it "tells FindFundActivities to return the fund activities" do
         activity = build(:programme_activity)
-        allow_any_instance_of(FindFundActivities).to receive(:call)
-        expect_any_instance_of(FindFundActivities).to receive(:call)
+        allow_any_instance_of(FindFundActivities).to receive(:call) { activities }
+        expect_any_instance_of(FindFundActivities).to receive(:call) { activities }
+        expect(activities).to receive(:where).with(form_state: "complete")
+
         helper.scoped_parent_activities(activity: activity, user: double(User))
       end
     end
@@ -39,8 +43,10 @@ RSpec.describe FormHelper, type: :helper do
     context "when the activity is a project" do
       it "tells FindProgrammeActivities to return the programme activities" do
         activity = build(:project_activity)
-        allow_any_instance_of(FindProgrammeActivities).to receive(:call)
-        expect_any_instance_of(FindProgrammeActivities).to receive(:call)
+        allow_any_instance_of(FindProgrammeActivities).to receive(:call) { activities }
+        expect_any_instance_of(FindProgrammeActivities).to receive(:call) { activities }
+        expect(activities).to receive(:where).with(form_state: "complete")
+
         helper.scoped_parent_activities(activity: activity, user: double(User))
       end
     end
@@ -48,8 +54,10 @@ RSpec.describe FormHelper, type: :helper do
     context "when the activity is a third-party project" do
       it "tells FindProjectActivities to return the project activities" do
         activity = build(:third_party_project_activity)
-        allow_any_instance_of(FindProjectActivities).to receive(:call)
-        expect_any_instance_of(FindProjectActivities).to receive(:call)
+        allow_any_instance_of(FindProjectActivities).to receive(:call) { activities }
+        expect_any_instance_of(FindProjectActivities).to receive(:call) { activities }
+        expect(activities).to receive(:where).with(form_state: "complete")
+
         helper.scoped_parent_activities(activity: activity, user: double(User))
       end
     end


### PR DESCRIPTION
Previously when prompting for a parent activity, all parent activities were shown on the form. This resulted in a bunch of incomplete or erroneously created activities showing up. This adds a filter to the `scoped_parent_activities` method that makes sure only activities with a `form_state` of `complete` are shown.

### Before

![image](https://user-images.githubusercontent.com/109774/105190499-f7900980-5b2d-11eb-9c75-625fb191bb92.png)

### After

![image](https://user-images.githubusercontent.com/109774/105190529-ff4fae00-5b2d-11eb-8aab-71aa2e46ebb9.png)
