### PR TITLE
Serve complete CSV downloads using chunked transfer encoding

### DIFF
--- a/app/controllers/concerns/stream_csv_download.rb
+++ b/app/controllers/concerns/stream_csv_download.rb
@@ -1,4 +1,5 @@
 module StreamCsvDownload
+  extend ActiveSupport::Concern
   include ActionController::Live
 
   def stream_csv_download(filename:, headers:)


### PR DESCRIPTION
We recently made some changes to how downloadable CSV responses are
generated, introducing the `StreamCsvDownload` module to share a single
implementation of this functionality. On deplying this to staging, we
found that requesting any CSV, for example a forecast bulk upload
template, contained the column headings but no data. Copying the request
as a cURL command from the browser, I found that the app returns this
response:

    HTTP/1.1 200 OK
    X-Frame-Options: SAMEORIGIN
    X-XSS-Protection: 1; mode=block
    X-Content-Type-Options: nosniff
    X-Download-Options: noopen
    X-Permitted-Cross-Domain-Policies: none
    Referrer-Policy: strict-origin-when-cross-origin
    Content-Type: text/csv
    Content-Disposition: attachment; filename=forecasts.csv
    ETag: W/"3d2f8c0a0126c1ac6b2719b54a42ff18"
    Cache-Control: max-age=0, private, must-revalidate
    Set-Cookie: _roda_session=[redacted]
    X-Request-Id: 387798c0-2c34-4c91-bff8-0e2e747c1a8a
    X-Runtime: 0.060846
    Transfer-Encoding: chunked

    Activity Name,Activity Delivery Partner Identifier,Activity RODA Identifier

After that there was no more data. I found that by adding the line
`extend ActiveSupport::Concern` to `StreamCsvDownload` causes the
application to return a complete response.

    HTTP/1.1 200 OK
    Content-Type: text/csv
    Content-Disposition: attachment; filename=forecasts.csv
    Cache-Control: no-cache
    Set-Cookie: _roda_session=[redacted]
    X-Request-Id: 80a476b5-ac74-4b3c-aee4-43f40df9e05c
    X-Runtime: 0.123258
    Transfer-Encoding: chunked

    Activity Name,Activity Delivery Partner Identifier,Activity RODA Identifier
    Airbus Flood and Drought,GCRF-CHNBI,GCRF-zdfal-bawqw
    Second Project - no children,GCRF-VCVGT,GCRF-zdfal-ucwlb
    ... etc.

Note that the response has different headers; it is missing the
following from the failing response:

    X-Frame-Options
    X-XSS-Protection
    X-Content-Type-Options
    X-Download-Options
    X-Permitted-Cross-Domain-Policies
    Referrer-Policy
    ETag

Missing most of these is fine, because they affect HTML pages loaded
into the browser, not responses served as attachments for opening
outside that context.

Missing `ETag` makes sense because, since this is a streamed response,
it's not meaningful to compute an `ETag` before any of the response has
been generated and you know what it contains. Removing `ETag` makes this
response uncachable but that's probably fine.

It's not clear why adding `ActiveSupport::Concern` to this module
changes any of this. Since `StreamCsvDownload` itself contains only
method definitions and other classes, and not any `included` hooks,
class methods, and so on, the only effect it can have is executing any
such hooks implemented in `ActionController::Live`, when
`StreamCsvDownload` is included into controller classes.

But, before we introduced `StreamCsvDownload`, most controllers that
offered CSV downloads did not include `ActionController::Live`, and they
worked fine -- including streaming.

The other complication is that this is untestable. In feature specs that
execute these download endpoints, the above headers do not show up and
therefore cannot be checked. The test works fine -- it receives the full
CSV payload from the application, even though that response was not
working in the browser. So I'm unsure how to write any tests that
prevent this bug being reintroduced.