### PR TITLE
Display RODA Identifiers consistently everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,6 +548,8 @@
 
 ## [unreleased]
 
+- Display the RODA Identifer anywhere we have an activity table with an "Identifier" column
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...HEAD
 [release-38]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-37...release-38
 [release-37]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-36...release-37

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -50,7 +50,7 @@
               - @historic_activity_presenters.each do |activity|
                 %tr.govuk-table__row{ id: activity.id }
                   %td.govuk-table__cell= activity.display_title
-                  %td.govuk-table__cell= activity.delivery_partner_identifier
+                  %td.govuk-table__cell= activity.roda_identifier
                   %td.govuk-table__cell= activity.level
                   %td.govuk-table__cell
                     = a11y_action_link t("table.body.activity.view_activity"),

--- a/app/views/staff/shared/activities/_current.html.haml
+++ b/app/views/staff/shared/activities/_current.html.haml
@@ -13,7 +13,7 @@
     - @activity_presenters.each do |activity|
       %tr.govuk-table__row{ id: activity.id }
         %td.govuk-table__cell= activity.display_title
-        %td.govuk-table__cell= activity.delivery_partner_identifier
+        %td.govuk-table__cell= activity.roda_identifier
         %td.govuk-table__cell= activity.level
         %td.govuk-table__cell
           = a11y_action_link t("table.body.activity.view_activity"),

--- a/app/views/staff/shared/programmes/_table.html.haml
+++ b/app/views/staff/shared/programmes/_table.html.haml
@@ -14,5 +14,5 @@
     - programmes.each do |programme|
       %tr.govuk-table__row{id: programme.id}
         %td.govuk-table__cell= link_to programme.display_title, organisation_activity_path(programme.organisation, programme), class: "govuk-link govuk-link--no-visited-state"
-        %td.govuk-table__cell= programme.delivery_partner_identifier
+        %td.govuk-table__cell= programme.roda_identifier
         %td.govuk-table__cell= programme.parent_title

--- a/app/views/staff/shared/projects/_table.html.haml
+++ b/app/views/staff/shared/projects/_table.html.haml
@@ -18,7 +18,7 @@
       - projects.each do |project|
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
-          %td.govuk-table__cell= project.delivery_partner_identifier
+          %td.govuk-table__cell= project.roda_identifier
           %td.govuk-table__cell= project.parent_title
           - if policy(:project).redact_from_iati?
             %td.govuk-table__cell

--- a/app/views/staff/shared/reports/_table_budgets.html.haml
+++ b/app/views/staff/shared/reports/_table_budgets.html.haml
@@ -15,7 +15,7 @@
     %tbody.govuk-table__body
       - budgets.each do |budget|
         %tr.govuk-table__row{id: budget.id}
-          %td.govuk-table__cell= budget.parent_activity.delivery_partner_identifier
+          %td.govuk-table__cell= budget.parent_activity.roda_identifier
           %td.govuk-table__cell= budget.period_start_date
           %td.govuk-table__cell= budget.period_end_date
           %td.govuk-table__cell= budget.value

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -32,5 +32,5 @@
             -elsif policy(:comment).create?
               = a11y_action_link(t("table.body.report.add_comment"), new_activity_comment_path(activity, report_id: @report.id), t("table.body.report.comment").downcase)
           %td.govuk-table__cell
-            = a11y_action_link(t('default.link.view'), organisation_activity_path(activity.organisation, activity), activity.delivery_partner_identifier)
+            = a11y_action_link(t('default.link.view'), organisation_activity_path(activity.organisation, activity), activity.roda_identifier)
 

--- a/app/views/staff/shared/third_party_projects/_table.html.haml
+++ b/app/views/staff/shared/third_party_projects/_table.html.haml
@@ -18,7 +18,7 @@
       - third_party_projects.each do |project|
         %tr.govuk-table__row{id: project.id}
           %td.govuk-table__cell= link_to project.display_title, organisation_activity_path(project.organisation, project), class: "govuk-link govuk-link--no-visited-state"
-          %td.govuk-table__cell= project.delivery_partner_identifier
+          %td.govuk-table__cell= project.roda_identifier
           %td.govuk-table__cell= project.parent_title
           - if policy(:third_party_project).redact_from_iati?
             %td.govuk-table__cell

--- a/config/locales/models/fund.en.yml
+++ b/config/locales/models/fund.en.yml
@@ -10,4 +10,4 @@ en:
     header:
       fund:
         title: Title
-        identifier: Identifier
+        identifier: RODA Identifier

--- a/config/locales/models/programme.en.yml
+++ b/config/locales/models/programme.en.yml
@@ -10,5 +10,5 @@ en:
     header:
       programme:
         title: Title
-        identifier: Identifier
+        identifier: RODA Identifier
         fund: Fund (level A)

--- a/config/locales/models/project.en.yml
+++ b/config/locales/models/project.en.yml
@@ -10,5 +10,5 @@ en:
     header:
       project:
         title: Title
-        identifier: Identifier
+        identifier: RODA Identifier
         programme: Programme (level B)

--- a/config/locales/models/third_party_project.en.yml
+++ b/config/locales/models/third_party_project.en.yml
@@ -10,5 +10,5 @@ en:
     header:
       third_party_project:
         title: Title
-        identifier: Identifier
+        identifier: RODA Identifier
         project: Project (level C)

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -21,13 +21,13 @@ RSpec.feature "Users can filter activities" do
       visit activities_path
 
       expect(page).to have_content programme.title
-      expect(page).to have_content programme.delivery_partner_identifier
+      expect(page).to have_content programme.roda_identifier
 
       select delivery_partner_organisation.name, from: "organisation_id"
       click_on t("filters.activity.submit")
 
       expect(page).to have_content project.title
-      expect(page).to have_content project.delivery_partner_identifier
+      expect(page).to have_content project.roda_identifier
     end
 
     scenario "they will see Current activities if they filter while on the 'Current' tab" do
@@ -41,9 +41,9 @@ RSpec.feature "Users can filter activities" do
       click_on t("filters.activity.submit")
 
       expect(page).to have_content current_project.title
-      expect(page).to have_content current_project.delivery_partner_identifier
+      expect(page).to have_content current_project.roda_identifier
       expect(page).to_not have_content historic_project.title
-      expect(page).to_not have_content historic_project.delivery_partner_identifier
+      expect(page).to_not have_content historic_project.roda_identifier
     end
 
     scenario "they will see Historic activities if they filter while on the 'Historic' tab" do
@@ -57,9 +57,9 @@ RSpec.feature "Users can filter activities" do
       click_on t("filters.activity.submit")
 
       expect(page).to have_content historic_project.title
-      expect(page).to have_content historic_project.delivery_partner_identifier
+      expect(page).to have_content historic_project.roda_identifier
       expect(page).to_not have_content current_project.title
-      expect(page).to_not have_content current_project.delivery_partner_identifier
+      expect(page).to_not have_content current_project.roda_identifier
     end
   end
 

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -21,9 +21,9 @@ RSpec.feature "Users can view activities" do
       first_activity = activities.first
       last_activity = activities.last
 
-      expect(page).to have_content first_activity.delivery_partner_identifier
-      expect(page).to have_content last_activity.delivery_partner_identifier
-      expect(page).not_to have_content another_activity.delivery_partner_identifier
+      expect(page).to have_content first_activity.roda_identifier
+      expect(page).to have_content last_activity.roda_identifier
+      expect(page).not_to have_content another_activity.roda_identifier
     end
 
     scenario "they can view another organisations activities" do
@@ -32,7 +32,7 @@ RSpec.feature "Users can view activities" do
 
       visit activities_path(organisation_id: activity.organisation)
 
-      expect(page).to have_content activity.delivery_partner_identifier
+      expect(page).to have_content activity.roda_identifier
     end
 
     context "when an organisation id query parameter is not supplied" do
@@ -41,7 +41,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: "")
 
-        expect(page).to have_content activity.delivery_partner_identifier
+        expect(page).to have_content activity.roda_identifier
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: delivery_partner.id)
 
-        expect(page).to have_content activity.delivery_partner_identifier
+        expect(page).to have_content activity.roda_identifier
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: "this-is-no-a-know-organisation")
 
-        expect(page).to have_content activity.delivery_partner_identifier
+        expect(page).to have_content activity.roda_identifier
       end
     end
   end
@@ -88,11 +88,11 @@ RSpec.feature "Users can view activities" do
       visit activities_path
 
       expect(page).to have_content(current_project.title)
-      expect(page).to have_content(current_project.delivery_partner_identifier)
-      expect(page).to have_content(another_current_project.delivery_partner_identifier)
+      expect(page).to have_content(current_project.roda_identifier)
+      expect(page).to have_content(another_current_project.roda_identifier)
 
       expect(page).to_not have_content(historic_project.title)
-      expect(page).to_not have_content(historic_project.delivery_partner_identifier)
+      expect(page).to_not have_content(historic_project.roda_identifier)
     end
 
     scenario "they can choose to see a list of historic activities" do
@@ -115,7 +115,7 @@ RSpec.feature "Users can view activities" do
 
       within("##{project.id}") do
         expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
-        expect(page).to have_content project.delivery_partner_identifier
+        expect(page).to have_content project.roda_identifier
       end
     end
 
@@ -181,9 +181,9 @@ RSpec.feature "Users can view activities" do
       first_activity = activities.first
       last_activity = activities.last
 
-      expect(page).to have_content first_activity.delivery_partner_identifier
+      expect(page).to have_content first_activity.roda_identifier
 
-      expect(page).to have_content last_activity.delivery_partner_identifier
+      expect(page).to have_content last_activity.roda_identifier
     end
 
     scenario "an activity can be viewed" do
@@ -199,7 +199,7 @@ RSpec.feature "Users can view activities" do
 
       activity_presenter = ActivityPresenter.new(activity)
 
-      expect(page).to have_content activity_presenter.delivery_partner_identifier
+      expect(page).to have_content activity_presenter.roda_identifier
       expect(page).to have_content activity_presenter.sector
       expect(page).to have_content activity_presenter.title
       expect(page).to have_content activity_presenter.description
@@ -219,7 +219,7 @@ RSpec.feature "Users can view activities" do
 
         visit activities_path(organisation_id: another_delivery_partner.id)
 
-        expect(page).to have_content activity.delivery_partner_identifier
+        expect(page).to have_content activity.roda_identifier
       end
     end
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(fund.organisation, fund)
 
         expect(page).to have_content programme.title
-        expect(page).to have_content programme.delivery_partner_identifier
+        expect(page).to have_content programme.roda_identifier
       end
 
       scenario "the child programme activities are ordered by created_at (oldest first)" do
@@ -63,13 +63,13 @@ RSpec.feature "Users can view an activity" do
 
         within("##{project.id}") do
           expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
-          expect(page).to have_content project.delivery_partner_identifier
+          expect(page).to have_content project.roda_identifier
           expect(page).to have_content project.parent.title
         end
 
         within("##{another_project.id}") do
           expect(page).to have_link another_project.title, href: organisation_activity_path(another_project.organisation, another_project)
-          expect(page).to have_content another_project.delivery_partner_identifier
+          expect(page).to have_content another_project.roda_identifier
           expect(page).to have_content another_project.parent.title
         end
       end
@@ -100,7 +100,7 @@ RSpec.feature "Users can view an activity" do
 
         within("##{third_party_project.id}") do
           expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
-          expect(page).to have_content third_party_project.delivery_partner_identifier
+          expect(page).to have_content third_party_project.roda_identifier
           expect(page).to have_content third_party_project.parent.title
         end
       end
@@ -154,7 +154,7 @@ RSpec.feature "Users can view an activity" do
       end
       activity_presenter = ActivityPresenter.new(activity)
 
-      expect(page).to have_content activity_presenter.delivery_partner_identifier
+      expect(page).to have_content activity_presenter.roda_identifier
       expect(page).to have_content activity_presenter.sector
       expect(page).to have_content activity_presenter.title
       expect(page).to have_content activity_presenter.description

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Users can view reports" do
       visit report_budgets_path(report)
 
       within "##{budget.id}" do
-        expect(page).to have_content budget.parent_activity.delivery_partner_identifier
+        expect(page).to have_content budget.parent_activity.roda_identifier
         expect(page).to have_content budget.value
       end
     end
@@ -270,7 +270,7 @@ RSpec.feature "Users can view reports" do
         visit report_budgets_path(report)
 
         within "##{budget.id}" do
-          expect(page).to have_content budget.parent_activity.delivery_partner_identifier
+          expect(page).to have_content budget.parent_activity.roda_identifier
           expect(page).to have_content budget.value
           expect(page).to have_link t("default.link.edit"), href: edit_activity_budget_path(budget.parent_activity, budget)
         end


### PR DESCRIPTION
There are a few places left in the application where we display the
Delivery Partner Identifier in a column labelled "RODA Identifier" or
just "Identifier". This is probably left over from when we first
introduced RODA Identifiers, and it creates confusion as activities are
shown with different IDs across pages.

This changes most of the places in the app where we show a single ID for
an activity, to display the RODA Identifier. We still display Delivery
Partner Identifiers in places where they're explicitly called out as
such, like the activity details page and XML export.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
