### PR TITLE
(1569) RODA team can import activities at Level B

### DIFF
--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -756,6 +756,26 @@ RSpec.describe Activities::ImportFromCsv do
         expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.implementing_organisation.attributes.organisation_type.inclusion"))
       end
     end
+
+    context "when the parent activity is a fund" do
+      let(:beis_organisation) { create(:beis_organisation) }
+      let!(:parent_activity) { create(:fund_activity, :newton, organisation: beis_organisation) }
+
+      it "creates a programme level activity correctly" do
+        expect { subject.import([new_activity_attributes]) }.to change { Activity.count }.by(1)
+
+        expect(subject.created.count).to eq(1)
+        expect(subject.updated.count).to eq(0)
+
+        expect(subject.errors.count).to eq(0)
+
+        new_activity = Activity.order(:created_at).last
+
+        expect(new_activity.level).to eq("programme")
+        expect(new_activity.organisation).to eq(beis_organisation)
+        expect(new_activity.extending_organisation).to eq(organisation)
+      end
+    end
   end
 
   context "when updating and importing" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Activities::ImportFromCsv do
   let(:organisation) { create(:organisation) }
-  let(:parent_activity) { create(:fund_activity, :newton) }
+  let(:parent_activity) { create(:programme_activity, :newton_funded) }
 
   # NB: 'let!' to prevent `to change { Activity.count }` from giving confusing results
   let!(:existing_activity) do
@@ -69,7 +69,7 @@ RSpec.describe Activities::ImportFromCsv do
     existing_activity_attributes.merge({
       "RODA ID" => "",
       "RODA ID Fragment" => "234566",
-      "Parent RODA ID" => parent_activity.roda_identifier_fragment,
+      "Parent RODA ID" => parent_activity.roda_identifier_compound,
       "Transparency identifier" => "23232332323",
     })
   end
@@ -290,7 +290,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       expect(new_activity.parent).to eq(parent_activity)
       expect(new_activity.source_fund_code).to eq(1)
-      expect(new_activity.level).to eq("programme")
+      expect(new_activity.level).to eq("project")
       expect(new_activity.roda_identifier_compound).to eq(expected_roda_identifier_compound)
       expect(new_activity.transparency_identifier).to eq(new_activity_attributes["Transparency identifier"])
       expect(new_activity.title).to eq(new_activity_attributes["Title"])


### PR DESCRIPTION
The initial intent of [the card](https://trello.com/c/4gl4n8Ef/1569-roda-team-can-import-activities-at-level-b) was to change the Rake importer so we could import Level B (Programme) activities via the command line. It turns out that recent changes we've made to the importer make this very easy to do, so this PR is simply adding some extra tests to make sure what we're testing for better reflects reality.

Another issue that this has raised is that, at the moment, delivery partners can, in theory, create level B activities, which we don't really want to do. This issue is logged in [another card](https://trello.com/c/W7orkOeN/1566-activity-import-respects-the-policies)