### PR TITLE
(1476) Show textarea content with wrapper HTML on the Activity details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -494,6 +494,7 @@
 ## [unreleased]
 
 - Serve CSV downloads encoded in UTF-8, prefixed with a byte order mark
+- Show textarea content with wrapper HTML on the Activity details page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...HEAD
 [release-31]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...release-31

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -64,7 +64,7 @@
     %dt.govuk-summary-list__key
       = t("summary.label.activity.description")
     %dd.govuk-summary-list__value
-      = activity_presenter.description
+      = simple_format(activity_presenter.description, class: "govuk-body")
     %dd.govuk-summary-list__actions
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
         = a11y_action_link(I18n.t("default.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("summary.label.activity.description").downcase)
@@ -74,7 +74,7 @@
       %dt.govuk-summary-list__key
         = t("summary.label.activity.objectives")
       %dd.govuk-summary-list__value
-        = activity_presenter.objectives
+        = simple_format(activity_presenter.objectives, class: "govuk-body")
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :objectives)
           = a11y_action_link(I18n.t("default.link.#{activity_presenter.call_to_action(:objectives)}"), activity_step_path(activity_presenter, :objectives), I18n.t("summary.label.activity.objectives").downcase)


### PR DESCRIPTION
Now descriptions and objectives that be presented with the line breaks as HTML

### Before

![image](https://user-images.githubusercontent.com/109774/107485590-ddb97380-6b7b-11eb-9ca4-7b10332caaff.png)

### After

![image](https://user-images.githubusercontent.com/109774/107485524-cb3f3a00-6b7b-11eb-9371-adfa0e9596be.png)