### PR TITLE
(1419) BEIS users can download a reports CSV file for all delivery partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,6 +499,8 @@
 
 ## [unreleased]
 
+- BEIS users can download a CSV report for all DPs
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...HEAD
 [release-32]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...release-32
 [release-31]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-30...release-31

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -6,6 +6,10 @@
       %h1.govuk-heading-xl
         = t("page_title.report.index")
 
+  - if current_user.service_owner?
+    .govuk-grid-column-full.page-actions
+      = link_to t("action.report.download.reports"), reports_path(format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
       %h2.govuk-heading-m

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Report", association: :fund
   end
 
   config.hosts = [

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -122,6 +122,7 @@ en:
           button: Confirm submission
       download:
         button: Download report as CSV file
+        reports: Download all reports as CSV
       in_review:
         confirm:
           button: Confirm

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -123,6 +123,7 @@ en:
       download:
         button: Download report as CSV file
         reports: Download all reports as CSV
+        failure: Reports could not be downloaded
       in_review:
         confirm:
           button: Confirm


### PR DESCRIPTION
Trello: https://trello.com/c/PuEeSnuJ

## Changes in this PR

With this new feature, BEIS users can download all relevant reports in just one click. The reports they will get are those which are subject to changes or additions on the financial data (active, submitted, in_review and awaiting_changes). Reports that are inactive or approved will not be included on this CSV file.

The Reports CSV file contains all the activities from the relevant reports. These are sorted by Delivery Partner first, and then by hierarchy level, by recommendation from our user researcher team. They include the same data than the individual reports.

To avoid BEIS users getting incorrect information due to some reports being from a different quarter (and hence having a different set of financial_quarters information) I'm guarding against downloading the report if one or more reports
are from different financial_quarters. In that case, the user will get an error message and the download will not happen.

## Screenshots of UI changes

### Before

<img width="1157" alt="Screenshot 2021-02-01 at 14 47 50" src="https://user-images.githubusercontent.com/48016017/107976697-de09a280-6fb1-11eb-99d9-142930ec026a.png">

### After

<img width="1157" alt="Screenshot 2021-02-01 at 15 47 34" src="https://user-images.githubusercontent.com/48016017/107976645-cdf1c300-6fb1-11eb-9a95-fc268673d8af.png">

<img width="1157" alt="Screenshot 2021-02-15 at 15 56 07" src="https://user-images.githubusercontent.com/48016017/107976723-eb269180-6fb1-11eb-9606-9e4278f1e651.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
