### PR TITLE
Fix puzzling test result ordering bug

### DIFF
--- a/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "users can upload planned disbursements" do
     it "puts no value in all forecast columns by default" do
       rows = CSV.parse(@csv_data, headers: true).map(&:to_h)
 
-      expect(rows.first).to eq({
+      expect(rows).to include({
         "Activity Name" => project.title,
         "Activity Delivery Partner Identifier" => project.delivery_partner_identifier,
         "Activity RODA Identifier" => project.roda_identifier,


### PR DESCRIPTION
The setup for the test in question generates a CSV containing two result rows. The order of these was consistently reversed on two developers' machines (including mine), whereas it was fine for another two.

Rather than spend to long puzzling over this strange issue, I've updated the test to check that the expected hash is *included* in `rows` rather than expecting it to be the first result.

We suspect something to do with Postgres versions (the two it was affecting are running older versions), but can't be certain.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
