### PR TITLE
(1423) Add a transfer model

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -1,0 +1,9 @@
+class Transfer < ApplicationRecord
+  belongs_to :source, class_name: "Activity"
+  belongs_to :destination, class_name: "Activity"
+
+  validates :source, :destination, :value, :date, presence: true
+
+  validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
+  validates :date, date_not_in_future: true, date_within_boundaries: true
+end

--- a/db/migrate/20210126124531_create_transfer.rb
+++ b/db/migrate/20210126124531_create_transfer.rb
@@ -1,0 +1,10 @@
+class CreateTransfer < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transfers, id: :uuid do |t|
+      t.references :source, foreign_key: {to_table: "activities", on_delete: :restrict}, type: :uuid, null: false
+      t.references :destination, foreign_key: {to_table: "activities", on_delete: :restrict}, type: :uuid, null: false
+      t.decimal :value, precision: 13, scale: 2, null: false
+      t.date :date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_163844) do
+ActiveRecord::Schema.define(version: 2021_01_26_124531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -225,6 +225,15 @@ ActiveRecord::Schema.define(version: 2021_01_05_163844) do
     t.index ["report_id"], name: "index_transactions_on_report_id"
   end
 
+  create_table "transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "source_id", null: false
+    t.uuid "destination_id", null: false
+    t.decimal "value", precision: 13, scale: 2, null: false
+    t.date "date"
+    t.index ["destination_id"], name: "index_transfers_on_destination_id"
+    t.index ["source_id"], name: "index_transfers_on_source_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "identifier"
     t.string "name"
@@ -246,5 +255,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_163844) do
   add_foreign_key "budgets", "activities", column: "parent_activity_id", on_delete: :cascade
   add_foreign_key "planned_disbursements", "activities", column: "parent_activity_id", on_delete: :cascade
   add_foreign_key "transactions", "activities", column: "parent_activity_id", on_delete: :cascade
+  add_foreign_key "transfers", "activities", column: "destination_id", on_delete: :restrict
+  add_foreign_key "transfers", "activities", column: "source_id", on_delete: :restrict
   add_foreign_key "users", "organisations", on_delete: :restrict
 end

--- a/spec/factories/transfer.rb
+++ b/spec/factories/transfer.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :transfer do
+    association :source, factory: :activity
+    association :destination, factory: :activity
+
+    date { Date.today }
+    value { BigDecimal("110.01") }
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "validations" do
+    it { should validate_attribute(:planned_start_date).with(:date_within_boundaries) }
+    it { should validate_attribute(:planned_end_date).with(:date_within_boundaries) }
+    it { should validate_attribute(:actual_start_date).with(:date_within_boundaries) }
+    it { should validate_attribute(:actual_end_date).with(:date_within_boundaries) }
+
     context "overall activity state" do
       context "when the activity form is a draft" do
         subject { build(:activity, :at_identifier_step, form_state: "blank") }
@@ -419,26 +424,6 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when planned_start_date is not blank" do
-      let(:activity) { build(:activity) }
-
-      it "does not allow a planned_start_date more than 10 years ago" do
-        activity = build(:activity, planned_start_date: 11.years.ago)
-        expect(activity.valid?).to be_falsey
-        expect(activity.errors[:planned_start_date]).to include "Date must be between 10 years ago and 25 years in the future"
-      end
-
-      it "does not allow a planned_start_date more than 25 years in the future" do
-        activity = build(:activity, planned_start_date: 26.years.from_now)
-        expect(activity.valid?).to be_falsey
-      end
-
-      it "allows a planned_start_date between 10 years ago and 25 years in the future" do
-        activity = build(:activity, planned_start_date: Date.today)
-        expect(activity.valid?).to be_truthy
-      end
-    end
-
     context "when planned_end_date is not blank" do
       let(:activity) { build(:activity) }
 
@@ -446,40 +431,6 @@ RSpec.describe Activity, type: :model do
         activity = build(:activity, planned_start_date: Date.today, planned_end_date: Date.yesterday)
         expect(activity.valid?).to be_falsey
         expect(activity.errors[:planned_end_date]).to include "Planned end date must be after planned start date"
-      end
-    end
-
-    context "when the actual_start_date is not blank" do
-      it "allows todays date" do
-        activity = build(:activity, actual_start_date: Date.today)
-        expect(activity.valid?).to be_truthy
-      end
-
-      it "allows dates in the past" do
-        activity = build(:activity, actual_start_date: 1.year.ago)
-        expect(activity.valid?).to be_truthy
-      end
-
-      it "does not allow a date in the future" do
-        activity = build(:activity, actual_start_date: 1.day.from_now)
-        expect(activity.valid?).to be_falsey
-      end
-    end
-
-    context "when the actual_end_date is not blank" do
-      it "allows todays date" do
-        activity = build(:activity, actual_end_date: Date.today)
-        expect(activity.valid?).to be_truthy
-      end
-
-      it "allows dates in the past" do
-        activity = build(:activity, actual_end_date: 1.year.ago)
-        expect(activity.valid?).to be_truthy
-      end
-
-      it "does not allow a date in the future" do
-        activity = build(:activity, actual_end_date: 1.day.from_now)
-        expect(activity.valid?).to be_falsey
       end
     end
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Budget do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:currency) }
 
+    it { should validate_attribute(:period_start_date).with(:date_within_boundaries) }
+    it { should validate_attribute(:period_end_date).with(:date_within_boundaries) }
+
     context "when the activity belongs to a delivery partner" do
       it "should validate that the report association exists" do
         activity = build(:activity, organisation: build_stubbed(:delivery_partner_organisation))
@@ -66,30 +69,6 @@ RSpec.describe Budget do
     it "allows a value between 1 and 99,999,999,999.00" do
       budget = build(:budget, value: 500_000.00)
       expect(budget).to be_valid
-    end
-  end
-
-  context "date must be between 10 years ago and 25 years from now" do
-    it "does not allow a date more than 10 years ago" do
-      budget = build(:budget, period_start_date: 11.years.ago)
-      expect(budget).to_not be_valid
-      expect(budget.errors[:period_start_date]).to include "Date must be between 10 years ago and 25 years in the future"
-    end
-
-    it "does not allow a date more than 25 years in the future" do
-      budget = build(:budget, period_start_date: 26.years.from_now)
-      expect(budget).to_not be_valid
-      expect(budget.errors[:period_start_date]).to include "Date must be between 10 years ago and 25 years in the future"
-    end
-
-    it "allows a date between 10 years ago and 25 years in the future" do
-      budget = build(:budget, period_start_date: Date.today)
-      expect(budget).to be_valid
-    end
-
-    it "does not allow nil date" do
-      budget = build(:budget, period_start_date: nil)
-      expect(budget).to_not be_valid
     end
   end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Transaction, type: :model do
     it { should validate_presence_of(:receiving_organisation_name) }
     it { should validate_presence_of(:receiving_organisation_type) }
 
+    it { should validate_attribute(:date).with(:date_within_boundaries) }
+    it { should validate_attribute(:date).with(:date_not_in_future) }
+
     context "when the activity belongs to a delivery partner organisation" do
       before { activity.update(organisation: build_stubbed(:delivery_partner_organisation)) }
 
@@ -62,38 +65,6 @@ RSpec.describe Transaction, type: :model do
       it "allows a negative value" do
         transaction = build(:transaction, parent_activity: activity, value: -500_000.00)
         expect(transaction.valid?).to be true
-      end
-    end
-  end
-
-  describe "#date" do
-    context "date must not be in the future" do
-      it "allows a date in the past" do
-        transaction = build(:transaction, parent_activity: activity, date: 1.year.ago)
-        expect(transaction.valid?).to be true
-      end
-
-      it "does not allow a date in the future" do
-        transaction = build(:transaction, parent_activity: activity, date: 1.year.from_now)
-        expect(transaction.valid?).to be false
-        expect(transaction.errors[:date]).to include "Date must not be in the future"
-      end
-
-      it "allows today's date" do
-        transaction = build(:transaction, parent_activity: activity, date: Date.today)
-        expect(transaction.valid?).to be true
-      end
-
-      it "allows a nil date" do
-        transaction = build(:transaction, parent_activity: activity, date: Date.today)
-        expect(transaction.valid?).to be true
-      end
-    end
-
-    context "when the value is more than 10 years in the past" do
-      it "is not valid" do
-        transaction = build(:transaction, date: 10.years.ago)
-        expect(transaction).to be_invalid
       end
     end
   end

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Transfer do
+  subject { build(:transfer) }
+
+  it { should belong_to(:source).class_name("Activity") }
+  it { should belong_to(:destination).class_name("Activity") }
+
+  describe "validations" do
+    it { should validate_presence_of(:source) }
+    it { should validate_presence_of(:destination) }
+    it { should validate_presence_of(:value) }
+    it { should validate_presence_of(:date) }
+
+    it { should validate_numericality_of(:value).is_less_than_or_equal_to(99_999_999_999.00) }
+    it { should validate_numericality_of(:value).is_other_than(0) }
+
+    it { should allow_value(Date.today).for(:date) }
+    it { should allow_value(Date.tomorrow).for(:date) }
+    it { should allow_value(10.years.ago - 1.day).for(:date) }
+  end
+
+  describe "foreign key constraints" do
+    subject { create(:transfer) }
+
+    it "prevents the associated source activity from being deleted" do
+      source_activity = subject.source
+
+      expect { source_activity.destroy }.to raise_exception(/ForeignKeyViolation/)
+    end
+
+    it "prevents the associated destination activity from being deleted" do
+      destination_activity = subject.destination
+
+      expect { destination_activity.destroy }.to raise_exception(/ForeignKeyViolation/)
+    end
+  end
+end

--- a/spec/models/transfer_spec.rb
+++ b/spec/models/transfer_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe Transfer do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:date) }
 
+    it { should validate_attribute(:date).with(:date_not_in_future) }
+    it { should validate_attribute(:date).with(:date_within_boundaries) }
+
     it { should validate_numericality_of(:value).is_less_than_or_equal_to(99_999_999_999.00) }
     it { should validate_numericality_of(:value).is_other_than(0) }
-
-    it { should allow_value(Date.today).for(:date) }
-    it { should allow_value(Date.tomorrow).for(:date) }
-    it { should allow_value(10.years.ago - 1.day).for(:date) }
   end
 
   describe "foreign key constraints" do

--- a/spec/support/matchers/validate_attribute_matcher.rb
+++ b/spec/support/matchers/validate_attribute_matcher.rb
@@ -1,0 +1,26 @@
+RSpec::Matchers.define :validate_attribute do |attribute|
+  match do |subject|
+    validators = subject.class.validators_on(attribute).select { |validator|
+      validator.class == @validator_class
+    }
+
+    validators.present?
+  end
+
+  chain :with do |validator|
+    @validator = validator
+    @validator_class = "#{validator}_validator".camelize.constantize
+  end
+
+  description do
+    "check that :#{attribute} is being validated using #{@validator_class}"
+  end
+
+  failure_message do
+    "expected #{attribute} to be validated using #{@validator_class}"
+  end
+
+  failure_message_when_negated do
+    "expected #{attribute} to not be validated using #{@validator_class}"
+  end
+end


### PR DESCRIPTION
Add a `Transfer` model for storing the transfers of money between activities.

I've added a foreign key constraint on `source_id` and `destination_id`, that will prevent those activities being deleted whilst transfers exist that reference them. 

NB: I didn't name the associations `source_activity` and `destination_activity` both to save typing and in case we need to have a source that isn't an activity in the future (e.g. external funding).

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
