### PR TITLE
(chore) Update readme to include a link to the DNS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ The app is currently hosted on GPaaS: [https://beis-roda-prod.london.cloudapps.d
 
 The `master` branch is deployed to production after a successful build via Travis CI.
 
+## DNS
+
+The DNS for the service is hosted and managed by [dxw](https://dxw.com) the
+source for which is maintained in this private repo:
+
+[https://github.com/dxw/beis-roda-dns](https://github.com/dxw/beis-roda-dns)
+
+
+
 ## Source
 
 This repository was bootstrapped from [dxw's `rails-template`](https://github.com/dxw/rails-template).


### PR DESCRIPTION
Even though the repo is private, I think it is best to document everything we can, imagine being on support and not knowing where the dns is or who manages it?


