### PR TITLE
(1557) Allow blank Channel of delivery code when importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@
 - BEIS users can no longer create funds
 - Send emails when the status of reports has changed
 - BEIS users can no longer edit a programme's extending organisation
+- Allow importing into existing activities without repeating the Channel of delivery code in the uploaded spreadsheet
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...HEAD
 [release-37]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-36...release-37

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -257,7 +257,6 @@ module Activities
         "DFID policy marker - Disability",
         "DFID policy marker - Disaster Risk Reduction",
         "DFID policy marker - Nutrition",
-        "Channel of delivery code",
         "Implementing organisation reference",
         "BEIS ID",
         "UK DP Named Contact (NF)",

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -425,8 +425,6 @@ module Activities
       end
 
       def convert_channel_of_delivery_code(channel_of_delivery_code)
-        raise I18n.t("importer.errors.activity.invalid_channel_of_delivery_code") if channel_of_delivery_code.blank?
-
         validate_channel_of_delivery_code(
           channel_of_delivery_code,
           "channel_of_delivery_code",

--- a/app/validators/channel_of_delivery_code_validator.rb
+++ b/app/validators/channel_of_delivery_code_validator.rb
@@ -6,7 +6,7 @@ class ChannelOfDeliveryCodeValidator < ActiveModel::Validator
 
     unless activity.channel_of_delivery_code.in?(valid_codes)
       activity.errors.add(:channel_of_delivery_code,
-        I18n.t("activerecord.errors.models.activity.attributes.channel_of_delivery_code"))
+        I18n.t("activerecord.errors.models.activity.attributes.channel_of_delivery_code.invalid"))
     end
   end
 end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe Activities::ImportFromCsv do
         expect(subject.errors.first.csv_column).to eq("Channel of delivery code")
         expect(subject.errors.first.column).to eq(:channel_of_delivery_code)
         expect(subject.errors.first.value).to eq("")
-        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.channel_of_delivery_code"))
+        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.channel_of_delivery_code.invalid"))
       end
     end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe Activities::ImportFromCsv do
 
     it "ignores any blank columns" do
       existing_activity_attributes["Title"] = ""
+      existing_activity_attributes["Channel of delivery code"] = ""
 
       expect { subject.import([existing_activity_attributes]) }.to_not change { existing_activity.title }
       expect(subject.errors.count).to eq(0)
@@ -588,20 +589,25 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_channel_of_delivery_code"))
     end
 
-    it "has an error if the 'Channel of delivery code' is empty" do
-      new_activity_attributes["Channel of delivery code"] = ""
+    context "when the activity is a project" do
+      let(:programme) { create(:programme_activity) }
 
-      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+      it "has an error if the 'Channel of delivery code' is empty" do
+        new_activity_attributes["Parent RODA ID"] = programme.roda_identifier_compound
+        new_activity_attributes["Channel of delivery code"] = ""
 
-      expect(subject.created.count).to eq(0)
-      expect(subject.updated.count).to eq(0)
+        expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
 
-      expect(subject.errors.count).to eq(1)
-      expect(subject.errors.first.csv_row).to eq(2)
-      expect(subject.errors.first.csv_column).to eq("Channel of delivery code")
-      expect(subject.errors.first.column).to eq(:channel_of_delivery_code)
-      expect(subject.errors.first.value).to eq("")
-      expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_channel_of_delivery_code"))
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Channel of delivery code")
+        expect(subject.errors.first.column).to eq(:channel_of_delivery_code)
+        expect(subject.errors.first.value).to eq("")
+        expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.channel_of_delivery_code"))
+      end
     end
 
     it "has an error if the Collaboration type option is invalid" do


### PR DESCRIPTION
## Changes in this PR
- Allow importing into existing activities without repeating the Channel of delivery code in the uploaded spreadsheet

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
