### PR TITLE
(1645) Make organisation and extending_organisation consistent

### DIFF
--- a/db/data/20210412134546_fix_extending_organisation_inconsistencies.rb
+++ b/db/data/20210412134546_fix_extending_organisation_inconsistencies.rb
@@ -1,0 +1,18 @@
+# Run me with `rails runner db/data/20210412134546_fix_extending_organisation_inconsistencies.rb`
+
+beis = Organisation.find_by(service_owner: true)
+
+Activity.fund.update_all(organisation_id: beis.id, extending_organisation_id: beis.id)
+
+Activity.programme.where.not(extending_organisation_id: beis.id).update_all(organisation_id: beis.id)
+
+Activity.project.update_all("extending_organisation_id = organisation_id")
+
+Activity.third_party_project.update_all("extending_organisation_id = organisation_id")
+
+bad_programmes = Activity.programme.where(extending_organisation_id: beis.id)
+
+if bad_programmes.any?
+  puts "Found #{bad_programmes.size} programme(s) whose extending_organisation is incorrectly set to BEIS and should be manually corrected:"
+  puts bad_programmes.ids.join("\n")
+end

--- a/spec/data/20210412134546_fix_extending_organisation_inconsistencies_spec.rb
+++ b/spec/data/20210412134546_fix_extending_organisation_inconsistencies_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Fix extending_organisation inconsistencies" do
+  let(:beis) { create(:beis_organisation) }
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+
+  describe "with a fund" do
+    let!(:activity) { create(:fund_activity, organisation: delivery_partner, extending_organisation: delivery_partner) }
+
+    it "sets the organisation and extending_organisation to BEIS" do
+      run_data_migration
+
+      expect(activity.organisation).to eql(beis)
+      expect(activity.extending_organisation).to eql(beis)
+    end
+  end
+
+  describe "with a programme" do
+    let!(:activity) { create(:programme_activity, organisation: delivery_partner, extending_organisation: delivery_partner) }
+
+    it "sets the organisation to BEIS" do
+      run_data_migration
+
+      expect(activity.organisation).to eql(beis)
+    end
+
+    it "doesn't update the organisation if the extending_organisation is BEIS and outputs a warning" do
+      activity.update(extending_organisation: beis)
+
+      expect { run_data_migration }.to output(/Found 1 programme/).to_stdout
+
+      expect(activity.organisation).to eql(delivery_partner)
+    end
+  end
+
+  describe "with a project" do
+    let!(:activity) { create(:project_activity, organisation: delivery_partner, extending_organisation: beis) }
+
+    it "sets the extending_organisation to the delivery_partner (copied from organisation)" do
+      run_data_migration
+
+      expect(activity.extending_organisation).to eql(delivery_partner)
+    end
+  end
+
+  describe "with a third-party project" do
+    let!(:activity) { create(:third_party_project_activity, organisation: delivery_partner, extending_organisation: beis) }
+
+    it "sets the extending_organisation to the delivery_partner (copied from organisation)" do
+      run_data_migration
+
+      expect(activity.extending_organisation).to eql(delivery_partner)
+    end
+  end
+
+  private
+
+  def run_data_migration
+    load(Rails.root.join("db", "data", "20210412134546_fix_extending_organisation_inconsistencies.rb"))
+
+    activity.reload
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    describe ".publishable_to_iati?" do
-      it "only returns activities with a `form_state` of :complete and/or `publish_to_iati` of true" do
+    describe ".publishable_to_iati" do
+      it "only returns activities where form_state is 'complete' and `publish_to_iati` is true" do
         complete_activity = create(:fund_activity)
         _incomplete_activity = create(:fund_activity, :at_purpose_step)
         _complete_redacted_activity = create(:fund_activity, publish_to_iati: false)
@@ -102,15 +102,17 @@ RSpec.describe Activity, type: :model do
         another_project = create(:project_activity, parent: another_programme, organisation: organisation)
         another_third_party_project = create(:third_party_project_activity, parent: another_project, organisation: organisation)
 
-        expect(Activity.projects_and_third_party_projects_for_report(report)).to include third_party_project
-        expect(Activity.projects_and_third_party_projects_for_report(report)).to include project
+        result = Activity.projects_and_third_party_projects_for_report(report)
 
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include fund
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include programme
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_fund
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_programme
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_project
-        expect(Activity.projects_and_third_party_projects_for_report(report)).not_to include another_third_party_project
+        expect(result).to include third_party_project
+        expect(result).to include project
+
+        expect(result).not_to include fund
+        expect(result).not_to include programme
+        expect(result).not_to include another_fund
+        expect(result).not_to include another_programme
+        expect(result).not_to include another_project
+        expect(result).not_to include another_third_party_project
       end
     end
   end
@@ -904,7 +906,7 @@ RSpec.describe Activity, type: :model do
       expect(activity.form_steps_completed?).to be_falsey
     end
 
-    it "is false when the form_stat is nil " do
+    it "is false when the form_state is nil" do
       activity = build(:activity, form_state: nil)
 
       expect(activity.form_steps_completed?).to be_falsey


### PR DESCRIPTION
This data migration ensures that existing activities have `organisation` and `extending_organisation` set consistently. This mirrors the values that `ActivityDefaults` assigns for new activities depending on their level:

- Fund: organisation / extending_organisation are always both BEIS
- Programme: organisation is BEIS and extending_organisation is set to a delivery partner
- Project: organisation / extending_organisation are the same DP
- Third-party Project: organisation / extending_organisation are the same DP

In the past `extending_organisation_id` has been an optional field, so we copy this value from `organisation_id` for projects and third-party projects.

I output a warning for any programmes whose `extending_organisation` is incorrectly set to BEIS, as these will need to be manually updated, to allow the relevant delivery partner to create child activities (projects) under them.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
