### PR TITLE
Fix flickering test

### DIFF
--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -95,8 +95,7 @@ RSpec.feature "users can upload activities" do
 
       expect(new_activites.count).to eq(2)
 
-      expect(new_activites[0].transparency_identifier).to eq("1234")
-      expect(new_activites[1].transparency_identifier).to eq("1235")
+      expect(new_activites.pluck(:transparency_identifier)).to match_array(["1234", "1235"])
     end
   end
 


### PR DESCRIPTION
This test was sometimes failing because the order of the new activities was not guaranteed.