### PR TITLE
(1418) Users can see Current and Historic activities separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,6 +485,7 @@
 - Relegate "Download report as CSV" link to tertiary status
 - Add a `funding_type` column to a budget
 - Work out a Budget's period based on the financial year
+- Users can see Current activities and Historic activities in different tabs
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...HEAD
 [release-30]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...release-30

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -2,11 +2,12 @@
 
 class Staff::ActivitiesController < Staff::BaseController
   include Secured
+  after_action :verify_authorized, except: [:index, :historic]
+  after_action :verify_policy_scoped, only: [:index, :historic]
 
   def index
     @organisation_id = organisation_id
-    @activities = policy_scope(Activity.where(organisation: organisation_id))
-    authorize @activities
+    @activities = policy_scope(Activity.where(organisation: organisation_id)).current
     @activity_presenters = @activities.includes(:organisation).order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
   end
 
@@ -38,6 +39,12 @@ class Staff::ActivitiesController < Staff::BaseController
     @activity.create_activity key: "activity.create", owner: current_user
 
     redirect_to activity_step_path(@activity.id, :blank)
+  end
+
+  def historic
+    @organisation_id = organisation_id
+    @historic_activities = policy_scope(Activity.where(organisation: organisation_id)).historic
+    @historic_activity_presenters = @historic_activities.includes(:organisation).order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -219,6 +219,14 @@ class Activity < ApplicationRecord
     for_organisation.merge(projects.or(third_party_projects))
   }
 
+  scope :current, -> {
+                    where.not(programme_status: ["completed", "stopped", "cancelled"]).or(where(programme_status: nil))
+                  }
+
+  scope :historic, -> {
+    where(programme_status: ["completed", "stopped", "cancelled"])
+  }
+
   def self.by_roda_identifier(identifier)
     find_by(roda_identifier_compound: identifier)
   end

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -1,0 +1,58 @@
+= content_for :page_title_prefix, t("document_title.activity.index")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_title.activity.index")
+
+  .govuk-grid-row
+    .govuk-grid-column-full.page-actions
+      = form_tag(organisation_activities_path(@organisation_id), method: "post") do
+        = submit_tag t("page_content.organisation.button.create_activity"), class: "govuk-button"
+
+  - if current_user.service_owner?
+    = render partial: "staff/shared/activities/filter", locals: { organisation_id: @organisation_id }
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Activities
+
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.activities.current"),
+              activities_path(organisation_id: @organisation_id),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: false } }
+
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.activities.historic"),
+              historic_activities_path(organisation_id: @organisation_id),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "historic", selected: true } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activities.historic")
+
+          %table.govuk-table.activities
+            %thead.govuk-table__head
+              %tr.govuk-table__row
+                %th.govuk-table__header
+                  = t("table.header.activity.title")
+                %th.govuk-table__header
+                  = t("table.header.activity.identifier")
+                %th.govuk-table__header
+                  = t("table.header.activity.level")
+                %th.govuk-table__header
+
+            %tbody.govuk-table__body
+              - @historic_activity_presenters.each do |activity|
+                %tr.govuk-table__row{ id: activity.id }
+                  %td.govuk-table__cell= activity.display_title
+                  %td.govuk-table__cell= activity.delivery_partner_identifier
+                  %td.govuk-table__cell= activity.level
+                  %td.govuk-table__cell
+                    = a11y_action_link t("table.body.activity.view_activity"),
+                      organisation_activity_path(activity.organisation, activity),
+                      activity.title

--- a/app/views/staff/shared/activities/_current.html.haml
+++ b/app/views/staff/shared/activities/_current.html.haml
@@ -1,0 +1,21 @@
+%table.govuk-table.activities
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        = t("table.header.activity.title")
+      %th.govuk-table__header
+        = t("table.header.activity.identifier")
+      %th.govuk-table__header
+        = t("table.header.activity.level")
+      %th.govuk-table__header
+
+  %tbody.govuk-table__body
+    - @activity_presenters.each do |activity|
+      %tr.govuk-table__row{ id: activity.id }
+        %td.govuk-table__cell= activity.display_title
+        %td.govuk-table__cell= activity.delivery_partner_identifier
+        %td.govuk-table__cell= activity.level
+        %td.govuk-table__cell
+          = a11y_action_link t("table.body.activity.view_activity"),
+            organisation_activity_path(activity.organisation, activity),
+            activity.title

--- a/app/views/staff/shared/activities/_filter.html.haml
+++ b/app/views/staff/shared/activities/_filter.html.haml
@@ -2,7 +2,7 @@
   .govuk-grid-column-full
     %h2.govuk-heading-s
       = t("filters.activity.title")
-    = form_with url: activities_path, method: :get do |f|
+    = form_with method: :get do |f|
       .govuk-form-group
         %label{ class: "govuk-label", for: :organistaion_id }
           = t("filters.activity.organisation")

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -1,23 +1,23 @@
 - unless activities.empty?
-  %table.govuk-table.activities
-    %thead.govuk-table__head
-      %tr.govuk-table__row
-        %th.govuk-table__header
-          = t("table.header.activity.title")
-        %th.govuk-table__header
-          = t("table.header.activity.identifier")
-        %th.govuk-table__header
-          = t("table.header.activity.level")
-        %th.govuk-table__header
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Activities
 
-    %tbody.govuk-table__body
-      - activities.each do |activity|
-        %tr.govuk-table__row{ id: activity.id }
-          %td.govuk-table__cell= activity.display_title
-          %td.govuk-table__cell= activity.delivery_partner_identifier
-          %td.govuk-table__cell= activity.level
-          %td.govuk-table__cell
-            = a11y_action_link t("table.body.activity.view_activity"),
-              organisation_activity_path(activity.organisation, activity),
-              activity.title
+        %ul.govuk-tabs__list
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+            = link_to t("tabs.activities.current"),
+              activities_path(organisation_id: @organisation_id),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: true } }
 
+          %li.govuk-tabs__list-item
+            = link_to t("tabs.activities.historic"),
+              historic_activities_path(organisation_id: @organisation_id),
+              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "historic", selected: false } }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activities.current")
+
+          = render partial: "staff/shared/activities/current"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -355,6 +355,9 @@ en:
       financials: Financials
       children: Child activities
       comments: Comments
+    activities:
+      current: Current
+      historic: Historic
   page_title:
     activity:
       index: Activities
@@ -365,6 +368,9 @@ en:
       financials: Financials
       children: Child activities
       upload: Upload bulk activity data
+    activities:
+      current: Current activities
+      historic: Historic activities
     activity_form:
       show:
         aid_type: Aid type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,11 @@ Rails.application.routes.draw do
   scope module: "staff" do
     resource :dashboard, only: :show
     resources :users
-    resources :activities, only: [:index]
+    resources :activities, only: [:index] do
+      collection do
+        get "historic" => "activities#historic"
+      end
+    end
     resources :organisations, except: [:destroy] do
       resources :activities, except: [:index, :destroy] do
         get "financials" => "activity_financials#show"

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -29,6 +29,38 @@ RSpec.feature "Users can filter activities" do
       expect(page).to have_content project.title
       expect(page).to have_content project.delivery_partner_identifier
     end
+
+    scenario "they will see Current activities if they filter while on the 'Current' tab" do
+      delivery_partner_organisation = create(:delivery_partner_organisation)
+      current_project = create(:project_activity, organisation: delivery_partner_organisation)
+      historic_project = create(:project_activity, organisation: delivery_partner_organisation, programme_status: "cancelled")
+
+      visit activities_path
+
+      select delivery_partner_organisation.name, from: "organisation_id"
+      click_on t("filters.activity.submit")
+
+      expect(page).to have_content current_project.title
+      expect(page).to have_content current_project.delivery_partner_identifier
+      expect(page).to_not have_content historic_project.title
+      expect(page).to_not have_content historic_project.delivery_partner_identifier
+    end
+
+    scenario "they will see Historic activities if they filter while on the 'Historic' tab" do
+      delivery_partner_organisation = create(:delivery_partner_organisation)
+      current_project = create(:project_activity, organisation: delivery_partner_organisation)
+      historic_project = create(:project_activity, organisation: delivery_partner_organisation, programme_status: "cancelled")
+
+      visit historic_activities_path
+
+      select delivery_partner_organisation.name, from: "organisation_id"
+      click_on t("filters.activity.submit")
+
+      expect(page).to have_content historic_project.title
+      expect(page).to have_content historic_project.delivery_partner_identifier
+      expect(page).to_not have_content current_project.title
+      expect(page).to_not have_content current_project.delivery_partner_identifier
+    end
   end
 
   context "when the user is signed in as a delivery partner user" do

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -71,6 +71,43 @@ RSpec.feature "Users can view activities" do
     let(:user) { create(:delivery_partner_user) }
     before { authenticate!(user: user) }
 
+    scenario "the page displays two tabs, one for current activities and one for historic ones" do
+      create_list(:project_activity, 5, organisation: user.organisation)
+      visit activities_path
+
+      expect(page).to have_css(".govuk-tabs__tab", count: 2)
+      expect(page).to have_css(".govuk-tabs__tab", text: "Current")
+      expect(page).to have_css(".govuk-tabs__tab", text: "Historic")
+    end
+
+    scenario "they see a list of current activities" do
+      current_project = create(:project_activity, organisation: user.organisation)
+      another_current_project = create(:project_activity, :at_purpose_step, organisation: user.organisation)
+      historic_project = create(:project_activity, organisation: user.organisation, programme_status: "completed")
+
+      visit activities_path
+
+      expect(page).to have_content(current_project.title)
+      expect(page).to have_content(current_project.delivery_partner_identifier)
+      expect(page).to have_content(another_current_project.title)
+      expect(page).to have_content(another_current_project.delivery_partner_identifier)
+      expect(page).to_not have_content(historic_project.title)
+      expect(page).to_not have_content(historic_project.delivery_partner_identifier)
+    end
+
+    scenario "they can choose to see a list of historic activities" do
+      current_project = create(:project_activity, organisation: user.organisation)
+      historic_project = create(:project_activity, organisation: user.organisation, programme_status: "completed")
+      another_historic_project = create(:project_activity, organisation: user.organisation, programme_status: "stopped")
+
+      visit activities_path
+      click_on t("tabs.activities.historic")
+
+      expect(page).to have_content(historic_project.title)
+      expect(page).to have_content(another_historic_project.title)
+      expect(page).to_not have_content(current_project.title)
+    end
+
     scenario "they see a list of all their projects" do
       project = create(:project_activity, organisation: user.organisation)
 


### PR DESCRIPTION
Trello: https://trello.com/c/NyH0BprF

## Changes in this PR

This new feature separates the activities view page into two different tabs. One containing the `Current` activities, which are more relevant for users, and the other containing the `Historic` activities, which are the ones where users are unlikely to add any financials, information, etc to them. These `historic activities` are the ones in which `programme_status` is set to either `completed`, `cancelled` or `stopped`. These activities cannot have any financial data added or modified and the users are unlikely to have to use them in the future. However, we still want to keep them in RODA.

The activities view will display two tabs `Current` and `Historic`, and the user will be able to select which ones they want to see.

## Screenshots of UI changes

### Before

<img width="1320" alt="Screenshot 2021-01-27 at 17 17 54" src="https://user-images.githubusercontent.com/48016017/106028250-9f27b180-60c3-11eb-96d6-289220951ac9.png">

### After

<img width="1320" alt="Screenshot 2021-01-27 at 17 13 25" src="https://user-images.githubusercontent.com/48016017/106028060-67206e80-60c3-11eb-8dfb-fd1778d891bc.png">

<img width="1320" alt="Screenshot 2021-01-27 at 17 13 40" src="https://user-images.githubusercontent.com/48016017/106028086-6daee600-60c3-11eb-94d5-0dc57802cb2b.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
