### PR TITLE
Fix typos in spec descriptions

### DIFF
--- a/config/locales/views/not_authorised.en.yml
+++ b/config/locales/views/not_authorised.en.yml
@@ -1,12 +1,12 @@
 # This translation file is used for Pundit errors
-# Use the Pundit polciy class name as the key
+# Use the Pundit policy class name as the key
 # otherwise the default is used
 #
 # For example one might add:
 #
 # not_authorised:
 #   organisation_policy:
-#     show?: You have not been authorised to see this organiastion.
+#     show?: You have not been authorised to see this organisation.
 ---
 en:
   not_authorised:

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Organisation show page" do
       end
 
       context "when viewing a delivery partners organisation" do
-        scenario "they see a download xml button for project activties" do
+        scenario "they see a download xml button for project activities" do
           delivery_partner_organisation = create(:delivery_partner_organisation)
           _project = create(:project_activity, organisation: delivery_partner_organisation)
 
@@ -50,7 +50,7 @@ RSpec.feature "Organisation show page" do
       authenticate!(user: delivery_partner_user)
     end
 
-    scenario "they do not see the edit detials button" do
+    scenario "they do not see the edit details button" do
       visit organisation_path(delivery_partner_user.organisation)
 
       expect(page).not_to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Users can activate reports" do
     end
 
     context "when the report is already active" do
-      scenario "it cannot be activated agian" do
+      scenario "it cannot be activated again" do
         report = create(:report, state: :active)
 
         visit report_path(report)

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can choose a recipient country" do
     end
 
     context "with JavaScript disabled" do
-      scenario "countries are choosen from a select box" do
+      scenario "countries are chosen from a select box" do
         expect(page).to have_select(t("form.label.activity.recipient_country"))
       end
 
@@ -25,7 +25,7 @@ RSpec.feature "Users can choose a recipient country" do
     end
 
     context "with JavaScript enabled", js: true do
-      scenario "countries are choosen from an autocomplete" do
+      scenario "countries are chosen from an autocomplete" do
         expect(page).not_to have_select(t("form.label.activity.recipient_country"))
         expect(page).to have_field(t("form.label.activity.recipient_country"))
         expect(page).to have_css("input.autocomplete__input")

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -306,7 +306,7 @@ RSpec.feature "Users can create a transaction" do
       end
     end
 
-    scenario "when the acitivity cannot be edited they cannot see the add transaction button" do
+    scenario "when the activity cannot be edited they cannot see the add transaction button" do
       activity = create(:project_activity, organisation: user.organisation)
       _report = create(:report, state: :inactive, organisation: activity.organisation, fund: activity.associated_fund)
 

--- a/spec/features/staff/users_can_manage_extending_organisation_spec.rb
+++ b/spec/features/staff/users_can_manage_extending_organisation_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Users can manage the extending organisation" do
         expect(implementing_organisation.reference).to eq(delivery_partner.iati_reference)
       end
 
-      scenario "they can change the extending organistion when the activity is valid" do
+      scenario "they can change the extending organisation when the activity is valid" do
         delivery_partner = create(:delivery_partner_organisation)
         programme.update(extending_organisation: delivery_partner)
         another_delivery_partner = create(:delivery_partner_organisation)
@@ -52,7 +52,7 @@ RSpec.feature "Users can manage the extending organisation" do
         expect(programme.reload.extending_organisation_id).to eql another_delivery_partner.id
       end
 
-      scenario "they can change the extending organistion when the activity is invalid i.e. not yet complete" do
+      scenario "they can change the extending organisation when the activity is invalid i.e. not yet complete" do
         delivery_partner = create(:delivery_partner_organisation)
         invalid_programme = create(:programme_activity)
         invalid_programme.update(extending_organisation: delivery_partner)

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "Users can view an organisation as XML" do
 
     before { authenticate!(user: user) }
 
-    context "when the user is viewing their own organisaton" do
+    context "when the user is viewing their own organisation" do
       let(:organisation) { user.organisation }
 
       scenario "they cannot download the organisation's activities as XML" do
@@ -203,7 +203,7 @@ RSpec.feature "Users can view an organisation as XML" do
       end
     end
 
-    context "when the user is viewing another organisaton" do
+    context "when the user is viewing another organisation" do
       let(:organisation) { create(:delivery_partner_organisation) }
 
       scenario "they cannot download the XML of the organisation" do

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity has no level" do
       let(:activity) { CreateActivity.new(organisation_id: create(:delivery_partner_organisation).id).call }
 
-      context "and the activity does not belong to the same organiasiton as the user" do
+      context "and the activity does not belong to the same organisation as the user" do
         it { is_expected.to permit_action(:show) }
 
         it { is_expected.to forbid_action(:edit) }
@@ -91,7 +91,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity has no level" do
       let(:activity) { create(:activity, :blank_form_state, level: nil) }
 
-      context "and does not belong to the same organiasiton as the user" do
+      context "and does not belong to the same organisation as the user" do
         it { is_expected.to forbid_action(:edit) }
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
@@ -113,7 +113,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity has a level but no parent" do
       let(:activity) { create(:activity, :blank_form_state, level: :project) }
 
-      context "and does not belong to the same organiasiton as the user" do
+      context "and does not belong to the same organisation as the user" do
         it { is_expected.to forbid_action(:edit) }
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
@@ -155,7 +155,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:redact_from_iati) }
       end
 
-      context "and the users organisation is the extending organiation" do
+      context "and the users organisation is the extending organisation" do
         before do
           activity.update(extending_organisation: user.organisation)
         end
@@ -173,7 +173,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the acitivty does not belong to the same organisation as the user" do
+      context "and the activity does not belong to the same organisation as the user" do
         it { is_expected.to forbid_action(:show) }
         it { is_expected.to forbid_action(:create) }
         it { is_expected.to forbid_action(:edit) }
@@ -182,7 +182,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:redact_from_iati) }
       end
 
-      context "and the acitivty belongs to the same organisation as the user" do
+      context "and the activity belongs to the same organisation as the user" do
         before do
           activity.update(organisation: user.organisation)
         end

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe BudgetPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the activity does not belong to the users organiastion" do
+      context "and the activity does not belong to the users organisation" do
         it { is_expected.to forbid_action(:show) }
         it { is_expected.to forbid_action(:create) }
         it { is_expected.to forbid_action(:edit) }
@@ -127,7 +127,7 @@ RSpec.describe BudgetPolicy do
           it { is_expected.to forbid_action(:destroy) }
         end
 
-        context "when there is an editiable report" do
+        context "when there is an editable report" do
           let(:report) { create(:report, state: :active) }
 
           context "and the report is not for the organisation or fund of the activity" do
@@ -157,7 +157,7 @@ RSpec.describe BudgetPolicy do
               report.update(organisation: activity.organisation, fund: activity.associated_fund)
             end
 
-            context "when the report is not the one in which the budtet was created" do
+            context "when the report is not the one in which the budget was created" do
               it { is_expected.to permit_action(:show) }
               it { is_expected.to permit_action(:create) }
 

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe PlannedDisbursementPolicy do
           it { is_expected.to forbid_action(:destroy) }
         end
 
-        context "when there is an editiable report" do
+        context "when there is an editable report" do
           let(:report) { create(:report, state: :active) }
 
           context "and the report is not for the organisation or fund of the activity" do

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe TransactionPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the activity does not belong to the users organiastion" do
+      context "and the activity does not belong to the users organisation" do
         it { is_expected.to forbid_action(:show) }
         it { is_expected.to forbid_action(:create) }
         it { is_expected.to forbid_action(:edit) }
@@ -126,7 +126,7 @@ RSpec.describe TransactionPolicy do
           it { is_expected.to forbid_action(:destroy) }
         end
 
-        context "when there is an editiable report" do
+        context "when there is an editable report" do
           let(:report) { create(:report, state: :active) }
 
           context "and the report is not for the organisation or fund of the activity" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_update.parent_present"))
     end
 
-    it "does not fail when the acitvity and import row has no implementing organiation" do
+    it "does not fail when the activity and import row has no implementing organisation" do
       existing_activity_attributes["Implementing organisation name"] = nil
       existing_activity_attributes["Implementing organisation reference"] = nil
       existing_activity_attributes["Implementing organisation sector"] = nil
@@ -258,7 +258,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.cannot_create"))
     end
 
-    it "does not fail when the row has no implementing organiation" do
+    it "does not fail when the row has no implementing organisation" do
       new_activity_attributes["Implementing organisation name"] = nil
       new_activity_attributes["Implementing organisation reference"] = nil
       new_activity_attributes["Implementing organisation sector"] = nil


### PR DESCRIPTION
## Changes in this PR

- Fix typos in spec descriptions

Typos in spec descriptions do not affect the code in any way! They only affect me, as I watch the test suite go by and a typo lodges in my brain. It's like seeing a loose hair on someone's otherwise immaculate lapel, and being constantly distracted by that instead of paying full attention to what they're saying. 😅 

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
