### PR TITLE
(1501) Store financial quarter and year on transaction

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -17,9 +17,22 @@ class Transaction < ApplicationRecord
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :date, date_not_in_future: true, date_within_boundaries: true
 
+  before_save :set_financial_quarter_from_date
+
   def financial_quarter_and_year
     return nil if date.blank?
 
     FinancialQuarter.for_date(date).to_s
+  end
+
+  private
+
+  def set_financial_quarter_from_date
+    return if date.blank?
+    return if financial_quarter.present? && financial_year.present?
+
+    financial_quarter = FinancialQuarter.for_date(date)
+    self.financial_quarter = financial_quarter.quarter
+    self.financial_year = financial_quarter.financial_year.start_year
   end
 end

--- a/db/migrate/20210216113434_add_financial_quarter_to_transactions.rb
+++ b/db/migrate/20210216113434_add_financial_quarter_to_transactions.rb
@@ -1,0 +1,6 @@
+class AddFinancialQuarterToTransactions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transactions, :financial_quarter, :integer
+    add_column :transactions, :financial_year, :integer
+  end
+end

--- a/db/migrate/20210216140931_set_financial_quarter_on_transactions.rb
+++ b/db/migrate/20210216140931_set_financial_quarter_on_transactions.rb
@@ -1,0 +1,12 @@
+class SetFinancialQuarterOnTransactions < ActiveRecord::Migration[6.0]
+  def up
+    Transaction.where.not(date: nil).find_each do |transaction|
+      financial_quarter = FinancialQuarter.for_date(transaction.date)
+
+      transaction.update_columns(
+        financial_quarter: financial_quarter.quarter,
+        financial_year: financial_quarter.financial_year.start_year
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_113434) do
+ActiveRecord::Schema.define(version: 2021_02_16_140931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_02_192712) do
+ActiveRecord::Schema.define(version: 2021_02_16_113434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -223,6 +223,8 @@ ActiveRecord::Schema.define(version: 2021_02_02_192712) do
     t.uuid "parent_activity_id"
     t.boolean "ingested", default: false
     t.uuid "report_id"
+    t.integer "financial_quarter"
+    t.integer "financial_year"
     t.index ["parent_activity_id"], name: "index_transactions_on_parent_activity_id"
     t.index ["report_id"], name: "index_transactions_on_report_id"
   end


### PR DESCRIPTION
This PR is the initial work that adds `transactions.financial_{quarter,year}` to the schema, and begins populating them for existing and newly created records. Once this is deployed, we should migrate the UI to set these fields directly, rather than the date.

I have one question related to this so far, which is how the quarter is inferred. There are two possible sources for this inference: the transaction's date, and the transaction's report's financial quarter. Some background information I found out while reviewing our existing data:

- In production, there are currently 3,116 transactions and all have a date set.

- Some transactions do not belong to a report, since they belong to level A/B activities. 2,989 transactions _do_ belong to a report.

- Most transactions belong to "historic" reports, i.e. those containing IATI ingested data, that do not have a financial quarter. Only 420 transactions belong to reports that have a financial quarter.

- Of those, 10 transactions have a date that falls outside their report's quarter; i.e. `FinancialQuarter.for_date(transaction.date)` returns a quarter different from that on `transaction.report`.