### PR TITLE
(1562) Provide Docker credentials to deploy process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
         run: script/docker-push
       - name: Deploy terraform to staging
         env:
+          TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
+          TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
           TF_VAR_environment: "staging"
           TF_VAR_secret_key_base: ${{ secrets.STAGING_SECRET_KEY_BASE }}
           TF_VAR_auth0_client_id: ${{ secrets.STAGING_AUTH0_CLIENT_ID }}
@@ -49,6 +51,8 @@ jobs:
         if: github.ref == 'refs/heads/develop'
       - name: Deploy terraform to production
         env:
+          TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
+          TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
           TF_VAR_environment: "prod"
           TF_VAR_secret_key_base: ${{ secrets.PROD_SECRET_KEY_BASE }}
           TF_VAR_auth0_client_id: ${{ secrets.PROD_AUTH0_CLIENT_ID }}

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,12 +1,16 @@
 # Create the web app.
 
 resource "cloudfoundry_app" "beis-roda-app" {
-  name                       = "beis-roda-${var.environment}"
-  space                      = cloudfoundry_space.space.id
-  instances                  = 2
-  disk_quota                 = 3072
-  timeout                    = 120
-  docker_image               = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
+  name         = "beis-roda-${var.environment}"
+  space        = cloudfoundry_space.space.id
+  instances    = 2
+  disk_quota   = 3072
+  timeout      = 120
+  docker_image = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
+  docker_credentials = {
+    username = "${var.docker_username}"
+    password = "${var.docker_password}"
+  }
   strategy                   = "blue-green-v2"
   health_check_http_endpoint = "/health_check"
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-redis.id }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,6 +63,17 @@ variable "docker_image" {
   type        = string
   description = "docker image to use"
 }
+
+variable "docker_username" {
+  type        = string
+  description = "docker username"
+}
+
+variable "docker_password" {
+  type        = string
+  description = "docker password"
+}
+
 variable "additional_hostnames" {
   type        = string
   description = "Additional hostnames for the application to be allowed to use (comma seperated)"

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -9,6 +9,10 @@ resource "cloudfoundry_app" "beis-roda-worker" {
   disk_quota        = 3072
   timeout           = 120
   docker_image      = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
+  docker_credentials = {
+    username = "${var.docker_username}"
+    password = "${var.docker_password}"
+  }
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-redis.id }
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-postgres.id }
   service_binding { service_instance = cloudfoundry_user_provided_service.papertrail.id }


### PR DESCRIPTION
Now we've made the Docker Hub repository private, we need to provide terraform with login credentials in order to pull the relevant image.
