### PR TITLE
(1515) Make the transaction upload CSV show activities hierarchically

### DIFF
--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -14,7 +14,7 @@ class Staff::TransactionUploadsController < Staff::BaseController
 
   def show
     stream_csv_download(filename: "transactions.csv", headers: csv_headers) do |csv|
-      @report.reportable_activities.each do |activity|
+      reportable_activities.each do |activity|
         csv << csv_row(activity)
       end
     end
@@ -57,5 +57,9 @@ class Staff::TransactionUploadsController < Staff::BaseController
       @report.financial_quarter.to_s,
       @report.financial_year.to_s,
     ]
+  end
+
+  def reportable_activities
+    @report.reportable_activities.hierarchically_grouped_projects
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -73,7 +73,7 @@ class Report < ApplicationRecord
   end
 
   def reportable_activities
-    Activity.projects_and_third_party_projects_for_report(self).with_roda_identifier
+    Activity.current.projects_and_third_party_projects_for_report(self).with_roda_identifier
   end
 
   def next_twelve_financial_quarters

--- a/spec/controllers/staff/transactions_uploads_controller_spec.rb
+++ b/spec/controllers/staff/transactions_uploads_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Staff::TransactionUploadsController do
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
+  describe "#show" do
+    let(:report) { create(:report, organisation: organisation, state: :active, fund: fund) }
+
+    let!(:fund) { create(:fund_activity, organisation: organisation, roda_identifier_fragment: "A") }
+    let!(:programme_a) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "A", created_at: rand(0..60).minutes.ago) }
+    let!(:programme_b) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "B", created_at: rand(0..60).minutes.ago) }
+    let!(:project_c) { create(:project_activity, parent: programme_a, organisation: report.organisation, roda_identifier_fragment: "C", created_at: rand(0..60).minutes.ago) }
+    let!(:project_d) { create(:project_activity, parent: programme_b, organisation: report.organisation, roda_identifier_fragment: "D", created_at: rand(0..60).minutes.ago) }
+    let!(:third_party_project_e) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier_fragment: "E", created_at: rand(0..60).minutes.ago) }
+    let!(:third_party_project_f) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier_fragment: "F", created_at: rand(0..60).minutes.ago) }
+
+    it "returns activities in a predictable order" do
+      get :show, params: {report_id: report.id}
+
+      csv = CSV.parse(response.body, headers: true)
+
+      expect(csv.count).to eq(4)
+      expect(csv[0]["Activity RODA Identifier"]).to eq(project_c.roda_identifier_compound)
+      expect(csv[1]["Activity RODA Identifier"]).to eq(third_party_project_e.roda_identifier_compound)
+      expect(csv[2]["Activity RODA Identifier"]).to eq(third_party_project_f.roda_identifier_compound)
+      expect(csv[3]["Activity RODA Identifier"]).to eq(project_d.roda_identifier_compound)
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe Report, type: :model do
     let!(:project_a) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:third_party_project) { create(:third_party_project_activity, parent: project_b, organisation: report.organisation) }
+    let!(:cancelled_project) { create(:project_activity, parent: programme, organisation: report.organisation, programme_status: "cancelled") }
     let!(:project_in_another_fund) { create(:project_activity, organisation: report.organisation) }
 
     it "returns the level C and D activities belonging to the report's fund and organisation" do
@@ -199,6 +200,7 @@ RSpec.describe Report, type: :model do
       expect(report.reportable_activities).not_to include(report.fund)
       expect(report.reportable_activities).not_to include(programme)
       expect(report.reportable_activities).not_to include(project_in_another_fund)
+      expect(report.reportable_activities).not_to include(cancelled_project)
     end
   end
 end


### PR DESCRIPTION
This is a two-step process, the first commit removes any activities that aren't reportable (i.e. not current) from the `reportable_activites` scope. The second commit uses the `hierarchically_grouped_projects` method we already use on the report variance page to organise the activities hierarchically. We hope this will make is easier for delivery partners to find the relevant activity, particularly when there are a lot of activities to parse in a big CSV.

# Excel Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/109183665-182f2d00-7786-11eb-9427-0b673c15ad8f.png)

# After

![image](https://user-images.githubusercontent.com/109774/109183072-7dcee980-7785-11eb-8f1e-780ff853ec7c.png)


