### PR TITLE
Redirect to previously visited URL if unauthorised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,8 @@
 
 ## [unreleased]
 
+- Clicking a link when signed-out should take you to the right place
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-33...HEAD
 [release-33]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-32...release-33
 [release-32]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-31...release-32

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -13,7 +13,8 @@ class Auth0Controller < ApplicationController
 
     # Redirect to the URL you want after successful auth
     if current_user.active && current_user.organisation
-      redirect_to organisation_path(current_user.organisation)
+      redirect_path = session[:redirect_path] || organisation_path(current_user.organisation)
+      redirect_to redirect_path
     else
       render "pages/errors/not_authorised",
         status: 401,

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -17,6 +17,10 @@ module Secured
       # Is Redis available as a session_store?
       Rails.logger.info(Redis.new(url: ENV["REDIS_URL"]).ping)
     end
-    redirect_to "/" if session[:userinfo].blank?
+
+    if session[:userinfo].blank?
+      session[:redirect_path] = request.env["PATH_INFO"]
+      redirect_to "/"
+    end
   end
 end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Users can sign in with Auth0" do
       uid: user.identifier, name: user.name, email: user.email
     )
 
-    visit dashboard_path
+    visit root_path
     expect(page).to have_content(t("start_page.title"))
 
     expect(page).to have_content(t("header.link.sign_in"))
@@ -31,6 +31,20 @@ RSpec.feature "Users can sign in with Auth0" do
 
     expect(page).to have_content(user.organisation.name)
     expect(page).to have_content(t("header.link.sign_out"))
+  end
+
+  scenario "a user is redirected to a link they originally requested" do
+    user = create(:administrator)
+
+    visit reports_path
+
+    mock_successful_authentication(
+      uid: user.identifier, name: user.name, email: user.email
+    )
+
+    click_on t("header.link.sign_in")
+
+    expect(current_path).to eq(reports_path)
   end
 
   scenario "any user lands on their organisation page" do
@@ -50,7 +64,7 @@ RSpec.feature "Users can sign in with Auth0" do
   end
 
   scenario "protected pages cannot be visited unless signed in" do
-    visit dashboard_path
+    visit root_path
 
     expect(page).to have_content(t("start_page.title"))
   end
@@ -62,7 +76,7 @@ RSpec.feature "Users can sign in with Auth0" do
         uid: "an-unknown-identifier", name: user.name, email: user.email
       )
 
-      visit dashboard_path
+      visit root_path
 
       expect(page).to have_content(t("header.link.sign_in"))
       click_on t("header.link.sign_in")
@@ -78,7 +92,7 @@ RSpec.feature "Users can sign in with Auth0" do
     end
 
     it "displays the error message so they can try to correct the problem themselves" do
-      visit dashboard_path
+      visit root_path
 
       expect(page).to have_content(t("header.link.sign_in"))
       click_on t("header.link.sign_in")
@@ -114,7 +128,7 @@ RSpec.feature "Users can sign in with Auth0" do
         uid: "deactivated-user", name: user.name, email: user.email
       )
 
-      visit dashboard_path
+      visit root_path
 
       expect(page).to have_content(t("header.link.sign_in"))
       click_on t("header.link.sign_in")


### PR DESCRIPTION
If a user accesses a URL (e.g. from a deep link), but is not signed in, this sets a session variable of the page they visited, and then redirects to that page after they sign in (if the variable is available).