### PR TITLE
(1512) Set correct domain in the worker container

### DIFF
--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -18,7 +18,7 @@ resource "cloudfoundry_app" "beis-roda-worker" {
     "RAILS_ENV"                     = "production"
     "DATA_MIGRATE"                  = var.data_migrate
     "SECRET_KEY_BASE"               = var.secret_key_base
-    "DOMAIN"                        = "https://beis-roda-${var.environment}.london.cloudapps.digital"
+    "DOMAIN"                        = "https://${var.custom_hostname}.${var.custom_domain}"
     "AUTH0_CLIENT_ID"               = var.auth0_client_id
     "AUTH0_CLIENT_SECRET"           = var.auth0_client_secret
     "AUTH0_DOMAIN"                  = var.auth0_domain


### PR DESCRIPTION
This had me scratching my head for a while, but I discovered that the worker container (which I didn't think we were using!) is used to send emails via Notify, and still has the old domain set, so any emails sent will have the old domain in URLs.