### PR TITLE
Remove spaces from identifier fragments in ImportConverter

### DIFF
--- a/app/services/import_converter.rb
+++ b/app/services/import_converter.rb
@@ -76,7 +76,7 @@ class ImportConverter
       when LEVEL_D then ""
     end
 
-    id_parts = ["Parent RODA ID", "RODA ID Fragment"].map { |key| @row.fetch(key) }
+    id_parts = ["Parent RODA ID", "RODA ID Fragment"].map { |key| @row.fetch(key).strip }
     [id_parts.join(separator)]
   end
 

--- a/spec/services/import_converter_spec.rb
+++ b/spec/services/import_converter_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ImportConverter do
   describe "transaction data" do
     let :input_row do
       {
-        "Parent RODA ID" => "AAA-BBB",
-        "RODA ID Fragment" => "CCC",
+        "Parent RODA ID" => "AAA-BBB ",
+        "RODA ID Fragment" => " CCC",
         "Act 2020/21 Q1" => "90",
         "Act 2020/21 FY Q2 (Jul, Aug, Sep)" => "70",
         "Q3 2020-2021 actuals" => "50",


### PR DESCRIPTION
We have noticed that some identifier fragments in import data sets
include leading or trailing space in their identifier fields, and these
spaces should not persist when we join the fragments together. This
change strips the space off the values when building the compound ID.