### PR TITLE
(1439) Add the last 12 actuals to the CSV activity export, if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,6 +490,7 @@
 - Group activities by hierarchy on the view of a single report page
 - Add links to the guidance across the site
 - Users can report Channel of delivery code through the activity form
+- Add the last 12 actuals to the CSV activity export, if available
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...HEAD
 [release-30]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-29...release-30

--- a/app/models/financial_quarter.rb
+++ b/app/models/financial_quarter.rb
@@ -64,4 +64,26 @@ class FinancialQuarter
   def to_i
     quarter
   end
+
+  def +(other)
+    months = other * 3
+    date = (start_date + months.months)
+
+    self.class.for_date(date)
+  end
+
+  def -(other)
+    months = other * 3
+    date = (start_date - months.months)
+
+    self.class.for_date(date)
+  end
+
+  def <=>(other)
+    start_date <=> other.start_date
+  end
+
+  def succ
+    self + 1
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -77,26 +77,15 @@ class Report < ApplicationRecord
   end
 
   def next_twelve_financial_quarters
-    quarter, year = financial_quarter, financial_year
+    quarter = FinancialQuarter.new(financial_year, financial_quarter)
 
-    (1..12).map do
-      year += 1 if quarter == 4
-      quarter = (quarter % 4) + 1
-
-      [quarter, year]
-    end
+    ((quarter + 1)..(quarter + 12)).to_a
   end
 
   def previous
-    quarter, year = financial_quarter, financial_year
+    quarter = FinancialQuarter.new(financial_year, financial_quarter)
+    previous_quarter = quarter - 1
 
-    quarter -= 1
-
-    if quarter == 0
-      quarter = 4
-      year -= 1
-    end
-
-    Report.find_by(fund: fund, organisation: organisation, financial_quarter: quarter, financial_year: year)
+    Report.find_by(fund: fund, organisation: organisation, financial_quarter: previous_quarter.quarter, financial_year: previous_quarter.financial_year.to_i)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -94,4 +94,10 @@ class Report < ApplicationRecord
 
     Report.find_by(fund: fund, organisation: organisation, financial_quarter: previous_quarter.quarter, financial_year: previous_quarter.financial_year.to_i)
   end
+
+  def previous_twelve_reports
+    previous_twelve_financial_quarters.map do |quarter|
+      Report.find_by(fund: fund, organisation: organisation, financial_quarter: quarter.to_i, financial_year: quarter.financial_year.to_i)
+    end
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -76,6 +76,12 @@ class Report < ApplicationRecord
     Activity.projects_and_third_party_projects_for_report(self).with_roda_identifier
   end
 
+  def previous_twelve_financial_quarters
+    quarter = FinancialQuarter.new(financial_year, financial_quarter)
+
+    ((quarter - 12)..(quarter - 1)).to_a.reverse
+  end
+
   def next_twelve_financial_quarters
     quarter = FinancialQuarter.new(financial_year, financial_quarter)
 

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -27,9 +27,9 @@ class ExportActivityToCsv
   end
 
   def next_twelve_quarter_forecasts
-    report_presenter.next_twelve_financial_quarters.map do |quarter, year|
+    report_presenter.next_twelve_financial_quarters.map do |quarter|
       overview = PlannedDisbursementOverview.new(activity_presenter)
-      value = overview.snapshot(report_presenter).value_for(financial_quarter: quarter, financial_year: year)
+      value = overview.snapshot(report_presenter).value_for(financial_quarter: quarter.to_i, financial_year: quarter.financial_year.to_i)
       "%.2f" % value
     end
   end
@@ -133,6 +133,6 @@ class ExportActivityToCsv
   end
 
   private def next_twelve_quarter_forecasts_headers
-    report_presenter.next_twelve_financial_quarters.map { |quarter, year| "Q#{quarter} #{year}" }
+    report_presenter.next_twelve_financial_quarters.map(&:to_s)
   end
 end

--- a/spec/models/financial_quarter_spec.rb
+++ b/spec/models/financial_quarter_spec.rb
@@ -70,4 +70,89 @@ RSpec.describe FinancialQuarter do
       expect(FinancialQuarter.for_date(march_date).to_s).to eq("Q4 2020-2021")
     end
   end
+
+  describe "#+" do
+    it "appends 1 to the quarter and leaves the year alone if the quarter is less than 4" do
+      q1 = FinancialQuarter.new(2020, 1)
+      q2 = FinancialQuarter.new(2020, 2)
+      q3 = FinancialQuarter.new(2020, 3)
+
+      expect((q1 + 1).to_s).to eq("Q2 2020-2021")
+      expect((q2 + 1).to_s).to eq("Q3 2020-2021")
+      expect((q3 + 1).to_s).to eq("Q4 2020-2021")
+    end
+
+    it "appends 1 to the quarter and 1 to the year if the quarter is Q4" do
+      q4 = FinancialQuarter.new(2020, 4)
+
+      expect((q4 + 1).to_s).to eq("Q1 2021-2022")
+    end
+
+    it "appends numbers that stretch over multiple financial years" do
+      quarter = FinancialQuarter.new(2020, 1)
+
+      expect((quarter + 10).to_s).to eq("Q3 2022-2023")
+    end
+  end
+
+  describe "#-" do
+    it "appends 1 to the quarter and leaves the year alone if the quarter is more than 1" do
+      q2 = FinancialQuarter.new(2020, 2)
+      q3 = FinancialQuarter.new(2020, 3)
+      q4 = FinancialQuarter.new(2020, 4)
+
+      expect((q2 - 1).to_s).to eq("Q1 2020-2021")
+      expect((q3 - 1).to_s).to eq("Q2 2020-2021")
+      expect((q4 - 1).to_s).to eq("Q3 2020-2021")
+    end
+
+    it "removes one 1 from the quarter and 1 from the year if the quarter is Q1" do
+      q1 = FinancialQuarter.new(2020, 1)
+
+      expect((q1 - 1).to_s).to eq("Q4 2019-2020")
+    end
+
+    it "appends numbers that stretch over multiple financial years" do
+      quarter = FinancialQuarter.new(2020, 1)
+
+      expect((quarter - 10).to_s).to eq("Q3 2017-2018")
+    end
+  end
+
+  describe "#succ" do
+    it "returns the next quarters" do
+      q1 = FinancialQuarter.new(2020, 1)
+      q2 = FinancialQuarter.new(2020, 2)
+      q3 = FinancialQuarter.new(2020, 3)
+      q4 = FinancialQuarter.new(2020, 4)
+
+      expect(q1.succ.to_s).to eq("Q2 2020-2021")
+      expect(q2.succ.to_s).to eq("Q3 2020-2021")
+      expect(q3.succ.to_s).to eq("Q4 2020-2021")
+      expect(q4.succ.to_s).to eq("Q1 2021-2022")
+    end
+  end
+
+  describe "range" do
+    it "returns a range of quarters" do
+      q1 = FinancialQuarter.new(2020, 1)
+      range = (q1...(q1 + 10))
+
+      expect(range.count).to eq(10)
+    end
+
+    it "returns the expected items in the range" do
+      q1 = FinancialQuarter.new(2020, 1)
+
+      range = (q1...(q1 + 5))
+
+      expect(range.to_a.map(&:to_s)).to eq([
+        "Q1 2020-2021",
+        "Q2 2020-2021",
+        "Q3 2020-2021",
+        "Q4 2020-2021",
+        "Q1 2021-2022",
+      ])
+    end
+  end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -168,6 +168,18 @@ RSpec.describe Report, type: :model do
     end
   end
 
+  describe "#previous_twelve_financial_quarters" do
+    it "returns an array with the previous twelve financial quarters from the date of the report" do
+      report = travel_to(Date.parse("1 April 2020")) { create(:report) }
+
+      expect(report.previous_twelve_financial_quarters.map(&:to_s)).to eq [
+        "Q4 2019-2020", "Q3 2019-2020", "Q2 2019-2020", "Q1 2019-2020",
+        "Q4 2018-2019", "Q3 2018-2019", "Q2 2018-2019", "Q1 2018-2019",
+        "Q4 2017-2018", "Q3 2017-2018", "Q2 2017-2018", "Q1 2017-2018",
+      ]
+    end
+  end
+
   describe "#previous" do
     it "returns the report for the previous quarter" do
       report = travel_to(Date.parse("1 April 2020")) { create(:report) }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -160,10 +160,10 @@ RSpec.describe Report, type: :model do
     it "returns an array with the next twelve financial quarters from the date of the report" do
       report = travel_to(Date.parse("1 April 2020")) { create(:report) }
 
-      expect(report.next_twelve_financial_quarters).to eq [
-        [2, 2020], [3, 2020], [4, 2020], [1, 2021],
-        [2, 2021], [3, 2021], [4, 2021], [1, 2022],
-        [2, 2022], [3, 2022], [4, 2022], [1, 2023],
+      expect(report.next_twelve_financial_quarters.map(&:to_s)).to eq [
+        "Q2 2020-2021", "Q3 2020-2021", "Q4 2020-2021", "Q1 2021-2022",
+        "Q2 2021-2022", "Q3 2021-2022", "Q4 2021-2022", "Q1 2022-2023",
+        "Q2 2022-2023", "Q3 2022-2023", "Q4 2022-2023", "Q1 2023-2024",
       ]
     end
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe ExportActivityToCsv do
   describe "#next_twelve_quarter_forecasts" do
     it "gets the forecasted total for the next twelve quarters" do
       quarters = report.next_twelve_financial_quarters
-      q1_forecast = PlannedDisbursementHistory.new(project, *quarters[0])
-      q3_forecast = PlannedDisbursementHistory.new(project, *quarters[2])
-      q11_forecast = PlannedDisbursementHistory.new(project, *quarters[10])
+      q1_forecast = PlannedDisbursementHistory.new(project, quarters[0].to_i, quarters[0].financial_year.to_i)
+      q3_forecast = PlannedDisbursementHistory.new(project, quarters[2].to_i, quarters[2].financial_year.to_i)
+      q11_forecast = PlannedDisbursementHistory.new(project, quarters[10].to_i, quarters[10].financial_year.to_i)
 
       q1_forecast.set_value(1000)
       q3_forecast.set_value(500)
@@ -105,7 +105,7 @@ RSpec.describe ExportActivityToCsv do
 
       headers = export_service.headers
 
-      expect(headers).to eql("Header A,Header B,Header C,Q2 2020,Q3 2020,Q4 2020,Q1 2021,Q2 2021,Q3 2021,Q4 2021,Q1 2022,Q2 2022,Q3 2022,Q4 2022,Q1 2023\n")
+      expect(headers).to eql("Header A,Header B,Header C,Q2 2020-2021,Q3 2020-2021,Q4 2020-2021,Q1 2021-2022,Q2 2021-2022,Q3 2021-2022,Q4 2021-2022,Q1 2022-2023,Q2 2022-2023,Q3 2022-2023,Q4 2022-2023,Q1 2023-2024\n")
     end
 
     it "uses the current report financial quarter to generate the actuals total column" do
@@ -130,9 +130,9 @@ RSpec.describe ExportActivityToCsv do
       headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
 
       expect(headers).to include [
-        "Q2 2020", "Q3 2020", "Q4 2020", "Q1 2021",
-        "Q2 2021", "Q3 2021", "Q4 2021", "Q1 2022",
-        "Q2 2022", "Q3 2022", "Q4 2022", "Q1 2023",
+        "Q2 2020-2021", "Q3 2020-2021", "Q4 2020-2021", "Q1 2021-2022",
+        "Q2 2021-2022", "Q3 2021-2022", "Q4 2021-2022", "Q1 2022-2023",
+        "Q2 2022-2023", "Q3 2022-2023", "Q4 2022-2023", "Q1 2023-2024",
       ].to_csv
     end
 


### PR DESCRIPTION
This updates the CSV activity exporter to include actuals data for anything up to twelve quarters ago, if the reports are available. If there are no reports, the headers and data are not made shown in the CSV.