### PR TITLE
Fix organisation seeds

### DIFF
--- a/db/seeds/organisations.rb
+++ b/db/seeds/organisations.rb
@@ -4,10 +4,11 @@ organisations = YAML.safe_load(File.read(File.join(Rails.root, "db", "seeds", "o
 organisations.each do |organisation|
   organisation_params = {
     name: organisation["name"],
+    beis_organisation_reference: organisation["short_name"],
     organisation_type: organisation["type"],
     language_code: "en",
     default_currency: "gbp",
     service_owner: organisation["service_owner"],
   }
-  Organisation.find_or_create_by(iati_reference: organisation["reference"]).update(organisation_params)
+  Organisation.find_or_create_by(iati_reference: organisation["reference"]).update!(organisation_params)
 end

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -1,32 +1,40 @@
 - name: Department for Business, Energy and Industrial Strategy
+  short_name: BEIS
   reference: GB-GOV-13
   type: 10
   service_owner: true
 - name: UK Space Agency
+  short_name: UKSA
   reference: GB-GOV-EA31
   type: 10
   service_owner: false
 - name: Met Office
+  short_name: MO
   reference: GB-GOV-EA46
   type: 10
   service_owner: false
 - name: British Council
+  short_name: BC
   reference: GB-GOV-OT313
   type: 10
   service_owner: false
 - name: Academy of Medical Sciences
+  short_name: AMS
   reference: GB-COH-03520281
   type: 22
   service_owner: false
 - name: Royal Society
+  short_name: RS
   reference: GB-COH-RC000519
   type: 22
   service_owner: false
 - name: British Academy
+  short_name: BA
   reference: GB-COH-RC000053
   type: 22
   service_owner: false
 - name: Royal Academy of Engineering
+  short_name: RAE
   reference: GB-CHC-293074
   type: 22
   service_owner: false


### PR DESCRIPTION
## Changes in this PR

When setting up the repo for the first time I received an error as part
of the database seeding process.

```
NoMethodError: undefined method `organisation' for nil:NilClass
```

This is was caused by the organisation records not being created due to
being considered invalid, meaning that no users were created.

There was a new validation added in a95d2f92c2c62721c4a80318ceed0c22da139426
to the Organisation model that checks for the validity of the
`beis_organisation_reference`, this field wasn't part of our sample
data for our seeds.

I've added the `short_name` property to the sample data YAML file and
populated it using the corresponding values from the
`vendor/data/beis_organisation_references.csv` file.

I've also added a bang to the the organisation update action so that
if something similar happens again, the error will be thrown much closer
to where the issue is.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
