### PR TITLE
(1420) Data migration to remove all legacy data

### DIFF
--- a/db/data/20210303102617_remove_royal_accademy_of_engineering_and_british_accademy_legacy_data.rb
+++ b/db/data/20210303102617_remove_royal_accademy_of_engineering_and_british_accademy_legacy_data.rb
@@ -1,0 +1,30 @@
+# Run me with `rails runner db/data/20210303102617_remove_royal_accademy_of_engineering_and_british_accademy_legacy_data.rb`
+#
+# Put your Ruby code here
+def remove_all_data_set_for_organisation_id(organisation_id)
+  # collect all activities
+  activities = Activity.where(organisation_id: organisation_id).or(Activity.where(extending_organisation_id: organisation_id))
+  activity_ids = activities.pluck(:id)
+
+  # destroy all transactions
+  transactions = Transaction.where(parent_activity_id: activity_ids)
+  transactions.destroy_all
+
+  # destroy all forecasts
+  forecasts = PlannedDisbursement.where(parent_activity_id: activity_ids)
+  forecasts.destroy_all
+
+  # destroy all budgets
+  budgets = Budget.where(parent_activity_id: activity_ids)
+  budgets.destroy_all
+
+  # destroy all activites
+  activities.destroy_all
+end
+
+royal_accademy_of_engineering = Organisation.find_by(name: "Royal Academy of Engineering", iati_reference: "GB-CHC-293074")
+british_accademy = Organisation.find_by(name: "British Academy", iati_reference: "GB-COH-RC000053")
+
+raise "Could not locate Royal Academy of Engineering or British Academy, both are required to run" if british_accademy.nil? || royal_accademy_of_engineering.nil?
+organisation_ids = [royal_accademy_of_engineering.id, british_accademy.id]
+organisation_ids.each { |id| remove_all_data_set_for_organisation_id(id) }


### PR DESCRIPTION
__** Requires data migration to be run manually once deployed **__

This data migration will remove all data for known  Delivery Partner
organisations.

The goal of this work is to remove all the data we have imported via the
legacy IATI data for:

- Royal Academy of Engineering
- British Academy

We are doing this because BEIS would like to change the RODA identifier
for all the activities which work 'top down' i.e. any changes to the ID
at the top level need to propagate down so effectively we would need to
change all the IDs. We decided that as the data is to be replaced
entirely (see below) the simplest approach is to remove the data in its
entirety.

It is safe to carry out this action as neither organisation has used RODA
to report as yet and the new data migration process will
replace all of the data with a cleaned and verified data set prepared
for this purpose.

This code has been run against a copy of production data and had the
results verified, we decided, on balance that the change here is at such
a high level that any automated test would not increase our confidence
in this code doing the right thing beyond that of running it locally.

The expectation, as with all data migrations, is that this will be
deleted once it has been deployed and run.

