### PR TITLE
Don't eager load files in `lib`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,8 +37,6 @@ module Roda
       g.orm :active_record, primary_key_type: :uuid
     end
 
-    config.eager_load_paths += %W[#{config.root}/lib]
-
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 


### PR DESCRIPTION
This causes problems when the application boots, because the code in our generators is modularised in a way that isn't compatible with how Zeitwerk auto loads code. We can make it work with Zeitwerk, but given we don't _need_ this code to be autoloaded in production, it seems like a waste of time. It also means the generated name of the generator is `generators:data_migration:data_migration`, which seems a bit of a mouthful, and there doesn't seem to be an easy way to override that.

All the classes we have in `lib/` are already required where they need to be required now, so we don't need to autoload them. 