### PR TITLE
(1463) Simplify the way we collect and show budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,7 +550,7 @@
 ## [unreleased]
 
 - Display the RODA Identifer anywhere we have an activity table with an "Identifier" column
-- Budgets do not collect IATI fields as they are set by default
+- Budgets do not collect IATI fields or currency as they are set by default
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...HEAD
 [release-38]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...release-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,7 @@
 
 - Display the RODA Identifer anywhere we have an activity table with an "Identifier" column
 - Budgets do not collect IATI fields or currency as they are set by default
+- Budgets tables do not show IATI fields and only show the financial year
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...HEAD
 [release-38]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...release-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,7 @@
 ## [unreleased]
 
 - Display the RODA Identifer anywhere we have an activity table with an "Identifier" column
+- Budgets do not collect IATI fields as they are set by default
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...HEAD
 [release-38]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...release-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -552,6 +552,7 @@
 - Display the RODA Identifer anywhere we have an activity table with an "Identifier" column
 - Budgets do not collect IATI fields or currency as they are set by default
 - Budgets tables do not show IATI fields and only show the financial year
+- Budgets funding type must be the same as the parent activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...HEAD
 [release-38]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...release-38

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -4,7 +4,7 @@ class Staff::BudgetsController < Staff::BaseController
   def new
     @activity = Activity.find(activity_id)
     @budget = Budget.new
-    @budget.parent_activity = @activity
+    set_budget_defaults
 
     authorize @budget
   end
@@ -68,5 +68,10 @@ class Staff::BudgetsController < Staff::BaseController
       :currency,
       :funding_type
     )
+  end
+
+  def set_budget_defaults
+    @budget.parent_activity = @activity
+    @budget.funding_type = @activity.source_fund_code
   end
 end

--- a/app/presenters/budget_presenter.rb
+++ b/app/presenters/budget_presenter.rb
@@ -19,6 +19,11 @@ class BudgetPresenter < SimpleDelegator
     I18n.l(super)
   end
 
+  def financial_year
+    return if super.blank?
+    "FY #{super}"
+  end
+
   def value
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end

--- a/app/services/create_budget.rb
+++ b/app/services/create_budget.rb
@@ -10,6 +10,10 @@ class CreateBudget
     budget.parent_activity = activity
     budget.assign_attributes(attributes)
 
+    budget.budget_type = :original
+    budget.status = :committed
+    budget.currency = activity.organisation.default_currency
+
     convert_and_assign_value(budget, attributes[:value])
 
     unless activity.organisation.service_owner?

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -12,6 +12,6 @@
   options: { selected: f.object.financial_year, prompt: t("form.prompt.budget.financial_year") },
   label: { size: "m", tag: "h2" }
 
-= f.govuk_text_field :value
+= f.govuk_text_field :value, class: "govuk-input govuk-input--width-10"
 
 = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -12,10 +12,6 @@
   options: { selected: f.object.financial_year, prompt: t("form.prompt.budget.financial_year") },
   label: { size: "m", tag: "h2" }
 
-= f.govuk_collection_select :currency,
-                               currency_select_options,
-                               :code,
-                               :name
 = f.govuk_text_field :value
 
 = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -1,16 +1,4 @@
 = f.govuk_error_summary
-= f.govuk_collection_radio_buttons :budget_type,
-  list_of_budget_types,
-  :id,
-  :name,
-  legend: { tag: :h2 }
-
-= f.govuk_collection_radio_buttons :status,
-  list_of_budget_statuses,
-  :id,
-  :name,
-  legend: { tag: :h2 }
-
 = f.govuk_collection_radio_buttons :funding_type,
   list_of_funding_types,
   :code,

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -2,28 +2,17 @@
   %table.govuk-table.budgets
     %thead.govuk-table__head
       %tr.govuk-table__row
-        %th.govuk-table__header
-          =t("table.header.budget.budget_type")
-        %th.govuk-table__header
-          =t("table.header.budget.status")
-        %th.govuk-table__header
-          =t("table.header.budget.period_start_date")
-        %th.govuk-table__header
-          =t("table.header.budget.period_end_date")
-        %th.govuk-table__header
-          =t("table.header.budget.currency")
-        %th.govuk-table__header
+        %th{ scope: "col", class: ["govuk-table__header", "govuk-!-width-one-half"] }
+          =t("table.header.budget.financial_year")
+        %th{ scope: "col", class: ["govuk-table__header", "govuk-!-width-one-quarter"] }
           =t("table.header.budget.value")
-        %th.govuk-table__header
+        %th{ scope: "col", class: ["govuk-table__header", "govuk-!-width-one-quarter"] }
 
     %tbody.govuk-table__body
       - budgets.each do |budget|
         %tr.govuk-table__row{id: budget.id}
-          %td.govuk-table__cell= budget.budget_type
-          %td.govuk-table__cell= budget.status
-          %td.govuk-table__cell= budget.period_start_date
-          %td.govuk-table__cell= budget.period_end_date
-          %td.govuk-table__cell= budget.currency
+          %td{ scope: "row", class: "govuk-table__cell" }
+            = budget.financial_year
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).create?

--- a/app/views/staff/shared/budgets/_table.html.haml
+++ b/app/views/staff/shared/budgets/_table.html.haml
@@ -15,5 +15,5 @@
             = budget.financial_year
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
-            - if policy(budget).create?
+            - if policy(budget).edit?
               = a11y_action_link(t('default.link.edit'), edit_activity_budget_path(budget.parent_activity_id, budget), t("table.body.budget.edit_noun"))

--- a/app/views/staff/shared/reports/_table_budgets.html.haml
+++ b/app/views/staff/shared/reports/_table_budgets.html.haml
@@ -5,9 +5,7 @@
         %th.govuk-table__header
           =t("table.header.activity.identifier")
         %th.govuk-table__header
-          =t("table.header.budget.period_start_date")
-        %th.govuk-table__header
-          =t("table.header.budget.period_end_date")
+          =t("table.header.budget.financial_year")
         %th.govuk-table__header
           =t("table.header.budget.value")
         %th.govuk-table__header
@@ -16,8 +14,7 @@
       - budgets.each do |budget|
         %tr.govuk-table__row{id: budget.id}
           %td.govuk-table__cell= budget.parent_activity.roda_identifier
-          %td.govuk-table__cell= budget.period_start_date
-          %td.govuk-table__cell= budget.period_end_date
+          %td.govuk-table__cell= budget.financial_year
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).edit?

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -9,37 +9,19 @@ en:
   form:
     label:
       budget:
-        currency: Currency
         value: Budget amount
         financial_year: Financial year
-        budget_type_options:
-          original: The original budget allocated to the activity
-          updated: The updated budget for an activity
-        status_options:
-          committed: Committed - A binding agreement for the described budget
-          indicative: Indicative - A non-binding estimate for the described budget
     legend:
       budget:
-        budget_type: Budget type
-        status: Budget status
-        period_end_date: Period end date
-        period_start_date: Period start date
         funding_type: Funding type
-    hint:
-      budget:
-        period_end_date: Period end date must not be more than one year after the period start date. For example, 11 3 2021
-        period_start_date: For example, 11 3 2020
     prompt:
       budget:
         financial_year: Select a financial year
   table:
     header:
       budget:
-        budget_type: Type
-        status: Status
-        period_start_date: Start date
-        period_end_date: End date
-        currency: Currency
+        financial_year: Financial year
+        funding_type: Funding type
         value: Budget amount
     body:
       budget:

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -65,5 +65,8 @@ en:
               blank: Enter a budget status
             funding_type:
               blank: Select a funding type
+              source_fund:
+                1: You cannot assign GCRF budget to a Newton funded activity
+                2: You cannot assign Newton budget to a GCRF funded activity.
             financial_year:
               blank: Select a financial year

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe "Users can create a budget" do
   def fill_in_and_submit_budget_form
     choose("budget[funding_type]", option: "1")
     select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
-    select "Pound Sterling", from: "budget[currency]"
     fill_in "budget[value]", with: "1000.00"
     click_button t("default.button.submit")
   end

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe "Users can create a budget" do
         expect(page).to have_content(t("action.budget.create.success"))
       end
 
+      scenario "a new budget has it's funding type set to that of it's parent activity's source fund" do
+        activity = create(:programme_activity, :gcrf_funded, organisation: user.organisation)
+
+        visit activities_path
+        click_on(activity.title)
+        click_on(t("page_content.budgets.button.create"))
+
+        expect(page.has_checked_field?("budget-funding-type-#{activity.source_fund_code}-field")).to be_truthy
+      end
+
       scenario "budget creation is tracked with public_activity" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -70,9 +70,6 @@ RSpec.describe "Users can create a budget" do
         click_button t("default.button.submit")
 
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.budget_type.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.status.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.funding_type.blank"))
         expect(page).to have_content(t("activerecord.errors.models.budget.attributes.financial_year.blank"))
         expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.blank")
       end
@@ -89,12 +86,8 @@ RSpec.describe "Users can create a budget" do
 
         click_on(t("page_content.budgets.button.create"))
 
-        click_button t("default.button.submit")
-
-        choose("budget[budget_type]", option: "1")
-        choose("budget[status]", option: "1")
+        select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
         choose("budget[funding_type]", option: "1")
-        select "Pound Sterling", from: "budget[currency]"
         fill_in "budget[value]", with: "10000000000000.00"
         click_button t("default.button.submit")
 
@@ -145,8 +138,6 @@ RSpec.describe "Users can create a budget" do
   end
 
   def fill_in_and_submit_budget_form
-    choose("budget[budget_type]", option: "1")
-    choose("budget[status]", option: "1")
     choose("budget[funding_type]", option: "1")
     select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
     select "Pound Sterling", from: "budget[currency]"

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe "Users can edit a budget" do
       end
 
       fill_in "budget[value]", with: "20"
-      choose("budget[budget_type]", option: "2")
       click_on t("default.button.submit")
 
       expect(page).to have_content(t("action.budget.update.success"))
-      expect(page).to have_content("20.00")
-      expect(page).to have_content("Updated")
+
+      within("##{budget.id}") do
+        expect(page).to have_content("20.00")
+      end
     end
   end
 
@@ -37,12 +38,12 @@ RSpec.describe "Users can edit a budget" do
       end
 
       fill_in "budget[value]", with: "20"
-      choose("budget[budget_type]", option: "2")
       click_on t("default.button.submit")
 
       expect(page).to have_content(t("action.budget.update.success"))
-      expect(page).to have_content("20.00")
-      expect(page).to have_content("Updated")
+      within("##{budget.id}") do
+        expect(page).to have_content("20.00")
+      end
     end
 
     scenario "budget update is tracked with public_activity" do
@@ -57,7 +58,6 @@ RSpec.describe "Users can edit a budget" do
         end
 
         fill_in "budget[value]", with: "20"
-        choose("budget[budget_type]", option: "2")
         click_on t("default.button.submit")
 
         budget = Budget.last

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -168,11 +168,7 @@ RSpec.feature "Users can view budgets on an activity page" do
   end
 
   def budget_information_is_shown_on_page(budget_presenter)
-    expect(page).to have_content(budget_presenter.budget_type)
-    expect(page).to have_content(budget_presenter.status)
-    expect(page).to have_content(budget_presenter.period_start_date)
-    expect(page).to have_content(budget_presenter.period_end_date)
-    expect(page).to have_content(budget_presenter.currency)
+    expect(page).to have_content(budget_presenter.financial_year)
     expect(page).to have_content(budget_presenter.value)
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -148,10 +148,10 @@ RSpec.feature "Users can view budgets on an activity page" do
 
       scenario "a delivery partner can edit/create a budget" do
         programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
+        report = create(:report, state: :active, organisation: user.organisation, fund: programme_activity.associated_fund)
         project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
-        _report = create(:report, state: :active, organisation: user.organisation, fund: project_activity.associated_fund)
 
-        budget = create(:budget, parent_activity: project_activity)
+        budget = create(:budget, parent_activity: project_activity, report_id: report.id)
 
         visit activities_path
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Budget do
     it { should validate_presence_of(:financial_year) }
 
     describe ".funding_type" do
+      context "when the parent activity is Newton funded" do
+        subject { build(:budget, parent_activity: build(:programme_activity, :newton_funded)) }
+        it { is_expected.not_to allow_value("2").for(:funding_type) }
+        it { is_expected.to allow_value("1").for(:funding_type) }
+      end
+
+      context "when the parent activity is GCRF funded" do
+        subject { build(:budget, parent_activity: build(:programme_activity, :gcrf_funded)) }
+        it { is_expected.not_to allow_value("1").for(:funding_type) }
+        it { is_expected.to allow_value("2").for(:funding_type) }
+      end
+
       it { is_expected.to allow_value("1").for(:funding_type) }
       it { is_expected.not_to allow_value("").for(:funding_type) }
       it { is_expected.not_to allow_value("9999").for(:funding_type) }

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe BudgetPolicy do
-  let(:budget) { create(:budget, parent_activity: activity) }
+  let(:budget) { create(:budget, parent_activity: activity, funding_type: 1) }
 
   subject { described_class.new(user, budget) }
 

--- a/spec/services/create_budget_spec.rb
+++ b/spec/services/create_budget_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe CreateBudget do
 
     context "when attributes are passed in" do
       it "sets the attributes passed in as budget attributes" do
-        attributes = ActionController::Parameters.new(status: "foo").permit!
+        attributes = ActionController::Parameters.new(funding_type: "1").permit!
         result = described_class.new(activity: activity).call(attributes: attributes)
-        expect(result.object.status).to eq("foo")
+        expect(result.object.funding_type).to eq(1)
       end
 
       subject { described_class.new(activity: activity) }


### PR DESCRIPTION
## Changes in this PR
This is the next step in changing budget to allow support for additional funding arrangements.

We do not need to collect the IATI budget type and budget status as we will be able to infer them; for the time being they are set to original and commited respectively.

We also know the funding_type based on the parent activity, for now we select the correct response by default and validate that the user does not try and provide an incorrect response. 

The resaon to keep the element in the form is that we will very soon add further funding types (transferred, external, etc) so it feels like a waste to remove something we will end up putting back in.


## Screenshots of UI changes

### Before
![before](https://user-images.githubusercontent.com/480578/108717590-5d98f380-7515-11eb-8f5f-f2fd24812055.png)

![before1](https://user-images.githubusercontent.com/480578/108717613-625da780-7515-11eb-8a4b-2249bb117fb0.png)

### After
![after](https://user-images.githubusercontent.com/480578/108717628-67225b80-7515-11eb-9825-d0d66097a7c9.png)
![after1](https://user-images.githubusercontent.com/480578/108717636-6a1d4c00-7515-11eb-9666-34ce8b131b97.png)
![Screenshot_2021-02-22 Edit budget — Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/108717749-8a4d0b00-7515-11eb-943d-d73e5674e3d5.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
