### PR TITLE
(chore) Backing services can be run with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ script/server
 script/test
 ```
 
+## Running backing services with Docker compose
+
+If you prefer not to install the backing services (Postgres and Redis) with
+Homebrew via the scripts above, run them in the background with Docker and
+then use standard rails commands to interact with the application (you will need
+Docker installed on your device):
+
+````
+docker-compose -f backing-services-docker-compose.yml up -d
+````
+
+To stop the backing services:
+
+````
+docker-compose -f backing-services-docker-compose.yml down
+````
+
 ## Architecture decision records
 
 We use ADRs to document architectural decisions that we make. They can be found in doc/architecture/decisions and contributed to with the [adr-tools](https://github.com/npryce/adr-tools).

--- a/backing-services-docker-compose.yml
+++ b/backing-services-docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+services:
+  postgres:
+    image: postgres:11.6
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis:4
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+volumes:
+  db_data:
+  redis_data:


### PR DESCRIPTION
## Changes in this PR

I prefer to run the two backing services (Postgres and Redis) with
Docker as I find managing version with Homebrew can effect my entire
system and I often find I update the backing services without meaning to
when updating my own tooling, which can cause horrible problems.

For those that prefer it, a simple docker compose file allows one to
start and stop the backing services via docker and not effect their
system at all. This has an added benefit of having the option to pin the
versions of the backing services to that of the ones used in production.

Whilst I am loathe to add alternatives to the one-script-to-rule-them-all,
I much prefer this approach personally and have real technical
reasons to avoid the Homebrew path, therefore I am adding this compose
file and a small section in the readme to cover its use for those that
prefer.

If the team are opposed to this in the readme, could we keep the compose file
so I don't have to have it somewhere else? 🙏 
