### PR TITLE
(1466) Remove ingested from activities

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -396,7 +396,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_call_dates?
-    !ingested? && is_project?
+    is_project?
   end
 
   def comment_for_report(report_id:)
@@ -404,11 +404,11 @@ class Activity < ApplicationRecord
   end
 
   def requires_collaboration_type?
-    !ingested? && !fund?
+    !fund?
   end
 
   def requires_policy_markers?
-    !ingested? && is_project?
+    is_project?
   end
 
   def is_project?

--- a/db/migrate/20210219121229_remove_ingested_from_activity.rb
+++ b/db/migrate/20210219121229_remove_ingested_from_activity.rb
@@ -1,0 +1,5 @@
+class RemoveIngestedFromActivity < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :activities, :ingested
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_140931) do
+ActiveRecord::Schema.define(version: 2021_02_19_121229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2021_02_16_140931) do
     t.uuid "reporting_organisation_id"
     t.string "previous_identifier"
     t.string "sector_category"
-    t.boolean "ingested", default: false
     t.string "legacy_iati_xml"
     t.boolean "publish_to_iati", default: true
     t.uuid "parent_id"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -581,24 +581,6 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when activity is not a fund" do
-      context "and is 'ingested: false'" do
-        context "and the collaboration_type is blank" do
-          subject(:activity) { build(:programme_activity, collaboration_type: nil, ingested: false) }
-          it "should not be valid" do
-            expect(activity.valid?(:collaboration_type_step)).to be_falsey
-          end
-        end
-      end
-
-      context "but the activity is 'ingested:true'" do
-        subject(:activity) { build(:programme_activity, collaboration_type: nil, ingested: true) }
-        it "should be valid" do
-          expect(activity.valid?(:collaboration_type_step)).to be_truthy
-        end
-      end
-    end
-
     context "when activity is a fund and collaboration_type is blank" do
       subject(:activity) { build(:fund_activity, collaboration_type: nil) }
       it "should be valid" do
@@ -717,17 +699,6 @@ RSpec.describe Activity, type: :model do
         subject(:activity) { build(:project_activity, call_present: true, total_awards: nil) }
         it "should not be valid" do
           expect(activity.valid?(:total_applications_and_awards_step)).to be_falsey
-        end
-      end
-
-      context "when the activity is 'ingested:true'" do
-        subject(:activity) { build(:project_activity, ingested: true, call_present: nil, total_applications: nil, total_awards: nil) }
-        it "should not require the presence of 'call_present'" do
-          expect(activity.valid?(:call_present_step)).to be_truthy
-        end
-
-        it "should not require the presence of neither total applications nor total awards" do
-          expect(activity.valid?(:total_applications_and_awards_step)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Some history:

The `ingested` flag was part of the old ingesting of historic activity
data from published activities. This was our first attempt to ingest
historic data and it was difficult for many reasons.

At the time we were also developing the application and that included
adding fields that were entirely new i.e. the fileds would not be in the
ingested data set.

This meant an `ingested` activity would be missing the new fields but
still needed to be considered valid in certain contexts.

You can see how the ingested flag was used to force certain validation
rules.

Why are we removing the field?

We no longer need the ingested flag as as new delivery partners are on
boarded to the service ALL of their historic is prepared by BEIS and
imported into the application replacing everything that would have been
ingested previously - therefore the ingested flag serves no purpose and
should have not impact on an activity's validity.

We performed a lot of checks against production data to be sure (which
are here https://trello.com/c/60NRg2BP) but the short version is:

Of the 949 activities, 674 are invalid before AND after removing the
column so we can see how it has no effect on validity.

We do have an issue of 'what does being valid actual mean' but that is
not part of this work.

We also still have an ingested flad on other entities, but they do not
change their validity so are not a concern for the moment.

