### PR TITLE
(1642) Remove the limit on the number of intended beneficiaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,7 @@
 - Change channel of delivery code to radio buttons
 - Collect transferred and external budget types
 - Show the type of budget in the application
+- Remove limit on the number of intended beneficiaries
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...HEAD
 [release-42]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-41...release-42

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -103,7 +103,7 @@ class Activity < ApplicationRecord
   validates :recipient_region, presence: true, on: :region_step, if: :recipient_region?
   validates :recipient_country, presence: true, on: :country_step, if: :recipient_country?
   validates :requires_additional_benefitting_countries, inclusion: {in: [true, false], message: I18n.t("activerecord.errors.models.activity.attributes.requires_additional_benefitting_countries.blank")}, on: :requires_additional_benefitting_countries_step
-  validates :intended_beneficiaries, presence: true, length: {maximum: 10}, on: :intended_beneficiaries_step, if: :requires_additional_benefitting_countries?
+  validates :intended_beneficiaries, presence: true, on: :intended_beneficiaries_step, if: :requires_additional_benefitting_countries?
   validates :gdi, presence: true, on: :gdi_step
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :covid19_related, presence: true, on: :covid19_related_step

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -178,7 +178,7 @@ en:
         gcrf_challenge_area: Select the most relevant GCRF challenge area for this activity. For broad programme calls, please select the challenge area most commonly represented across the individual projects within the programme. If the activity is a delivery line, you may select 'Not applicable'.
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India
         objectives: Please refrain from using any abbreviations
-        intended_beneficiaries: You can select up to 10 different countries
+        intended_beneficiaries: Select all that apply
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         oda_eligibility_lead: This will be used by us as a first point of contact for anything ODA related.
         planned_end_date: For example, 28 11 2020

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -58,36 +58,6 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
         expect(activity.intended_beneficiaries).to eq(["GM", "ID", "YE"])
         expect(page).to have_current_path(activity_step_path(activity, :gdi))
       end
-
-      scenario "the user will not be able to select more than 10 intended beneficiaries" do
-        visit activity_step_path(activity, :geography)
-        choose "Country"
-        click_button t("form.button.activity.submit")
-        expect(page).to have_select(t("form.label.activity.recipient_country"))
-
-        select "Burundi"
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
-        choose "Yes"
-        click_button t("form.button.activity.submit")
-
-        expect(page).to have_content t("form.legend.activity.intended_beneficiaries")
-        check "Comoros"
-        check "Eritrea"
-        check "Ethiopia"
-        check "Kenya"
-        check "Madagascar"
-        check "Mozambique"
-        check "Somalia"
-        check "Sudan"
-        check "Tanzania"
-        check "Uganda"
-        check "Zambia"
-        click_button t("form.button.activity.submit")
-
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.intended_beneficiaries.too_long")
-        expect(activity.intended_beneficiaries).to be_nil
-      end
     end
   end
 end


### PR DESCRIPTION
This is required in order to import data for new partners, whose
activities may exceed the limit currently in place.