### PR TITLE
(1641) Start documenting view helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,6 +594,7 @@
 
 - Allow forecasts to have negative values
 - Add links to Guidance for all Activity fields that have guidance
+- Create a [pattern library](doc/patterns.md) for developers
 
 ## [unreleased]
 

--- a/doc/patterns.md
+++ b/doc/patterns.md
@@ -1,0 +1,44 @@
+# Pattern Library
+
+## Accessible action link
+
+Provide a screen reader more context for an action link.
+
+Parameters:
+
+- text
+- href
+- context (optional)
+
+```ruby
+a11y_action_link("Show", "https://example.com/", "this quarter's budgets")
+```
+
+### Output
+
+```html
+<a href="https://example.com/" class="govuk-link">
+  Show <span class="govuk-visually-hidden">this quarter's budgets</span>
+</a>
+```
+
+## Link that opens in a new tab
+
+Parameters:
+
+- text
+- href
+
+```ruby
+link_to_new_tab("Example", "https://example.com")
+```
+
+### Output
+
+```html
+<a href="https://example.com/" class="govuk-link" target="_blank" rel="noreferrer
+noopener">
+  Example (opens in new tab)
+</a>
+```
+


### PR DESCRIPTION
Create a guide to the various view helpers that developers have available to them. Starting with:

- `a11y_action_link`
- `link_to_new_tab`

I did wonder about implementing a proper pattern library, especially as we have a number of shared partials that might be useful to document, but this like a good start.

---
<img width="767" alt="Screenshot 2021-04-14 at 16 18 29" src="https://user-images.githubusercontent.com/3166/114735470-1bce4180-9d3d-11eb-9a25-f88a0b110244.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
