### PR TITLE
(1665) Allow forecasts to be negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -592,6 +592,8 @@
 
 ## [unreleased]
 
+- Allow forecasts to have negative values
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-44...HEAD
 [release-44]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-43...release-44
 [release-43]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-42...release-43

--- a/app/models/planned_disbursement.rb
+++ b/app/models/planned_disbursement.rb
@@ -22,5 +22,4 @@ class PlannedDisbursement < ApplicationRecord
     :providing_organisation_reference,
     :financial_quarter,
     :financial_year
-  validates :value, inclusion: {in: 0..99_999_999_999.00}
 end

--- a/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "users can upload planned disbursements" do
     upload_csv <<~CSV
       Activity RODA Identifier | FC 2021/22 FY Q2 | FC 2021/22 FY Q3 | FC 2021/22 FY Q4
       #{ids[0]}                | 10               | 20               | 30
-      #{ids[1]}                | 40               | 50               | 60
+      #{ids[1]}                | 40               | -50              | 60
     CSV
 
     expect(PlannedDisbursement.count).to eq(6)

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -104,13 +104,13 @@ RSpec.describe ExportActivityToCsv do
       q19_forecast = PlannedDisbursementHistory.new(project, **quarters[18])
 
       q1_forecast.set_value(1000)
-      q3_forecast.set_value(500)
+      q3_forecast.set_value(-500)
       q19_forecast.set_value(300)
 
       totals = ExportActivityToCsv.new(activity: project, report: report).next_twenty_quarter_forecasts
 
       expect(totals).to eq [
-        "0.00", "1000.00", "0.00", "500.00",
+        "0.00", "1000.00", "0.00", "-500.00",
         "0.00", "0.00", "0.00", "0.00",
         "0.00", "0.00", "0.00", "0.00",
         "0.00", "0.00", "0.00", "0.00",

--- a/spec/services/planned_disbursement_history_spec.rb
+++ b/spec/services/planned_disbursement_history_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe PlannedDisbursementHistory do
       ])
     end
 
+    it "creates an original with a negative value" do
+      history.set_value(-10)
+
+      expect(history_entries).to eq([
+        ["original", nil, nil, -10],
+      ])
+    end
+
     it "does not create an original entry with a zero value" do
       history.set_value(0)
       expect(history_entries).to eq([])
@@ -55,6 +63,16 @@ RSpec.describe PlannedDisbursementHistory do
       ])
     end
 
+    it "adds a revision with a negative value" do
+      history.set_value(10)
+      history.set_value(-20)
+
+      expect(history_entries).to eq([
+        ["original", nil, nil, 10],
+        ["revised", nil, nil, -20],
+      ])
+    end
+
     it "modifies the revision on all further updates" do
       history.set_value(10)
       history.set_value(20)
@@ -74,6 +92,17 @@ RSpec.describe PlannedDisbursementHistory do
       expect(history_entries).to eq([
         ["original", nil, nil, 10],
         ["revised", nil, nil, 0],
+      ])
+    end
+
+    it "modifies the revision with a negative value" do
+      history.set_value(10)
+      history.set_value(20)
+      history.set_value(-30)
+
+      expect(history_entries).to eq([
+        ["original", nil, nil, 10],
+        ["revised", nil, nil, -30],
       ])
     end
 


### PR DESCRIPTION
## Changes in this PR

Under the assurance process, over any given quarter, the forecast for an
activity should match its actual net spending. Since transactions can
have negative values (representing refunds), it follows that forecasts
should be allowed to be negative, to record a prediction that an
activity's net spending will be negative in some future quarter.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
