### PR TITLE
Fix broken migration

### DIFF
--- a/db/migrate/20210326054912_remove_null_from_activity_level.rb
+++ b/db/migrate/20210326054912_remove_null_from_activity_level.rb
@@ -1,5 +1,11 @@
 class RemoveNullFromActivityLevel < ActiveRecord::Migration[6.0]
-  def change
+  def up
+    Activity.where(level: nil).destroy_all
+
     change_column_null(:activities, :level, false)
+  end
+
+  def down
+    change_column_null(:activities, :level, true)
   end
 end


### PR DESCRIPTION
Remove any activities with a `NULL` value in the `levels` column of the `activities` table, to allow the migration to complete successfully.

This caused the deployment to staging to fail.