### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)


### PR DESCRIPTION
All versions prior to 0.3.6 have been pulled by the developer, presumably due to a security vulnerability. [1]

[1] Conversation on the repo https://github.com/minad/mimemagic/issues/98
