### PR TITLE
(1601) Add financial quarter headings to forecast upload template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,6 +567,8 @@
 
 ## [unreleased]
 
+- Add headings for the next 20 financial quarters to the forecast CSV upload template
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...HEAD
 [release-41]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-40...release-41
 [release-40]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-39...release-40

--- a/app/controllers/staff/planned_disbursement_uploads_controller.rb
+++ b/app/controllers/staff/planned_disbursement_uploads_controller.rb
@@ -14,7 +14,7 @@ class Staff::PlannedDisbursementUploadsController < Staff::BaseController
 
   def show
     @report_presenter = ReportPresenter.new(@report)
-    generator = ImportPlannedDisbursements::Generator.new
+    generator = ImportPlannedDisbursements::Generator.new(@report)
     filename = @report_presenter.filename_for_forecasts_template
 
     stream_csv_download(filename: filename, headers: generator.column_headings) do |csv|

--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -35,7 +35,7 @@ class ImportPlannedDisbursements
     end
 
     def csv_row(activity)
-      forecast_values = Array.new(FORECAST_QUARTERS)
+      forecast_values = Array.new(FORECAST_QUARTERS, "")
 
       [
         activity.title,
@@ -103,6 +103,7 @@ class ImportPlannedDisbursements
   end
 
   def import_forecast(activity, financial_quarter, value, header:)
+    return if value.blank?
     history = PlannedDisbursementHistory.new(activity, user: @uploader, report: @report, **financial_quarter)
     history.set_value(value)
   rescue ConvertFinancialValue::Error

--- a/app/services/import_planned_disbursements.rb
+++ b/app/services/import_planned_disbursements.rb
@@ -10,6 +10,7 @@ class ImportPlannedDisbursements
 
   RODA_ID_KEY = "Activity RODA Identifier"
   FORECAST_COLUMN_HEADER = /FC +(\d{4})\/\d{2} +FY +Q([1-4])/
+  FORECAST_QUARTERS = 20
 
   COLUMN_HEADINGS = [
     "Activity Name",
@@ -18,16 +19,29 @@ class ImportPlannedDisbursements
   ]
 
   class Generator
+    def initialize(report)
+      @report = report
+    end
+
     def column_headings
-      COLUMN_HEADINGS
+      reportable_quarters = @report.own_financial_quarter.following(FORECAST_QUARTERS)
+
+      quarter_headers = reportable_quarters.map { |quarter|
+        year = quarter.financial_year.start_year
+        "FC #{year}/#{(year + 1) % 100} FY Q#{quarter.quarter}"
+      }
+
+      COLUMN_HEADINGS + quarter_headers
     end
 
     def csv_row(activity)
+      forecast_values = Array.new(FORECAST_QUARTERS)
+
       [
         activity.title,
         activity.delivery_partner_identifier,
         activity.roda_identifier,
-      ]
+      ] + forecast_values
     end
   end
 

--- a/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
@@ -57,6 +57,41 @@ RSpec.feature "users can upload planned disbursements" do
         "FC 2025/26 FY Q2", "FC 2025/26 FY Q3", "FC 2025/26 FY Q4", "FC 2026/27 FY Q1",
       ])
     end
+
+    it "puts no value in all forecast columns by default" do
+      rows = CSV.parse(@csv_data, headers: true).map(&:to_h)
+
+      expect(rows.first).to eq({
+        "Activity Name" => project.title,
+        "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,
+        "Activity RODA Identifier" => project.roda_identifier,
+
+        "FC 2021/22 FY Q2" => "",
+        "FC 2021/22 FY Q3" => "",
+        "FC 2021/22 FY Q4" => "",
+        "FC 2022/23 FY Q1" => "",
+
+        "FC 2022/23 FY Q2" => "",
+        "FC 2022/23 FY Q3" => "",
+        "FC 2022/23 FY Q4" => "",
+        "FC 2023/24 FY Q1" => "",
+
+        "FC 2023/24 FY Q2" => "",
+        "FC 2023/24 FY Q3" => "",
+        "FC 2023/24 FY Q4" => "",
+        "FC 2024/25 FY Q1" => "",
+
+        "FC 2024/25 FY Q2" => "",
+        "FC 2024/25 FY Q3" => "",
+        "FC 2024/25 FY Q4" => "",
+        "FC 2025/26 FY Q1" => "",
+
+        "FC 2025/26 FY Q2" => "",
+        "FC 2025/26 FY Q3" => "",
+        "FC 2025/26 FY Q4" => "",
+        "FC 2026/27 FY Q1" => "",
+      })
+    end
   end
 
   scenario "not uploading a file" do
@@ -97,6 +132,20 @@ RSpec.feature "users can upload planned disbursements" do
       expect(page).to have_xpath("td[3]", text: "not a number")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.planned_disbursement.non_numeric_value"))
     end
+  end
+
+  scenario "uploading a partially completed template" do
+    ids = [project, sibling_project].map(&:roda_identifier)
+
+    upload_csv <<~CSV
+      Activity RODA Identifier | FC 2021/22 FY Q2 | FC 2021/22 FY Q3 | FC 2021/22 FY Q4
+      #{ids[0]}                | 10               |                  |
+      #{ids[1]}                | 40               |                  | 60
+    CSV
+
+    expect(PlannedDisbursement.count).to eq(3)
+    expect(page).to have_text(t("action.planned_disbursement.upload.success"))
+    expect(page).not_to have_xpath("//tbody/tr")
   end
 
   scenario "uploading a set of forecasts with encoding errors" do

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -120,6 +120,28 @@ RSpec.describe ImportPlannedDisbursements do
     end
   end
 
+  context "when the data includes empty cells" do
+    before do
+      importer.import([
+        {
+          "Activity RODA Identifier" => project.roda_identifier,
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "",
+          "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+        },
+      ])
+    end
+
+    it "reports no errors" do
+      expect(importer.errors).to eq([])
+    end
+
+    it "imports the forecasts, ignoring blank cells" do
+      expect(forecast_values).to eq([
+        [4, 2020, 310_793.0],
+      ])
+    end
+  end
+
   context "when the data includes unrecognised columns" do
     before do
       importer.import([


### PR DESCRIPTION
## Changes in this PR

This adds column headings for the next 20 financial quarters to the forecast CSV template. The cell values are left blank rather than being filled with zeros, so that only cells the user actually fills in are treated as new data. A fuller explanation for this is in the commit messages.

## Screenshots of UI changes

<img width="963" alt="Screenshot 2021-03-25 at 16 50 20" src="https://user-images.githubusercontent.com/9265/112511361-40607a80-8d8a-11eb-8ef4-6b030fb7a1a6.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
