### PR TITLE
(1450) Make report CSV download link a tertiary link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,6 +482,8 @@
 
 ## [unreleased]
 
+- Relegate "Download report as CSV" link to tertiary status
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...HEAD
 [release-30]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...release-30
 [release-29]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-28...release-29

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -4,9 +4,6 @@
     = link_to t("action.planned_disbursement.upload.link"), new_report_planned_disbursement_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
     = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
-    - if policy(@report_presenter).download?
-      = link_to t("action.report.download.button"), report_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-
     - if policy(@report_presenter).activate?
       = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 

--- a/app/views/staff/reports/_download.haml
+++ b/app/views/staff/reports/_download.haml
@@ -1,0 +1,2 @@
+.govuk-grid-column-one-third.page-actions
+  = link_to t("action.report.download.button"), report_path(report_presenter, format: :csv), class: "govuk-link"

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -6,6 +6,9 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
+    - if policy(@report_presenter).download?
+      = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
+
   = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -6,6 +6,9 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
+    - if policy(@report_presenter).download?
+      = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
+
   = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row


### PR DESCRIPTION
## Changes in this PR

Moves the link to the report CSV download out of the actions, and removes the button styling so it's a plain link.

I’ve reused the `.page-actions` class because all it currently does is right-align. Open to making its own class if we think it's worth it.

## Screenshots of UI changes

### Before
![Screenshot 2021-01-26 at 18 26 58](https://user-images.githubusercontent.com/579522/105888088-683e9680-6004-11eb-98d6-6af067604ab0.png)

### After
![Screenshot 2021-01-26 at 18 26 40](https://user-images.githubusercontent.com/579522/105888101-6e347780-6004-11eb-86ad-44bf02331256.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
