### PR TITLE
Add cdn-route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
           TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
           TF_VAR_google_tag_manager_environment_auth: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
           TF_VAR_google_tag_manager_environment_preview: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
+          TF_VAR_custom_domain: ${{ secrets.STAGING_CUSTOM_DOMAIN }}
+          TF_VAR_custom_hostname: ${{ secrets.STAGING_CUSTOM_HOSTNAME }}
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/develop'
@@ -64,6 +66,8 @@ jobs:
           TF_VAR_google_tag_manager_container_id: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
           TF_VAR_google_tag_manager_environment_auth: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
           TF_VAR_google_tag_manager_environment_preview: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
+          TF_VAR_custom_domain: ${{ secrets.PROD_CUSTOM_DOMAIN }}
+          TF_VAR_custom_hostname: ${{ secrets.PROD_CUSTOM_HOSTNAME }}
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/master'

--- a/doc/architecture/decisions/0028-add-cdn-route.md
+++ b/doc/architecture/decisions/0028-add-cdn-route.md
@@ -1,0 +1,20 @@
+# 28. Add CDN route
+
+Date: 2021-02-10
+
+## Status
+
+Accepted
+
+## Context
+
+The apps need to be hosted on a custom domain, behind CloudFront
+
+## Decision
+
+We will create a cdn-route on GPaas, which will create a CloudFront endpoint with the custom domain
+This will also generate the TLS certificates
+
+## Consequences
+
+We may need to configure the cdn-route to forward particular headers or cookies, if they are configured to not be forwarded to the application

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -35,6 +35,11 @@ resource "cloudfoundry_app" "beis-roda-app" {
     "GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW" = var.google_tag_manager_environment_preview
   }
   # routes need to be declared with the app for blue green deployments to work
-  routes { route = cloudfoundry_route.beis-roda-route.id }
+  routes {
+    route = cloudfoundry_route.beis-roda-route.id
+  }
+  routes {
+    route = cloudfoundry_route.beis-roda-custom-domain-route.id
+  }
 
 }

--- a/terraform/cdn-route.tf
+++ b/terraform/cdn-route.tf
@@ -1,0 +1,13 @@
+data "cloudfoundry_service" "cdn_route" {
+  name = "cdn-route"
+}
+
+resource "cloudfoundry_service_instance" "cdn_route" {
+  name         = "beis-roda-${var.environment}-cdn-route"
+  space        = cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.cdn_route.service_plans["cdn-route"]
+  json_params  = <<EOF
+{"domain": "${var.custom_hostname}.${var.custom_domain}"}
+EOF
+}
+

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -2,3 +2,8 @@
 data "cloudfoundry_domain" "default" {
   name = "london.cloudapps.digital"
 }
+
+# Get data for the custom domain on the PaaS
+data "cloudfoundry_domain" "custom" {
+  name = "${var.custom_domain}"
+}

--- a/terraform/routes.tf
+++ b/terraform/routes.tf
@@ -5,3 +5,11 @@ resource "cloudfoundry_route" "beis-roda-route" {
   space    = cloudfoundry_space.space.id
   hostname = "beis-roda-${var.environment}"
 }
+
+# Create a route for the app using the default domain
+# and useful hostname provided from tfvars (which allows us to easily set www for prod)
+resource "cloudfoundry_route" "beis-roda-custom-domain-route" {
+  domain   = data.cloudfoundry_domain.custom.id
+  space    = cloudfoundry_space.space.id
+  hostname = var.custom_hostname
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -95,3 +95,13 @@ variable "rollbar_disabled" {
   description = "Flag to turn off rollbar reporting"
   default     = "false"
 }
+
+variable "custom_domain" {
+  type        = string
+  description = "Name of custom domain created in the cf org"
+}
+
+variable "custom_hostname" {
+  type        = string
+  description = "Custom hostname (prepended to custom_domain for the app and cdn-route)"
+}


### PR DESCRIPTION
Creates a cdn-route, and maps it to the app using the custom domain

This introduces 2 new tfvars:

```
custom_domain (the apex domain of where the app will be hosted)
custom_hostname (the subdomain, eg. www or staging)
```
