### PR TITLE
(1602) Add total spend and total budget to the activity financials page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,6 +571,7 @@
 - Only set provided variables when updating via the CSV upload
 - Refactor handling of implementing organisations
 - Set all activity policy marker fields to `not_assessed` by default
+- Add total spend and total budget to the activity financials page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...HEAD
 [release-41]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-40...release-41

--- a/app/assets/stylesheets/partials/_definition_list.scss
+++ b/app/assets/stylesheets/partials/_definition_list.scss
@@ -7,3 +7,16 @@
     }
   }
 }
+
+.financial-summary {
+  .govuk-summary-list__key {
+    @include govuk-media-query($from: desktop) {
+      width: 50%;
+    }
+  }
+  .govuk-summary-list__value {
+    @include govuk-media-query($from: desktop) {
+      text-align: right;
+    }
+  }
+}

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -4,17 +4,18 @@ class Staff::ActivityFinancialsController < Staff::BaseController
   include Secured
 
   def show
-    @activity = Activity.find(params[:activity_id])
-    authorize @activity
+    activity = Activity.find(params[:activity_id])
+    authorize activity
 
-    @transactions = policy_scope(Transaction).where(parent_activity: @activity).order("date DESC")
-    @budgets = policy_scope(Budget).where(parent_activity: @activity).order("financial_year DESC")
-    @planned_disbursements = policy_scope(@activity.latest_planned_disbursements)
+    @transactions = policy_scope(Transaction).where(parent_activity: activity).order("date DESC")
+    @budgets = policy_scope(Budget).where(parent_activity: activity).order("financial_year DESC")
+    @planned_disbursements = policy_scope(activity.latest_planned_disbursements)
 
+    @activity = ActivityPresenter.new(activity)
     @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
     @budget_presenters = @budgets.includes(:parent_activity).map { |budget| BudgetPresenter.new(budget) }
     @planned_disbursement_presenters = @planned_disbursements.map { |planned_disbursement| PlannedDisbursementPresenter.new(planned_disbursement) }
-    @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
-    @transfers = @activity.source_transfers.map { |transfer| TransferPresenter.new(transfer) }
+    @implementing_organisation_presenters = activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
+    @transfers = activity.source_transfers.map { |transfer| TransferPresenter.new(transfer) }
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -270,6 +270,11 @@ class Activity < ApplicationRecord
     transactions.sum(:value)
   end
 
+  def total_budget
+    activity_ids = descendants.pluck(:id).append(id)
+    Budget.where(parent_activity_id: activity_ids).sum(:value)
+  end
+
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?
     super(context)

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -248,4 +248,8 @@ class ActivityPresenter < SimpleDelegator
 
     "#{item["code"]}: #{item["name"]}"
   end
+
+  def total_spend
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -252,4 +252,8 @@ class ActivityPresenter < SimpleDelegator
   def total_spend
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
+
+  def total_budget
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
 end

--- a/app/views/staff/activity_financials/show.html.haml
+++ b/app/views/staff/activity_financials/show.html.haml
@@ -21,6 +21,17 @@
           %h2.govuk-heading-l
             = t("page_title.activity.financials")
 
+          .govuk-grid-row
+            .govuk-grid-column-one-half
+              %h3.govuk-heading-m
+                Summary
+              %dl.govuk-summary-list.financial-summary
+                .govuk-summary-list__row
+                  %dt.govuk-summary-list__key
+                    Total spend to date
+                  %dd.govuk-summary-list__value
+                    = @activity.total_spend
+
           - if @activity.fund? && policy(:fund).create?
             = render partial: "staff/shared/activities/budgets",
               locals: { activity: @activity, budget_presenters: @budget_presenters }

--- a/app/views/staff/activity_financials/show.html.haml
+++ b/app/views/staff/activity_financials/show.html.haml
@@ -28,6 +28,11 @@
               %dl.govuk-summary-list.financial-summary
                 .govuk-summary-list__row
                   %dt.govuk-summary-list__key
+                    Total budget to date
+                  %dd.govuk-summary-list__value
+                    = @activity.total_budget
+                .govuk-summary-list__row
+                  %dt.govuk-summary-list__key
                     Total spend to date
                   %dd.govuk-summary-list__value
                     = @activity.total_spend

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -122,9 +122,10 @@ RSpec.feature "Users can view an activity" do
     scenario "the financial summary and activity financials can be viewed" do
       activity = create(:programme_activity, organisation: user.organisation)
       transaction = create(:transaction, parent_activity: activity, value: 10)
-      budget = create(:budget, parent_activity: activity)
+      budget = create(:budget, parent_activity: activity, value: 10)
 
       create(:transaction, parent_activity: activity, value: 50)
+      create(:budget, parent_activity: activity, value: 55)
 
       visit organisation_activity_financials_path(activity.organisation, activity)
       within ".govuk-tabs__list-item--selected" do
@@ -132,6 +133,7 @@ RSpec.feature "Users can view an activity" do
       end
       within ".financial-summary" do
         expect(page).to have_content "Total spend to date £60.00"
+        expect(page).to have_content "Total budget to date £65.00"
       end
       expect(page).to have_content transaction.value
       expect(page).to have_content budget.value

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -119,14 +119,19 @@ RSpec.feature "Users can view an activity" do
       end
     end
 
-    scenario "the activity financials can be viewed" do
+    scenario "the financial summary and activity financials can be viewed" do
       activity = create(:programme_activity, organisation: user.organisation)
-      transaction = create(:transaction, parent_activity: activity)
+      transaction = create(:transaction, parent_activity: activity, value: 10)
       budget = create(:budget, parent_activity: activity)
+
+      create(:transaction, parent_activity: activity, value: 50)
 
       visit organisation_activity_financials_path(activity.organisation, activity)
       within ".govuk-tabs__list-item--selected" do
         expect(page).to have_content "Financials"
+      end
+      within ".financial-summary" do
+        expect(page).to have_content "Total spend to date £60.00"
       end
       expect(page).to have_content transaction.value
       expect(page).to have_content budget.value

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1646,5 +1646,36 @@ RSpec.describe Activity, type: :model do
         end
       end
     end
+
+    describe "#total_budget" do
+      before do
+        create(:budget, value: 100, parent_activity: fund)
+        create(:budget, value: 100, parent_activity: programme1)
+        create(:budget, value: 100, parent_activity: programme2)
+        create(:budget, value: 50, parent_activity: programme1_projects[0])
+        create(:budget, value: 50, parent_activity: programme1_projects[1])
+        create(:budget, value: 100, parent_activity: programme2_projects[0])
+        create(:budget, value: 100, parent_activity: programme2_projects[1])
+        create(:budget, value: 100, parent_activity: programme1_third_party_project)
+        create(:budget, value: 100, parent_activity: programme2_third_party_project)
+      end
+
+      it "returns the total budget for a fund" do
+        expect(fund.total_budget).to eq(800)
+      end
+
+      it "returns the total budget for a programme" do
+        expect(programme1.total_budget).to eq(300)
+        expect(programme2.total_budget).to eq(400)
+      end
+
+      it "returns the total budget for a project" do
+        expect(programme1_projects[0].total_budget).to eq(150)
+        expect(programme1_projects[1].total_budget).to eq(50)
+
+        expect(programme2_projects[0].total_budget).to eq(100)
+        expect(programme2_projects[1].total_budget).to eq(200)
+      end
+    end
   end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -622,4 +622,12 @@ RSpec.describe ActivityPresenter do
       expect(described_class.new(activity).total_spend).to eq("£20.00")
     end
   end
+
+  describe "#total_budget" do
+    it "returns the value to two decimal places with a currency symbol" do
+      activity = build(:programme_activity)
+      create(:budget, parent_activity: activity, value: 50)
+      expect(described_class.new(activity).total_budget).to eq("£50.00")
+    end
+  end
 end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -614,4 +614,12 @@ RSpec.describe ActivityPresenter do
       expect(result.channel_of_delivery_code).to eq("20000: Non-Governmental Organisation (NGO) and Civil Society")
     end
   end
+
+  describe "#total_spend" do
+    it "returns the value to two decimal places with a currency symbol" do
+      activity = build(:programme_activity)
+      create(:transaction, parent_activity: activity, value: 20)
+      expect(described_class.new(activity).total_spend).to eq("£20.00")
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- Add total spend and total budget to the activity financials page

## Screenshots of UI changes

<img width="1287" alt="Screenshot 2021-03-29 at 16 16 31" src="https://user-images.githubusercontent.com/2804149/112858882-3603f080-90aa-11eb-9491-6be299b782dc.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
