### PR TITLE
(1449) Reorder reports in a more helpful order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,6 +486,7 @@
 - Add a `funding_type` column to a budget
 - Work out a Budget's period based on the financial year
 - Users can see Current activities and Historic activities in different tabs
+- Reorder reports in a more intuitive manner
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...HEAD
 [release-30]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...release-30

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -6,13 +6,19 @@
       %h1.govuk-heading-xl
         = t("page_title.report.index")
 
-  - if current_user.service_owner?
-    .govuk-grid-row.activity-page
-      .govuk-grid-column-full
-        %h2.govuk-heading-m
-          = t("table.title.report.inactive")
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("table.title.report.awaiting_changes")
 
-        = render partial: "staff/shared/reports/table_inactive", locals: { reports: @inactive_report_presenters }
+      = render partial: "staff/shared/reports/table_awaiting_changes", locals: { reports: @awaiting_changes_report_presenters }
+
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("table.title.report.in_review")
+
+      = render partial: "staff/shared/reports/table_in_review", locals: { reports: @in_review_report_presenters }
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
@@ -31,22 +37,14 @@
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
       %h2.govuk-heading-m
-        = t("table.title.report.in_review")
-
-      = render partial: "staff/shared/reports/table_in_review", locals: { reports: @in_review_report_presenters }
-
-  .govuk-grid-row.activity-page
-    .govuk-grid-column-full
-      %h2.govuk-heading-m
-        = t("table.title.report.awaiting_changes")
-
-      = render partial: "staff/shared/reports/table_awaiting_changes", locals: { reports: @awaiting_changes_report_presenters }
-
-  .govuk-grid-row.activity-page
-    .govuk-grid-column-full
-      %h2.govuk-heading-m
         = t("table.title.report.approved")
 
       = render partial: "staff/shared/reports/table_approved", locals: { reports: @approved_report_presenters }
 
+  - if current_user.service_owner?
+    .govuk-grid-row.activity-page
+      .govuk-grid-column-full
+        %h2.govuk-heading-m
+          = t("table.title.report.inactive")
 
+        = render partial: "staff/shared/reports/table_inactive", locals: { reports: @inactive_report_presenters }

--- a/app/views/staff/shared/reports/_table_active.html.haml
+++ b/app/views/staff/shared/reports/_table_active.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           =t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header

--- a/app/views/staff/shared/reports/_table_approved.html.haml
+++ b/app/views/staff/shared/reports/_table_approved.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           = t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header

--- a/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
+++ b/app/views/staff/shared/reports/_table_awaiting_changes.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           = t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header

--- a/app/views/staff/shared/reports/_table_in_review.html.haml
+++ b/app/views/staff/shared/reports/_table_in_review.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           = t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header

--- a/app/views/staff/shared/reports/_table_inactive.html.haml
+++ b/app/views/staff/shared/reports/_table_inactive.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           =t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header

--- a/app/views/staff/shared/reports/_table_submitted.html.haml
+++ b/app/views/staff/shared/reports/_table_submitted.html.haml
@@ -6,7 +6,7 @@
       = t("page_content.reports.title")
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
+        %th{class: "govuk-table__header govuk-!-width-one-quarter"}
           =t("table.header.report.financial_quarter")
         - if current_user.service_owner?
           %th.govuk-table__header


### PR DESCRIPTION
## Changes in this PR

- Reports awaiting changes are the most important to emphasise, while inactive reports (only visible to service owners) are the least. Reorder them according to design.

## Screenshots of UI changes (delivery partner view)

### Before
<img width="1125" alt="Screenshot 2021-01-28 at 17 06 34" src="https://user-images.githubusercontent.com/579522/106172895-3a378e80-618b-11eb-9fe1-be6983355e9a.png">

### After
<img width="1146" alt="Screenshot 2021-01-28 at 17 06 13" src="https://user-images.githubusercontent.com/579522/106172922-43c0f680-618b-11eb-94ed-52f4725e8fb2.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
