### PR TITLE
(1461) Flow is always "10" ("ODA")

### DIFF
--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -66,11 +66,6 @@ module CodelistHelper
     Codelist.new(type: "collaboration_type").to_objects(with_empty_item: false).sort_by(&:code)
   end
 
-  def flow_select_options
-    objects = Codelist.new(type: "flow").to_objects(with_empty_item: false)
-    objects.unshift(OpenStruct.new(name: "ODA", code: "10")).uniq
-  end
-
   def sector_category_radio_options
     Codelist.new(type: "sector_category").to_objects(with_empty_item: false)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -38,7 +38,6 @@ class Activity < ApplicationRecord
     :intended_beneficiaries,
     :gdi,
     :collaboration_type,
-    :flow,
     :sustainable_development_goals,
     :fund_pillar,
     :aid_type,
@@ -72,7 +71,6 @@ class Activity < ApplicationRecord
     :intended_beneficiaries_step,
     :gdi_step,
     :collaboration_type_step,
-    :flow_step,
     :sustainable_development_goals_step,
     :aid_type_step,
     :fund_pillar_step,
@@ -111,7 +109,6 @@ class Activity < ApplicationRecord
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :covid19_related, presence: true, on: :covid19_related_step
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
-  validates :flow, presence: true, on: :flow_step
   validates :fund_pillar, presence: true, on: :fund_pillar_step, if: :is_newton_funded?
   validates :sdg_1, presence: true, on: :sustainable_development_goals_step, if: :sdgs_apply?
   validates :aid_type, presence: true, on: :aid_type_step

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -5,6 +5,7 @@ class Activity < ApplicationRecord
   STANDARD_GRANT_FINANCE_CODE = "110"
   UNTIED_TIED_STATUS_CODE = "5"
   CAPITAL_SPEND_PERCENTAGE = 0
+  DEFAULT_FLOW_TYPE = "10"
 
   POLICY_MARKER_CODES = {
     not_targeted: 0,
@@ -250,6 +251,10 @@ class Activity < ApplicationRecord
 
   def capital_spend
     CAPITAL_SPEND_PERCENTAGE
+  end
+
+  def flow
+    DEFAULT_FLOW_TYPE
   end
 
   def default_currency

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -104,12 +104,10 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def flow
-    return if super.blank?
     I18n.t("activity.flow.#{super}")
   end
 
   def flow_with_code
-    return if flow.blank?
     "#{flow} (#{to_model.flow})"
   end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -240,7 +240,6 @@ module Activities
         policy_marker_disability: "DFID policy marker - Disability",
         policy_marker_disaster_risk_reduction: "DFID policy marker - Disaster Risk Reduction",
         policy_marker_nutrition: "DFID policy marker - Nutrition",
-        flow: "Flow",
         aid_type: "Aid type",
         fstc_applies: "Free Standing Technical Cooperation",
         objectives: "Aims/Objectives (DP Definition)",
@@ -439,14 +438,6 @@ module Activities
           collaboration_type,
           "collaboration_type",
           I18n.t("importer.errors.activity.invalid_collaboration_type"),
-        )
-      end
-
-      def convert_flow(flow)
-        validate_from_codelist(
-          flow,
-          "flow",
-          I18n.t("importer.errors.activity.invalid_flow"),
         )
       end
 

--- a/app/views/staff/activity_forms/flow.html.haml
+++ b/app/views/staff/activity_forms/flow.html.haml
@@ -1,2 +1,0 @@
-= render layout: "wrapper" do |f|
-  = f.govuk_collection_select :flow, flow_select_options, :code, :name, options: { selected: f.object.flow || flow_select_options.first.code }, label: { tag: 'h1', size: 'xl' }, hint: { text: t("form.hint.activity.flow").html_safe }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -275,15 +275,6 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :collaboration_type)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:collaboration_type)}"), activity_step_path(activity_presenter, :collaboration_type), t("summary.label.activity.collaboration_type"))
 
-  .govuk-summary-list__row.flow
-    %dt.govuk-summary-list__key
-      = t("summary.label.activity.flow")
-    %dd.govuk-summary-list__value
-      = activity_presenter.flow
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :flow)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:flow)}"), activity_step_path(activity_presenter, :flow), t("summary.label.activity.flow"))
-
   - unless activity_presenter.fund?
     .govuk-summary-list__row.sustainable_development_goals
       %dt.govuk-summary-list__key

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -28,7 +28,6 @@ en:
         back: Back to activity details
     label:
       activity:
-        flow: What is the flow type?
         call_present:
           "true": "Yes"
           "false": "No"
@@ -169,7 +168,6 @@ en:
         call_open_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity start date! Date call will be/was launched. Estimate sufficient until Activity Status is 'Decided'. Where there will be calls for outline and then full proposals, the opening date of the first call (outline) only is sufficient
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Activity Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         country_delivery_partners: "Please provide up to ten country delivery partners. A name is required, provide a acronym where applicable, for example: 'National Council for the State Funding Agencies (CONFAP)'"
-        flow: Read <a href='http://reference.iatistandard.org/203/codelists/FlowType/' target='_blank'>International Aid Transparency Initiative descriptions</a> of each flow type (opens in new window)
         fund_pillar: The Newton Fund largely comprises three pillar activities, which all activities must fall under. Use 'Not applicable' for delivery, other non-programme/project lines.
         delivery_partner_identifier: This could be the reference you use in your internal systems
         gcrf_challenge_area: Select the most relevant GCRF challenge area for this activity. For broad programme calls, please select the challenge area most commonly represented across the individual projects within the programme. If the activity is a delivery line, you may select 'Not applicable'.
@@ -241,7 +239,6 @@ en:
         form_state:
           complete: Complete
           incomplete: Incomplete
-        flow: Flow type
         fstc_applies:
           label: Free-Standing Technical Cooperation applies?
           "false": "No"
@@ -381,7 +378,6 @@ en:
         country_delivery_partners: Country delivery partner
         covid19_related: Is this activity related to Covid-19?
         dates: What are the start and end dates for the %{level}?
-        flow: Flow
         gcrf_challenge_area: GCRF challenge area
         fund_pillar: What Newton Fund Pillar does this activity fall under?
         gdi: GDI
@@ -495,7 +491,6 @@ en:
         invalid_planned_end_date: The Planned end date is in an invalid format
         invalid_sector: The sector code is not valid
         invalid_collaboration_type: The collaboration type code is not valid
-        invalid_flow: The flow code is not valid
         invalid_aid_type: The aid type code is not valid
         invalid_fstc_applies: The free standing technical cooperation column is not valid
         invalid_parent: The parent activity is not valid

--- a/db/migrate/20210202192712_remove_flow_from_activities.rb
+++ b/db/migrate/20210202192712_remove_flow_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveFlowFromActivities < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :activities, :flow
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_124531) do
+ActiveRecord::Schema.define(version: 2021_02_02_192712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -29,7 +29,6 @@ ActiveRecord::Schema.define(version: 2021_01_26_124531) do
     t.date "actual_start_date"
     t.date "actual_end_date"
     t.string "recipient_region"
-    t.string "flow"
     t.string "aid_type"
     t.string "form_state"
     t.string "level"
@@ -198,7 +197,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_124531) do
     t.date "deadline"
     t.integer "financial_quarter"
     t.integer "financial_year"
-    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> ALL ((ARRAY['inactive'::character varying, 'approved'::character varying])::text[]))"
+    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> ALL (ARRAY[('inactive'::character varying)::text, ('approved'::character varying)::text]))"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -20,7 +20,6 @@ FactoryBot.define do
     intended_beneficiaries { ["CU", "DM", "DO"] }
     gdi { "4" }
     fstc_applies { true }
-    flow { "10" }
     aid_type { "B02" }
     level { :fund }
     publish_to_iati { true }
@@ -197,7 +196,6 @@ FactoryBot.define do
     recipient_region { nil }
     recipient_country { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -231,7 +229,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -263,7 +260,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -282,7 +278,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -302,7 +297,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -322,7 +316,6 @@ FactoryBot.define do
   trait :at_collaboration_type_step do
     form_state { "collaboration_type" }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -363,7 +356,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -400,7 +392,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     policy_marker_gender { nil }
     policy_marker_climate_change_adaptation { nil }
@@ -435,7 +426,6 @@ FactoryBot.define do
     intended_beneficiaries { nil }
     gdi { nil }
     collaboration_type { nil }
-    flow { nil }
     aid_type { nil }
     extending_organisation_id { nil }
     parent { nil }

--- a/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_fund_level_activity_spec.rb
@@ -37,9 +37,6 @@ RSpec.feature "Users can create a fund level activity" do
 
       visit activity_step_path(activity, :region)
       expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.recipient_region
-
-      visit activity_step_path(activity, :flow)
-      expect(page.find("option[@selected = 'selected']").text).to eq activity_presenter.flow
     end
 
     scenario "the activity has the appropriate accountable organisation defaults" do
@@ -232,13 +229,8 @@ RSpec.feature "Users can create a fund level activity" do
         choose "GDI not applicable"
         click_button t("form.button.activity.submit")
 
-        # Skip the collaboration type step, and instead goto the flow step
+        # Skip the collaboration type step
         expect(page).to have_no_content t("form.label.activity.collaboration_type")
-        expect(page).to have_content t("form.label.activity.flow")
-
-        # Flow has a default and can't be set to blank so we skip
-        select "ODA", from: "activity[flow]"
-        click_button t("form.button.activity.submit")
 
         # Skip the SDGs step and instead go to the aid type step
         expect(page).to have_no_content t("form.legend.activity.sdgs_apply")
@@ -313,7 +305,7 @@ RSpec.feature "Users can create a fund level activity" do
 
         fund = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
         auditable_events = PublicActivity::Activity.where(trackable_id: fund.id)
-        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.aid_type")
         expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
         expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [fund.id]
       end

--- a/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_programme_level_activity_spec.rb
@@ -178,11 +178,7 @@ RSpec.feature "Users can create a programme activity" do
 
         # Collaboration_type has a pre-selected option
         click_button t("form.button.activity.submit")
-        expect(page).to have_content t("form.label.activity.flow")
 
-        # Flow has a default and can't be set to blank so we skip
-        select "ODA", from: "activity[flow]"
-        click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.sdgs_apply")
 
         # Choose option that SDGs apply, but do not select any SDGs
@@ -300,7 +296,7 @@ RSpec.feature "Users can create a programme activity" do
 
         programme = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
         auditable_events = PublicActivity::Activity.where(trackable_id: programme.id)
-        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+        expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.aid_type")
         expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
         expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [programme.id]
       end

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "Users can create a project" do
 
           project = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
           auditable_events = PublicActivity::Activity.where(trackable_id: project.id)
-          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.aid_type")
           expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
           expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [project.id]
         end

--- a/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Users can create a project" do
 
           third_party_project = Activity.find_by(delivery_partner_identifier: "my-unique-identifier")
           auditable_events = PublicActivity::Activity.where(trackable_id: third_party_project.id)
-          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.flow", "activity.create.aid_type")
+          expect(auditable_events.map { |event| event.key }).to include("activity.create", "activity.create.identifier", "activity.create.purpose", "activity.create.sector", "activity.create.geography", "activity.create.region", "activity.create.aid_type")
           expect(auditable_events.map { |event| event.owner_id }.uniq).to eq [user.id]
           expect(auditable_events.map { |event| event.trackable_id }.uniq).to eq [third_party_project.id]
         end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -600,15 +600,6 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
     click_on t("tabs.activity.details")
   end
 
-  within(".flow") do
-    click_on(t("default.link.edit"))
-    expect(page).to have_current_path(
-      activity_step_path(activity, :flow)
-    )
-  end
-  click_on(t("default.link.back"))
-  click_on t("tabs.activity.details")
-
   within(".aid_type") do
     click_on(t("default.link.edit"))
     expect(page).to have_current_path(

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -38,7 +38,6 @@ RSpec.feature "users can upload activities" do
       "DFID policy marker - Disability", "DFID policy marker - Disaster Risk Reduction",
       "DFID policy marker - Gender", "DFID policy marker - Nutrition",
       "Delivery partner identifier",
-      "Flow",
       "Free Standing Technical Cooperation",
       "GCRF Challenge Area",
       "GDI",

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -206,7 +206,6 @@ RSpec.feature "Users can view activities" do
       expect(page).to have_content activity_presenter.planned_start_date
       expect(page).to have_content activity_presenter.planned_end_date
       expect(page).to have_content activity_presenter.recipient_region
-      expect(page).to have_content activity_presenter.flow
 
       within ".sustainable_development_goals" do
         expect(page).to have_content "Gender Equality"

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -161,7 +161,6 @@ RSpec.feature "Users can view an activity" do
       expect(page).to have_content activity_presenter.planned_start_date
       expect(page).to have_content activity_presenter.planned_end_date
       expect(page).to have_content activity_presenter.recipient_region
-      expect(page).to have_content activity_presenter.flow
     end
 
     scenario "the activity links to the parent activity" do

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(helper.step_is_complete_or_next?(activity: activity, step: "dates")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "region")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(false)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "flow")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
       end
     end
@@ -31,7 +30,6 @@ RSpec.describe ActivityHelper, type: :helper do
         expect(helper.step_is_complete_or_next?(activity: activity, step: "dates")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "region")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "country")).to be(true)
-        expect(helper.step_is_complete_or_next?(activity: activity, step: "flow")).to be(false)
       end
 
       it "returns false for the next fields" do

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -49,13 +49,6 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
-    describe "#flow_select_options" do
-      it "returns an array of flow objects with 10 as the first (default) option" do
-        expect(helper.flow_select_options.first)
-          .to eq(OpenStruct.new(name: "ODA", code: "10"))
-      end
-    end
-
     describe "#sector_radio_options" do
       it "returns all sectors when no category is passed" do
         options = helper.sector_radio_options

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#flow" do
+    it "always returns the default ODA flow type, code '10'" do
+      activity = Activity.new
+      expect(activity.flow).to eq "10"
+    end
+  end
+
   describe "scopes" do
     describe ".funds" do
       it "only returns fund level activities" do
@@ -597,13 +604,6 @@ RSpec.describe Activity, type: :model do
       subject(:activity) { build(:fund_activity, collaboration_type: nil) }
       it "should be valid" do
         expect(activity.valid?(:collaboration_type_step)).to be_truthy
-      end
-    end
-
-    context "when flow is blank" do
-      subject(:activity) { build(:activity, flow: nil) }
-      it "should not be valid" do
-        expect(activity.valid?(:flow_step)).to be_falsey
       end
     end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -334,27 +334,17 @@ RSpec.describe ActivityPresenter do
   end
 
   describe "#flow" do
-    context "when flow aid_type exists" do
-      it "returns the locale value for the code" do
-        activity = build(:activity, flow: "20")
-        result = described_class.new(activity).flow
-        expect(result).to eql("OOF")
-      end
-    end
-
-    context "when the activity does not have a flow set" do
-      it "returns nil" do
-        activity = build(:activity, flow: nil)
-        result = described_class.new(activity)
-        expect(result.flow).to be_nil
-      end
+    it "returns the locale value for the default ODA code" do
+      activity = build(:activity)
+      result = described_class.new(activity).flow
+      expect(result).to eql("ODA")
     end
   end
 
   describe "#flow_with_code" do
-    it "returns the flow string & code number" do
-      fund = create(:activity, flow: "20")
-      expect(described_class.new(fund).flow_with_code).to eql("OOF (20)")
+    it "returns the default flow string & code number" do
+      fund = create(:activity)
+      expect(described_class.new(fund).flow_with_code).to eql("ODA (10)")
     end
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Activities::ImportFromCsv do
       "DFID policy marker - Disability" => "",
       "DFID policy marker - Disaster Risk Reduction" => "0",
       "DFID policy marker - Nutrition" => "",
-      "Flow" => "10",
       "Aid type" => "B03",
       "Free Standing Technical Cooperation" => "1",
       "Aims/Objectives (DP Definition)" => "Foo bar baz",
@@ -180,7 +179,6 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.policy_marker_disability).to eq("not_assessed")
       expect(existing_activity.policy_marker_disaster_risk_reduction).to eq("not_targeted")
       expect(existing_activity.policy_marker_nutrition).to eq("not_assessed")
-      expect(existing_activity.flow).to eq(existing_activity_attributes["Flow"])
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
@@ -318,7 +316,6 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.sector_category).to eq("112")
       expect(new_activity.channel_of_delivery_code).to eq(new_activity_attributes["Channel of delivery code"])
       expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
-      expect(new_activity.flow).to eq(new_activity_attributes["Flow"])
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
       expect(new_activity.fstc_applies).to eq(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
@@ -630,22 +627,6 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.column).to eq(:collaboration_type)
       expect(subject.errors.first.value).to eq("99")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_collaboration_type"))
-    end
-
-    it "has an error if the Flow option is invalid" do
-      new_activity_attributes["Flow"] = "1"
-
-      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
-
-      expect(subject.created.count).to eq(0)
-      expect(subject.updated.count).to eq(0)
-
-      expect(subject.errors.count).to eq(1)
-      expect(subject.errors.first.csv_row).to eq(2)
-      expect(subject.errors.first.csv_column).to eq("Flow")
-      expect(subject.errors.first.column).to eq(:flow)
-      expect(subject.errors.first.value).to eq("1")
-      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_flow"))
     end
 
     it "has an error if the Aid Type option is invalid" do

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -45,9 +45,6 @@ module ActivityHelpers
     expect(page).to have_content t("summary.label.activity.recipient_region")
     expect(page).to have_content activity_presenter.recipient_region
 
-    expect(page).to have_content t("summary.label.activity.flow")
-    expect(page).to have_content activity_presenter.flow
-
     expect(page).to have_content t("summary.label.activity.aid_type")
     expect(page).to have_content activity_presenter.aid_type
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -36,7 +36,6 @@ module FormHelpers
     intended_beneficiaries: "Haiti",
     gdi: "GDI not applicable",
     collaboration_type: "Bilateral",
-    flow: "ODA",
     sdg_1: 1,
     fund_pillar: "1",
     aid_type: "B02",
@@ -222,11 +221,6 @@ module FormHelpers
       click_button t("form.button.activity.submit")
     end
 
-    expect(page).to have_content t("form.label.activity.flow")
-    expect(page.html).to include t("form.hint.activity.flow")
-    select flow, from: "activity[flow]"
-    click_button t("form.button.activity.submit")
-
     unless level == "fund"
       expect(page).to have_content t("form.legend.activity.sdgs_apply")
       expect(page).to have_content t("form.hint.activity.sdgs_apply")
@@ -354,7 +348,6 @@ module FormHelpers
     expect(page).to have_content recipient_region
     expect(page).to have_content intended_beneficiaries
     expect(page).to have_content gdi
-    expect(page).to have_content flow
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
 
     within(".govuk-summary-list__row.fstc_applies") do

--- a/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
+++ b/spec/support/shared_examples/behaves_like_valid_activity_xml.rb
@@ -76,6 +76,12 @@ RSpec.shared_examples "valid activity XML" do
     expect(xml.at("iati-activity/default-tied-status/@code").text).to eq("5")
   end
 
+  it "contains the default value for Flow type" do
+    visit organisation_activity_path(organisation, activity, format: :xml)
+
+    expect(xml.at("iati-activity/default-flow-type/@code").text).to eq("10")
+  end
+
   it "contains the transaction XML" do
     transaction = create(:transaction, parent_activity: activity)
     visit organisation_activity_path(organisation, activity, format: :xml)


### PR DESCRIPTION
## Changes in this PR

- We don't ask the users for the Flow type, because it is always going to be ODA ("10"). We don't import it from CSV. When exporting to CSV and to XML, the flow is added and hardcoded to "10".

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
