### PR TITLE
Add script for converting import data files

### DIFF
--- a/app/services/import_converter.rb
+++ b/app/services/import_converter.rb
@@ -1,0 +1,94 @@
+class ImportConverter
+  TRANSACTION_HEADER_PATTERNS = [
+    /^Act +(?<year>\d{4})\/\d{2} +FY +Q(?<quarter>[1-4]) +\(.*\)$/,
+    /^Act +(?<year>\d{4})\/\d{2} +Q(?<quarter>[1-4])$/,
+    /^Q(?<quarter>[1-4]) +(?<year>\d{4})-\d{4} actuals$/,
+  ]
+
+  FORECAST_HEADER_PATTERNS = [
+    /^FC +Q(?<quarter>[1-4]) +(?<year>\d{4})-\d{2}$/,
+    /^FC +Q(?<quarter>[1-4]) +(?<year>\d{4})$/,
+    /^FC +(?<year>\d{4})\/\d{2} +FY +Q(?<quarter>[1-4]) +\(.*\)$/,
+    /^Q(?<quarter>[1-4]) +(?<year>\d{4})-\d{4} forecast$/,
+  ]
+
+  IDENTIFIER_HEADERS = ["Activity RODA Identifier"]
+  TRANSACTION_HEADERS = ["Financial Year", "Financial Quarter", "Value"].freeze
+
+  LEVEL_C = "C"
+  LEVEL_D = "D"
+
+  def initialize(row, level:, forecast_mappings: nil)
+    @row = row
+    @level = level
+    @forecast_mappings = forecast_mappings
+  end
+
+  def transaction_headers
+    IDENTIFIER_HEADERS + TRANSACTION_HEADERS
+  end
+
+  def transaction_tuples
+    tuples = []
+
+    @row.each do |header, value|
+      year, quarter = match_quarter(header, TRANSACTION_HEADER_PATTERNS)
+      if year && quarter && value.strip != "0"
+        tuples << identifier_tuple + [year, quarter, value]
+      end
+    end
+
+    tuples
+  end
+
+  def forecast_headers
+    IDENTIFIER_HEADERS + forecast_mappings.map(&:first)
+  end
+
+  def forecast_tuples
+    tuple = forecast_mappings.map { |_, row_header| @row.fetch(row_header) }
+    [identifier_tuple + tuple]
+  end
+
+  def forecast_mappings
+    return @forecast_mappings if @forecast_mappings
+    @forecast_mappings = []
+
+    @row.each do |row_header, _|
+      year, quarter = match_quarter(row_header, FORECAST_HEADER_PATTERNS)
+      next unless year && quarter
+
+      output_header = forecast_header(year, quarter)
+      @forecast_mappings << [output_header, row_header]
+    end
+
+    @forecast_mappings.sort_by!(&:first)
+    @forecast_mappings
+  end
+
+  private
+
+  def identifier_tuple
+    separator = case @level
+      when LEVEL_C then "-"
+      when LEVEL_D then ""
+    end
+
+    id_parts = @row.values_at("Parent RODA ID", "RODA ID Fragment")
+    [id_parts.join(separator)]
+  end
+
+  def forecast_header(year, quarter)
+    next_year = (year.to_i + 1) % 100
+    "FC #{year}/#{next_year} FY Q#{quarter}"
+  end
+
+  def match_quarter(header, patterns)
+    patterns.each do |pattern|
+      match = pattern.match(header)
+      return [match[:year], match[:quarter]] if match
+    end
+
+    nil
+  end
+end

--- a/script/convert_import.rb
+++ b/script/convert_import.rb
@@ -1,0 +1,40 @@
+require "csv"
+require "optparse"
+require_relative "../app/services/import_converter"
+
+parser = OptionParser.new { |args|
+  args.on "-i", "--input FILE"
+  args.on "-o", "--output FILE"
+  args.on "-l", "--level LEVEL"
+}
+
+options = {}
+parser.parse!(into: options)
+
+level = options.fetch(:level).upcase
+rows = CSV.read(options.fetch(:input), headers: true)
+
+output = options.fetch(:output)
+transaction_output = CSV.open("#{output}_transactions.csv", "w")
+forecast_output = CSV.open("#{output}_forecasts.csv", "w")
+
+first_row = ImportConverter.new(rows.first, level: level)
+forecast_mappings = first_row.forecast_mappings
+
+transaction_output << first_row.transaction_headers
+forecast_output << first_row.forecast_headers
+
+rows.each do |row|
+  converter = ImportConverter.new(row, level: level, forecast_mappings: forecast_mappings)
+
+  converter.transaction_tuples.each do |tuple|
+    transaction_output << tuple
+  end
+
+  converter.forecast_tuples.each do |tuple|
+    forecast_output << tuple
+  end
+end
+
+transaction_output.close
+forecast_output.close

--- a/spec/services/import_converter_spec.rb
+++ b/spec/services/import_converter_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe ImportConverter do
+  let(:activity_level) { "C" }
+  let(:forecast_mappings) { nil }
+
+  let :converter do
+    ImportConverter.new(input_row, level: activity_level, forecast_mappings: forecast_mappings)
+  end
+
+  describe "transaction data" do
+    let :input_row do
+      {
+        "Parent RODA ID" => "AAA-BBB",
+        "RODA ID Fragment" => "CCC",
+        "Act 2020/21 Q1" => "90",
+        "Act 2020/21 FY Q2 (Jul, Aug, Sep)" => "70",
+        "Q3 2020-2021 actuals" => "50",
+        "Act 2020/21 Q4" => "0",
+        "Q3 2020-2021 forecast" => "40",
+      }
+    end
+
+    it "returns the transaction importer column headers" do
+      expect(converter.transaction_headers).to eq([
+        "Activity RODA Identifier",
+        "Financial Year",
+        "Financial Quarter",
+        "Value",
+      ])
+    end
+
+    it "recognises all transaction headers" do
+      expect(converter.transaction_tuples).to eq([
+        ["AAA-BBB-CCC", "2020", "1", "90"],
+        ["AAA-BBB-CCC", "2020", "2", "70"],
+        ["AAA-BBB-CCC", "2020", "3", "50"],
+      ])
+    end
+
+    context "for level D activities" do
+      let(:activity_level) { "D" }
+
+      it "does not insert '-' between the ID fragments" do
+        expect(converter.transaction_tuples).to eq([
+          ["AAA-BBBCCC", "2020", "1", "90"],
+          ["AAA-BBBCCC", "2020", "2", "70"],
+          ["AAA-BBBCCC", "2020", "3", "50"],
+        ])
+      end
+    end
+  end
+
+  describe "forecast data" do
+    let :input_row do
+      {
+        "Parent RODA ID" => "AAA-BBB",
+        "RODA ID Fragment" => "CCC",
+        "FC Q1 2020-21" => "90",
+        "FC Q2 2020" => "80",
+        "Q3 2020-2021 forecast" => "70",
+        "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "60",
+        "Q3 2020-2021 actuals" => "50",
+      }
+    end
+
+    it "returns the forecast importer column headers" do
+      expect(converter.forecast_headers).to eq([
+        "Activity RODA Identifier",
+        "FC 2020/21 FY Q1",
+        "FC 2020/21 FY Q2",
+        "FC 2020/21 FY Q3",
+        "FC 2020/21 FY Q4",
+      ])
+    end
+
+    it "recognises all forecast headers" do
+      expect(converter.forecast_tuples).to eq([
+        ["AAA-BBB-CCC", "90", "80", "70", "60"],
+      ])
+    end
+
+    it "returns forecast column mappings" do
+      expect(converter.forecast_mappings).to eq([
+        ["FC 2020/21 FY Q1", "FC Q1 2020-21"],
+        ["FC 2020/21 FY Q2", "FC Q2 2020"],
+        ["FC 2020/21 FY Q3", "Q3 2020-2021 forecast"],
+        ["FC 2020/21 FY Q4", "FC 2020/21 FY Q4 (Jan, Feb, Mar)"],
+      ])
+    end
+
+    context "when given forecast mappings explicitly" do
+      let :forecast_mappings do
+        [
+          ["FC 2020/21 FY Q3", "Q3 2020-2021 forecast"],
+          ["FC 2020/21 FY Q2", "FC Q2 2020"],
+          ["FC 2020/21 FY Q4", "FC 2020/21 FY Q4 (Jan, Feb, Mar)"],
+        ]
+      end
+
+      it "returns forecast values in the matching order" do
+        expect(converter.forecast_tuples).to eq([
+          ["AAA-BBB-CCC", "70", "80", "60"],
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
To perform the initial import of new delivery partners' records into
RODA, we need to take the spreadsheets they've provided and convert them
into the schema supported by the transaction and forecast importers.

To run the script:

    $ ruby script/convert_import.rb \
        --level C \
        --input path/to/input_file.csv \
        --output path/to/output

This reads the data from `path/to/input_file.csv` and writes two new
files: `path/to/output_transactions.csv` and
`path/to/output_forecasts.csv`, which will be compatible with our
existing importers. It does not write anything to the database or
interact with the application in any other way, it purely converts one
CSV file into two others.

The `--level` option must be either `C` or `D` to indicate the level of
the activities being imported.

The main job of this converter is to recognise the various ways that
identifiers, transactions and forecasts are represented in the files
we've been provided, and canonicalise them.

Identifiers are presented as two columns: `Parent RODA ID` and `RODA ID
Fragment`, as is usual for creating new activities. To build the RODA ID
of the new activity we combine these fields with either `-` at level C
or the empty string at level D.

Transactions are presented column-wise, whereas our importer expects
them row-wise, with these standard columns:

    Activity RODA Identifier
    Financial Year
    Financial Quarter
    Value

So we convert a single input row into multiple possible output rows by
matching column headings that represent transactions. We recognise the
following formats that we have observed in files provided to us:

    Act <yyyy>/<yy> FY Q<q> (<month>, <month>, <month>)
    Act <yyyy>/<yy> Q<q>
    Q<q> <yyyy>-<yyyy> actuals

We extract the year and quarter from these and emit one row of output
for each column we find in the input.

Forecasts are presented column-wise and are also consumed column-wise by
our importer, but there are many different heading formats in the input
we've been given. They include:

    FC Q<q> <yyyy>-<yy>
    FC Q<q> <yyyy>
    FC <yyyy>/<yy> FY Q<q> (<month>, <month>, <month>)
    Q<q> <yyyy>-<yyyy> forecast

We recognise all these and emit a CSV with headings in the form
recognised by our importer:

    FC <yyyy>/<yy> FY Q<q>

Since this set of output columns is dynamic and we're emitting a single
CSV, we need to make sure all rows are emitted with the same set of
quarters in the same order. To achieve this, we use the first row of the
input to extract a set of `forecast_mappings` -- a list of the columns
we plan to emit along with their source column names in the input. We
pass these mappings in to convert each data row.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
