### PR TITLE
(1649) Change GCRF stategic area checkboxes to integers

### DIFF
--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -171,7 +171,7 @@ class ActivityPresenter < SimpleDelegator
 
   def gcrf_strategic_area
     return if super.blank?
-    gcrf_strategic_area_options.select { |area| super.include?(area.code.to_s) }
+    gcrf_strategic_area_options.select { |area| super.include?(area.code) }
       .map(&:description)
       .to_sentence
   end

--- a/db/migrate/20210406094816_change_gcrf_strategic_area_arrays_to_integers.rb
+++ b/db/migrate/20210406094816_change_gcrf_strategic_area_arrays_to_integers.rb
@@ -1,0 +1,23 @@
+class ChangeGcrfStrategicAreaArraysToIntegers < ActiveRecord::Migration[6.0]
+  def up
+    rename_column :activities, :gcrf_strategic_area, :gcrf_strategic_area_string
+    add_column :activities, :gcrf_strategic_area, :integer, array: true, default: []
+
+    Activity.where.not(gcrf_strategic_area_string: nil).all.each do |activity|
+      activity.gcrf_strategic_area = activity.gcrf_strategic_area_string.map(&:to_i)
+    end
+
+    remove_column :activities, :gcrf_strategic_area_string
+  end
+
+  def down
+    rename_column :activities, :gcrf_strategic_area, :gcrf_strategic_area_integer
+    add_column :activities, :gcrf_strategic_area, :string, array: true
+
+    Activity.where.not(gcrf_strategic_area_integer: []).all.each do |activity|
+      activity.gcrf_strategic_area = activity.gcrf_strategic_area_string.map(&:to_s)
+    end
+
+    remove_column :activities, :gcrf_strategic_area_integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_134730) do
+ActiveRecord::Schema.define(version: 2021_04_06_094816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_134730) do
     t.integer "programme_status"
     t.string "channel_of_delivery_code"
     t.integer "source_fund_code"
-    t.string "gcrf_strategic_area", array: true
+    t.integer "gcrf_strategic_area", default: [], array: true
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -236,7 +236,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(page).to have_content t("activerecord.errors.models.activity.attributes.gcrf_strategic_area.too_long")
 
       # GCRF strategic area (GCRF)
-      check "Resilient Futures"
+      uncheck "Resilient Futures"
       click_button t("form.button.activity.submit")
 
       expect(page).to have_content t("form.legend.activity.gcrf_challenge_area")

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
       expect(existing_activity.gdi).to eq("1")
-      expect(existing_activity.gcrf_strategic_area).to eq(["1", "3"])
+      expect(existing_activity.gcrf_strategic_area).to eq([1, 3])
       expect(existing_activity.gcrf_challenge_area).to eq(4)
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.fund_pillar).to eq(existing_activity_attributes["Newton Fund Pillar"].to_i)


### PR DESCRIPTION
This was  also causing issues where the `gcrf_strategic_area_options` were returning the code as an integer, but the codes were stored as a string. I looked into tweaking how the options were presented, or even changing the underlying YAML to made the codes into strings, but I finished up taking the approach that we should trust the codelist and if the codes are integers, so the data should be stored as an integer too.