### PR TITLE
(1639) Introduce "create_child?" method to ActivityPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,6 +581,7 @@
 - Collect transferred and external budget types
 - Show the type of budget in the application
 - Remove limit on the number of intended beneficiaries
+- Introduce `create_child?` check in ActivityPolicy
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...HEAD
 [release-42]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...release-42

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -10,7 +10,7 @@ class ActivityPolicy < ApplicationPolicy
     if beis_user?
       return true if record.fund? || record.programme?
     end
-    return false if editable_report_for_organisation_and_fund.nil?
+    return false unless editable_report?
     record.organisation == user.organisation
   end
 
@@ -24,7 +24,7 @@ class ActivityPolicy < ApplicationPolicy
     if delivery_partner_user?
       return false if record.organisation != user.organisation
       return false if record.fund? || record.programme?
-      return false if editable_report_for_organisation_and_fund.nil?
+      return false unless editable_report?
       return true
     end
     false
@@ -47,8 +47,9 @@ class ActivityPolicy < ApplicationPolicy
     end
   end
 
-  private def editable_report_for_organisation_and_fund
-    fund = record.associated_fund
-    Report.editable.find_by(organisation: record.organisation, fund: fund)
+  private
+
+  def editable_report?
+    Report.editable.for_activity(record).exists?
   end
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -10,7 +10,7 @@ class ActivityPolicy < ApplicationPolicy
     if beis_user?
       return true if record.fund? || record.programme?
     end
-    return false if editable_report_for_organisation.nil?
+    return false if editable_report_for_organisation_and_fund.nil?
     record.organisation == user.organisation
   end
 
@@ -47,12 +47,8 @@ class ActivityPolicy < ApplicationPolicy
     end
   end
 
-  private def editable_report_for_organisation
-    Report.editable.find_by(organisation: record.organisation)
-  end
-
   private def editable_report_for_organisation_and_fund
-    fund = record.parent.associated_fund
+    fund = record.associated_fund
     Report.editable.find_by(organisation: record.organisation, fund: fund)
   end
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -14,6 +14,15 @@ class ActivityPolicy < ApplicationPolicy
     record.organisation == user.organisation
   end
 
+  def create_child?
+    return record.fund? if beis_user?
+
+    return false if record.third_party_project?
+    return false unless editable_report?
+
+    record.extending_organisation == user.organisation
+  end
+
   def edit?
     update?
   end
@@ -50,6 +59,11 @@ class ActivityPolicy < ApplicationPolicy
   private
 
   def editable_report?
-    Report.editable.for_activity(record).exists?
+    fund = record.associated_fund
+
+    Report.editable.where(
+      fund: fund,
+      organisation: [record.extending_organisation, record.organisation]
+    ).exists?
   end
 end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
+
+      it { is_expected.to permit_action(:create_child) }
     end
 
     context "when the activity is a programme" do
@@ -31,6 +33,8 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
+
+      it { is_expected.to forbid_action(:create_child) }
     end
 
     context "when the activity is a project" do
@@ -43,6 +47,8 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
+
+      it { is_expected.to forbid_action(:create_child) }
     end
 
     context "when the activity is a third-party project" do
@@ -55,6 +61,8 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
+
+      it { is_expected.to forbid_action(:create_child) }
     end
   end
 
@@ -70,6 +78,8 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
+
+      it { is_expected.to forbid_action(:create_child) }
     end
 
     context "when the activity is a programme" do
@@ -82,6 +92,8 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
         it { is_expected.to forbid_action(:redact_from_iati) }
+
+        it { is_expected.to forbid_action(:create_child) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -96,6 +108,16 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
         it { is_expected.to forbid_action(:redact_from_iati) }
+
+        it { is_expected.to forbid_action(:create_child) }
+
+        context "and there is an editable report for the users organisation" do
+          before do
+            report.update(state: :active)
+          end
+
+          it { is_expected.to permit_action(:create_child) }
+        end
       end
     end
 
@@ -109,6 +131,8 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
         it { is_expected.to forbid_action(:redact_from_iati) }
+
+        it { is_expected.to forbid_action(:create_child) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -124,6 +148,8 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to forbid_action(:update) }
           it { is_expected.to forbid_action(:destroy) }
           it { is_expected.to forbid_action(:redact_from_iati) }
+
+          it { is_expected.to forbid_action(:create_child) }
         end
 
         context "and there is an editable report for the users organisation" do
@@ -138,6 +164,8 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to forbid_action(:destroy) }
           it { is_expected.to forbid_action(:redact_from_iati) }
+
+          it { is_expected.to permit_action(:create_child) }
         end
       end
     end
@@ -152,6 +180,8 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
         it { is_expected.to forbid_action(:redact_from_iati) }
+
+        it { is_expected.to forbid_action(:create_child) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -167,6 +197,8 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to forbid_action(:update) }
           it { is_expected.to forbid_action(:destroy) }
           it { is_expected.to forbid_action(:redact_from_iati) }
+
+          it { is_expected.to forbid_action(:create_child) }
         end
 
         context "and there is an editable report for the users organisation" do
@@ -181,6 +213,8 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to forbid_action(:destroy) }
           it { is_expected.to forbid_action(:redact_from_iati) }
+
+          it { is_expected.to forbid_action(:create_child) }
         end
       end
     end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ActivityPolicy do
-  let(:report) { create(:report, organisation: user.organisation) }
+  let!(:report) { create(:report, organisation: user.organisation, fund: activity.associated_fund, state: :approved) }
   let(:user) { build_stubbed(:beis_user) }
 
   subject { described_class.new(user, activity) }
@@ -117,10 +117,6 @@ RSpec.describe ActivityPolicy do
         end
 
         context "and there is no editable report for the users organisation" do
-          before do
-            report.update(state: :approved)
-          end
-
           it { is_expected.to permit_action(:show) }
 
           it { is_expected.to forbid_action(:create) }
@@ -135,28 +131,13 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          context "and the associated fund is not the same as the activity" do
-            it { is_expected.to permit_action(:show) }
+          it { is_expected.to permit_action(:show) }
+          it { is_expected.to permit_action(:create) }
+          it { is_expected.to permit_action(:edit) }
+          it { is_expected.to permit_action(:update) }
 
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
-            it { is_expected.to forbid_action(:redact_from_iati) }
-          end
-
-          context "and the associated fund is the same as the activity" do
-            before do
-              report.update(fund: activity.associated_fund)
-            end
-
-            it { is_expected.to permit_action(:show) }
-            it { is_expected.to permit_action(:create) }
-            it { is_expected.to permit_action(:edit) }
-            it { is_expected.to permit_action(:update) }
-
-            it { is_expected.to forbid_action(:destroy) }
-            it { is_expected.to forbid_action(:redact_from_iati) }
-          end
+          it { is_expected.to forbid_action(:destroy) }
+          it { is_expected.to forbid_action(:redact_from_iati) }
         end
       end
     end
@@ -179,10 +160,6 @@ RSpec.describe ActivityPolicy do
         end
 
         context "and there is no editable report for the users organisation" do
-          before do
-            report.update(state: :approved)
-          end
-
           it { is_expected.to permit_action(:show) }
 
           it { is_expected.to forbid_action(:create) }
@@ -197,28 +174,13 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          context "and the associated fund is not the same as the activity" do
-            it { is_expected.to permit_action(:show) }
+          it { is_expected.to permit_action(:show) }
+          it { is_expected.to permit_action(:create) }
+          it { is_expected.to permit_action(:edit) }
+          it { is_expected.to permit_action(:update) }
 
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
-            it { is_expected.to forbid_action(:redact_from_iati) }
-          end
-
-          context "and the associated fund is the same as the activity" do
-            before do
-              report.update(fund: activity.associated_fund)
-            end
-
-            it { is_expected.to permit_action(:show) }
-            it { is_expected.to permit_action(:create) }
-            it { is_expected.to permit_action(:edit) }
-            it { is_expected.to permit_action(:update) }
-
-            it { is_expected.to forbid_action(:destroy) }
-            it { is_expected.to forbid_action(:redact_from_iati) }
-          end
+          it { is_expected.to forbid_action(:destroy) }
+          it { is_expected.to forbid_action(:redact_from_iati) }
         end
       end
     end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActivityPolicy do
     let(:user) { create(:beis_user) }
 
     context "when the activity is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      let(:activity) { create(:fund_activity, organisation: user.organisation, extending_organisation: user.organisation) }
 
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:create) }
@@ -102,7 +102,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the activity does not belong to the same organisation as the user" do
+      context "and the users organisation is not the extending organisation" do
         it { is_expected.to forbid_action(:show) }
         it { is_expected.to forbid_action(:create) }
         it { is_expected.to forbid_action(:edit) }
@@ -111,12 +111,16 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:redact_from_iati) }
       end
 
-      context "and the activity belongs to the same organisation as the user" do
+      context "and the users organisation is the extending organisation" do
         before do
-          activity.update(organisation: user.organisation)
+          activity.update(organisation: user.organisation, extending_organisation: user.organisation)
         end
 
-        context "when there is no editable report for the users organisation" do
+        context "and there is no editable report for the users organisation" do
+          before do
+            report.update(state: :approved)
+          end
+
           it { is_expected.to permit_action(:show) }
 
           it { is_expected.to forbid_action(:create) }
@@ -126,7 +130,7 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to forbid_action(:redact_from_iati) }
         end
 
-        context "when there is an editable report for the users organisation" do
+        context "and there is an editable report for the users organisation" do
           before do
             report.update(state: :active)
           end


### PR DESCRIPTION
Currently the only way to determine whether an activity can be created at a particular level is to check using `ActivityPolicy.create?`. This doesn't really work when you're trying to run this check against an activity that doesn't yet exist. This means we're forced to call the `create?` check without passing in a given activity, which means we're unable to check for an editable report, for example.

Instead of doing this, we introduce a new method `ActivityPolicy.create_child?`. Asking the parent activity whether a child can be created under it means we have enough information to give an accurate response.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
