### PR TITLE
(1578) Receiving organisation is optional for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,7 @@
 - Budgets do not collect IATI fields or currency as they are set by default
 - Budgets tables do not show IATI fields and only show the financial year
 - Budgets funding type must be the same as the parent activity
+- Make receiving organisation optional
 
 ## [unreleased]
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,11 +10,9 @@ class Transaction < ApplicationRecord
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
 
+  validates_with TransactionOrganisationValidator
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
-  validates_presence_of :value,
-    :financial_year,
-    :receiving_organisation_name,
-    :receiving_organisation_type
+  validates_presence_of :value, :financial_year
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :date, date_within_boundaries: true
   validates :financial_quarter, inclusion: {in: 1..4}

--- a/app/presenters/transaction_presenter.rb
+++ b/app/presenters/transaction_presenter.rb
@@ -8,4 +8,10 @@ class TransactionPresenter < SimpleDelegator
     return if super.blank?
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
+
+  def receiving_organisation_name
+    return "N/A" if super.blank?
+
+    super
+  end
 end

--- a/app/services/import_transactions.rb
+++ b/app/services/import_transactions.rb
@@ -172,6 +172,10 @@ class ImportTransactions
       )
     end
 
+    def convert_receiving_organisation_name(name)
+      name.presence
+    end
+
     def validate_from_codelist(code, type, message)
       return nil if code.blank?
 

--- a/app/validators/transaction_organisation_validator.rb
+++ b/app/validators/transaction_organisation_validator.rb
@@ -1,0 +1,16 @@
+class TransactionOrganisationValidator < ActiveModel::Validator
+  def validate(transaction)
+    if has_at_least_one_organisation_field?(transaction)
+      transaction.errors.add(:receiving_organisation_name, :blank) if transaction.receiving_organisation_name.blank?
+      transaction.errors.add(:receiving_organisation_type, :blank) if transaction.receiving_organisation_type.blank?
+    end
+  end
+
+  private
+
+  def has_at_least_one_organisation_field?(transaction)
+    transaction.receiving_organisation_name.present? ||
+      transaction.receiving_organisation_type.present? ||
+      transaction.receiving_organisation_reference.present?
+  end
+end

--- a/app/views/staff/shared/xml/_transaction.xml.haml
+++ b/app/views/staff/shared/xml/_transaction.xml.haml
@@ -6,7 +6,8 @@
     %narrative=transaction.description
   %provider-org{"provider-activity-id" => "", "type" => transaction.providing_organisation_type, "ref" => transaction.providing_organisation_reference}
     %narrative=transaction.providing_organisation_name
-  %receiver-org{"receiver-activity-id" => "", "type" => transaction.receiving_organisation_type, "ref" => transaction.receiving_organisation_reference}
-    %narrative=transaction.receiving_organisation_name
+  - if transaction.receiving_organisation_name.present?
+    %receiver-org{"receiver-activity-id" => "", "type" => transaction.receiving_organisation_type, "ref" => transaction.receiving_organisation_reference}
+      %narrative=transaction.receiving_organisation_name
   - if transaction.disbursement_channel.present?
     %disbursement-channel{"code" => transaction.disbursement_channel}

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -36,7 +36,7 @@ en:
       transaction:
         date: Date of transaction
         providing_organisation: Providing organisation
-        receiving_organisation: Receiving organisation
+        receiving_organisation: Receiving organisation (optional)
     hint:
       transaction:
         csv_file: Upload a spreadsheet containing transaction information in CSV format.

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -20,5 +20,11 @@ FactoryBot.define do
 
     association :parent_activity, factory: :activity
     association :report
+
+    trait :without_receiving_organisation do
+      receiving_organisation_name { nil }
+      receiving_organisation_reference { nil }
+      receiving_organisation_type { nil }
+    end
   end
 end

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -72,8 +72,6 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.blank")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
     end
 
@@ -91,8 +89,6 @@ RSpec.feature "Users can create a transaction" do
 
         expect(page).to_not have_content(t("action.transaction.create.success"))
         expect(page).to have_content t("activerecord.errors.models.transaction.attributes.value.not_a_number")
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
     end
 
@@ -204,6 +200,60 @@ RSpec.feature "Users can create a transaction" do
         fill_in_transaction_form(value: "123,000,000", expectations: false)
 
         expect(page).to have_content "£123,000,000"
+      end
+    end
+
+    context "organisation validation" do
+      it "shows an error when the organisation type is blank, but not the name" do
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
+
+        visit activities_path
+
+        click_on(activity.title)
+
+        click_on(t("page_content.transactions.button.create"))
+
+        fill_in_transaction_form(
+          receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-123", type: nil),
+          expectations: false
+        )
+
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
+      end
+
+      it "shows an error when the organisation name is blank, but not the type" do
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
+
+        visit activities_path
+
+        click_on(activity.title)
+
+        click_on(t("page_content.transactions.button.create"))
+
+        fill_in_transaction_form(
+          receiving_organisation: OpenStruct.new(name: nil, reference: "GB-COH-123", type: "Private Sector"),
+          expectations: false
+        )
+
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+      end
+
+      it "shows errors if the organisation reference is present, but not the name or reference" do
+        activity = create(:programme_activity, :with_report, organisation: user.organisation)
+
+        visit activities_path
+
+        click_on(activity.title)
+
+        click_on(t("page_content.transactions.button.create"))
+
+        fill_in_transaction_form(
+          receiving_organisation: OpenStruct.new(name: nil, reference: "GB-COH-123", type: nil),
+          expectations: false
+        )
+
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_name.blank"))
+        expect(page).to have_content(t("activerecord.errors.models.transaction.attributes.receiving_organisation_type.blank"))
       end
     end
 

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -71,6 +71,20 @@ RSpec.feature "users can upload transactions" do
     expect(page).not_to have_xpath("//tbody/tr")
   end
 
+  scenario "uploading a valid set of transactions with no organisation data" do
+    ids = [project, sibling_project].map(&:roda_identifier)
+
+    upload_csv <<~CSV
+      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 20    |                             |                             |
+      #{ids[1]}                | 1                 | 2020           | 30    |                             |                             |
+    CSV
+
+    expect(Transaction.count).to eq(2)
+    expect(page).to have_text(t("action.transaction.upload.success"))
+    expect(page).not_to have_xpath("//tbody/tr")
+  end
+
   scenario "uploading a valid set of transactions including zero values" do
     ids = [project, sibling_project].map(&:roda_identifier)
 

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -260,12 +260,23 @@ RSpec.feature "Users can view an activity as XML" do
         end
 
         it "has the correct transaction XML" do
-          _transaction = create(:transaction, parent_activity: activity)
+          transaction = create(:transaction, parent_activity: activity)
+
+          visit organisation_activity_path(organisation, activity, format: :xml)
+
+          expect(xml.xpath("//iati-activity/transaction/transaction-type/@code").text).to eq("1")
+          expect(xml.xpath("//iati-activity/transaction/receiver-org/narrative").text).to eq(transaction.receiving_organisation_name)
+          expect(xml.xpath("//iati-activity/transaction/value").text).to eq("110.01")
+        end
+
+        it "omits the receiving organisation if one is not present" do
+          _transaction = create(:transaction, :without_receiving_organisation, parent_activity: activity)
 
           visit organisation_activity_path(organisation, activity, format: :xml)
 
           expect(xml.xpath("//iati-activity/transaction/transaction-type/@code").text).to eq("1")
           expect(xml.xpath("//iati-activity/transaction/value").text).to eq("110.01")
+          expect(xml.xpath("//iati-activity/transaction/receiver-org").count).to eq(0)
         end
       end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Transaction, type: :model do
   describe "validations" do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:financial_year) }
-    it { should validate_presence_of(:receiving_organisation_name) }
-    it { should validate_presence_of(:receiving_organisation_type) }
 
     it { should validate_attribute(:date).with(:date_within_boundaries) }
 
@@ -26,6 +24,63 @@ RSpec.describe Transaction, type: :model do
       it "should not validate the prescence of report" do
         transaction = build_stubbed(:transaction, parent_activity: activity, report: nil)
         expect(transaction.valid?).to be true
+      end
+    end
+
+    describe "organisation validation" do
+      subject do
+        build(:transaction,
+          receiving_organisation_name: receiving_organisation_name,
+          receiving_organisation_type: receiving_organisation_type,
+          receiving_organisation_reference: receiving_organisation_reference)
+      end
+
+      context "when there is no organisation specified" do
+        let(:receiving_organisation_name) { nil }
+        let(:receiving_organisation_type) { nil }
+        let(:receiving_organisation_reference) { nil }
+
+        it { should be_valid }
+      end
+
+      context "when the receiving organisation name is present, but not the type" do
+        let(:receiving_organisation_name) { Faker::Company.name }
+        let(:receiving_organisation_type) { nil }
+        let(:receiving_organisation_reference) { nil }
+
+        it { should be_invalid }
+      end
+
+      context "when the receiving organisation type is present, but not the name" do
+        let(:receiving_organisation_name) { nil }
+        let(:receiving_organisation_type) { "70" }
+        let(:receiving_organisation_reference) { nil }
+
+        it { should be_invalid }
+      end
+
+      context "when the receiving organisation reference is present, but not the name and type" do
+        let(:receiving_organisation_name) { nil }
+        let(:receiving_organisation_type) { nil }
+        let(:receiving_organisation_reference) { "ABC-123" }
+
+        it { should be_invalid }
+      end
+
+      context "when the receiving organisation reference is present, but not the type" do
+        let(:receiving_organisation_name) { Faker::Company.name }
+        let(:receiving_organisation_type) { nil }
+        let(:receiving_organisation_reference) { "ABC-123" }
+
+        it { should be_invalid }
+      end
+
+      context "when the receiving organisation reference is present, but not the name" do
+        let(:receiving_organisation_name) { nil }
+        let(:receiving_organisation_type) { "70" }
+        let(:receiving_organisation_reference) { "ABC-123" }
+
+        it { should be_invalid }
       end
     end
   end

--- a/spec/presenters/transaction_presenter_spec.rb
+++ b/spec/presenters/transaction_presenter_spec.rb
@@ -1,18 +1,43 @@
 require "rails_helper"
 
 RSpec.describe TransactionPresenter do
-  let(:transaction) { build_stubbed(:transaction, currency: "GBP") }
+  let(:transaction) do
+    build_stubbed(:transaction,
+      currency: "GBP",
+      date: "2020-06-25",
+      value: BigDecimal("110.01"))
+  end
+
+  subject { described_class.new(transaction) }
 
   describe "#date" do
     it "returns a human readable date" do
-      transaction.date = "2020-06-25"
-      expect(described_class.new(transaction).date).to eq("25 Jun 2020")
+      expect(subject.date).to eq("25 Jun 2020")
     end
   end
 
   describe "#value" do
     it "returns the value to two decimal places with a currency symbol" do
-      expect(described_class.new(transaction).value).to eq("£110.01")
+      expect(subject.value).to eq("£110.01")
+    end
+  end
+
+  describe "#receiving_organisation_name" do
+    context "when the organisation is nil" do
+      let(:transaction) { build(:transaction, receiving_organisation_name: nil) }
+
+      it "returns N/A" do
+        expect(subject.receiving_organisation_name).to eq("N/A")
+      end
+    end
+
+    context "when the organisation is present" do
+      let(:organisation_name) { Faker::Company.name }
+      let(:transaction) { build(:transaction, receiving_organisation_name: organisation_name) }
+
+      it "returns the organisation name" do
+        expect(subject.receiving_organisation_name).to eq(organisation_name)
+      end
     end
   end
 end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -295,6 +295,34 @@ RSpec.describe ImportTransactions do
         expect(transaction.receiving_organisation_reference).to eq("Rec-Org-IATI-Ref")
       end
     end
+
+    context "when the Receiving Organisation fields are blank" do
+      let :transaction_row do
+        super().merge(
+          "Receiving Organisation Name" => "",
+          "Receiving Organisation Type" => "",
+          "Receiving Organisation IATI Reference" => ""
+        )
+      end
+
+      it "imports a single transaction" do
+        expect(report.transactions.count).to eq(1)
+      end
+
+      it "assigns the attributes from the row data" do
+        transaction = report.transactions.first
+
+        expect(transaction).to have_attributes(
+          parent_activity: project,
+          financial_quarter: 4,
+          financial_year: 2019,
+          value: 50.0,
+          receiving_organisation_name: nil,
+          receiving_organisation_type: nil,
+          description: "FQ4 1999-2000 spend on Example Project",
+        )
+      end
+    end
   end
 
   describe "importing multiple transactions" do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -450,7 +450,7 @@ module FormHelpers
     choose financial_quarter, name: "transaction[financial_quarter]"
     select financial_year, from: "transaction[financial_year]"
     fill_in "transaction[receiving_organisation_name]", with: receiving_organisation.name
-    select receiving_organisation.type, from: "transaction[receiving_organisation_type]"
+    select receiving_organisation.type, from: "transaction[receiving_organisation_type]" if receiving_organisation.type.present?
     fill_in "transaction[receiving_organisation_reference]", with: receiving_organisation.reference
 
     click_on(t("default.button.submit"))


### PR DESCRIPTION
This updates the transaction validations to make the Organisation optional. However, if one of the Organisation fields are present, then at least the Name and Type should be present. I've also updated the form to make it clearer that Organisation is now optional. The XML should now not include receiving organisation data, and the receiving organisation shows as `N/A` if an organisation is not provided too.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/112014969-4a347480-8b23-11eb-847a-3c88381e34c3.png)

![image](https://user-images.githubusercontent.com/109774/112015021-57e9fa00-8b23-11eb-8e86-9f72d8cc9649.png)

![image](https://user-images.githubusercontent.com/109774/112015061-620bf880-8b23-11eb-9c8d-b8977f0ff917.png)

![image](https://user-images.githubusercontent.com/109774/112015102-6afcca00-8b23-11eb-8605-4c248773d9a1.png)

![image](https://user-images.githubusercontent.com/109774/112027950-9ab1cf00-8b2f-11eb-93d4-90d4f4a49948.png)

