### PR TITLE
Fix changelog link for release 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -539,7 +539,7 @@ and populate it via a data migration
 ## [unreleased]
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...HEAD
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-36...release-37
+[release-37]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-36...release-37
 [release-36]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-35...release-36
 [release-35]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-34...release-35
 [release-34]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-33...release-34


### PR DESCRIPTION
Missed replacing `unreleased` with the correct release number.