### PR TITLE
(1644) Use ActivityPolicy#create_child? for more "create activity" buttons

### DIFF
--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -62,8 +62,8 @@ class ActivityPolicy < ApplicationPolicy
     fund = record.associated_fund
 
     Report.editable.where(
-      fund: fund,
-      organisation: [record.extending_organisation, record.organisation]
+      fund_id: fund.id,
+      organisation_id: [record.extending_organisation_id, record.organisation_id]
     ).exists?
   end
 end

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -8,16 +8,17 @@
       %h1.govuk-heading-xl
         = @organisation_presenter.name
 
-  - if policy(:programme).create? && !@organisation_presenter.service_owner?
+  - if @funds.any? { |fund| policy(fund).create_child? }
     .govuk-grid-row
       .govuk-grid-column-full
         %h2.govuk-heading-m
           = t("create_programme", scope: "page_content.organisation")
 
         - @funds.each do |fund|
-          = button_to t("form.button.activity.new_child", name: fund.title),
-              organisation_activity_children_path(@organisation_presenter, fund),
-              class: "govuk-button govuk-!-margin-right-4"
+          - if policy(fund).create_child?
+            = button_to t("form.button.activity.new_child", name: fund.title),
+                organisation_activity_children_path(@organisation_presenter, fund),
+                class: "govuk-button govuk-!-margin-right-4"
 
   - if policy(@organisation_presenter).download? && @organisation_funds.any?
     .govuk-grid-row

--- a/app/views/staff/shared/activities/_projects.html.haml
+++ b/app/views/staff/shared/activities/_projects.html.haml
@@ -3,6 +3,8 @@
     %h2.govuk-heading-m
       = t("page_content.activity.projects")
     - if policy(activity).create_child?
-      = form_tag(organisation_activity_children_path(activity.extending_organisation, activity), method: "post") do
-        = submit_tag t("page_content.organisation.button.create_activity"), class: "govuk-button"
+      = button_to t("action.activity.add_child"),
+          organisation_activity_children_path(activity.extending_organisation, activity),
+          class: "govuk-button"
+
     = render partial: '/staff/shared/projects/table', locals: { projects: activities }

--- a/app/views/staff/shared/activities/_third_party_projects.html.haml
+++ b/app/views/staff/shared/activities/_third_party_projects.html.haml
@@ -2,8 +2,9 @@
   .govuk-grid-column-full
     %h2.govuk-heading-m
       = t("page_content.activity.third_party_projects")
-    - if ThirdPartyProjectPolicy.new(current_user, activity).create?
-      = form_tag(organisation_activity_children_path(activity.organisation, activity), method: "post") do
-        = submit_tag t("action.activity.add_child"), class: "govuk-button"
+    - if policy(activity).create_child?
+      = button_to t("action.activity.add_child"),
+          organisation_activity_children_path(activity.extending_organisation, activity),
+          class: "govuk-button"
 
     = render partial: '/staff/shared/third_party_projects/table', locals: { third_party_projects: activities }

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -44,7 +44,6 @@ en:
       create_programme: Add level B activity
       button:
         choose_extending_organisation: Choose extending organisation
-        create_activity: Add activity
         edit: Edit organisation
         edit_details: Edit details
       details: Organisation details

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can create a project" do
         click_on programme.title
         click_on t("tabs.activity.children")
 
-        expect(page).to_not have_button(t("page_content.organisation.button.create_activity"))
+        expect(page).to have_no_button(t("action.activity.add_child"))
       end
 
       scenario "a new project can be added to the programme" do
@@ -21,7 +21,7 @@ RSpec.feature "Users can create a project" do
         visit activities_path
         click_on programme.title
         click_on t("tabs.activity.children")
-        click_on t("page_content.organisation.button.create_activity")
+        click_on t("action.activity.add_child")
 
         fill_in_activity_form(level: "project", parent: programme)
 
@@ -38,7 +38,7 @@ RSpec.feature "Users can create a project" do
         _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         visit organisation_activity_children_path(programme.extending_organisation, programme)
-        click_on t("page_content.organisation.button.create_activity")
+        click_on t("action.activity.add_child")
 
         fill_in_activity_form(level: "project", parent: programme)
 
@@ -55,7 +55,7 @@ RSpec.feature "Users can create a project" do
         identifier = "a-project"
 
         visit organisation_activity_children_path(programme.extending_organisation, programme)
-        click_on t("page_content.organisation.button.create_activity")
+        click_on t("action.activity.add_child")
 
         fill_in_activity_form(roda_identifier_fragment: identifier, level: "project", parent: programme)
 
@@ -68,7 +68,7 @@ RSpec.feature "Users can create a project" do
         _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         visit organisation_activity_children_path(programme.extending_organisation, programme)
-        click_on t("page_content.organisation.button.create_activity")
+        click_on t("action.activity.add_child")
 
         fill_in "activity[delivery_partner_identifier]", with: "no-country-selected"
         click_button t("form.button.activity.submit")
@@ -103,7 +103,7 @@ RSpec.feature "Users can create a project" do
 
         PublicActivity.with_tracking do
           visit organisation_activity_children_path(programme.extending_organisation, programme)
-          click_on t("page_content.organisation.button.create_activity")
+          click_on t("action.activity.add_child")
 
           fill_in_activity_form(level: "project", delivery_partner_identifier: "my-unique-identifier", parent: programme)
 
@@ -124,7 +124,7 @@ RSpec.feature "Users can create a project" do
           identifier = "newton-project"
 
           visit organisation_activity_children_path(newton_programme.extending_organisation, newton_programme)
-          click_on t("page_content.organisation.button.create_activity")
+          click_on t("action.activity.add_child")
 
           fill_in_activity_form(level: "project", roda_identifier_fragment: identifier, parent: newton_programme)
 
@@ -139,7 +139,7 @@ RSpec.feature "Users can create a project" do
           identifier = "newton-project"
 
           visit organisation_activity_children_path(newton_programme.extending_organisation, newton_programme)
-          click_on t("page_content.organisation.button.create_activity")
+          click_on t("action.activity.add_child")
 
           fill_in_activity_form(level: "project", roda_identifier_fragment: identifier, parent: newton_programme, country_delivery_partners: nil)
 
@@ -155,7 +155,7 @@ RSpec.feature "Users can create a project" do
           _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
           visit organisation_activity_children_path(programme.extending_organisation, programme)
-          click_on t("page_content.organisation.button.create_activity")
+          click_on t("action.activity.add_child")
 
           # Test is done in this method:
           fill_in_activity_form(level: "project", parent: programme, aid_type: "D02")
@@ -171,7 +171,7 @@ RSpec.feature "Users can create a project" do
           _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
           visit organisation_activity_children_path(programme.extending_organisation, programme)
-          click_on t("page_content.organisation.button.create_activity")
+          click_on t("action.activity.add_child")
 
           # Test is done in this method:
           fill_in_activity_form(level: "project", parent: programme, aid_type: "C01", fstc_applies: false)

--- a/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can create a third-party project" do
       end
 
       scenario "a new third party project can be added to the project" do
-        project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
+        project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
 
         visit activities_path
@@ -37,7 +37,7 @@ RSpec.feature "Users can create a third-party project" do
 
       context "without an editable report" do
         scenario "a new third party project cannot be added" do
-          project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
+          project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation)
 
           visit activities_path
 
@@ -49,7 +49,7 @@ RSpec.feature "Users can create a third-party project" do
       end
 
       scenario "the activity saves its identifier as read-only `transparency_identifier`" do
-        project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
+        project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
         identifier = "3rd-party-proj"
 
@@ -67,7 +67,7 @@ RSpec.feature "Users can create a third-party project" do
       end
 
       scenario "third party project creation is tracked with public_activity" do
-        project = create(:project_activity, :gcrf_funded, organisation: user.organisation)
+        project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: project.associated_fund)
 
         PublicActivity.with_tracking do
@@ -91,7 +91,7 @@ RSpec.feature "Users can create a third-party project" do
       scenario "a new third party project requires specific fields when the project is Newton-funded" do
         newton_fund = create(:fund_activity, :newton)
         newton_programme = create(:programme_activity, parent: newton_fund, extending_organisation: user.organisation)
-        newton_project = create(:project_activity, parent: newton_programme, organisation: user.organisation)
+        newton_project = create(:project_activity, parent: newton_programme, organisation: user.organisation, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: newton_fund)
 
         visit activities_path

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -53,10 +53,5 @@ RSpec.feature "Users can view fund level activities" do
 
       expect(page).not_to have_content(fund_activity.title)
     end
-
-    it "does not let them create a fund level activity" do
-      visit organisation_path(user.organisation)
-      expect(page).not_to have_button(t("page_content.organisation.button.create_activity"))
-    end
   end
 end

--- a/spec/features/staff/users_can_view_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_project_level_activities_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Users can view project level activities" do
       visit organisation_activity_path(project.organisation, project)
 
       expect(page).to have_content project.title
-      expect(page).to_not have_content t("page_content.organisation.button.create_activity")
+      expect(page).to have_no_button t("action.activity.add_child")
     end
 
     scenario "can download a project as XML" do

--- a/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Users can view third-party project level activities" do
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
       expect(page).to have_content third_party_project.title
-      expect(page).to_not have_content t("page_content.organisation.button.create_activity")
+      expect(page).to have_no_button t("action.activity.add_child")
     end
 
     scenario "can download a third-party project as XML" do


### PR DESCRIPTION
Update Organisation#show and the third-party projects shared partial to use the `ActivityPolicy#create_child?` check.

NB: There are still a few places where we're using the old level-specific `create?` checks, but it proved pretty difficult to remove without breaking many tests, so let's leave it for now.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
