### PR TITLE
Change channel of delivery code to radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,6 +577,7 @@
 
 - Data dictionary link opens in a new window/tab by default
 - Add supporting hint text about the soft limits to title and description
+- Change channel of delivery code to radio buttons
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...HEAD
 [release-42]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...release-42

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -179,13 +179,10 @@ module CodelistHelper
     iati_data = Codelist.new(type: "channel_of_delivery_code")
     beis_allowed_codes = beis_allowed_channel_of_delivery_codes
 
-    iati_data.select { |item| item["code"].in?(beis_allowed_codes) }
-  end
-
-  def channel_of_delivery_code_select_options
-    data = channel_of_delivery_codes
-    data.collect { |item|
-      OpenStruct.new(code: item["code"], name: "#{item["code"]}: #{item["name"]}")
-    }.compact.sort_by(&:code).unshift(OpenStruct.new(code: "", name: "Please select a value"))
+    iati_data.select { |item|
+      item["code"].in?(beis_allowed_codes)
+    }.map { |item|
+      OpenStruct.new(name: "#{item["code"]}: #{item["name"]}", code: item["code"])
+    }
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -243,10 +243,11 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def channel_of_delivery_code
-    item = channel_of_delivery_codes.find { |item| item["code"] == super }
+    item = channel_of_delivery_codes.find { |item| item.code == super }
+
     return if item.blank?
 
-    "#{item["code"]}: #{item["name"]}"
+    item.name
   end
 
   def total_spend

--- a/app/views/staff/activity_forms/channel_of_delivery_code.html.haml
+++ b/app/views/staff/activity_forms/channel_of_delivery_code.html.haml
@@ -1,7 +1,6 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_collection_select :channel_of_delivery_code,
-                              channel_of_delivery_code_select_options,
-                              :code,
-                              :name,
-                              options: { selected: f.object.channel_of_delivery_code },
-                              label: { tag: 'h1', size: 'xl' }
+  = f.govuk_collection_radio_buttons :channel_of_delivery_code,
+                                      channel_of_delivery_codes,
+                                      :code,
+                                      :name,
+                                      legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.channel_of_delivery_code") }

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -248,26 +248,8 @@ RSpec.describe CodelistHelper, type: :helper do
       it "returns items with their IATI code and name" do
         first_item = helper.channel_of_delivery_codes.first
 
-        expect(first_item.fetch("code")).to eql "11000"
-        expect(first_item.fetch("name")).to eql "Donor Government"
-      end
-    end
-
-    describe "#channel_of_delivery_code_select_options" do
-      it "returns a list of options starting with an empty item" do
-        options = helper.channel_of_delivery_code_select_options
-
-        first_option = options.first
-        expect(first_option.code).to eql ""
-        expect(first_option.name).to eql "Please select a value"
-      end
-
-      it "returns a list of options where the value is the IATI code and the name is the IATI code plus the IATI name" do
-        options = helper.channel_of_delivery_code_select_options
-
-        second_option = options[1]
-        expect(second_option.code).to eql "11000"
-        expect(second_option.name).to eql "11000: Donor Government"
+        expect(first_item.code).to eql "11000"
+        expect(first_item.name).to eql "11000: Donor Government"
       end
     end
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -295,7 +295,7 @@ module FormHelpers
 
     if level == "project" || level == "third_party_project"
       expect(page).to have_content t("form.legend.activity.channel_of_delivery_code")
-      select channel_of_delivery_code, from: "activity[channel_of_delivery_code]"
+      choose("activity[channel_of_delivery_code]", option: channel_of_delivery_code)
       click_button t("form.button.activity.submit")
     end
 


### PR DESCRIPTION
This changes the channel of delivery code options to radio buttons, rather than a select, as recent usability testing that radio buttons are easier to use to report with. I've also changed the labels to be consistent with how we display them in the details tab.

![image](https://user-images.githubusercontent.com/109774/113009364-c8ba9300-916f-11eb-940b-314516b469c5.png)


