### PR TITLE
(1501) Store financial quarter and year on transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,6 +511,7 @@
 ## [unreleased]
 
 - Clicking a link when signed-out should take you to the right place
+- Accept financial quarters instead of dates when inputting transactions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-33...HEAD
 [release-33]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...release-33

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -52,6 +52,8 @@ class Staff::TransactionUploadsController < Staff::BaseController
       activity.title,
       activity.delivery_partner_identifier,
       activity.roda_identifier,
+      @report.financial_quarter.to_s,
+      @report.financial_year.to_s,
     ]
   end
 end

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -8,6 +8,10 @@ class Staff::TransactionsController < Staff::BaseController
     @transaction = Transaction.new
     @transaction.parent_activity = @activity
 
+    @report = Report.editable_for_activity(@activity)
+    @transaction.financial_quarter = @report&.financial_quarter
+    @transaction.financial_year = @report&.financial_year
+
     authorize @transaction
   end
 
@@ -69,7 +73,8 @@ class Staff::TransactionsController < Staff::BaseController
   def transaction_params
     params.require(:transaction).permit(
       :value,
-      :date,
+      :financial_quarter,
+      :financial_year,
       :receiving_organisation_name,
       :receiving_organisation_reference,
       :receiving_organisation_type

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -32,9 +32,9 @@ module FormHelper
     end
   end
 
-  def list_of_financial_years
+  def list_of_financial_years(years = FinancialYear.next_ten)
     @list_of_financial_years ||= begin
-      FinancialYear.next_ten.map { |year| OpenStruct.new(id: year.to_i, name: year.to_s) }
+      years.map { |year| OpenStruct.new(id: year.to_i, name: year.to_s) }
     end
   end
 

--- a/app/models/financial_year.rb
+++ b/app/models/financial_year.rb
@@ -21,9 +21,16 @@ class FinancialYear
 
     def next_ten
       this_financial_year = for_date(Date.today).to_i
-      tenth_year = this_financial_year.to_i + 9
+      tenth_year = this_financial_year + 9
 
       (this_financial_year..tenth_year).map { |year| new(year) }
+    end
+
+    def previous_ten
+      this_financial_year = for_date(Date.today).to_i
+      first_year = this_financial_year - 9
+
+      (first_year..this_financial_year).map { |year| new(year) }
     end
   end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -11,13 +11,14 @@ class Transaction < ApplicationRecord
 
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :value,
-    :date,
+    :financial_year,
     :receiving_organisation_name,
     :receiving_organisation_type
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
-  validates :date, date_not_in_future: true, date_within_boundaries: true
+  validates :date, date_within_boundaries: true
+  validates :financial_quarter, inclusion: {in: 1..4}
 
-  before_save :set_financial_quarter_from_date
+  before_validation :set_financial_quarter_from_date
 
   def financial_quarter_and_year
     if financial_year.present? && financial_quarter.present?
@@ -28,11 +29,16 @@ class Transaction < ApplicationRecord
   private
 
   def set_financial_quarter_from_date
-    return if date.blank?
-    return if financial_quarter.present? && financial_year.present?
+    has_date = date.present?
+    has_quarter = (1..4).cover?(financial_quarter) && financial_year.present?
 
-    financial_quarter = FinancialQuarter.for_date(date)
-    self.financial_quarter = financial_quarter.quarter
-    self.financial_year = financial_quarter.financial_year.start_year
+    if has_date && !has_quarter
+      quarter = FinancialQuarter.for_date(date)
+      self.financial_quarter = quarter.quarter
+      self.financial_year = quarter.financial_year.start_year
+    elsif has_quarter && !has_date
+      quarter = FinancialQuarter.new(financial_year, financial_quarter)
+      self.date = quarter.end_date
+    end
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -20,9 +20,9 @@ class Transaction < ApplicationRecord
   before_save :set_financial_quarter_from_date
 
   def financial_quarter_and_year
-    return nil if date.blank?
-
-    FinancialQuarter.for_date(date).to_s
+    if financial_year.present? && financial_quarter.present?
+      FinancialQuarter.new(financial_year, financial_quarter).to_s
+    end
   end
 
   private

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -8,10 +8,4 @@ class TransactionPresenter < SimpleDelegator
     return if super.blank?
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
-
-  def financial_quarter_and_year
-    return nil if date.blank?
-
-    FinancialQuarter.for_date(to_model.date).to_s
-  end
 end

--- a/app/services/create_transaction.rb
+++ b/app/services/create_transaction.rb
@@ -41,8 +41,9 @@ class CreateTransaction
   end
 
   def default_description
-    return nil unless transaction.date.present?
+    quarter = transaction.financial_quarter_and_year
+    return nil unless quarter.present?
 
-    "#{transaction.financial_quarter_and_year} spend on #{activity.title}"
+    "#{quarter} spend on #{activity.title}"
   end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -1,5 +1,3 @@
-require "date"
-
 class ImportTransactions
   Error = Struct.new(:row, :column, :value, :message) {
     def csv_row
@@ -104,7 +102,8 @@ class ImportTransactions
   class Converter
     FIELDS = {
       activity: "Activity RODA Identifier",
-      date: "Date",
+      financial_quarter: "Financial Quarter",
+      financial_year: "Financial Year",
       value: "Value",
       receiving_organisation_name: "Receiving Organisation Name",
       receiving_organisation_type: "Receiving Organisation Type",
@@ -155,13 +154,6 @@ class ImportTransactions
 
     def convert_activity(id)
       Activity.by_roda_identifier(id)
-    end
-
-    def convert_date(date)
-      return nil unless date.present?
-      Date.strptime(date, "%d/%m/%Y")
-    rescue ArgumentError
-      raise I18n.t("importer.errors.transaction.invalid_date")
     end
 
     def convert_value(value)

--- a/app/views/staff/transactions/_form.html.haml
+++ b/app/views/staff/transactions/_form.html.haml
@@ -2,7 +2,21 @@
 
 = f.govuk_text_field :value, width: 'one-third'
 
-= f.govuk_date_field :date, legend: {  size: "s" }
+= f.govuk_fieldset legend: { text: nil } do
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = f.govuk_collection_radio_buttons :financial_quarter,
+        list_of_financial_quarters,
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Financial quarter" , tag: :h2 }
+    .govuk-grid-column-one-third
+      = f.govuk_collection_select :financial_year,
+        list_of_financial_years(FinancialYear.previous_ten),
+        :id,
+        :name,
+        label: { text: "Financial year", tag: :h2, size: "m" }
 
 = f.govuk_fieldset legend: { text: t("form.legend.transaction.receiving_organisation") } do
   %span.govuk-hint= t("form.hint.transaction.receiving_organisation")

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -74,6 +74,10 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
               not_in_future: Date must not be in the future
               blank: Enter a date the transaction was made
+            financial_quarter:
+              inclusion: Enter a financial quarter between 1 and 4
+            financial_year:
+              blank: Enter a financial year the transaction was made
             value:
               less_than_or_equal_to: Value must be less than or equal to 99,999,999,999.00
               other_than: Value must not be zero

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :transaction do
     description { Faker::Lorem.paragraph }
     transaction_type { "1" }
-    date { Date.today }
+    financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
+    financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
     value { BigDecimal("110.01") }
     disbursement_channel { "1" }
     currency { "gbp" }

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.blank")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.financial_year.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
@@ -93,7 +93,7 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.not_a_number")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.date.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.financial_year.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
@@ -214,20 +214,6 @@ RSpec.feature "Users can create a transaction" do
     end
 
     context "Date validation" do
-      scenario "When the date is in the future" do
-        activity = create(:programme_activity, :with_report, organisation: user.organisation)
-
-        visit activities_path
-
-        click_on(activity.title)
-
-        click_on(t("page_content.transactions.button.create"))
-
-        fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2100, expectations: false)
-
-        expect(page).to have_content "Date must not be in the future"
-      end
-
       scenario "When the date is in the past" do
         activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
@@ -254,7 +240,7 @@ RSpec.feature "Users can create a transaction" do
 
         fill_in_transaction_form(date_day: "", date_month: "", date_year: "", expectations: false)
 
-        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.date.blank")
+        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.financial_year.blank")
       end
     end
 

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature "Users can create a transaction" do
 
       expect(page).to have_content t("page_title.transaction.new")
       expect(page).to have_content t("form.label.transaction.value")
-      expect(page).to have_content t("form.legend.transaction.date")
       expect(page).to have_content t("form.legend.transaction.receiving_organisation")
     end
 
@@ -73,7 +72,6 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.blank")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.financial_year.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
@@ -93,7 +91,6 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.not_a_number")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.financial_year.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
         expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
@@ -110,9 +107,8 @@ RSpec.feature "Users can create a transaction" do
         click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[value]", with: "100000000000"
-        fill_in "transaction[date(3i)]", with: "1"
-        fill_in "transaction[date(2i)]", with: "1"
-        fill_in "transaction[date(1i)]", with: "2020"
+        choose "4", name: "transaction[financial_quarter]"
+        select "2019-2020", from: "transaction[financial_year]"
         click_on(t("default.button.submit"))
 
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.less_than_or_equal_to")
@@ -128,9 +124,8 @@ RSpec.feature "Users can create a transaction" do
         click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[value]", with: "0"
-        fill_in "transaction[date(3i)]", with: "1"
-        fill_in "transaction[date(2i)]", with: "1"
-        fill_in "transaction[date(1i)]", with: "2020"
+        choose "4", name: "transaction[financial_quarter]"
+        select "2019-2020", from: "transaction[financial_year]"
         click_on(t("default.button.submit"))
 
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.other_than")
@@ -146,9 +141,8 @@ RSpec.feature "Users can create a transaction" do
         click_on(t("page_content.transactions.button.create"))
 
         fill_in "transaction[value]", with: "-500000"
-        fill_in "transaction[date(3i)]", with: "1"
-        fill_in "transaction[date(2i)]", with: "1"
-        fill_in "transaction[date(1i)]", with: "2020"
+        choose "4", name: "transaction[financial_quarter]"
+        select "2019-2020", from: "transaction[financial_year]"
         fill_in "transaction[receiving_organisation_name]", with: "Company"
         select "Government", from: "transaction[receiving_organisation_type]"
         click_on(t("default.button.submit"))
@@ -210,37 +204,6 @@ RSpec.feature "Users can create a transaction" do
         fill_in_transaction_form(value: "123,000,000", expectations: false)
 
         expect(page).to have_content "£123,000,000"
-      end
-    end
-
-    context "Date validation" do
-      scenario "When the date is in the past" do
-        activity = create(:programme_activity, :with_report, organisation: user.organisation)
-
-        visit activities_path
-
-        click_on(activity.title)
-
-        click_on(t("page_content.transactions.button.create"))
-
-        fill_in_transaction_form(date_day: 0o1, date_month: 0o1, date_year: 2.years.ago, expectations: false)
-
-        expect(page).to_not have_content "Date must not be in the future"
-        expect(page).to have_content t("action.transaction.create.success")
-      end
-
-      scenario "When the date is nil" do
-        activity = create(:programme_activity, :with_report, organisation: user.organisation)
-
-        visit activities_path
-
-        click_on(activity.title)
-
-        click_on(t("page_content.transactions.button.create"))
-
-        fill_in_transaction_form(date_day: "", date_month: "", date_year: "", expectations: false)
-
-        expect(page).to have_content t("activerecord.errors.models.transaction.attributes.financial_year.blank")
       end
     end
 

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -26,9 +26,8 @@ RSpec.feature "Users can edit a transaction" do
 
       fill_in_transaction_form(
         value: "2000.51",
-        date_day: "1",
-        date_month: "1",
-        date_year: "2020",
+        financial_quarter: "4",
+        financial_year: "2019-2020",
       )
 
       expect(page).to have_content(t("action.transaction.update.success"))
@@ -48,9 +47,8 @@ RSpec.feature "Users can edit a transaction" do
 
         fill_in_transaction_form(
           value: "2000.51",
-          date_day: "1",
-          date_month: "1",
-          date_year: "2020",
+          financial_quarter: "4",
+          financial_year: "2019-2020",
         )
 
         auditable_event = PublicActivity::Activity.find_by(trackable_id: transaction.id)

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -30,7 +30,8 @@ RSpec.feature "users can upload transactions" do
         "Activity Name" => project.title,
         "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,
         "Activity RODA Identifier" => project.roda_identifier,
-        "Date" => nil,
+        "Financial Quarter" => report.financial_quarter.to_s,
+        "Financial Year" => report.financial_year.to_s,
         "Value" => nil,
         "Receiving Organisation Name" => nil,
         "Receiving Organisation Type" => nil,
@@ -40,7 +41,8 @@ RSpec.feature "users can upload transactions" do
         "Activity Name" => sibling_project.title,
         "Activity Delivery Partner Identifier" => sibling_project.delivery_partner_identifier,
         "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Date" => nil,
+        "Financial Quarter" => report.financial_quarter.to_s,
+        "Financial Year" => report.financial_year.to_s,
         "Value" => nil,
         "Receiving Organisation Name" => nil,
         "Receiving Organisation Type" => nil,
@@ -59,9 +61,9 @@ RSpec.feature "users can upload transactions" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Date       | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1/4/2020   | 20    | Example University          | 80                          |
-      #{ids[1]}                | 2/4/2020   | 30    | Example Foundation          | 60                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 20    | Example University          | 80                          |
+      #{ids[1]}                | 1                 | 2020           | 30    | Example Foundation          | 60                          |
     CSV
 
     expect(Transaction.count).to eq(2)
@@ -73,9 +75,9 @@ RSpec.feature "users can upload transactions" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Date       | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1/4/2020   | 0     | Example University          | 80                          |
-      #{ids[1]}                | 2/4/2020   | 30    | Example Foundation          | 61                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 0     | Example University          | 80                          |
+      #{ids[1]}                | 1                 | 2020           | 30    | Example Foundation          | 61                          |
     CSV
 
     expect(Transaction.count).to eq(0)
@@ -100,9 +102,9 @@ RSpec.feature "users can upload transactions" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     csv = <<~CSV
-      Activity RODA Identifier,Date,Value,Receiving Organisation Name,Receiving Organisation Type,Receiving Organisation IATI Reference
-      #{ids[0]},1/4/2020,\xA320,Example University,80
-      #{ids[1]},2/4/2020,\xA330,Example Foundation,60
+      Activity RODA Identifier,Financial Quarter,Financial Year,,Value,Receiving Organisation Name,Receiving Organisation Type,Receiving Organisation IATI Reference
+      #{ids[0]},1,2020,\xA320,Example University,80
+      #{ids[1]},1,2020,\xA330,Example Foundation,60
     CSV
 
     file = Tempfile.new("transactions.csv")
@@ -124,9 +126,9 @@ RSpec.feature "users can upload transactions" do
     bom = "\uFEFF"
 
     upload_csv bom + <<~CSV
-      Activity RODA Identifier | Date       | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1/4/2020   | 20    | Example University          | 80                          |
-      #{ids[1]}                | 2/4/2020   | 30    | Example Foundation          | 60                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 20    | Example University          | 80                          |
+      #{ids[1]}                | 2                 | 2020           | 30    | Example Foundation          | 60                          |
     CSV
 
     expect(Transaction.count).to eq(2)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Transaction, type: :model do
 
   describe "#financial_quarter_and_year" do
     it "returns the financial quarter and year that the transaction's date occurs in" do
-      transaction = build(:transaction, date: Date.parse("2020-04-01"))
+      transaction = build(:transaction, financial_quarter: 1, financial_year: 2020)
 
       expect(transaction.financial_quarter_and_year).to eq("Q1 2020-2021")
     end
 
     it "returns nil if the date is nil" do
-      transaction = build(:transaction, date: nil)
+      transaction = build(:transaction, financial_quarter: nil, financial_year: 2020)
 
       expect(transaction.financial_quarter_and_year).to eq(nil)
     end

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -15,20 +15,4 @@ RSpec.describe TransactionPresenter do
       expect(described_class.new(transaction).value).to eq("£110.01")
     end
   end
-
-  describe "#financial_quarter_and_year" do
-    it "returns the formatted financial quarter and year e.g. Q1 2020-2021 for the date" do
-      transaction.date = Date.new(2020, 6, 1)
-      result = described_class.new(transaction).financial_quarter_and_year
-
-      expect(result).to eql "Q1 2020-2021"
-    end
-
-    it "returns nil when the transaction has no date" do
-      transaction.date = nil
-      result = described_class.new(transaction).financial_quarter_and_year
-
-      expect(result).to be_nil
-    end
-  end
 end

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe CreateTransaction do
     context "when the description is blank" do
       it "sets a default description" do
         activity = create(:activity, title: "Some activity")
-        attributes = ActionController::Parameters.new(date: Date.parse("2020-04-01")).permit!
+        attributes = ActionController::Parameters.new(financial_quarter: 1, financial_year: 2020).permit!
 
         result = described_class.new(activity: activity).call(attributes: attributes)
 

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe ImportTransactions do
     let :transaction_row do
       {
         "Activity RODA Identifier" => project.roda_identifier,
-        "Date" => "8/9/2020",
+        "Financial Quarter" => "4",
+        "Financial Year" => "2019",
         "Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
@@ -44,7 +45,8 @@ RSpec.describe ImportTransactions do
 
       expect(transaction).to have_attributes(
         parent_activity: project,
-        date: Date.new(2020, 9, 8),
+        financial_quarter: 4,
+        financial_year: 2019,
         value: 50.0,
         receiving_organisation_name: "Example University",
         receiving_organisation_type: "80",
@@ -121,19 +123,9 @@ RSpec.describe ImportTransactions do
       end
     end
 
-    context "when the Date is blank" do
+    context "when the Financial Quarter is blank" do
       let :transaction_row do
-        super().merge("Date" => "")
-      end
-
-      it "does not import any transactions" do
-        expect(report.transactions.count).to eq(0)
-      end
-    end
-
-    context "when the Date is invalid" do
-      let :transaction_row do
-        super().merge("Date" => "99/4/2020")
+        super().merge("Financial Quarter" => "")
       end
 
       it "does not import any transactions" do
@@ -142,20 +134,40 @@ RSpec.describe ImportTransactions do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportTransactions::Error.new(0, "Date", "99/4/2020", t("importer.errors.transaction.invalid_date")),
+          ImportTransactions::Error.new(0, "Financial Quarter", "", t("activerecord.errors.models.transaction.attributes.financial_quarter.inclusion")),
         ])
       end
+    end
 
-      context "two-digit date" do
-        let :transaction_row do
-          super().merge("Date" => "21/10/15")
-        end
+    context "when the Financial Year is blank" do
+      let :transaction_row do
+        super().merge("Financial Year" => "")
+      end
 
-        it "returns an error" do
-          expect(importer.errors).to eq([
-            ImportTransactions::Error.new(0, "Date", "21/10/15", t("activerecord.errors.models.transaction.attributes.date.between", min: 10, max: 25)),
-          ])
-        end
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Financial Year", "", t("activerecord.errors.models.transaction.attributes.financial_year.blank")),
+        ])
+      end
+    end
+
+    context "when the Financial Quarter is invalid" do
+      let :transaction_row do
+        super().merge("Financial Quarter" => "5")
+      end
+
+      it "does not import any transactions" do
+        expect(report.transactions.count).to eq(0)
+      end
+
+      it "returns an error" do
+        expect(importer.errors).to eq([
+          ImportTransactions::Error.new(0, "Financial Quarter", "5", t("activerecord.errors.models.transaction.attributes.financial_quarter.inclusion")),
+        ])
       end
     end
 
@@ -295,7 +307,8 @@ RSpec.describe ImportTransactions do
     let :first_transaction_row do
       {
         "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Date" => "8/9/2020",
+        "Financial Quarter" => "3",
+        "Financial Year" => "2020",
         "Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
@@ -305,7 +318,8 @@ RSpec.describe ImportTransactions do
     let :second_transaction_row do
       {
         "Activity RODA Identifier" => project.roda_identifier,
-        "Date" => "10/9/2020",
+        "Financial Quarter" => "3",
+        "Financial Year" => "2020",
         "Value" => "150.00",
         "Receiving Organisation Name" => "Example Corporation",
         "Receiving Organisation Type" => "70",
@@ -315,7 +329,8 @@ RSpec.describe ImportTransactions do
     let :third_transaction_row do
       {
         "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Date" => "25/12/2019",
+        "Financial Quarter" => "3",
+        "Financial Year" => "2019",
         "Value" => "£5,000",
         "Receiving Organisation Name" => "Example Foundation",
         "Receiving Organisation Type" => "60",
@@ -375,7 +390,7 @@ RSpec.describe ImportTransactions do
       end
 
       let :third_transaction_row do
-        super().merge("Date" => 6.months.from_now.strftime("%-d/%-m/%Y"), "Value" => "0")
+        super().merge("Financial Quarter" => "5", "Value" => "0")
       end
 
       it "does not import any transactions" do
@@ -387,6 +402,7 @@ RSpec.describe ImportTransactions do
 
         expect(errors).to eq([
           ImportTransactions::Error.new(0, "Receiving Organisation Type", "81", t("importer.errors.transaction.invalid_iati_organisation_type")),
+          ImportTransactions::Error.new(2, "Financial Quarter", third_transaction_row["Financial Quarter"], t("activerecord.errors.models.transaction.attributes.financial_quarter.inclusion")),
           ImportTransactions::Error.new(2, "Value", "0", t("activerecord.errors.models.transaction.attributes.value.other_than")),
         ])
       end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -129,12 +129,6 @@ RSpec.describe ImportTransactions do
       it "does not import any transactions" do
         expect(report.transactions.count).to eq(0)
       end
-
-      it "returns an error" do
-        expect(importer.errors).to eq([
-          ImportTransactions::Error.new(0, "Date", "", t("activerecord.errors.models.transaction.attributes.date.blank")),
-        ])
-      end
     end
 
     context "when the Date is invalid" do
@@ -393,7 +387,6 @@ RSpec.describe ImportTransactions do
 
         expect(errors).to eq([
           ImportTransactions::Error.new(0, "Receiving Organisation Type", "81", t("importer.errors.transaction.invalid_iati_organisation_type")),
-          ImportTransactions::Error.new(2, "Date", third_transaction_row["Date"], t("activerecord.errors.models.transaction.attributes.date.not_in_future")),
           ImportTransactions::Error.new(2, "Value", "0", t("activerecord.errors.models.transaction.attributes.value.other_than")),
         ])
       end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -431,15 +431,13 @@ module FormHelpers
 
   def fill_in_transaction_form(expectations: true,
     value: "1000.01",
-    date_year: "2020",
-    date_month: "1",
-    date_day: "2",
+    financial_quarter: "4",
+    financial_year: "2019-2020",
     receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-123", type: "Private Sector"))
 
     fill_in "transaction[value]", with: value
-    fill_in "transaction[date(3i)]", with: date_day
-    fill_in "transaction[date(2i)]", with: date_month
-    fill_in "transaction[date(1i)]", with: date_year
+    choose financial_quarter, name: "transaction[financial_quarter]"
+    select financial_year, from: "transaction[financial_year]"
     fill_in "transaction[receiving_organisation_name]", with: receiving_organisation.name
     select receiving_organisation.type, from: "transaction[receiving_organisation_type]"
     fill_in "transaction[receiving_organisation_reference]", with: receiving_organisation.reference
@@ -448,7 +446,8 @@ module FormHelpers
 
     if expectations
       within ".transactions" do
-        expect(page).to have_content financial_quarter_and_year_from_date_input_fields(year: date_year, month: date_month, day: date_day)
+        start_year = financial_year.split("-").first.to_i
+        expect(page).to have_content(FinancialQuarter.new(start_year, financial_quarter).to_s)
         expect(page).to have_content(ActionController::Base.helpers.number_to_currency(value, unit: "£"))
         expect(page).to have_content(receiving_organisation.name)
       end
@@ -481,11 +480,6 @@ module FormHelpers
 
   def localise_date_from_input_fields(year:, month:, day:)
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
-  end
-
-  def financial_quarter_and_year_from_date_input_fields(year:, month:, day:)
-    date = Date.parse("#{year}-#{month}-#{day}")
-    TransactionPresenter.new(Transaction.new(date: date)).financial_quarter_and_year
   end
 
   private def activity_level(level)


### PR DESCRIPTION
## Changes in this PR

We have already deployed a change that adds `financial_quarter` and `financial_year` to `Transaction`, and fills those in implicitly from the `date` value. This PR changes the input mechanisms to accept quarters instead of dates.

I would particularly like the validation logic checked, as I'm uncertain about how report quarters work. My understanding is that, for example, the _current time_ is that we're in Q4, and I would therefore be filling out the Q4 report, and therefore entering transactions whose quarter is Q4 2020. These would have a date of 31 March 2021 assigned, which is in the future, and the current validation rules disallow that. Is this correct?

## Screenshots of UI changes

The web form for entering a single transaction now uses the same quarter inputs as we do on forecasts.

<img width="1158" alt="Screenshot 2021-02-22 at 11 32 32" src="https://user-images.githubusercontent.com/9265/108703091-10f7ed00-7502-11eb-813b-f97f195f7240.png">

The bulk upload template now includes financial quarters instead of a date column for each transaction. If any CSV is uploaded with the old schema (using a `Date` column) it will fail.

<img width="941" alt="Screenshot 2021-02-22 at 11 33 55" src="https://user-images.githubusercontent.com/9265/108703096-12291a00-7502-11eb-88b0-1f4ceca45906.png">

Both of these input mechanisms default the transaction's quarter to match that of the current report for the relevant activity.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
