### PR TITLE
(1509) Redirect old domain to new one

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,6 @@ jobs:
           TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
           TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
           TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
-          TF_VAR_domain: ${{ secrets.STAGING_DOMAIN }}
           TF_VAR_additional_hostnames: ${{ secrets.STAGING_ADDITIONAL_HOSTNAMES }}
           TF_VAR_papertrail_destination: ${{ secrets.STAGING_PAPERTRAIL_DESTINATION }}
           TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
@@ -63,7 +62,6 @@ jobs:
           TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
           TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
           TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
-          TF_VAR_domain: ${{ secrets.PROD_DOMAIN }}
           TF_VAR_additional_hostnames: ${{ secrets.PROD_ADDITIONAL_HOSTNAMES }}
           TF_VAR_papertrail_destination: ${{ secrets.PROD_PAPERTRAIL_DESTINATION }}
           TF_VAR_google_tag_manager_container_id: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
           TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
           TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
           TF_VAR_domain: ${{ secrets.STAGING_DOMAIN }}
+          TF_VAR_additional_hostnames: ${{ secrets.STAGING_ADDITIONAL_HOSTNAMES }}
           TF_VAR_papertrail_destination: ${{ secrets.STAGING_PAPERTRAIL_DESTINATION }}
           TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
           TF_VAR_google_tag_manager_environment_auth: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
@@ -63,6 +64,7 @@ jobs:
           TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
           TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
           TF_VAR_domain: ${{ secrets.PROD_DOMAIN }}
+          TF_VAR_additional_hostnames: ${{ secrets.PROD_ADDITIONAL_HOSTNAMES }}
           TF_VAR_papertrail_destination: ${{ secrets.PROD_PAPERTRAIL_DESTINATION }}
           TF_VAR_google_tag_manager_container_id: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
           TF_VAR_google_tag_manager_environment_auth: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -512,6 +512,7 @@
 
 - Clicking a link when signed-out should take you to the right place
 - Accept financial quarters instead of dates when inputting transactions
+- Redirect old domains to canonical one
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-33...HEAD
 [release-33]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...release-33

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -130,5 +130,6 @@ Rails.application.configure do
   # This whitelists the hosts the application can trust when using `url_for` and related helpers
   hosts = []
   hosts << URI(ENV["DOMAIN"])&.host if ENV["DOMAIN"].present?
+  hosts += ENV["ADDITIONAL_HOSTNAMES"].split(",") if ENV["ADDITIONAL_HOSTNAMES"].present?
   config.hosts = hosts.compact
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # If the DOMAIN env var is present, and the request doesn't come from that
+  # hostname, redirect us to the canonical hostname with the path and query string present
+  if ENV["CANONICAL_HOSTNAME"].present?
+    constraints(host: Regexp.new("^(?!#{ENV["CANONICAL_HOSTNAME"]})")) do
+      match "/(*path)" => redirect(host: ENV["CANONICAL_HOSTNAME"]), :via => [:all]
+    end
+  end
+
   scope module: "public" do
     get "health_check" => "base#health_check"
     root to: "visitors#index"

--- a/spec/requests/domain_redirect_spec.rb
+++ b/spec/requests/domain_redirect_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Canonical domain redirect", type: :request do
+  before(:all) do
+    @original_hostname = ENV["CANONICAL_HOSTNAME"]
+    ENV["CANONICAL_HOSTNAME"] = "http://beis-roda.com"
+    Rails.application.reload_routes!
+  end
+
+  after(:all) do
+    ENV["CANONICAL_HOSTNAME"] = @original_domain
+    Rails.application.reload_routes!
+  end
+
+  it "redirects to the canonical domain" do
+    expect(get("http://test.local/")).to redirect_to("http://beis-roda.com/")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps the original path" do
+    expect(get("http://test.local/pages/cookie_statement")).to redirect_to("http://beis-roda.com/pages/cookie_statement")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps query strings in place" do
+    expect(get("http://test.local/pages/cookie_statement?foo=bar")).to redirect_to("http://beis-roda.com/pages/cookie_statement?foo=bar")
+    expect(response.status).to eq(301)
+  end
+end

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -19,6 +19,7 @@ resource "cloudfoundry_app" "beis-roda-app" {
     "DATA_MIGRATE"                           = var.data_migrate
     "SECRET_KEY_BASE"                        = var.secret_key_base
     "DOMAIN"                                 = var.domain
+    "ADDITIONAL_HOSTNAMES"                   = var.additional_hostnames
     "AUTH0_CLIENT_ID"                        = var.auth0_client_id
     "AUTH0_CLIENT_SECRET"                    = var.auth0_client_secret
     "AUTH0_DOMAIN"                           = var.auth0_domain

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -18,7 +18,8 @@ resource "cloudfoundry_app" "beis-roda-app" {
     "RAILS_ENV"                              = "production"
     "DATA_MIGRATE"                           = var.data_migrate
     "SECRET_KEY_BASE"                        = var.secret_key_base
-    "DOMAIN"                                 = var.domain
+    "DOMAIN"                                 = "https://${var.custom_hostname}.${var.custom_domain}"
+    "CANONICAL_HOSTNAME"                     = "${var.custom_hostname}.${var.custom_domain}"
     "ADDITIONAL_HOSTNAMES"                   = var.additional_hostnames
     "AUTH0_CLIENT_ID"                        = var.auth0_client_id
     "AUTH0_CLIENT_SECRET"                    = var.auth0_client_secret

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,12 @@ variable "docker_image" {
 
 variable "domain" {
   type        = string
-  description = "Domain used in email links"
+  description = "The canonical domain for the application to be served from"
+}
+
+variable "additional_hostnames" {
+  type        = string
+  description = "Additional hostnames for the application to be allowed to use (comma seperated)"
 }
 
 variable "google_tag_manager_container_id" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,12 +69,6 @@ variable "docker_image" {
   type        = string
   description = "docker image to use"
 }
-
-variable "domain" {
-  type        = string
-  description = "The canonical domain for the application to be served from"
-}
-
 variable "additional_hostnames" {
   type        = string
   description = "Additional hostnames for the application to be allowed to use (comma seperated)"


### PR DESCRIPTION
This redirects the old domains (https://beis-roda-[staging|prod].london.cloudapps.digital/) to the new domains. Currently, trying to access the site via the old domains results in an error. This adds the old domains to the list of allowed domains, and then redirects them to the canonincal domain. The env vars are ready to go and set in Github, so no extra work is required to deploy this