### PR TITLE
(1581) Backfill forecasts data into historic reports for new partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,6 +558,7 @@
 ## [unreleased]
 
 - Users can report the strategic area under which the GCRF allocation was made
+- Bring back script for importing forecast data into an in-review/approved report
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-39...HEAD
 [release-39]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-38...release-39

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -3,10 +3,11 @@ class PlannedDisbursementHistory
 
   attr_reader :financial_year, :financial_quarter
 
-  def initialize(activity, financial_quarter:, financial_year:, user: nil)
+  def initialize(activity, financial_quarter:, financial_year:, report: nil, user: nil)
     @activity = activity
     @financial_quarter = financial_quarter.to_i
     @financial_year = financial_year.to_i
+    @report = report
     @user = user
   end
 
@@ -59,7 +60,7 @@ class PlannedDisbursementHistory
   end
 
   def update_history(latest_entry, value)
-    report = Report.editable_for_activity(@activity)
+    report = @report || Report.editable_for_activity(@activity)
     check_forecast_in_future(report)
 
     if latest_entry&.report_id == report.id

--- a/script/import_forecasts.rb
+++ b/script/import_forecasts.rb
@@ -25,11 +25,16 @@ unless organisation
   exit 1
 end
 
+def zero_option_to_nil(options, field)
+  value = options.fetch(field)
+  value == 0 ? nil : value
+end
+
 report = Report.find_by(
   fund: fund,
   organisation: organisation,
-  financial_quarter: options.fetch(:quarter),
-  financial_year: options.fetch(:year)
+  financial_quarter: zero_option_to_nil(options, :quarter),
+  financial_year: zero_option_to_nil(options, :year),
 )
 
 unless report

--- a/script/import_forecasts.rb
+++ b/script/import_forecasts.rb
@@ -1,0 +1,65 @@
+require "optparse"
+require_relative "../config/environment"
+
+parser = OptionParser.new { |args|
+  args.on "-f", "--fund FUND"
+  args.on "-o", "--organisation ORGANISATION"
+  args.on "-q", "--quarter QUARTER", Integer
+  args.on "-y", "--year YEAR", Integer
+  args.on "-i", "--input FILE"
+}
+
+options = {}
+parser.parse!(into: options)
+
+fund = Activity.fund.by_roda_identifier(options.fetch(:fund))
+organisation = Organisation.find_by(name: options.fetch(:organisation))
+
+unless fund
+  warn "Could not find fund with RODA identifier '#{options.fetch(:fund)}'"
+  exit 1
+end
+
+unless organisation
+  warn "Could not find organisation with name '#{options.fetch(:organisation)}'"
+  exit 1
+end
+
+report = Report.find_by(
+  fund: fund,
+  organisation: organisation,
+  financial_quarter: options.fetch(:quarter),
+  financial_year: options.fetch(:year)
+)
+
+unless report
+  warn "Could not find report with the given parameters"
+  exit 1
+end
+
+puts "\nRunning import with the following report:\n\n"
+puts "    id:           #{report.id}"
+puts "    description:  #{report.description}"
+puts "    fund:         #{report.fund.roda_identifier}"
+puts "    organisation: #{report.organisation.name}"
+puts "    quarter:      #{report.financial_quarter_and_year}"
+puts "    state:        #{report.state}"
+
+puts "\nIs this correct? [y/n]"
+confirmation = gets
+exit unless confirmation.strip == "y"
+
+importer = ImportPlannedDisbursements.new(report: report)
+rows = CSV.parse(File.read(options.fetch(:input)), headers: true)
+
+importer.import(rows)
+
+importer.errors.each do |error|
+  warn "Line #{error.csv_row}, column '#{error.column}': #{error.message}"
+end
+
+if importer.errors.empty?
+  exit 0
+else
+  exit 1
+end

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -2,17 +2,20 @@ require "rails_helper"
 
 RSpec.describe ImportPlannedDisbursements do
   let(:project) { create(:project_activity) }
+
   let(:reporting_cycle) { ReportingCycle.new(project, 1, 2020) }
+  let(:latest_report) { Report.in_historical_order.first }
+  let(:selected_report) { nil }
 
   let(:reporter_organisation) { project.organisation }
   let(:reporter) { create(:delivery_partner_user, organisation: reporter_organisation) }
 
   let :importer do
-    ImportPlannedDisbursements.new(uploader: reporter)
+    ImportPlannedDisbursements.new(uploader: reporter, report: selected_report)
   end
 
   before do
-    reporting_cycle.tick
+    2.times { reporting_cycle.tick }
   end
 
   def forecast_values
@@ -147,6 +150,121 @@ RSpec.describe ImportPlannedDisbursements do
 
     it "does not import any forecasts" do
       expect(forecast_values).to eq([])
+    end
+  end
+
+  context "importing into a specific report" do
+    let(:selected_report) { latest_report }
+    let(:reporter) { nil }
+
+    describe "importing a row of forecasts to an in-review report" do
+      before do
+        selected_report.update!(state: :in_review)
+      end
+
+      let :forecast_row do
+        {
+          "Activity RODA Identifier" => project.roda_identifier,
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+          "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+          "FC 2021/22 FY Q1 (Apr, May, Jun)" => "984150",
+          "FC 2021/22 FY Q2 (Jul, Aug, Sep)" => "206206",
+        }
+      end
+
+      before do
+        importer.import([forecast_row])
+      end
+
+      it "imports the forecasts" do
+        expect(forecast_values).to eq([
+          [3, 2020, 200_436.0],
+          [4, 2020, 310_793.0],
+          [1, 2021, 984_150.0],
+          [2, 2021, 206_206.0],
+        ])
+      end
+
+      it "reports no errors" do
+        expect(importer.errors).to eq([])
+      end
+    end
+
+    context "when the selected report is not the latest one" do
+      let(:selected_report) { Report.in_historical_order.to_a.last }
+
+      let(:organisation) { project.organisation.name }
+      let(:fund) { project.associated_fund.roda_identifier }
+
+      before do
+        importer.import([
+          {
+            "Activity RODA Identifier" => project.roda_identifier,
+            "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+          },
+        ])
+      end
+
+      it "reports an error" do
+        expect(importer.errors).to eq([
+          ImportPlannedDisbursements::Error.new(
+            nil,
+            nil,
+            nil,
+            "The report #{selected_report.id} (#{organisation}, FQ1 2020-2021 for #{fund}, approved)\
+ is not the latest for that organisation and fund. The latest is #{latest_report.id},\
+ for FQ2 2020-2021 (active).",
+          ),
+        ])
+      end
+
+      it "does not import any forecasts" do
+        expect(forecast_values).to eq([])
+      end
+    end
+
+    context "when the data includes a project unrelated to the report" do
+      let(:unrelated_project) { create(:project_activity) }
+
+      let(:organisation) { project.organisation.name }
+      let(:fund) { project.associated_fund.roda_identifier }
+
+      before do
+        importer.import([
+          {
+            "Activity RODA Identifier" => project.roda_identifier,
+            "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+          },
+          {
+            "Activity RODA Identifier" => unrelated_project.roda_identifier,
+            "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+          },
+        ])
+      end
+
+      it "reports an error" do
+        expect(importer.errors).to eq([
+          ImportPlannedDisbursements::Error.new(
+            1,
+            "Activity RODA Identifier",
+            unrelated_project.roda_identifier,
+            "The activity is not related to the report, which belongs to #{fund} and #{organisation}.",
+          ),
+        ])
+      end
+
+      it "does not import any forecasts" do
+        expect(forecast_values).to eq([])
+      end
+    end
+  end
+
+  describe "setting an uploader and a report" do
+    let(:reporter) { create(:delivery_partner_user, organisation: reporter_organisation) }
+    let(:selected_report) { latest_report }
+
+    it "is forbidden" do
+      expect { importer }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe PlannedDisbursementHistory do
-  let(:history) { PlannedDisbursementHistory.new(activity, financial_quarter: 3, financial_year: 2020) }
+  let(:edited_report) { nil }
+  let(:history) { PlannedDisbursementHistory.new(activity, financial_quarter: 3, financial_year: 2020, report: edited_report) }
   let(:reporting_cycle) { ReportingCycle.new(activity, 1, 2015) }
 
   def history_entries
@@ -275,6 +276,25 @@ RSpec.describe PlannedDisbursementHistory do
         ["original", 1, 2015, 10],
         ["revised", 2, 2015, 20],
         ["revised", 1, 2016, 30],
+      ])
+    end
+  end
+
+  context "adding data to a specific report" do
+    let(:delivery_partner) { create(:delivery_partner_organisation) }
+    let(:activity) { create(:project_activity, organisation: delivery_partner) }
+    let(:edited_report) { Report.in_historical_order.first }
+
+    before do
+      reporting_cycle.tick
+      Report.update_all(state: :in_review)
+    end
+
+    it "allows data to be added to the given report" do
+      history.set_value(10)
+
+      expect(history_entries).to eq([
+        ["original", 1, 2015, 10],
       ])
     end
   end


### PR DESCRIPTION
## Changes in this PR

This revives a script we used in the previous quarter to back-fill some forecast data into the previous quarter's approved report, before opening the next reporting round.

Since this was first introduced and then removed, the forecast import service has been exposed to end users and so has gained some authorization logic and other checks that meant this functionality had to be reworked beyond just reverting the commits that removed it. Details in the commit messages.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
