### PR TITLE
Memoize codelists in tests

### DIFF
--- a/app/models/codelist.rb
+++ b/app/models/codelist.rb
@@ -17,10 +17,10 @@ class Codelist
 
   class << self
     def codelists
-      if Rails.env.production?
-        @codelists ||= initialize_codelists
-      else
+      if Rails.env.development?
         initialize_codelists
+      else
+        @codelists ||= initialize_codelists
       end
     end
 

--- a/spec/models/codelist_spec.rb
+++ b/spec/models/codelist_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Codelist do
     before { allow(Rails).to receive(:env) { "production".inquiry } }
 
     it "does not reinitialize the codelist once it has been initialized" do
+      Codelist.instance_variable_set(:@codelists, nil)
       expect(Codelist).to receive(:initialize_codelists).once.and_call_original
 
       Codelist.new(type: "default_currency")


### PR DESCRIPTION
While it's potentially useful to reload codelists in dev, it's less useful in test, and almost doubles the time it takes our tests to run (from c. 3 minutes to c. 6 minutes on my local machine!). I have had to update the Codelist tests to reset the class's instance variable (fact fans: a variable starting with an `@` is still called an instance variable when it's being used inside a class, not a class variable)