### PR TITLE
Fix rebase action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: 0
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: +1
+          reactions: "+1"
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The action can't trigger an action from another action without using a personal access token. I thought the access token we had by default was enough, but apparently not