### PR TITLE
(1603) Remove `legacy_iati_xml` column

### DIFF
--- a/db/migrate/20210324161847_remove_legacy_iati_xml_from_activity.rb
+++ b/db/migrate/20210324161847_remove_legacy_iati_xml_from_activity.rb
@@ -1,0 +1,9 @@
+class RemoveLegacyIatiXmlFromActivity < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :activities, :legacy_iati_xml
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_154548) do
+ActiveRecord::Schema.define(version: 2021_03_24_161847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -38,7 +38,6 @@ ActiveRecord::Schema.define(version: 2021_03_19_154548) do
     t.uuid "reporting_organisation_id"
     t.string "previous_identifier"
     t.string "sector_category"
-    t.string "legacy_iati_xml"
     t.boolean "publish_to_iati", default: true
     t.uuid "parent_id"
     t.string "transparency_identifier"


### PR DESCRIPTION
## Changes in this PR

This column was added in 71ba7adcf04cc700fba6014e6fbbe0652838dad3 in order to preserve the IATI data used to generate ingested activities.

This historical data hasn’t been needed since, and is adding visual noise when inspecting activities via a console.

We think it’s safe to drop this column. We will check with the responsible person from BEIS before doing so in production.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
