### PR TITLE
Update deployment process docs to the new emoji

### DIFF
--- a/doc/deployment-process.md
+++ b/doc/deployment-process.md
@@ -44,7 +44,7 @@ The heading should link to a Github URL at the bottom of the file, which shows t
    Let the team know about the release. This is posted in Slack under #beis-roda. Typical form is:
 
    ```
-   @here :badger: Release N of RODA going to production :badger:
+   @here :badgerbadgerbadger: Release N of RODA going to production :badgerbadgerbadger:
    ```
 
 1. Manually merge to master to release


### PR DESCRIPTION
Now there's an "official" badger emoji, the announcements in Slack are much less celebratory (and a bit baffling!). Let's fix this.

# Before

![image](https://user-images.githubusercontent.com/109774/107213389-3b28b580-6a00-11eb-8c99-fe705ac3d0ec.png)

# After

![image](https://user-images.githubusercontent.com/109774/107213433-4ed41c00-6a00-11eb-9f80-b4213be0415c.png)

Much better!