### PR TITLE
(1567) Activity importer can update an activity without requiring the sector code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,7 @@
 ## [unreleased]
 
 - Add headings for the next 20 financial quarters to the forecast CSV upload template
+- Only set provided variables when updating via the CSV upload
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...HEAD
 [release-41]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-40...release-41

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.planned_end_date).to eq(DateTime.parse(existing_activity_attributes["Planned end date"]))
       expect(existing_activity.actual_start_date).to eq(DateTime.parse(existing_activity_attributes["Actual start date"]))
       expect(existing_activity.actual_end_date).to eq(DateTime.parse(existing_activity_attributes["Actual end date"]))
-      expect(existing_activity.call_present).to eq(true)
       expect(existing_activity.sector).to eq(existing_activity_attributes["Sector"])
       expect(existing_activity.sector_category).to eq("112")
       expect(existing_activity.channel_of_delivery_code).to eq(existing_activity_attributes["Channel of delivery code"])

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -177,9 +177,9 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.policy_marker_climate_change_mitigation).to eq("significant_objective")
       expect(existing_activity.policy_marker_biodiversity).to eq("principal_objective")
       expect(existing_activity.policy_marker_desertification).to eq("not_assessed")
-      expect(existing_activity.policy_marker_disability).to eq("not_assessed")
+      expect(existing_activity.policy_marker_disability).to eq(nil)
       expect(existing_activity.policy_marker_disaster_risk_reduction).to eq("not_targeted")
-      expect(existing_activity.policy_marker_nutrition).to eq("not_assessed")
+      expect(existing_activity.policy_marker_nutrition).to eq(nil)
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
@@ -238,6 +238,57 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.created.count).to eq(0)
       expect(subject.updated.count).to eq(0)
       expect(subject.errors.count).to eq(1)
+    end
+
+    context "when carrying out a partial update" do
+      let!(:old_activity_attributes) { existing_activity.attributes }
+
+      let(:attributes) do
+        attributes = existing_activity_attributes.map { |k, _v| [k, ""] }.to_h
+        attributes["RODA ID"] = existing_activity.roda_identifier_compound
+        attributes
+      end
+      let(:changed_attributes) do
+        (existing_activity.reload.attributes.to_a - old_activity_attributes.to_a).to_h.except("updated_at")
+      end
+
+      it "allows a partial update without a sector code" do
+        attributes["Title"] = "New Title"
+        attributes["Description"] = "Here is a description"
+
+        subject.import([attributes])
+
+        expect(subject.updated.count).to eq(1)
+
+        expect(changed_attributes).to eq(
+          "title" => "New Title",
+          "description" => "Here is a description"
+        )
+      end
+
+      it "infers the geography" do
+        existing_activity.geography = "recipient_country"
+        existing_activity.save
+
+        attributes["Recipient Region"] = 789
+
+        subject.import([attributes])
+
+        expect(existing_activity.reload.geography).to eq("recipient_region")
+      end
+
+      it "infers the region if it is not present" do
+        existing_activity.recipient_region = nil
+        existing_activity.save
+
+        attributes["Recipient Country"] = "KH"
+
+        subject.import([attributes])
+
+        expect(subject.updated.count).to eq(1)
+
+        expect(existing_activity.reload.recipient_region).to eq("789")
+      end
     end
   end
 


### PR DESCRIPTION
When we're updating an activity, we don't always want to have to set every single variable. As it stands, when we update a record, there are some variables we're expected to set every single time (e.g. sector code).

This updates the Converter to behave differently when updating to when creating a new activity. If we're updating, we grab the row, and only run the converter on fields that are expressly filled out. We also don't do any of the inferrence when updating, as this can overwrite data that is already set on the Activity.

This also has the side effect of any policy marker fields not being set to `not_assessed` by default. This is fine for now, and we're going to write a seperate card to write a migration that sets all Activity policy marker fields to default to `not_assessed` at the database level.