### PR TITLE
Remove byte order mark from the start of import files

### DIFF
--- a/app/services/import_converter.rb
+++ b/app/services/import_converter.rb
@@ -76,7 +76,7 @@ class ImportConverter
       when LEVEL_D then ""
     end
 
-    id_parts = @row.values_at("Parent RODA ID", "RODA ID Fragment")
+    id_parts = ["Parent RODA ID", "RODA ID Fragment"].map { |key| @row.fetch(key) }
     [id_parts.join(separator)]
   end
 

--- a/script/convert_import.rb
+++ b/script/convert_import.rb
@@ -3,6 +3,8 @@ require "optparse"
 require_relative "../config/environment"
 require_relative "../app/services/import_converter"
 
+BYTE_ORDER_MARK = "\uFEFF".encode(Encoding::UTF_8)
+
 parser = OptionParser.new { |args|
   args.on "-i", "--input FILE"
   args.on "-o", "--output FILE"
@@ -13,7 +15,9 @@ options = {}
 parser.parse!(into: options)
 
 level = options.fetch(:level).upcase
-rows = CSV.read(options.fetch(:input), headers: true)
+input_data = File.read(options.fetch(:input))
+input_data.delete_prefix!(BYTE_ORDER_MARK)
+rows = CSV.parse(input_data, headers: true)
 
 output = options.fetch(:output)
 transaction_output = CSV.open("#{output}_transactions.csv", "w")

--- a/script/convert_import.rb
+++ b/script/convert_import.rb
@@ -1,5 +1,6 @@
 require "csv"
 require "optparse"
+require_relative "../config/environment"
 require_relative "../app/services/import_converter"
 
 parser = OptionParser.new { |args|


### PR DESCRIPTION
Our script for extracting transactions and forecasts from import data
files was failing to recognise the first heading in CSV files because of
the presence of a byte order mark. We remove this before parsing.

We also make the converter throw an error if the ID columns it requires
are not present; `values_at` returns nil instead of throwing on
unrecognised keys.