### PR TITLE
(1336) Remove reports that belong to BEIS

### DIFF
--- a/app/services/remove_beis_reports.rb
+++ b/app/services/remove_beis_reports.rb
@@ -1,0 +1,26 @@
+class RemoveBeisReports
+  def self.execute
+    new.execute
+  end
+
+  def execute
+    unlink_level_ab_transactions_from_reports
+    delete_service_owner_reports
+  end
+
+  private
+
+  def unlink_level_ab_transactions_from_reports
+    Transaction
+      .joins(:parent_activity)
+      .where(activities: {level: %w[fund programme]})
+      .update_all(report_id: nil)
+  end
+
+  def delete_service_owner_reports
+    Report
+      .joins(:organisation)
+      .where(organisations: {service_owner: true})
+      .delete_all
+  end
+end

--- a/spec/services/remove_beis_reports_spec.rb
+++ b/spec/services/remove_beis_reports_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe RemoveBeisReports do
+  let(:beis) { create(:beis_organisation) }
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+
+  let(:fund) { programme.parent }
+  let(:programme) { create(:programme_activity, organisation: beis) }
+  let(:project) { create(:project_activity, organisation: delivery_partner, parent: programme) }
+
+  context "when there are reports for the service owner" do
+    let!(:approved_report) { create(:report, fund: fund, organisation: beis, financial_year: 2020, financial_quarter: 2, state: :approved) }
+    let!(:active_report) { create(:report, fund: fund, organisation: beis, financial_year: 2020, financial_quarter: 3, state: :active) }
+
+    it "deletes all the reports" do
+      RemoveBeisReports.execute
+      expect(Report.count).to eq(0)
+    end
+  end
+
+  context "when there are reports for the service owner and delivery partner" do
+    let!(:beis_approved_report) { create(:report, fund: fund, organisation: beis, financial_year: 2020, financial_quarter: 2, state: :approved) }
+    let!(:beis_active_report) { create(:report, fund: fund, organisation: beis, financial_year: 2020, financial_quarter: 3, state: :active) }
+    let!(:dp_active_report) { create(:report, fund: fund, organisation: delivery_partner, financial_year: 2020, financial_quarter: 3, state: :active) }
+
+    it "deletes only the service owner's reports" do
+      RemoveBeisReports.execute
+      expect(Report.count).to eq(1)
+      expect(Report.all.map(&:organisation)).to eq [delivery_partner]
+    end
+
+    context "with level A/B transactions in service owner reports" do
+      let!(:beis_approved_txn) { create(:transaction, parent_activity: programme, report: beis_approved_report) }
+      let!(:beis_active_txn) { create(:transaction, parent_activity: programme, report: beis_active_report) }
+
+      it "retains all the transactions" do
+        RemoveBeisReports.execute
+        expect(Transaction.count).to eq(2)
+      end
+
+      it "unlinks these transactions from their report" do
+        RemoveBeisReports.execute
+        expect(Transaction.where.not(report_id: nil).count).to eq(0)
+      end
+    end
+
+    context "with level A/B transactions in delivery partner reports" do
+      let!(:dp_active_txn) { create(:transaction, parent_activity: programme, report: dp_active_report) }
+
+      it "retains all the transactions" do
+        RemoveBeisReports.execute
+        expect(Transaction.count).to eq(1)
+      end
+
+      it "unlinks these transactions from their report" do
+        RemoveBeisReports.execute
+        expect(Transaction.all.map(&:report)).to eq [nil]
+      end
+    end
+
+    context "with level C/D transactions in delivery partner reports" do
+      let!(:dp_active_txn) { create(:transaction, parent_activity: project, report: dp_active_report) }
+
+      it "retains all the transactions" do
+        RemoveBeisReports.execute
+        expect(Transaction.count).to eq(1)
+      end
+
+      it "leaves these transactions linked to their reports" do
+        RemoveBeisReports.execute
+        expect(Transaction.all.map(&:report)).to eq [dp_active_report]
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are two reports in production that belong to BEIS:

    > Report.joins(:organisation).where(organisations: { service_owner: true }).count
    => 2

We'd like to remove them, because BEIS themselves do not submit data to
the report assurance process. But first we need to consider any records
that are linked to them and decide how to handle these. Most types of
record linked to transactions have no instances related to these
reports:

    > Budget.joins(report: [:organisation]).where(organisations: { service_owner: true }).count
    => 0
    > Comment.joins(report: [:organisation]).where(organisations: { service_owner: true }).count
    => 0
    > PlannedDisbursement.joins(report: [:organisation]).where(organisations: { service_owner: true }).count
    => 0

However there are some transactions linked to the reports belonging to
BEIS:

    > Transaction.joins(report: [:organisation]).
        where(organisations: { service_owner: true }).
        count

    => 3

All these transactions belong to level B activities, and should
therefore not be linked to reports at all:

    > Transaction.joins(report: [:organisation]).
        where(organisations: { service_owner: true }).
        map { |t| t.parent_activity.level }

    => ["programme", "programme", "programme"]

These transactions should be retained, but should be unlinked from the
reports we're removing, and so we should set `report_id = null` on these
records.

There is actually a broader set of transaction records we should
consider: those that belong to a level A/B activity, but are also linked
to a report. Level A/B activities belong to BEIS and their financial
data do not go through the assurance process.

    > txns = Transaction.joins(:parent_activity).
        where(activities: { level: %w[fund programme] }).
        where.not(report_id: nil)

    > txns.count
    => 187

The reports these are linked to are one belonging to BEIS (to be
removed), and some historic reports for Royal Society, British Academy,
and Royal Academy of Engineering:

    > txns.map(&:report).uniq.map { |r|
        [r.organisation.name, r.fund.roda_identifier, r.financial_year, r.financial_quarter] }

    =>  [
          ["Royal Society", "GCRF", nil, nil],
          ["British Academy", "GCRF", nil, nil],
          ["Royal Academy of Engineering", "GCRF", nil, nil],
          ["Department for Business, Energy and Industrial Strategy", "GCRF", 2020, 2]
        ]

They belong to 20 different activities:

    > txns.map { |t| t.parent_activity.roda_identifier }.uniq.size
    => 20

But all of those activities belong to BEIS, since they are level A or B:

    > txns.map { |t| t.parent_activity.organisation.name }.uniq
    => ["Department for Business, Energy and Industrial Strategy"]

The service defined in this commit removes all associations between
level A/B transactions and reports, and then deletes any reports that
belong to BEIS.

This should leave no records linked to BEIS reports, and does not delete
any transactions.