### PR TITLE
(1609) Refactor handling of implementing organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,7 @@
 
 - Add headings for the next 20 financial quarters to the forecast CSV upload template
 - Only set provided variables when updating via the CSV upload
+- Refactor handling of implementing organisations
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...HEAD
 [release-41]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-40...release-41


### PR DESCRIPTION
In certain circumstances, when trying to update an activity, we hit an error in the ImplemeningOrganisationBuilder, where the builder tried to add an error to the Errors array, but because there were no implementing organisations available, we got an `undefined method `errors' for nil:NilClass` error.

This reworks how the `ImplemeningOrganisationBuilder` works to memoize the organisation that gets built, rather than fetching the organisation's last implementing organisation, which may or may not be the correct one, or even exist at all.

I've also updated the updater, so it only attempts to build an implementing organisation if the relevant fields are present, in a similar way to how the creator works.