### PR TITLE
(1648) Users cannot create or edit activites whilst there is no active report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -587,6 +587,7 @@
 
 - Change policy markers to radio buttons
 - The activity upload UI looks similar to the actuals and forecasts upload UI
+- Hide "Add child" buttons when users cannot create a child
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-43...HEAD
 [release-43]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...release-43

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -29,7 +29,7 @@ class Staff::OrganisationsController < Staff::BaseController
     respond_to do |format|
       format.html do
         @grouped_programmes = Activity.programme
-          .includes(:parent, :extending_organisation)
+          .includes(:extending_organisation, :organisation, parent: [:parent])
           .where(extending_organisation: organisation)
           .order(:roda_identifier_compound)
           .group_by(&:parent)

--- a/app/views/staff/organisations/_grouped_programmes.html.haml
+++ b/app/views/staff/organisations/_grouped_programmes.html.haml
@@ -25,6 +25,6 @@
                   %td{class: "govuk-table__cell"}
                     = activity.roda_identifier_compound
                   %td{class: "govuk-table__cell"}
-                    - if policy(:project).create?
+                    - if policy(activity).create_child?
                       = link_to(t("action.activity.add_child"), organisation_activity_children_path(activity.extending_organisation, activity), method: :post, class: "govuk-link govuk-!-margin-right-4")
                     = link_to(t("default.link.view"), organisation_activity_details_path(activity.extending_organisation, activity), class: "govuk-link govuk-!-margin-right-4")

--- a/app/views/staff/shared/activities/_projects.html.haml
+++ b/app/views/staff/shared/activities/_projects.html.haml
@@ -2,7 +2,7 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.projects")
-    - if policy(:project).create?
+    - if policy(activity).create_child?
       = form_tag(organisation_activity_children_path(activity.extending_organisation, activity), method: "post") do
         = submit_tag t("page_content.organisation.button.create_activity"), class: "govuk-button"
     = render partial: '/staff/shared/projects/table', locals: { projects: activities }

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -4,6 +4,16 @@ RSpec.feature "Users can create a project" do
     before { authenticate!(user: user) }
 
     context "when viewing a programme" do
+      scenario "a new project cannot be added to the programme when a report does not exist" do
+        programme = create(:programme_activity, :newton_funded, organisation: user.organisation, extending_organisation: user.organisation)
+
+        visit activities_path
+        click_on programme.title
+        click_on t("tabs.activity.children")
+
+        expect(page).to_not have_button(t("page_content.organisation.button.create_activity"))
+      end
+
       scenario "a new project can be added to the programme" do
         programme = create(:programme_activity, :newton_funded, organisation: user.organisation, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)

--- a/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -4,6 +4,16 @@ RSpec.feature "Users can create a third-party project" do
     before { authenticate!(user: user) }
 
     context "when viewing a project" do
+      scenario "a new third party project cannot be added to the programme when a report does not exist" do
+        project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
+
+        visit activities_path
+        click_on project.title
+        click_on t("tabs.activity.children")
+
+        expect(page).to_not have_button(t("action.activity.add_child"))
+      end
+
       scenario "a new third party project can be added to the project" do
         project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -244,8 +244,8 @@ RSpec.feature "Users can edit an activity" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).not_to have_content("Edit")
-        expect(page).not_to have_content("Add")
+        expect(page).not_to have_link(t("default.link.edit"))
+        expect(page).not_to have_link(t("default.link.add"))
       end
 
       scenario "it does not show the Publish to Iati field" do
@@ -258,6 +258,17 @@ RSpec.feature "Users can edit an activity" do
     end
 
     context "when the activity is a project" do
+      it "does not show edit/add actions if there is no report" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within ".activity-details" do
+          expect(page).not_to have_link(t("default.link.edit"))
+          expect(page).not_to have_link(t("default.link.add"))
+        end
+      end
+
       it "shows an update success message" do
         activity = create(:project_activity, organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -156,6 +156,17 @@ RSpec.feature "Users can view an organisation" do
       expect(page).to have_content t("form.label.activity.roda_identifier_fragment", level: "programme")
     end
 
+    scenario "cannot add a new child activity when a report does not exist" do
+      gcrf = create(:fund_activity, :gcrf)
+      programme = create(:programme_activity, parent: gcrf, extending_organisation: organisation)
+
+      visit organisation_path(organisation)
+
+      within(id: programme.id) do
+        expect(page).to_not have_link(t("action.activity.add_child"))
+      end
+    end
+
     scenario "does not see a back link on their organisation home page" do
       visit organisation_path(organisation)
 


### PR DESCRIPTION
This is already controlled by the ActivityPolicy, which means that a delivery partner can't create or edit an activity when there is no editable report. This PR just hides the "Add Child" buttons based on the policy - currently clicking on "Add child" will result in a "Not Authorised" error.

I've also added a test to make sure a delivery partner can't see "Add" or "Edit" links on any part of an Activity's details when there is no editable report. This is already the case, but gives us more confidence and documents the expected behaviour.