### PR TITLE
Fix brittle transfer tests

### DIFF
--- a/spec/features/staff/beis_users_can_create_a_transfer_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_transfer_spec.rb
@@ -11,14 +11,19 @@ RSpec.feature "BEIS users can create a transfer" do
   end
 
   scenario "successfully creates a transfer" do
-    transfer = fill_in_transfer_form
+    quarter = FinancialQuarter.for_date(Date.today)
+
+    transfer = fill_in_transfer_form(
+      financial_quarter: quarter.to_i,
+      financial_year: quarter.financial_year.to_i
+    )
 
     click_on t("form.button.transfer.submit")
 
     expect(page).to have_content(t("page_title.transfer.confirm"))
     expect(page).to have_content(transfer.destination.title)
     expect(page).to have_content(transfer.destination.organisation.name)
-    expect(page).to have_content(FinancialQuarter.new(2020, 1).to_s)
+    expect(page).to have_content(quarter.to_s)
     expect(page).to have_content("£1,234.00")
 
     expect {
@@ -38,7 +43,7 @@ RSpec.feature "BEIS users can create a transfer" do
     within "#transfers" do
       expect(page).to have_content(transfer.destination.roda_identifier)
       expect(page).to have_content(transfer.destination.organisation.name)
-      expect(page).to have_content(FinancialQuarter.new(2020, 1).to_s)
+      expect(page).to have_content(quarter.to_s)
       expect(page).to have_content("£1,234.00")
     end
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -475,7 +475,7 @@ module FormHelpers
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
   end
 
-  def fill_in_transfer_form(destination: create(:activity), financial_quarter: 1, financial_year: 2020, value: 1234)
+  def fill_in_transfer_form(destination: create(:activity), financial_quarter: FinancialQuarter.for_date(Date.today).to_i, financial_year: FinancialYear.for_date(Date.today).to_i, value: 1234)
     transfer = build(
       :transfer,
       destination: destination,


### PR DESCRIPTION
Now we've moved into a new financial year, the tests for the transfers were breaking, as the financial years and quarters were hardcoded to the previous financial year. To fix this, I've set the parameters to always default to the current financial year and quarter.