### PR TITLE
Write a script to automate the database restore process

### DIFF
--- a/bin/db-restore
+++ b/bin/db-restore
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# bin/restore: Restore the local database from staging/production.
+
+set -e
+
+ENVIRONMENT_NAME="${1:-staging}"
+environments="pentest prod staging"
+
+# Check `ENVIRONMENT_NAME` is one we expect
+if ! echo "$environments"| grep -w "$ENVIRONMENT_NAME" > /dev/null; then
+    echo "The environment name must be one of the following: $environments"
+    exit 1
+fi
+
+# Make sure we're in the root of the project
+cd "$(dirname "$0")/.."
+
+# Check prerequisites are installed
+if ! command -v cf > /dev/null; then
+    echo "The Cloud Foundry (cf) tool is not installed. See https://docs.cloud.service.gov.uk/get_started.html#set-up-the-cloud-foundry-command-line for how to get started"
+    exit 1
+fi
+
+if ! cf plugins | grep -q "conduit"; then
+    echo "The cf conduit plugin is not installed. See https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/database-backup-and-restore.md#installing-the-cf-conduit-plugin for installation instructions."
+    exit 1
+fi
+
+# exit with this by default, if it is not set later
+exit_code=0
+
+# Create a unique filename, so we can delete it later
+timestamp=$(date +"%Y%m%d%I%M%S")
+filename="/tmp/dump-$timestamp.sql"
+
+# Cleanup on exit, no matter what happens
+cleanup () {
+    echo "==> Cleaning up..."
+    rm "$filename" &> /dev/null
+    exit "$exit_code"
+}
+
+# register the cleanup function for all these signal types
+trap cleanup EXIT ERR INT TERM
+
+echo "==> Logging into GOV.UK PaaS..."
+
+cf login -s "$ENVIRONMENT_NAME"
+
+# Set the Postgres service name, depending on our environment
+service="beis-roda-${ENVIRONMENT_NAME}-postgres"
+
+echo "==> Running pg_dump on ${service} on ${ENVIRONMENT_NAME}"
+
+cf conduit "$service" -- \
+    pg_dump \
+        --file "$filename" \
+        --no-acl \
+        --no-owner \
+        --exclude-table="users"
+
+echo "==> Destroying the existing local database"
+
+# Check the user wants to continue before blowing away the development data
+echo "THIS WILL DELETE ALL DATA IN YOUR DEVELOPMENT ENVIRONMENT."
+echo "Are you sure you want to continue? (y to continue)"
+read -p "" -r delete_data
+
+if [ "$delete_data" == "y" ]; then
+    echo "==> Dropping and recreating the roda-development database..."
+    psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
+
+    echo "==> Restoring the data from the backup..."
+    psql -d roda-development < "$filename"
+
+    echo "==> Removing extraneous Postgres extensions..."
+    psql -d roda-development -c 'DROP extension citext; DROP extension postgis; DROP extension "uuid-ossp";'
+
+    echo "==> Running the migrations..."
+    bundle exec rails db:migrate
+
+    echo "==> Seeding development users..."
+    rails runner 'load File.join(Rails.root, "db", "seeds", "development_users.rb")'
+fi
+
+exit_code=$?

--- a/doc/database-backup-and-restore.md
+++ b/doc/database-backup-and-restore.md
@@ -70,50 +70,22 @@ You will need to be a user of the services GPaaS account. You're OK if you can s
 
 ### PaaS to local
 
-In this example we will overwrite our local development database with the
-contents of the production database and add the local users so we can sign in to
-the application.
-
----
-
-### Prerequisites
+#### Prerequisites
 
 - Cloud Foundry (`cf`) tool installed
 - Credentials for the BEIS Government Platform as a Service (GPaaS) account
 - [GPaaS Conduit plugin installed](#installing-the-cf-conduit-plugin)
 
-1. Login and select the production space:
-   ```
-   cf login
-   ```
-1. List the backing services and note the name of the postgres service, this
-   should be `beis-roda-prod-postgres` but we should confirm:
-   ```
-   cf services
-   ```
-1. Create a new backup of production data locally using cf conduit:
-   ```
-   cf conduit POSTGRES_SERVICE_NAME -- pg_dump --file PROD_DATA_FILE_NAME.sql --no-acl --no-owner
-   ```
-1. Destroy the existing local database in postgres and create a new empty one:
-   ```
-   psql -d postgres
-     > DROP DATABASE "roda-development";
-     > CREATE DATABASE "roda-development";
-     > \q
-   ```
-1. Add production data to the new local database
-   ```
-   psql -d roda-development < PROD_DATA_FILE_NAME.sql
-   ```
-1. Add the local development users to the data we just imported using
-   the Rails console, so that we can login to the application locally:
-   ```
-   bundle exec rails console
-   ```
-   ```
-   load File.join(Rails.root, "db", "seeds", "development_users.rb")
-   ```
+To overwrite your local development environment with the contents of a
+live environment, and seed the database with the local users, you can
+run this command:
+
+```bash
+bin/db-restore ENVIRONMENT
+```
+
+(Where `ENVIRONMENT` is one of `pentest`, `prod` or `staging` - default is
+`staging`)
 
 ## Installing the CF Conduit plugin
 


### PR DESCRIPTION
This adds a script that:

- dumps the data from a live database (either staging, prod,  or pentest) to a known location (in `/tmp`) WITHOUT the `users` table
- drops the existing development database
- loads the data into the dev databse
- removes any extraneous Postgres extensions (added by GOV.UK PaaS),
- makes sure the migrations are updated
- seeds the local users

There is also a trap function that runs no matter what happens, to clean up our backup file. I've also updated the documentation, so users know to just run this script.