### PR TITLE
(1652) Activity uploads interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,7 @@
 ## [unreleased]
 
 - Change policy markers to radio buttons
+- The activity upload UI looks similar to the actuals and forecasts upload UI
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-43...HEAD
 [release-43]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...release-43

--- a/app/controllers/staff/activity_uploads_controller.rb
+++ b/app/controllers/staff/activity_uploads_controller.rb
@@ -22,6 +22,7 @@ class Staff::ActivityUploadsController < Staff::BaseController
   def update
     @report_presenter = ReportPresenter.new(@report)
     upload = CsvFileUpload.new(params[:report], :activity_csv)
+    @success = false
 
     if upload.valid?
       importer = Activities::ImportFromCsv.new(organisation: current_user.organisation)
@@ -29,6 +30,7 @@ class Staff::ActivityUploadsController < Staff::BaseController
       @errors = importer.errors
 
       if @errors.empty?
+        @success = true
         flash.now[:notice] = t("action.activity.upload.success")
       end
     else

--- a/app/views/staff/activity_uploads/_upload_form.html.haml
+++ b/app/views/staff/activity_uploads/_upload_form.html.haml
@@ -1,9 +1,9 @@
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     = form_for @report_presenter, url: report_activity_upload_path(@report_presenter) do |f|
 
       = f.govuk_file_field :activity_csv,
-        label: { text: t("form.label.activity.csv_file") },
-        hint: { text: t("form.hint.activity.csv_file") }
+        label: { text: t("form.label.activity.csv_file_recover_from_error") },
+        hint: { text: t("form.hint.activity.csv_file_recover_from_error_html", link: report_activity_upload_path(@report_presenter, format: :csv)) }
 
       = f.govuk_submit t("action.activity.upload.button")

--- a/app/views/staff/activity_uploads/new.html.haml
+++ b/app/views/staff/activity_uploads/new.html.haml
@@ -8,7 +8,17 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body.govuk-heading-m
+      %h2.govuk-heading-m
         = link_to t("action.activity.download.button"), report_activity_upload_path(@report_presenter, format: :csv), class: "govuk-link"
 
-  = render partial: "upload_form"
+      %p.govuk-body
+        = t("action.activity.download.hint_html")
+
+      .govuk-body.upload-form
+        = form_for @report_presenter, url: report_activity_upload_path(@report_presenter) do |f|
+
+          = f.govuk_file_field :activity_csv,
+            label: { text: t("form.label.activity.csv_file") },
+            hint: { text: t("form.hint.activity.csv_file") }
+
+          = f.govuk_submit t("action.activity.upload.button")

--- a/app/views/staff/activity_uploads/new.html.haml
+++ b/app/views/staff/activity_uploads/new.html.haml
@@ -5,7 +5,8 @@
         = t("page_title.activity.upload")
 
   .govuk-grid-row
-    .govuk-grid-column-full.page-actions
-      = link_to t("action.activity.download.button"), report_activity_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+    .govuk-grid-column-two-thirds
+      %p.govuk-body.govuk-heading-m
+        = link_to t("action.activity.download.button"), report_activity_upload_path(@report_presenter, format: :csv), class: "govuk-link"
 
   = render partial: "upload_form"

--- a/app/views/staff/activity_uploads/new.html.haml
+++ b/app/views/staff/activity_uploads/new.html.haml
@@ -1,3 +1,5 @@
+= content_for :page_title_prefix, t("page_title.activity.upload")
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/staff/activity_uploads/update.html.haml
+++ b/app/views/staff/activity_uploads/update.html.haml
@@ -11,4 +11,5 @@
       .govuk-grid-column-full
         = render partial: "error_table"
 
-  = render partial: "upload_form"
+  - unless @success
+    = render partial: "upload_form"

--- a/app/views/staff/activity_uploads/update.html.haml
+++ b/app/views/staff/activity_uploads/update.html.haml
@@ -1,3 +1,5 @@
+= content_for :page_title_prefix, t("page_title.activity.upload")
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -4,7 +4,8 @@ en:
     activity:
       add_child: Add child activity
       download:
-        button: Download activity CSV template
+        button: Download CSV template
+        hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update activities related to your current report.</p><p class='govuk-body'>Edit it to add the values for your organisation's activities, then upload it through the form.</p>"
       upload:
         button: Upload and continue
         file_missing_or_invalid: Please upload a valid CSV file
@@ -108,7 +109,7 @@ en:
           "true": "Yes"
           "false": "No"
         uk_dp_named_contact: Who is the UK delivery partner named contact for this activity?
-        csv_file: Activity spreadsheet
+        csv_file: Upload CSV spreadsheet
     legend:
       activity:
         aid_type: What is the aid type?
@@ -215,7 +216,7 @@ en:
             "D01": "Experts, consultants, teachers, academics, researchers, volunteers and contributions to public and private bodies for sending experts to developing countries."
             "D02": "Provision of technical assistance in recipient countries outside of project described in project-type interventions (C01). This includes conferences, workshops and seminars but does not include activities such as scholarships/training described in (E01)"
             "G01": "Costs of development assistance programmes not already included under other ODA items as an integral part of the costs of delivering or implementing the aid provided. This includes delivery costs and in-house agency staff and contractors but not donor experts and consultants"
-        csv_file: Upload a spreadsheet containing activity information in CSV format.
+        csv_file: Upload a spreadsheet containing activity data in CSV format.
       organisation:
         hint: The organisation this activity is associated with
   summary:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -110,6 +110,7 @@ en:
           "false": "No"
         uk_dp_named_contact: Who is the UK delivery partner named contact for this activity?
         csv_file: Upload CSV spreadsheet
+        csv_file_recover_from_error: Re-upload CSV spreadsheet
     legend:
       activity:
         aid_type: What is the aid type?
@@ -217,6 +218,7 @@ en:
             "D02": "Provision of technical assistance in recipient countries outside of project described in project-type interventions (C01). This includes conferences, workshops and seminars but does not include activities such as scholarships/training described in (E01)"
             "G01": "Costs of development assistance programmes not already included under other ODA items as an integral part of the costs of delivering or implementing the aid provided. This includes delivery costs and in-house agency staff and contractors but not donor experts and consultants"
         csv_file: Upload a spreadsheet containing activity data in CSV format.
+        csv_file_recover_from_error_html: Upload a spreadsheet containing activity data in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
       organisation:
         hint: The organisation this activity is associated with
   summary:


### PR DESCRIPTION
## Changes in this PR
- The activity upload UI looks similar to the actuals and forecasts upload UI

## Screenshots of UI changes

### Before

*Upload page*
<img width="1140" alt="Screenshot 2021-04-01 at 17 17 55" src="https://user-images.githubusercontent.com/579522/113323801-4e744500-930e-11eb-8aa3-fcb431ddcedd.png">

*Post-upload page*
<img width="1126" alt="Screenshot 2021-04-01 at 17 18 04" src="https://user-images.githubusercontent.com/579522/113323913-6b107d00-930e-11eb-9cea-a990f438fb9f.png">

### After

*Upload page*
<img width="758" alt="Screenshot 2021-04-01 at 17 17 02" src="https://user-images.githubusercontent.com/579522/113323964-7794d580-930e-11eb-8ad0-12e44957ce1f.png">

*Post-upload page*
<img width="1133" alt="Screenshot 2021-04-01 at 17 17 16" src="https://user-images.githubusercontent.com/579522/113323994-7ebbe380-930e-11eb-941e-d41e057fd0e6.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
