### PR TITLE
(1576) Users can report the strategic area under which the GCRF allocation was made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,7 @@
 - Budgets do not collect IATI fields or currency as they are set by default
 - Budgets tables do not show IATI fields and only show the financial year
 - Budgets funding type must be the same as the parent activity
+- Users can report the strategic area under which the GCRF allocation was made
 
 ## [unreleased]
 

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -41,8 +41,10 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step unless @activity.is_project?
     when :sustainable_development_goals
       skip_step if @activity.fund?
-    when :gcrf_challenge_area, :gcrf_strategic_area
+    when :gcrf_challenge_area
       skip_step unless @activity.is_gcrf_funded?
+    when :gcrf_strategic_area
+      skip_step unless @activity.is_gcrf_funded? && @activity.programme?
     when :fund_pillar
       skip_step unless @activity.is_newton_funded?
     when :channel_of_delivery_code

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -41,7 +41,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step unless @activity.is_project?
     when :sustainable_development_goals
       skip_step if @activity.fund?
-    when :gcrf_challenge_area
+    when :gcrf_challenge_area, :gcrf_strategic_area
       skip_step unless @activity.is_gcrf_funded?
     when :fund_pillar
       skip_step unless @activity.is_newton_funded?

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -32,7 +32,7 @@ class Staff::ReportsController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
+    @report_activities = Activity.includes(:parent, {parent: :parent}).projects_and_third_party_projects_for_report(@report)
 
     respond_to do |format|
       format.html do
@@ -177,7 +177,7 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def report_activities_sorted_by_level(report)
-    Activity.includes(:organisation).projects_and_third_party_projects_for_report(report).sort_by { |a| a.level }
+    Activity.includes(:organisation, :parent, {parent: :parent}).projects_and_third_party_projects_for_report(report).sort_by { |a| a.level }
   end
 
   def reports_have_same_quarter?

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -136,6 +136,10 @@ module CodelistHelper
     }.compact.sort_by(&:code)
   end
 
+  def gcrf_strategic_area_options
+    Codelist.new(type: "gcrf_strategic_area", source: "beis").to_objects_with_description
+  end
+
   def gcrf_challenge_area_options
     data = Codelist.new(type: "gcrf_challenge_area", source: "beis")
     data.collect { |item|

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -123,6 +123,7 @@ class Activity < ApplicationRecord
   validates :policy_marker_disaster_risk_reduction, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_nutrition, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :gcrf_challenge_area, presence: true, on: :gcrf_challenge_area_step, if: :is_gcrf_funded?
+  validates :gcrf_strategic_area, presence: true, on: :gcrf_strategic_area_step, if: :is_gcrf_funded?
   validates :oda_eligibility, presence: true, on: :oda_eligibility_step
   validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :is_project?
   validates :uk_dp_named_contact, presence: true, on: :uk_dp_named_contact_step, if: :is_project?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -124,7 +124,7 @@ class Activity < ApplicationRecord
   validates :policy_marker_disaster_risk_reduction, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_nutrition, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :gcrf_challenge_area, presence: true, on: :gcrf_challenge_area_step, if: :is_gcrf_funded?
-  validates :gcrf_strategic_area, presence: true, on: :gcrf_strategic_area_step, if: :is_gcrf_funded?
+  validates :gcrf_strategic_area, presence: true, length: {maximum: 2}, on: :gcrf_strategic_area_step, if: :is_gcrf_funded?
   validates :oda_eligibility, presence: true, on: :oda_eligibility_step
   validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :is_project?
   validates :uk_dp_named_contact, presence: true, on: :uk_dp_named_contact_step, if: :is_project?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -44,6 +44,7 @@ class Activity < ApplicationRecord
     :fstc_applies,
     :policy_markers,
     :covid19_related,
+    :gcrf_strategic_area,
     :gcrf_challenge_area,
     :channel_of_delivery_code,
     :oda_eligibility,

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -340,6 +340,15 @@ class Activity < ApplicationRecord
     service_owner
   end
 
+  def gcrf_strategic_area
+    case level
+    when "fund" then nil
+    when "programme" then attributes["gcrf_strategic_area"]
+    when "project" then parent.attributes["gcrf_strategic_area"]
+    when "third_party_project" then parent.parent.attributes["gcrf_strategic_area"]
+    end
+  end
+
   def accountable_organisation
     return service_owner if fund? || programme?
 

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -169,6 +169,13 @@ class ActivityPresenter < SimpleDelegator
     end
   end
 
+  def gcrf_strategic_area
+    return if super.blank?
+    gcrf_strategic_area_options.select { |area| super.include?(area.code.to_s) }
+      .map(&:description)
+      .to_sentence
+  end
+
   def gcrf_challenge_area
     return if super.blank?
     I18n.t(super, scope: "form.label.activity.gcrf_challenge_area_options")

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -217,6 +217,7 @@ module Activities
         delivery_partner_identifier: "Delivery partner identifier",
         roda_identifier_fragment: "RODA ID Fragment",
         gdi: "GDI",
+        gcrf_strategic_area: "GCRF Strategic Area",
         gcrf_challenge_area: "GCRF Challenge Area",
         sdg_1: "SDG 1",
         sdg_2: "SDG 2",
@@ -357,6 +358,14 @@ module Activities
         raise I18n.t("importer.errors.activity.invalid_gcrf_challenge_area") unless valid_codes.include?(gcrf_challenge_area)
 
         gcrf_challenge_area.to_i
+      end
+
+      def convert_gcrf_strategic_area(gcrf_strategic_area)
+        gcrf_strategic_area.split("|").map do |code|
+          valid_codes = gcrf_strategic_area_options.map { |area| area.code.to_s }
+          raise I18n.t("importer.errors.activity.invalid_gcrf_strategic_area") unless valid_codes.include?(code)
+          code
+        end
       end
 
       def convert_sustainable_development_goal(goal)

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -104,6 +104,13 @@ class Activity
       activity.assign_attributes(intended_beneficiaries: intended_beneficiaries)
     end
 
+    def set_gcrf_strategic_area
+      gcrf_strategic_area = activity_params
+        .permit(gcrf_strategic_area: [])
+        .fetch("gcrf_strategic_area", []).reject(&:blank?)
+      activity.assign_attributes(gcrf_strategic_area: gcrf_strategic_area)
+    end
+
     def set_aid_type
       activity.assign_attributes(aid_type: params_for("aid_type"))
       if can_infer_fstc?(activity.aid_type)

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -55,6 +55,7 @@ class ExportActivityToCsv
       "Recipient country" => -> { activity_presenter.recipient_country },
       "Intended beneficiaries" => -> { activity_presenter.intended_beneficiaries },
       "GDI" => -> { activity_presenter.gdi },
+      "GCRF Strategic Area" => -> { activity_presenter.gcrf_strategic_area },
       "GCRF Challenge Area" => -> { activity_presenter.gcrf_challenge_area },
       "Fund Pillar" => -> { activity_presenter.fund_pillar },
       "SDG 1" => -> { activity_presenter.sdg_1 },

--- a/app/views/staff/activity_forms/gcrf_strategic_area.html.haml
+++ b/app/views/staff/activity_forms/gcrf_strategic_area.html.haml
@@ -1,0 +1,7 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_collection_check_boxes :gcrf_strategic_area,
+    gcrf_strategic_area_options,
+    :code,
+    :description,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.gcrf_strategic_area") },
+    hint: { text: t("form.hint.activity.gcrf_strategic_area") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -256,6 +256,16 @@
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gdi)}"), activity_step_path(activity_presenter, :gdi), t("summary.label.activity.gdi"))
 
   - if activity_presenter.is_gcrf_funded?
+    .govuk-summary-list__row.gcrf_strategic_area
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.gcrf_strategic_area")
+      %dd.govuk-summary-list__value
+        = activity_presenter.gcrf_strategic_area
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gcrf_strategic_area)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gcrf_strategic_area)}"), activity_step_path(activity_presenter, :gcrf_strategic_area), t("summary.label.activity.gcrf_strategic_area"))
+
+  - if activity_presenter.is_gcrf_funded?
     .govuk-summary-list__row.gcrf_challenge_area
       %dt.govuk-summary-list__key
         = t("summary.label.activity.gcrf_challenge_area")

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -262,7 +262,7 @@
       %dd.govuk-summary-list__value
         = activity_presenter.gcrf_strategic_area
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gcrf_strategic_area)
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gcrf_strategic_area) && activity_presenter.programme?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gcrf_strategic_area)}"), activity_step_path(activity_presenter, :gcrf_strategic_area), t("summary.label.activity.gcrf_strategic_area"))
 
   - if activity_presenter.is_gcrf_funded?

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -127,6 +127,7 @@ en:
         call_close_date: Call close date
         channel_of_delivery_code: Channel of delivery code
         country_delivery_partners: Country delivery partner
+        gcrf_strategic_area: What GCRF Strategic area does your activity relate to?
         gcrf_challenge_area: GCRF challenge area
         fund_pillar: What Newton Fund Pillar does this activity fall under?
         gdi: Is your activity affected by the Global Development Impact (GDI) policy?
@@ -173,6 +174,7 @@ en:
         country_delivery_partners: "Please provide up to ten country delivery partners. A name is required, provide a acronym where applicable, for example: 'National Council for the State Funding Agencies (CONFAP)'"
         fund_pillar: The Newton Fund largely comprises three pillar activities, which all activities must fall under. Use 'Not applicable' for delivery, other non-programme/project lines.
         delivery_partner_identifier: This could be the reference you use in your internal systems
+        gcrf_strategic_area: Select no more than two areas.
         gcrf_challenge_area: Select the most relevant GCRF challenge area for this activity. For broad programme calls, please select the challenge area most commonly represented across the individual projects within the programme. If the activity is a delivery line, you may select 'Not applicable'.
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
         objectives: Please refrain from using any abbreviations
@@ -378,6 +380,7 @@ en:
         country_delivery_partners: Country delivery partner
         covid19_related: Is this activity related to Covid-19?
         dates: What are the start and end dates for the %{level}?
+        gcrf_strategic_area: What GCRF Strategic area does your activity relate to?
         gcrf_challenge_area: GCRF challenge area
         fund_pillar: What Newton Fund Pillar does this activity fall under?
         gdi: GDI
@@ -465,6 +468,8 @@ en:
               blank: Select the aid type
             fstc_applies:
               inclusion: You must select "Yes" or "No"
+            gcrf_strategic_area:
+              blank: Choose a GCRF strategic area
             gcrf_challenge_area:
               blank: Select a GCRF challenge area
             channel_of_delivery_code:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -484,6 +484,7 @@ en:
         invalid_country: The country code cannot be found
         invalid_intended_beneficiaries: The intended beneficiaries are invalid
         invalid_gdi: The GDI code is invalid
+        invalid_gcrf_strategic_area: The GCRF strategic area is invalid
         invalid_gcrf_challenge_area: The GCRF challenge area is invalid
         invalid_sdg_goal: The sustainable development goal is invalid
         invalid_covid19_related: The COVID 19 Related option is invalid

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -249,6 +249,7 @@ en:
           label: Free-Standing Technical Cooperation applies?
           "false": "No"
           "true": "Yes"
+        gcrf_strategic_area: GCRF strategic area
         gcrf_challenge_area: GCRF challenge area
         fund_pillar: Fund pillar
         gdi: GDI

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -470,6 +470,7 @@ en:
               inclusion: You must select "Yes" or "No"
             gcrf_strategic_area:
               blank: Choose a GCRF strategic area
+              too_long: Choose a maximum of 2 GCRF strategic areas
             gcrf_challenge_area:
               blank: Select a GCRF challenge area
             channel_of_delivery_code:

--- a/db/migrate/20210319154548_add_strategic_area_to_activities.rb
+++ b/db/migrate/20210319154548_add_strategic_area_to_activities.rb
@@ -1,0 +1,5 @@
+class AddStrategicAreaToActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :gcrf_strategic_area, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_102910) do
+ActiveRecord::Schema.define(version: 2021_03_19_154548) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -77,6 +78,7 @@ ActiveRecord::Schema.define(version: 2021_03_16_102910) do
     t.integer "programme_status"
     t.string "channel_of_delivery_code"
     t.integer "source_fund_code"
+    t.string "gcrf_strategic_area", array: true
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe Staff::ActivityFormsController do
           it { is_expected.to render_current_step }
         end
       end
+
+      context "gcrf_strategic_area step" do
+        subject { get_step :gcrf_strategic_area }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when activity is the GCRF fund" do
+          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+
+          it { is_expected.to render_current_step }
+        end
+      end
     end
 
     context "when editing a project" do

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe Staff::ActivityFormsController do
           it { is_expected.to skip_to_next_step }
         end
       end
+
+      context "gcrf_strategic_area step" do
+        subject { get_step :gcrf_strategic_area }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when activity is the GCRF fund" do
+          let(:activity) { create(:fund_activity, :gcrf, organisation: organisation) }
+
+          it { is_expected.to skip_to_next_step }
+        end
+      end
     end
 
     context "when editing a programme" do
@@ -60,7 +72,7 @@ RSpec.describe Staff::ActivityFormsController do
         it { is_expected.to skip_to_next_step }
 
         context "when activity is the GCRF fund" do
-          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+          let(:activity) { create(:programme_activity, organisation: organisation, parent: fund, source_fund_code: Fund::MAPPINGS["GCRF"]) }
 
           it { is_expected.to render_current_step }
         end
@@ -89,6 +101,18 @@ RSpec.describe Staff::ActivityFormsController do
           it { is_expected.to render_current_step }
         end
       end
+
+      context "gcrf_strategic_area step" do
+        subject { get_step :gcrf_strategic_area }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when activity is associated with the GCRF fund" do
+          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+
+          it { is_expected.to skip_to_next_step }
+        end
+      end
     end
 
     context "when editing a third-party project" do
@@ -112,6 +136,18 @@ RSpec.describe Staff::ActivityFormsController do
           let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund::MAPPINGS["GCRF"]) }
 
           it { is_expected.to render_current_step }
+        end
+      end
+
+      context "gcrf_strategic_area step" do
+        subject { get_step :gcrf_strategic_area }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when activity is associated with the GCRF fund" do
+          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+
+          it { is_expected.to skip_to_next_step }
         end
       end
     end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     aid_type { "B02" }
     level { :fund }
     publish_to_iati { true }
+    gcrf_strategic_area { ["1", "2"] }
     gcrf_challenge_area { 0 }
     oda_eligibility_lead { Faker::Name.name }
     uk_dp_named_contact { Faker::Name.name }

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -221,6 +221,17 @@ RSpec.feature "BEIS users can create a programme level activity" do
 
       # Covid19-related has a default and can't be set to blank so we skip
       click_button t("form.button.activity.submit")
+      expect(page).to have_content t("form.legend.activity.gcrf_strategic_area")
+      expect(page).to have_content t("form.hint.activity.gcrf_strategic_area")
+
+      # Don't select a GCRF strategic area
+      click_button t("form.button.activity.submit")
+      expect(page).to have_content t("activerecord.errors.models.activity.attributes.gcrf_strategic_area.blank")
+
+      # GCRF strategic area (GCRF)
+      check "Resilient Futures"
+      click_button t("form.button.activity.submit")
+
       expect(page).to have_content t("form.legend.activity.gcrf_challenge_area")
       expect(page).to have_content t("form.hint.activity.gcrf_challenge_area")
 

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -228,6 +228,13 @@ RSpec.feature "BEIS users can create a programme level activity" do
       click_button t("form.button.activity.submit")
       expect(page).to have_content t("activerecord.errors.models.activity.attributes.gcrf_strategic_area.blank")
 
+      # Select too many GCRF strategic areas
+      check "Resilient Futures"
+      check "Coherence and Impact"
+      check "International Partnerships"
+      click_button t("form.button.activity.submit")
+      expect(page).to have_content t("activerecord.errors.models.activity.attributes.gcrf_strategic_area.too_long")
+
       # GCRF strategic area (GCRF)
       check "Resilient Futures"
       click_button t("form.button.activity.submit")

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -579,6 +579,17 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on t("tabs.activity.details")
 
   if activity.is_gcrf_funded?
+    within(".gcrf_strategic_area") do
+      click_on(t("default.link.edit"))
+      expect(page).to have_current_path(
+        activity_step_path(activity, :gcrf_strategic_area)
+      )
+    end
+    click_on(t("default.link.back"))
+    click_on t("tabs.activity.details")
+  end
+
+  if activity.is_gcrf_funded?
     within(".gcrf_challenge_area") do
       click_on(t("default.link.edit"))
       expect(page).to have_current_path(

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -329,6 +329,15 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
 
+      it "does not show an edit link for the GCRF strategic area" do
+        activity = create(:project_activity, :gcrf_funded, organisation: user.organisation, parent: create(:programme_activity, :gcrf_funded))
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+        within(".gcrf_strategic_area") do
+          expect(page).to_not have_content t("default.link.edit")
+        end
+      end
+
       context "when the project does not have a RODA identifier" do
         let(:fund) { create(:fund_activity, roda_identifier_fragment: "AAA") }
         let(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "BBB") }
@@ -422,6 +431,15 @@ RSpec.feature "Users can edit an activity" do
 
         click_button t("form.button.activity.submit")
         expect(page).to have_content(t("action.third_party_project.update.success"))
+      end
+    end
+
+    it "does not show an edit link for the GCRF strategic area" do
+      activity = create(:project_activity, :gcrf_funded, organisation: user.organisation, parent: create(:programme_activity, :gcrf_funded))
+
+      visit organisation_activity_details_path(activity.organisation, activity)
+      within(".gcrf_strategic_area") do
+        expect(page).to_not have_content t("default.link.edit")
       end
     end
 
@@ -578,7 +596,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
 
-  if activity.is_gcrf_funded?
+  if activity.is_gcrf_funded? && activity.programme?
     within(".gcrf_strategic_area") do
       click_on(t("default.link.edit"))
       expect(page).to have_current_path(

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "users can upload activities" do
       "DFID policy marker - Gender", "DFID policy marker - Nutrition",
       "Delivery partner identifier",
       "Free Standing Technical Cooperation",
+      "GCRF Strategic Area",
       "GCRF Challenge Area",
       "GDI",
       "Intended Beneficiaries",

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -622,6 +622,25 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when gcrf_strategic_area is blank" do
+      let(:source_fund_code) { Fund::MAPPINGS["NF"] }
+      subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_strategic_area: nil) }
+
+      it { is_expected.to be_valid(:gcrf_strategic_area_step) }
+
+      context "with a GCRF funded activity" do
+        let(:source_fund_code) { Fund::MAPPINGS["GCRF"] }
+
+        it { is_expected.to be_invalid(:gcrf_strategic_area_step) }
+      end
+
+      context "for a fund" do
+        subject { build(:fund_activity, :gcrf, gcrf_strategic_area: nil) }
+
+        it { is_expected.to be_valid(:gcrf_strategic_area_step) }
+      end
+    end
+
     context "when gcrf_challenge_area is blank" do
       let(:source_fund_code) { Fund::MAPPINGS["NF"] }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_challenge_area: nil) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1010,6 +1010,31 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#gcrf_strategic_area" do
+    it "returns nil if the activity is a fund" do
+      fund = build(:fund_activity)
+      expect(fund.gcrf_strategic_area).to be_nil
+    end
+
+    it "returns the attribute’s value if the activity is a programme" do
+      programme = build(:programme_activity, gcrf_strategic_area: ["1"])
+      expect(programme.gcrf_strategic_area).to eql ["1"]
+    end
+
+    it "returns the programme’s attribute value if the activity is a project" do
+      programme = build(:programme_activity, gcrf_strategic_area: ["2"])
+      project = build(:project_activity, parent: programme, gcrf_strategic_area: nil)
+      expect(project.gcrf_strategic_area).to eql ["2"]
+    end
+
+    it "returns the programme’s attribute value if the activity is a third party project" do
+      programme = build(:programme_activity, gcrf_strategic_area: ["3"])
+      project = build(:project_activity, parent: programme, gcrf_strategic_area: nil)
+      third_party_project = build(:third_party_project_activity, parent: project, gcrf_strategic_area: nil)
+      expect(third_party_project.gcrf_strategic_area).to eql ["3"]
+    end
+  end
+
   describe "#accountable_organisation" do
     let(:beis) { build_stubbed(:beis_organisation) }
     let(:delivery_partner) { build_stubbed(:delivery_partner_organisation) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -641,6 +641,18 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when gcrf_strategic_area has too many values" do
+      let(:source_fund_code) { Fund::MAPPINGS["NF"] }
+      let(:strategic_areas) { %w[1 2 3] }
+      subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_strategic_area: strategic_areas) }
+
+      context "with a GCRF funded activity" do
+        let(:source_fund_code) { Fund::MAPPINGS["GCRF"] }
+
+        it { is_expected.to be_invalid(:gcrf_strategic_area_step) }
+      end
+    end
+
     context "when gcrf_challenge_area is blank" do
       let(:source_fund_code) { Fund::MAPPINGS["NF"] }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_challenge_area: nil) }

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -414,6 +414,15 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#gcrf_strategic_area" do
+    it "returns the code list description values for the stored integers" do
+      activity = build(:activity, gcrf_strategic_area: %w[1 3])
+      result = described_class.new(activity)
+
+      expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Resilient Futures"
+    end
+  end
+
   describe "#gcrf_challenge_area" do
     it "returns the locale value for the stored integer" do
       activity = build(:activity, gcrf_challenge_area: 2)

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe ActivityPresenter do
 
   describe "#gcrf_strategic_area" do
     it "returns the code list description values for the stored integers" do
-      activity = build(:activity, gcrf_strategic_area: %w[1 3])
+      activity = build(:programme_activity, gcrf_strategic_area: %w[1 3])
       result = described_class.new(activity)
 
       expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Resilient Futures"

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Intended Beneficiaries" => "KH|KP|ID",
       "Delivery partner identifier" => "1234567890",
       "GDI" => "1",
+      "GCRF Strategic Area" => "1|3",
       "GCRF Challenge Area" => "4",
       "SDG 1" => "1",
       "SDG 2" => "2",
@@ -152,6 +153,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
       expect(existing_activity.gdi).to eq("1")
+      expect(existing_activity.gcrf_strategic_area).to eq(["1", "3"])
       expect(existing_activity.gcrf_challenge_area).to eq(4)
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.fund_pillar).to eq(existing_activity_attributes["Newton Fund Pillar"].to_i)

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Activities::ImportFromCsv do
 
   # NB: 'let!' to prevent `to change { Activity.count }` from giving confusing results
   let!(:existing_activity) do
-    create(:activity) do |activity|
+    create(:programme_activity) do |activity|
       activity.implementing_organisations = [
         create(:implementing_organisation, activity: activity),
       ]

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -50,6 +50,7 @@ module FormHelpers
     policy_marker_disaster_risk_reduction: "Not assessed",
     policy_marker_nutrition: "Not assessed",
     covid19_related: "4",
+    gcrf_strategic_area: "Academies Collective Fund",
     gcrf_challenge_area: "1",
     oda_eligibility: "Eligible",
     oda_eligibility_lead: Faker::Name.name,
@@ -297,6 +298,11 @@ module FormHelpers
     click_button t("form.button.activity.submit")
 
     if parent&.is_gcrf_funded? || parent&.roda_identifier_fragment == "GCRF"
+      expect(page).to have_content t("form.legend.activity.gcrf_strategic_area")
+      expect(page).to have_content t("form.hint.activity.gcrf_strategic_area")
+      check gcrf_strategic_area
+      click_button t("form.button.activity.submit")
+
       expect(page).to have_content t("form.legend.activity.gcrf_challenge_area")
       expect(page).to have_content t("form.hint.activity.gcrf_challenge_area")
       choose("activity[gcrf_challenge_area]", option: gcrf_challenge_area)

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -297,12 +297,14 @@ module FormHelpers
     choose("activity[covid19_related]", option: covid19_related)
     click_button t("form.button.activity.submit")
 
-    if parent&.is_gcrf_funded? || parent&.roda_identifier_fragment == "GCRF"
+    if level == "programme" && (parent&.is_gcrf_funded? || parent&.roda_identifier_fragment == "GCRF")
       expect(page).to have_content t("form.legend.activity.gcrf_strategic_area")
       expect(page).to have_content t("form.hint.activity.gcrf_strategic_area")
       check gcrf_strategic_area
       click_button t("form.button.activity.submit")
+    end
 
+    if parent&.is_gcrf_funded? || parent&.roda_identifier_fragment == "GCRF"
       expect(page).to have_content t("form.legend.activity.gcrf_challenge_area")
       expect(page).to have_content t("form.hint.activity.gcrf_challenge_area")
       choose("activity[gcrf_challenge_area]", option: gcrf_challenge_area)

--- a/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
+++ b/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
@@ -1,0 +1,15 @@
+data:
+  - code: 0
+    description: Core
+  - code: 1
+    description: UKRI Collective Fund (2017 allocation)
+  - code: 2
+    description: Academies Collective Fund
+  - code: 3
+    description: Resilient Futures
+  - code: 4
+    description: Coherence and Impact
+  - code: 5
+    description: International Partnerships
+  - code: 6
+    description: Innovation and Commercialisation


### PR DESCRIPTION
## Changes in this PR

> Users need to be able to report which strategic area their GCRF funding applies to. This has previously been captured by the UID but is unlikely to be the case in the future. This is important for Fund Managers and BEIS finance team.

- Users can now report the strategic area under which the GCRF allocation was made
- They can choose a maximum of two areas
- The strategic area is included in the CSV report
- The activity CSV import will ingest the strategic area
- Only show the strategic area question for programme level activities
- For project and third-party level activities use the strategic area from the programme level activity

## Screenshots of UI changes

<img width="1333" alt="Screenshot 2021-03-22 at 17 11 31" src="https://user-images.githubusercontent.com/2804149/112029988-b0c08f00-8b31-11eb-86d3-7041b3c314f5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
