### PR TITLE
Handle nil values in ImportConverter

### DIFF
--- a/app/services/import_converter.rb
+++ b/app/services/import_converter.rb
@@ -32,7 +32,9 @@ class ImportConverter
     tuples = []
 
     @row.each do |header, value|
+      next if value.blank?
       year, quarter = match_quarter(header, TRANSACTION_HEADER_PATTERNS)
+
       if year && quarter && value.strip != "0"
         tuples << identifier_tuple + [year, quarter, value]
       end


### PR DESCRIPTION
Ruby's CSV parse emits `nil` rather than an empty string for empty
cells, so we need to skip such values when extracting transactions and
forecasts from import data sets.