### PR TITLE
(1608) "bin/db-restore" script fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,4 @@ spec/examples.txt
 # SQL files
 **/*.sql
 
+bin/db-restore

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# bin/restore: Restore the local database from staging/production.
+# bin/db-restore: Restore the local database from staging/production.
 
 set -e
 
@@ -58,7 +58,9 @@ cf conduit "$service" -- \
         --file "$filename" \
         --no-acl \
         --no-owner \
-        --exclude-table="users"
+        --exclude-table-data="users" \
+        --exclude-table="ar_internal_metadata" \
+        --exclude-table="spatial_ref_sys"
 
 echo "==> Destroying the existing local database"
 
@@ -72,16 +74,19 @@ if [ "$delete_data" == "y" ]; then
     psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
 
     echo "==> Restoring the data from the backup..."
-    psql -d roda-development < "$filename"
+    psql -d roda-development -f "$filename"
 
     echo "==> Removing extraneous Postgres extensions..."
     psql -d roda-development -c 'DROP extension citext; DROP extension postgis; DROP extension "uuid-ossp";'
 
-    echo "==> Running the migrations..."
+    echo "==> Setting database environment..."
+    bundle exec rails db:environment:set RAILS_ENV=development
+
+    echo "==> Running database migrations..."
     bundle exec rails db:migrate
 
     echo "==> Seeding development users..."
-    rails runner 'load File.join(Rails.root, "db", "seeds", "development_users.rb")'
+    bundle exec rails runner 'load File.join(Rails.root, "db", "seeds", "development_users.rb")'
 fi
 
 exit_code=$?


### PR DESCRIPTION
The command wasn't working correctly because it was attempting to seed the `users` table that didn't exist as it was explicitly excluded from the database dump.

Changing `--exclude-table` to `--exclude-table-data` means that the schema for the users table is dumped, but its contents isn't.

I've also excluded the internal `ar_internal_metadata` and`spatial_ref_sys` tables from the backup as well.

Finally calling `rails db:environment:set` let's Rails know we're running a development environment (despite the copy of the database looking like a production one).

NB: I'm entirely sure why this is needed when we're excluding `ar_internal_metadata` from the dump, but I got warnings without it.

Using `pgsql -f dump.sql` instead of `pgsql ... < dump.sql` seemed to resolve a lot of the random `Invalid command \n` errors.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
