### PR TITLE
(1458) Show programmes grouped by fund on organisation show page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -503,6 +503,7 @@
 - Transaction description is populated from the financial quarter and year and from the activity's title
 - The default type for a transaction is Disbursement, set during creation and import
 - The providing organisation for a transaction is set from the activity
+- Show a list of programmes grouped by fund on the organisation pages
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...HEAD
 [release-32]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...release-32

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -27,7 +27,14 @@ class Staff::OrganisationsController < Staff::BaseController
     @source_funds = Fund.all
 
     respond_to do |format|
-      format.html
+      format.html do
+        @grouped_programmes = Activity.programme
+          .includes(:parent, :extending_organisation)
+          .where(extending_organisation: organisation)
+          .order(:roda_identifier_compound)
+          .group_by(&:parent)
+      end
+
       format.xml do
         @activities = case level
         when "programme"

--- a/app/views/staff/organisations/_grouped_programmes.html.haml
+++ b/app/views/staff/organisations/_grouped_programmes.html.haml
@@ -1,0 +1,28 @@
+- if grouped_programmes.any?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-m
+        = t("page_content.organisation.programmes")
+
+      - grouped_programmes.each do |fund, activities|
+        - if activities.any?
+          %table{id: fund.id, class: "govuk-table"}
+            %caption{class: "govuk-table__caption govuk-table__caption--s"}
+              = fund.title
+            %thead{class: "govuk-table__head"}
+              %tr{class: "govuk-table__row"}
+                %th{scope: "col", class: "govuk-table__header"}
+                  = Activity.human_attribute_name(:title)
+                %th{scope: "col", class: "govuk-table__header"}
+                  = Activity.human_attribute_name(:roda_identifier_compound)
+                %th{scope: "col", class: "govuk-table__header"}
+
+            %tbody{class: "govuk-table__body"}
+              - activities.each do |activity|
+                %tr{class: "govuk-table__row", id: activity.id}
+                  %td{scope: "row", class: "govuk-table__cell"}
+                    = activity.title
+                  %td{class: "govuk-table__cell"}
+                    = activity.roda_identifier_compound
+                  %td{class: "govuk-table__cell"}
+                    = link_to(t("default.link.view"), organisation_activity_details_path(activity.extending_organisation, activity), class: "govuk-link")

--- a/app/views/staff/organisations/_grouped_programmes.html.haml
+++ b/app/views/staff/organisations/_grouped_programmes.html.haml
@@ -7,11 +7,11 @@
       - grouped_programmes.each do |fund, activities|
         - if activities.any?
           %table{id: fund.id, class: "govuk-table"}
-            %caption{class: "govuk-table__caption govuk-table__caption--s"}
+            %caption{class: "govuk-table__caption govuk-table__caption--m govuk-!-margin-top-4"}
               = fund.title
             %thead{class: "govuk-table__head"}
               %tr{class: "govuk-table__row"}
-                %th{scope: "col", class: "govuk-table__header"}
+                %th{scope: "col", class: "govuk-table__header govuk-!-width-one-half"}
                   = Activity.human_attribute_name(:title)
                 %th{scope: "col", class: "govuk-table__header"}
                   = Activity.human_attribute_name(:roda_identifier_compound)

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -50,6 +50,9 @@
           = t("page_content.organisation.download.third-party-projects.explanation")
         = link_to t("default.button.download_as_xml"), organisation_path(@organisation_presenter, format: :xml, level: :third_party_project), class: "govuk-button"
 
+  - unless @organisation_presenter.service_owner?
+    = render partial: "grouped_programmes", locals: { grouped_programmes: @grouped_programmes }
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -408,6 +408,7 @@ en:
   activerecord:
     attributes:
       activity:
+        roda_identifier_compound: RODA identifier
         sector: Focus area
         sector_category: Focus area category
     errors:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,40 @@
 {
   "name": "beis-report-official-development-assistance",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "beis-report-official-development-assistance",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "accessible-autocomplete": "^2.0.2",
+        "govuk-frontend": "^3.3.0"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.2.tgz",
+      "integrity": "sha512-cdA4O4u1xmefZuAdtL+0VBnDivdapgIZRQjm0E1bcekHnH5h67Vt1QL79NqPtlAn+6lyrR+H+pbnYVvUOJ1ULQ==",
+      "dependencies": {
+        "preact": "^8.3.1"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
+    }
+  },
   "dependencies": {
     "accessible-autocomplete": {
       "version": "2.0.2",
@@ -13,9 +45,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.3.0.tgz",
-      "integrity": "sha1-kMVSCbe69d8uQA7jqhEeG8Fg+bQ="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
     },
     "preact": {
       "version": "8.5.3",

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Users can view an organisation" do
   end
 
   context "when the user does not belong to BEIS" do
-    let(:organisation) { create(:organisation) }
+    let(:organisation) { create(:delivery_partner_organisation) }
 
     before do
       authenticate!(user: create(:administrator, organisation: organisation))
@@ -79,6 +79,54 @@ RSpec.feature "Users can view an organisation" do
       visit organisation_path(organisation)
 
       expect(page).to have_content(organisation.name)
+    end
+
+    scenario "can see a list of their programmes, grouped by fund" do
+      newton = create(:fund_activity, :newton)
+      newton_funded_programmes = create_list(:programme_activity, 3, parent: newton, extending_organisation: organisation)
+
+      gcrf = create(:fund_activity, :gcrf)
+      gcrf_funded_programmes = create_list(:programme_activity, 2, parent: gcrf, extending_organisation: organisation)
+
+      visit organisation_path(organisation)
+
+      within_table(id: newton.id) do
+        newton_funded_programmes.each do |programme|
+          within(id: programme.id) do
+            expect(page).to have_content(programme.title)
+            expect(page).to have_content(programme.roda_identifier_compound)
+            expect(page).to have_link(t("default.link.view"))
+          end
+        end
+      end
+
+      within_table(id: gcrf.id) do
+        gcrf_funded_programmes.each do |programme|
+          within(id: programme.id) do
+            expect(page).to have_content(programme.title)
+            expect(page).to have_content(programme.roda_identifier_compound)
+            expect(page).to have_link(t("default.link.view"))
+          end
+        end
+      end
+    end
+
+    scenario "clicking the 'view' link goes to the activity details page" do
+      gcrf = create(:fund_activity, :gcrf)
+      programme = create(:programme_activity, parent: gcrf, extending_organisation: organisation)
+
+      visit organisation_path(organisation)
+
+      within(id: programme.id) do
+        click_link t("default.link.view")
+      end
+
+      expected_path = organisation_activity_details_path(organisation, programme)
+      expect(page.current_path).to eq(expected_path)
+
+      within("h1") do
+        expect(page).to have_content(programme.title)
+      end
     end
 
     scenario "does not see a back link on their organisation home page" do


### PR DESCRIPTION
Allow users to see a list of programmes an organisation is extending from the organisation's show page (which is also the first page delivery partners will see when signing into RODA).

The next step will allow users to create a child activity from this page.

## Screenshots of UI changes

### Before

![before](https://user-images.githubusercontent.com/3166/108113499-83df0f00-708f-11eb-9797-1fd103de4fe8.png)

### After

![download](https://user-images.githubusercontent.com/3166/108113509-86d9ff80-708f-11eb-894c-dc06dd9a88af.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
