### PR TITLE
(1490) No search engine indexing on environments other than production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
           TF_VAR_google_tag_manager_environment_preview: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
           TF_VAR_custom_domain: ${{ secrets.STAGING_CUSTOM_DOMAIN }}
           TF_VAR_custom_hostname: ${{ secrets.STAGING_CUSTOM_HOSTNAME }}
+          TF_VAR_robot_noindex: "true"
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/develop'
@@ -68,6 +69,7 @@ jobs:
           TF_VAR_google_tag_manager_environment_preview: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
           TF_VAR_custom_domain: ${{ secrets.PROD_CUSTOM_DOMAIN }}
           TF_VAR_custom_hostname: ${{ secrets.PROD_CUSTOM_HOSTNAME }}
+          TF_VAR_robot_noindex: "false"
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/master'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,6 +506,7 @@
 - Show a list of programmes grouped by fund on the organisation pages
 - Publish terms of service on RODA
 - Add RODA ID column to the activity import template
+- Only tell robots to index the production site
 
 ## [unreleased]
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
     - if current_user.present?
       = render partial: 'shared/google_tag_manager_service_owner', locals: { user_type: current_user.service_owner? ? "service_owner" : "non_service_owner" }
     = render partial: 'shared/google_tag_manager_head'
+    = render partial: 'shared/no_index' if ENV["ROBOT_NOINDEX"] == "true"
     %meta{charset: "utf-8"}/
     %title #{content_for :page_title_prefix} — #{t('app.title')}
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/

--- a/app/views/shared/_no_index.html.haml
+++ b/app/views/shared/_no_index.html.haml
@@ -1,0 +1,2 @@
+%meta{name: "robots", content: "noindex"}/
+%meta{name: "googlebot", content: "noindex"}/

--- a/doc/manage-environment-variables.md
+++ b/doc/manage-environment-variables.md
@@ -1,6 +1,6 @@
 # Manage environment variables
 
-Environment variables are passed to live environments through Terraform by either Travis or a manual deployment.
+Environment variables are passed to live environments through Terraform by either Github Actions or a manual deployment.
 
 ## Adding a new environment variable
 
@@ -22,15 +22,18 @@ Environment variables are passed to live environments through Terraform by eithe
    ```
 1. Add the new variable to the deploy settings for staging and production in
    `.github/workflows/deploy.yml`, check the correct step for each env:
-  ```
-  TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
-  ```
+
+```
+TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
+```
 
 1. Add 2 new environment variables to GitHub secrets - one for staging, one for prod. [GitHub settings can be managed here.](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/settings/secrets/actions) prepending the environment name as appropriate, `STAGING_` for staging and `PROD_` for production.
-  ```
-  STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID=...
-  PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID=...
-  ```
+
+```
+STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID=...
+PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID=...
+```
+
 1. Once all steps are complete and merged, the next time GitHub Actions deploys either staging and production those environment variables will be made available to the app
 1. Add those variables to our environment files and tfvars files in the RODA 1Password vault as they cannot be read back out of GitHub Secrets
 

--- a/spec/views/layouts/application_spec.rb
+++ b/spec/views/layouts/application_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "layouts/application" do
+  class ActionView::TestCase::TestController
+    include Auth
+
+    def current_user
+      nil
+    end
+  end
+
+  it "shows the meta tags when ROBOT_NOINDEX is set to true" do
+    ClimateControl.modify ROBOT_NOINDEX: "true" do
+      render
+      expect(response).to include("<meta content='noindex' name='robots'>")
+      expect(response).to include("<meta content='noindex' name='googlebot'>")
+    end
+  end
+
+  it "does not show the meta tags when ROBOT_NOINDEX is set to false" do
+    ClimateControl.modify ROBOT_NOINDEX: "false" do
+      render
+      expect(response).to_not include("<meta content='noindex' name='robots'>")
+      expect(response).to_not include("<meta content='noindex' name='googlebot'>")
+    end
+  end
+end

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -33,6 +33,7 @@ resource "cloudfoundry_app" "beis-roda-app" {
     "GOOGLE_TAG_MANAGER_CONTAINER_ID"        = var.google_tag_manager_container_id
     "GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH"    = var.google_tag_manager_environment_auth
     "GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW" = var.google_tag_manager_environment_preview
+    "ROBOT_NOINDEX"                          = var.robot_noindex
   }
   # routes need to be declared with the app for blue green deployments to work
   routes {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,3 +105,9 @@ variable "custom_hostname" {
   type        = string
   description = "Custom hostname (prepended to custom_domain for the app and cdn-route)"
 }
+
+variable "robot_noindex" {
+  type        = string
+  description = "should robots be able to index the site?"
+  default     = "false"
+}


### PR DESCRIPTION
This adds a new environment variable to the application: `ROBOT_NOINDEX`. If it is set to true, the application renders two `meta` tags in the header, which tell search engines to not crawl the site.