### PR TITLE
(1475) Encode CSV downloads for Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,10 @@
 - Add links to the guidance across the site
 - Users can report Channel of delivery code through the activity form
 
+## [unreleased]
+
+- Serve CSV downloads encoded in UTF-8, prefixed with a byte order mark
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...HEAD
 [release-31]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...release-31
 [release-30]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...release-30

--- a/app/controllers/concerns/stream_csv_download.rb
+++ b/app/controllers/concerns/stream_csv_download.rb
@@ -1,0 +1,34 @@
+module StreamCsvDownload
+  include ActionController::Live
+
+  def stream_csv_download(filename:, headers:)
+    response.headers["Content-Type"] = "text/csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{filename}"
+
+    writer = Writer.new(response.stream)
+    writer << headers
+    yield writer if block_given?
+
+    response.stream.close
+  end
+
+  class Writer
+    DEFAULT_ENCODING = Encoding::UTF_8
+    BYTE_ORDER_MARK = "\uFEFF"
+
+    def initialize(stream)
+      @stream = stream
+      @stream.write(encode(BYTE_ORDER_MARK))
+    end
+
+    def <<(row)
+      @stream.write(encode(CSV.generate_line(row)))
+    end
+
+    private
+
+    def encode(string)
+      string.encode(DEFAULT_ENCODING)
+    end
+  end
+end

--- a/app/controllers/staff/activity_uploads_controller.rb
+++ b/app/controllers/staff/activity_uploads_controller.rb
@@ -4,6 +4,7 @@ require "csv"
 
 class Staff::ActivityUploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   before_action :authorize_report
 
@@ -12,11 +13,7 @@ class Staff::ActivityUploadsController < Staff::BaseController
   end
 
   def show
-    response.headers["Content-Type"] = "text/csv"
-    response.headers["Content-Disposition"] = "attachment; filename=activities.csv"
-
-    response.stream.write(CSV.generate_line(csv_headers))
-    response.stream.close
+    stream_csv_download(filename: "activities.csv", headers: csv_headers)
   end
 
   def update

--- a/app/controllers/staff/planned_disbursement_uploads_controller.rb
+++ b/app/controllers/staff/planned_disbursement_uploads_controller.rb
@@ -4,6 +4,7 @@ require "csv"
 
 class Staff::PlannedDisbursementUploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   before_action :authorize_report
 
@@ -12,16 +13,13 @@ class Staff::PlannedDisbursementUploadsController < Staff::BaseController
   end
 
   def show
-    response.headers["Content-Type"] = "text/csv"
-    response.headers["Content-Disposition"] = "attachment; filename=forecasts.csv"
-
     generator = ImportPlannedDisbursements::Generator.new
 
-    response.stream.write(CSV.generate_line(generator.column_headings))
-    @report.reportable_activities.each do |activity|
-      response.stream.write(CSV.generate_line(generator.csv_row(activity)))
+    stream_csv_download(filename: "forecasts.csv", headers: generator.column_headings) do |csv|
+      @report.reportable_activities.each do |activity|
+        csv << generator.csv_row(activity)
+      end
     end
-    response.stream.close
   end
 
   def update

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -4,6 +4,7 @@ require "csv"
 
 class Staff::TransactionUploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   before_action :authorize_report
 
@@ -12,14 +13,11 @@ class Staff::TransactionUploadsController < Staff::BaseController
   end
 
   def show
-    response.headers["Content-Type"] = "text/csv"
-    response.headers["Content-Disposition"] = "attachment; filename=transactions.csv"
-
-    response.stream.write(CSV.generate_line(csv_headers))
-    @report.reportable_activities.each do |activity|
-      response.stream.write(CSV.generate_line(csv_row(activity)))
+    stream_csv_download(filename: "transactions.csv", headers: csv_headers) do |csv|
+      @report.reportable_activities.each do |activity|
+        csv << csv_row(activity)
+      end
     end
-    response.stream.close
   end
 
   def update

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -12,14 +12,14 @@ class ExportActivityToCsv
     values = columns.values.map(&:call)
     values = values.push(previous_quarter_actuals) if previous_report.present?
     values = values.concat(next_twelve_quarter_forecasts)
-    values.to_csv
+    values
   end
 
   def headers
     values = columns.keys
     values = values.push(previous_quarter_actuals_header) if previous_report.present?
     values = values.concat(next_twelve_quarter_forecasts_headers)
-    values.to_csv
+    values
   end
 
   def previous_quarter_actuals

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -20,7 +20,8 @@ RSpec.feature "users can upload activities" do
   scenario "downloading the CSV template" do
     click_link t("action.activity.download.button")
 
-    rows = CSV.parse(page.body, headers: false).first
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: false).first
 
     expect(rows).to match_array([
       "Activity Status",

--- a/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature "users can upload planned disbursements" do
   scenario "downloading a CSV template with activities for the current report" do
     click_link t("action.planned_disbursement.download.button")
 
-    rows = CSV.parse(page.body, headers: true).map(&:to_h)
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: true).map(&:to_h)
 
     expect(rows).to match_array([
       {

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -22,7 +22,8 @@ RSpec.feature "users can upload transactions" do
   scenario "downloading a CSV template with activities for the current report" do
     click_link t("action.transaction.download.button")
 
-    rows = CSV.parse(page.body, headers: true).map(&:to_h)
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: true).map(&:to_h)
 
     expect(rows).to match_array([
       {

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe ExportActivityToCsv do
 
       result = export_service.call
 
-      expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00\n")
+      expect(result).to eql [
+        "Value A", "Value B", "Value C",
+        "0.00", "0.00", "0.00", "0.00",
+        "0.00", "0.00", "0.00", "0.00",
+        "0.00", "0.00", "0.00", "0.00",
+      ]
     end
 
     it "includes the forecast and actuals for the previous quarter, if a suitable report is available" do
@@ -36,7 +41,12 @@ RSpec.describe ExportActivityToCsv do
 
       result = export_service.call
 
-      expect(result).to eql("Value A,Value B,Value C,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00\n")
+      expect(result).to eql [
+        "Value A", "Value B", "Value C",
+        "0.00", "0.00", "0.00", "0.00",
+        "0.00", "0.00", "0.00", "0.00",
+        "0.00", "0.00", "0.00", "0.00", "0.00",
+      ]
     end
 
     it "includes the BEIS id if there is one" do
@@ -105,7 +115,12 @@ RSpec.describe ExportActivityToCsv do
 
       headers = export_service.headers
 
-      expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021,Q2 2021,Q3 2021,Q4 2021,Q1 2022,Q2 2022,Q3 2022,Q4 2022,Q1 2023\n")
+      expect(headers).to eql [
+        "Header A", "Header B", "Header C",
+        "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
+        "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
+        "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",
+      ]
     end
 
     it "uses the current report financial quarter to generate the actuals total column" do
@@ -129,7 +144,7 @@ RSpec.describe ExportActivityToCsv do
 
       headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
-      expect(headers).to include [
+      expect(headers.to_csv).to include [
         "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
         "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
         "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",


### PR DESCRIPTION
This PR addresses a problem that happens when people use Excel to open a CSV downloaded from RODA. All the data stored in RODA is UTF-8, and does not contain any _encoding_ errors; that is, all text stored in RODA is a valid UTF-8 byte sequence. The CSVs served by RODA are also valid UTF-8 encoded CSV, but when opened in Excel some of their content is mis-interpreted.

We ran some experiments where we encoded a CSV file containing text from a variety of Unicode blocks. We encoded this file as UTF-8, UTF-16BE and UTF-16LE, and made copies of each of these with and without a byte order mark (BOM) at the start.

We found that Excel is able to read UTF-8 successfully if it's prefixed with a BOM. If this is missing, Excel will mis-read many of the characters in the file, including mis-interpreting the boundaries between rows and cells. It appears to be interpreting the data in some other ASCII-compatible encoding such as Windows-1252, but we're unsure which one.

Excel can read UTF-16LE with a BOM, in the sense that it reads all the codepoints represented in the file correctly. However, it ignores the commas that separate cells and so merges all the data into one column.

We saw mixed results for UTF-16BE on various platforms.

Given this, I've unified the code for all parts of the application that serve downloadable CSV, so we have one implementation for how this works. It encodes the data in UTF-8 and prefixes it with a BOM.

One thing we learned while investigating this is that some programs will strip the BOM off the file, rendering it unreadable. For example, sending the file via Slack results in the BOM being removed from it.