### PR TITLE
(1496) Set default values for various Transaction attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,6 +500,9 @@
 ## [unreleased]
 
 - BEIS users can download a CSV report for all DPs
+- Transaction description is populated from the financial quarter and year and from the activity's title
+- The default type for a transaction is Disbursement, set during creation and import
+- The providing organisation for a transaction is set from the activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...HEAD
 [release-32]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...release-32

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,6 +1,9 @@
 class Transaction < ApplicationRecord
   include PublicActivity::Common
 
+  TRANSACTION_TYPE_DISBURSEMENT = "3"
+  DEFAULT_TRANSACTION_TYPE = TRANSACTION_TYPE_DISBURSEMENT
+
   strip_attributes only: [:providing_organisation_reference, :receiving_organisation_reference]
 
   belongs_to :parent_activity, class_name: "Activity"

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -13,4 +13,10 @@ class Transaction < ApplicationRecord
     :receiving_organisation_type
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :date, date_not_in_future: true, date_within_boundaries: true
+
+  def financial_quarter_and_year
+    return nil if date.blank?
+
+    FinancialQuarter.for_date(date).to_s
+  end
 end

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -1,8 +1,6 @@
 class CreateTransaction
   attr_accessor :activity, :report, :transaction
 
-  DEFAULT_TRANSACTION_TYPE = "3"
-
   def initialize(activity:, report: nil)
     self.activity = activity
     self.report = report || Report.editable_for_activity(activity)
@@ -16,7 +14,7 @@ class CreateTransaction
     convert_and_assign_value(transaction, attributes[:value])
 
     transaction.description = default_description if transaction.description.nil?
-    transaction.transaction_type = DEFAULT_TRANSACTION_TYPE if transaction.transaction_type.nil?
+    transaction.transaction_type = Transaction::DEFAULT_TRANSACTION_TYPE if transaction.transaction_type.nil?
 
     unless activity.organisation.service_owner?
       transaction.report = report

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -1,6 +1,8 @@
 class CreateTransaction
   attr_accessor :activity, :report, :transaction
 
+  DEFAULT_TRANSACTION_TYPE = "3"
+
   def initialize(activity:, report: nil)
     self.activity = activity
     self.report = report || Report.editable_for_activity(activity)
@@ -14,6 +16,7 @@ class CreateTransaction
     convert_and_assign_value(transaction, attributes[:value])
 
     transaction.description = default_description if transaction.description.nil?
+    transaction.transaction_type = DEFAULT_TRANSACTION_TYPE if transaction.transaction_type.nil?
 
     unless activity.organisation.service_owner?
       transaction.report = report

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -15,6 +15,9 @@ class CreateTransaction
 
     transaction.description = default_description if transaction.description.nil?
     transaction.transaction_type = Transaction::DEFAULT_TRANSACTION_TYPE if transaction.transaction_type.nil?
+    transaction.providing_organisation_name = activity.providing_organisation.name
+    transaction.providing_organisation_type = activity.providing_organisation.organisation_type
+    transaction.providing_organisation_reference = activity.providing_organisation.iati_reference
 
     unless activity.organisation.service_owner?
       transaction.report = report

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -1,18 +1,19 @@
 class CreateTransaction
-  attr_accessor :activity, :report
+  attr_accessor :activity, :report, :transaction
 
   def initialize(activity:, report: nil)
     self.activity = activity
     self.report = report || Report.editable_for_activity(activity)
+    self.transaction = Transaction.new
   end
 
   def call(attributes: {})
-    transaction = Transaction.new
-
     transaction.parent_activity = activity
     transaction.assign_attributes(attributes)
 
     convert_and_assign_value(transaction, attributes[:value])
+
+    transaction.description = default_description if transaction.description.nil?
 
     unless activity.organisation.service_owner?
       transaction.report = report
@@ -33,5 +34,11 @@ class CreateTransaction
     transaction.value = ConvertFinancialValue.new.convert(value.to_s)
   rescue ConvertFinancialValue::Error
     transaction.errors.add(:value, I18n.t("activerecord.errors.models.transaction.attributes.value.not_a_number"))
+  end
+
+  def default_description
+    return nil unless transaction.date.present?
+
+    "#{transaction.financial_quarter_and_year} spend on #{activity.title}"
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -102,7 +102,7 @@ class ImportTransactions
       attrs[:providing_organisation_type] = organisation.organisation_type
 
       presenter = ReportPresenter.new(@report)
-      attrs[:description] = "#{presenter.financial_quarter_and_year} spend on #{@activity.description}"
+      attrs[:description] = "#{presenter.financial_quarter_and_year} spend on #{@activity.title}"
     end
   end
 

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -40,8 +40,6 @@ class ImportTransactions
   end
 
   class RowImporter
-    TRANSACTION_TYPE_DISBURSEMENT = "3"
-
     attr_reader :errors
 
     def initialize(report, uploader, row)
@@ -98,7 +96,7 @@ class ImportTransactions
       organisation = @activity.providing_organisation
 
       attrs[:currency] = organisation.default_currency
-      attrs[:transaction_type] = TRANSACTION_TYPE_DISBURSEMENT
+      attrs[:transaction_type] = Transaction::DEFAULT_TRANSACTION_TYPE
       attrs[:providing_organisation_reference] = organisation.iati_reference
       attrs[:providing_organisation_name] = organisation.name
       attrs[:providing_organisation_type] = organisation.organisation_type

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -96,11 +96,6 @@ class ImportTransactions
       organisation = @activity.providing_organisation
 
       attrs[:currency] = organisation.default_currency
-      attrs[:transaction_type] = Transaction::DEFAULT_TRANSACTION_TYPE
-      attrs[:providing_organisation_reference] = organisation.iati_reference
-      attrs[:providing_organisation_name] = organisation.name
-      attrs[:providing_organisation_type] = organisation.organisation_type
-
       presenter = ReportPresenter.new(@report)
       attrs[:description] = "#{presenter.financial_quarter_and_year} spend on #{@activity.title}"
     end

--- a/db/data/20210215165822_set_default_attributes_on_transaction.rb
+++ b/db/data/20210215165822_set_default_attributes_on_transaction.rb
@@ -1,0 +1,26 @@
+class SetDefaultAttributesOnTransaction < ActiveRecord::Migration[6.0]
+  def up
+    transaction_scope = Transaction.includes(:parent_activity)
+
+    transactions = transaction_scope.where(description: nil)
+      .or(transaction_scope.where(transaction_type: nil))
+      .or(transaction_scope.where(providing_organisation_name: nil))
+      .or(transaction_scope.where(providing_organisation_type: nil))
+      .or(transaction_scope.where(providing_organisation_reference: nil))
+
+    transactions.each do |transaction|
+      transaction.transaction_type = Transaction::DEFAULT_TRANSACTION_TYPE if transaction.transaction_type.blank?
+
+      transaction.description = "#{transaction.financial_quarter_and_year} spend on #{transaction.parent_activity.title}" if transaction.description.blank?
+
+      transaction.providing_organisation_name = transaction.parent_activity.providing_organisation.name if transaction.providing_organisation_name.blank?
+      transaction.providing_organisation_type = transaction.parent_activity.providing_organisation.organisation_type if transaction.providing_organisation_type.blank?
+      transaction.providing_organisation_reference = transaction.parent_activity.providing_organisation.iati_reference if transaction.providing_organisation_reference.blank?
+      transaction.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210202104522)
+DataMigrate::Data.define(version: 20210215165822)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe Transaction, type: :model do
       end
     end
   end
+
+  describe "#financial_quarter_and_year" do
+    it "returns the financial quarter and year that the transaction's date occurs in" do
+      transaction = build(:transaction, date: Date.parse("2020-04-01"))
+
+      expect(transaction.financial_quarter_and_year).to eq("Q1 2020-2021")
+    end
+
+    it "returns nil if the date is nil" do
+      transaction = build(:transaction, date: nil)
+
+      expect(transaction.financial_quarter_and_year).to eq(nil)
+    end
+  end
 end

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -78,6 +78,24 @@ RSpec.describe CreateTransaction do
       end
     end
 
+    context "when the transaction type is not set" do
+      it "sets the default transaction type" do
+        attributes = ActionController::Parameters.new.permit!
+        result = described_class.new(activity: activity).call(attributes: attributes)
+
+        expect(result.object.transaction_type).to eq CreateTransaction::DEFAULT_TRANSACTION_TYPE
+      end
+    end
+
+    context "when the transaction type is set" do
+      it "sets the default transaction type" do
+        attributes = ActionController::Parameters.new({transaction_type: 2}).permit!
+        result = described_class.new(activity: activity).call(attributes: attributes)
+
+        expect(result.object.transaction_type).to eq "2"
+      end
+    end
+
     context "when unknown attributes are passed in" do
       it "raises an error" do
         attributes = ActionController::Parameters.new(foo: "bar").permit!

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe CreateTransaction do
         attributes = ActionController::Parameters.new.permit!
         result = described_class.new(activity: activity).call(attributes: attributes)
 
-        expect(result.object.transaction_type).to eq CreateTransaction::DEFAULT_TRANSACTION_TYPE
+        expect(result.object.transaction_type).to eq Transaction::DEFAULT_TRANSACTION_TYPE
       end
     end
 

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe CreateTransaction do
       it_behaves_like "sanitises monetary field"
     end
 
+    context "when the description is blank" do
+      it "sets a default description" do
+        activity = create(:activity, title: "Some activity")
+        attributes = ActionController::Parameters.new(date: Date.parse("2020-04-01")).permit!
+
+        result = described_class.new(activity: activity).call(attributes: attributes)
+
+        expect(result.object.description).to eq "Q1 2020-2021 spend on Some activity"
+      end
+    end
+
+    context "when the date and description is blank" do
+      it "does not set the default description" do
+        attributes = ActionController::Parameters.new.permit!
+        result = described_class.new(activity: activity).call(attributes: attributes)
+
+        expect(result.object.description).to eq nil
+      end
+    end
+
     context "when unknown attributes are passed in" do
       it "raises an error" do
         attributes = ActionController::Parameters.new(foo: "bar").permit!

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -96,6 +96,15 @@ RSpec.describe CreateTransaction do
       end
     end
 
+    it "sets the providing organisation from the activity" do
+      attributes = ActionController::Parameters.new.permit!
+      result = described_class.new(activity: activity).call(attributes: attributes)
+
+      expect(result.object.providing_organisation_name).to eq activity.providing_organisation.name
+      expect(result.object.providing_organisation_type).to eq activity.providing_organisation.organisation_type
+      expect(result.object.providing_organisation_reference).to eq activity.providing_organisation.iati_reference
+    end
+
     context "when unknown attributes are passed in" do
       it "raises an error" do
         attributes = ActionController::Parameters.new(foo: "bar").permit!

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ImportTransactions do
-  let(:project) { create(:project_activity, description: "Example Project") }
+  let(:project) { create(:project_activity, title: "Example Project", description: "Longer description") }
 
   let(:reporter_organisation) { project.organisation }
   let(:reporter) { create(:delivery_partner_user, organisation: reporter_organisation) }
@@ -295,7 +295,7 @@ RSpec.describe ImportTransactions do
 
   describe "importing multiple transactions" do
     let :sibling_project do
-      create(:project_activity, organisation: project.organisation, parent: project.parent, description: "Sibling Project")
+      create(:project_activity, organisation: project.organisation, parent: project.parent, title: "Sibling Project")
     end
 
     let :first_transaction_row do


### PR DESCRIPTION
## Changes in this PR

- Transaction description is populated from the financial quarter and year and from the activity's title
- The default type for a transaction is Disbursement, set during creation and import
- The providing organisation for a transaction is set from the activity

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
