### PR TITLE
(1664) Export spending and refund data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,7 @@
 - Bump Ruby and Rails versions
 - Update Rails configuration files with v6.1 settings
 - Add tests to guard against missing Activity field translations
+- Provide a breakdown of spend, refund and net values as a report CSV download
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-45...HEAD
 [release-45]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-44...release-45

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -80,11 +80,11 @@ class Staff::ReportsController < Staff::BaseController
 
   def reports_for_service_owner
     inactive_reports
-    active_reports_with_organisations
-    submitted_reports_with_organisations
-    in_review_reports_with_organisations
-    awaiting_changes_reports_with_organisations
-    approved_reports_with_organisations
+    active_reports(including: [:organisation])
+    submitted_reports(including: [:organisation])
+    in_review_reports(including: [:organisation])
+    awaiting_changes_reports(including: [:organisation])
+    approved_reports(including: [:organisation])
   end
 
   def reports_for_delivery_partner
@@ -95,68 +95,38 @@ class Staff::ReportsController < Staff::BaseController
     approved_reports
   end
 
-  def inactive_reports
-    inactive_reports = policy_scope(Report.inactive).includes([:fund, :organisation])
+  def inactive_reports(including: [:organisation])
+    inactive_reports = policy_scope(Report.inactive).includes([:fund] + including)
     authorize inactive_reports
     @inactive_report_presenters = inactive_reports.map { |report| ReportPresenter.new(report) }
   end
 
-  def active_reports_with_organisations
-    active_reports = policy_scope(Report.active).includes([:fund, :organisation])
+  def active_reports(including: [])
+    active_reports = policy_scope(Report.active).includes([:fund] + including)
     authorize active_reports
     @active_report_presenters = active_reports.map { |report| ReportPresenter.new(report) }
   end
 
-  def active_reports
-    active_reports = policy_scope(Report.active).includes(:fund)
-    authorize active_reports
-    @active_report_presenters = active_reports.map { |report| ReportPresenter.new(report) }
-  end
-
-  def submitted_reports_with_organisations
-    submitted_reports = policy_scope(Report.submitted).includes([:fund, :organisation])
+  def submitted_reports(including: [])
+    submitted_reports = policy_scope(Report.submitted).includes([:fund] + including)
     authorize submitted_reports
     @submitted_report_presenters = submitted_reports.map { |report| ReportPresenter.new(report) }
   end
 
-  def submitted_reports
-    submitted_reports = policy_scope(Report.submitted).includes(:fund)
-    authorize submitted_reports
-    @submitted_report_presenters = submitted_reports.map { |report| ReportPresenter.new(report) }
-  end
-
-  def in_review_reports_with_organisations
-    in_review_reports = policy_scope(Report.in_review).includes([:fund, :organisation])
+  def in_review_reports(including: [])
+    in_review_reports = policy_scope(Report.in_review).includes([:fund] + including)
     authorize in_review_reports
     @in_review_report_presenters = in_review_reports.map { |report| ReportPresenter.new(report) }
   end
 
-  def in_review_reports
-    in_review_reports = policy_scope(Report.in_review).includes(:fund)
-    authorize in_review_reports
-    @in_review_report_presenters = in_review_reports.map { |report| ReportPresenter.new(report) }
-  end
-
-  def awaiting_changes_reports_with_organisations
-    awaiting_changes_reports = policy_scope(Report.awaiting_changes).includes([:fund, :organisation])
+  def awaiting_changes_reports(including: [])
+    awaiting_changes_reports = policy_scope(Report.awaiting_changes).includes([:fund] + including)
     authorize awaiting_changes_reports
     @awaiting_changes_report_presenters = awaiting_changes_reports.map { |report| ReportPresenter.new(report) }
   end
 
-  def awaiting_changes_reports
-    awaiting_changes_reports = policy_scope(Report.awaiting_changes).includes(:fund)
-    authorize awaiting_changes_reports
-    @awaiting_changes_report_presenters = awaiting_changes_reports.map { |report| ReportPresenter.new(report) }
-  end
-
-  def approved_reports_with_organisations
-    approved_reports = policy_scope(Report.approved).includes([:fund, :organisation])
-    authorize approved_reports
-    @approved_report_presenters = approved_reports.map { |report| ReportPresenter.new(report) }
-  end
-
-  def approved_reports
-    approved_reports = policy_scope(Report.approved).includes(:fund)
+  def approved_reports(including: [])
+    approved_reports = policy_scope(Report.approved).includes([:fund] + including)
     authorize approved_reports
     @approved_report_presenters = approved_reports.map { |report| ReportPresenter.new(report) }
   end
@@ -173,7 +143,13 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def downloadable_reports_for_beis_users
-    [active_reports_with_organisations, submitted_reports_with_organisations, in_review_reports_with_organisations, awaiting_changes_reports_with_organisations].sum.sort_by { |report| report.organisation.name }
+    report_sets = [
+      active_reports(including: [:organisation]),
+      submitted_reports(including: [:organisation]),
+      in_review_reports(including: [:organisation]),
+      awaiting_changes_reports(including: [:organisation]),
+    ]
+    report_sets.sum.sort_by { |report| report.organisation.name }
   end
 
   def report_activities_sorted_by_level(report)

--- a/app/controllers/staff/spending_breakdowns_controller.rb
+++ b/app/controllers/staff/spending_breakdowns_controller.rb
@@ -1,0 +1,30 @@
+class Staff::SpendingBreakdownsController < Staff::BaseController
+  include Secured
+  include StreamCsvDownload
+
+  def show
+    @report = Report.find(params[:report_id])
+    authorize @report
+
+    @report_presenter = ReportPresenter.new(@report)
+    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
+
+    respond_to do |format|
+      format.csv { send_csv }
+    end
+  end
+
+  private
+
+  def send_csv
+    filename = @report_presenter.filename_for_report_download
+    headers = ActivitySpendingBreakdown.new(report: @report).headers
+
+    stream_csv_download(filename: filename, headers: headers) do |csv|
+      @report_activities.each do |activity|
+        breakdown = ActivitySpendingBreakdown.new(report: @report, activity: activity)
+        csv << breakdown.values
+      end
+    end
+  end
+end

--- a/app/services/activity_spending_breakdown.rb
+++ b/app/services/activity_spending_breakdown.rb
@@ -1,5 +1,6 @@
 class ActivitySpendingBreakdown
   RECENT_QUARTERS = 7
+  OLDER_QUARTERS = 13
 
   Actuals = Struct.new(:spend, :refund) {
     def net
@@ -24,6 +25,7 @@ class ActivitySpendingBreakdown
   def combined_hash
     identifiers
       .merge(metadata)
+      .merge(old_quarters_net_spending)
       .merge(recent_quarters_detailed_spending)
   end
 
@@ -44,8 +46,14 @@ class ActivitySpendingBreakdown
     }
   end
 
+  def old_quarters_net_spending
+    previous_quarters_actuals.take(OLDER_QUARTERS).map { |quarter, actual|
+      ["#{quarter} actual net", format_amount(actual.net)]
+    }.to_h
+  end
+
   def recent_quarters_detailed_spending
-    previous_quarters_actuals.flat_map { |quarter, actual|
+    previous_quarters_actuals.drop(OLDER_QUARTERS).flat_map { |quarter, actual|
       [
         ["#{quarter} actual spend", format_amount(actual.spend)],
         ["#{quarter} actual refund", format_amount(actual.refund)],
@@ -72,7 +80,7 @@ class ActivitySpendingBreakdown
   end
 
   def previous_quarters
-    count = RECENT_QUARTERS
+    count = RECENT_QUARTERS + OLDER_QUARTERS
     financial_quarter.preceding(count - 1) + [financial_quarter]
   end
 

--- a/app/services/activity_spending_breakdown.rb
+++ b/app/services/activity_spending_breakdown.rb
@@ -1,0 +1,36 @@
+class ActivitySpendingBreakdown
+  def initialize(activity:, report:)
+    @activity = activity
+    @activity_presenter = ActivityPresenter.new(activity)
+    @report = report
+  end
+
+  def headers
+    combined_hash.keys
+  end
+
+  def values
+    combined_hash.values
+  end
+
+  def combined_hash
+    identifiers.merge(metadata)
+  end
+
+  def identifiers
+    {
+      "RODA identifier" => @activity.roda_identifier,
+      "BEIS identifier" => @activity.beis_id,
+      "Delivery partner identifier" => @activity.delivery_partner_identifier,
+    }
+  end
+
+  def metadata
+    {
+      "Title" => @activity_presenter.display_title,
+      "Description" => @activity_presenter.description,
+      "Programme status" => @activity_presenter.programme_status,
+      "ODA eligibility" => @activity_presenter.oda_eligibility,
+    }
+  end
+end

--- a/app/views/staff/reports/_download.haml
+++ b/app/views/staff/reports/_download.haml
@@ -1,2 +1,4 @@
 .govuk-grid-column-one-third.page-actions
   = link_to t("action.report.download.button"), report_path(report_presenter, format: :csv), class: "govuk-link"
+  %br
+  = link_to t("action.report.spending_download.button"), report_spending_breakdown_path(report_presenter, format: :csv), class: "govuk-link"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -137,6 +137,8 @@ en:
         button: Download report as CSV file
         reports: Download all reports as CSV
         failure: Reports could not be downloaded
+      spending_download:
+        button: Download spending breakdown as CSV file
       in_review:
         confirm:
           button: Confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     end
 
     resources :reports, only: [:show, :edit, :update, :index] do
+      resource :spending_breakdown, only: [:show], path: "spending"
       resource :state, only: [:edit, :update], controller: :reports_state
       resource :activity_upload, only: [:new, :show, :update]
       resource :planned_disbursement_upload, only: [:new, :show, :update]

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -90,6 +90,22 @@ RSpec.feature "Users can view reports" do
       expect(header).to match(/#{ERB::Util.url_encode("#{report.organisation.beis_organisation_reference}-report.csv")}\z/)
     end
 
+    scenario "can download a spending breakdown CSV of the report" do
+      report = create(:report, :active)
+
+      visit reports_path
+
+      within "##{report.id}" do
+        click_on t("default.link.show")
+      end
+
+      click_on t("action.report.spending_download.button")
+
+      expect(page.response_headers["Content-Type"]).to include("text/csv")
+      header = page.response_headers["Content-Disposition"]
+      expect(header).to match(/#{ERB::Util.url_encode("#{report.organisation.beis_organisation_reference}-report.csv")}\z/)
+    end
+
     context "when they download a CSV for all reports" do
       let!(:programme) { create(:programme_activity) }
       scenario "reports are sorted by DP" do
@@ -310,6 +326,24 @@ RSpec.feature "Users can view reports" do
         end
 
         click_on t("action.report.download.button")
+
+        expect(page.response_headers["Content-Type"]).to include("text/csv")
+
+        expect(page.response_headers["Content-Type"]).to include("text/csv")
+        header = page.response_headers["Content-Disposition"]
+        expect(header).to match(ERB::Util.url_encode("#{report.organisation.beis_organisation_reference}-report.csv"))
+      end
+
+      scenario "can download a spending breakdown CSV of their own report" do
+        report = create(:report, :active, organisation: delivery_partner_user.organisation)
+
+        visit reports_path
+
+        within "##{report.id}" do
+          click_on t("default.link.show")
+        end
+
+        click_on t("action.report.spending_download.button")
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
 

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe ActivitySpendingBreakdown do
       "FQ1 2020-2021 actual spend", "FQ1 2020-2021 actual refund", "FQ1 2020-2021 actual net",
       "FQ2 2020-2021 actual spend", "FQ2 2020-2021 actual refund", "FQ2 2020-2021 actual net",
       "FQ3 2020-2021 actual spend", "FQ3 2020-2021 actual refund", "FQ3 2020-2021 actual net",
+
+      "FQ4 2020-2021 forecast",
+      "FQ1 2021-2022 forecast",
+      "FQ2 2021-2022 forecast",
+      "FQ3 2021-2022 forecast",
+      "FQ4 2021-2022 forecast",
     ])
   end
 
@@ -186,6 +192,30 @@ RSpec.describe ActivitySpendingBreakdown do
           "FQ3 2020-2021 actual net" => "-10.00",
         )
       end
+    end
+  end
+
+  describe "upcoming forecast columns" do
+    before do
+      quarters = report.own_financial_quarter.following(5)
+
+      q1_forecast = PlannedDisbursementHistory.new(project, **quarters[1])
+      q2_forecast = PlannedDisbursementHistory.new(project, **quarters[2])
+      q3_forecast = PlannedDisbursementHistory.new(project, **quarters[3])
+
+      q1_forecast.set_value(10)
+      q2_forecast.set_value(20)
+      q3_forecast.set_value(40)
+    end
+
+    it "includes forecasts for the next few quarters" do
+      expect(breakdown.combined_hash).to include(
+        "FQ4 2020-2021 forecast" => "0.00",
+        "FQ1 2021-2022 forecast" => "10.00",
+        "FQ2 2021-2022 forecast" => "20.00",
+        "FQ3 2021-2022 forecast" => "40.00",
+        "FQ4 2021-2022 forecast" => "0.00"
+      )
     end
   end
 end

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe ActivitySpendingBreakdown do
+  let(:project) { travel_to_quarter(3, 2020) { create(:project_activity, :with_report) } }
+  let(:report) { Report.for_activity(project).in_historical_order.first }
+  let(:breakdown) { ActivitySpendingBreakdown.new(activity: project, report: report) }
+
+  it "generates columns in the given order" do
+    expect(breakdown.headers).to eq([
+      "RODA identifier",
+      "BEIS identifier",
+      "Delivery partner identifier",
+      "Title",
+      "Description",
+      "Programme status",
+      "ODA eligibility",
+    ])
+  end
+
+  it "exports some metadata relating to the activity" do
+    presenter = ActivityPresenter.new(project)
+
+    expect(breakdown.combined_hash).to include(
+      "RODA identifier" => project.roda_identifier,
+      "BEIS identifier" => project.beis_id,
+      "Delivery partner identifier" => project.delivery_partner_identifier,
+      "Title" => project.title,
+      "Description" => project.description,
+      "Programme status" => presenter.programme_status,
+      "ODA eligibility" => presenter.oda_eligibility
+    )
+  end
+end

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ActivitySpendingBreakdown do
   let(:report) { Report.for_activity(project).in_historical_order.first }
   let(:breakdown) { ActivitySpendingBreakdown.new(activity: project, report: report) }
 
+  def create_transaction(financial_year, financial_quarter, value)
+    create(:transaction, report: report, parent_activity: project, financial_year: financial_year, financial_quarter: financial_quarter, value: value)
+  end
+
   it "generates columns in the given order" do
     expect(breakdown.headers).to eq([
       "RODA identifier",
@@ -15,6 +19,14 @@ RSpec.describe ActivitySpendingBreakdown do
       "Description",
       "Programme status",
       "ODA eligibility",
+
+      "FQ1 2019-2020 actual spend", "FQ1 2019-2020 actual refund", "FQ1 2019-2020 actual net",
+      "FQ2 2019-2020 actual spend", "FQ2 2019-2020 actual refund", "FQ2 2019-2020 actual net",
+      "FQ3 2019-2020 actual spend", "FQ3 2019-2020 actual refund", "FQ3 2019-2020 actual net",
+      "FQ4 2019-2020 actual spend", "FQ4 2019-2020 actual refund", "FQ4 2019-2020 actual net",
+      "FQ1 2020-2021 actual spend", "FQ1 2020-2021 actual refund", "FQ1 2020-2021 actual net",
+      "FQ2 2020-2021 actual spend", "FQ2 2020-2021 actual refund", "FQ2 2020-2021 actual net",
+      "FQ3 2020-2021 actual spend", "FQ3 2020-2021 actual refund", "FQ3 2020-2021 actual net",
     ])
   end
 
@@ -30,5 +42,84 @@ RSpec.describe ActivitySpendingBreakdown do
       "Programme status" => presenter.programme_status,
       "ODA eligibility" => presenter.oda_eligibility
     )
+  end
+
+  describe "detailed spending columns" do
+    context "with a positive transaction" do
+      before do
+        create_transaction(2020, 3, 50)
+      end
+
+      it "includes the transaction as a spend and net value" do
+        expect(breakdown.combined_hash).to include(
+          "FQ3 2020-2021 actual spend" => "50.00",
+          "FQ3 2020-2021 actual refund" => "0.00",
+          "FQ3 2020-2021 actual net" => "50.00"
+        )
+      end
+
+      it "includes a zero value for quarters with no transactions" do
+        expect(breakdown.combined_hash).to include(
+          "FQ2 2020-2021 actual spend" => "0.00",
+          "FQ2 2020-2021 actual refund" => "0.00",
+          "FQ2 2020-2021 actual net" => "0.00"
+        )
+      end
+    end
+
+    context "with multiple positive transactions" do
+      before do
+        create_transaction(2020, 2, 80)
+        create_transaction(2020, 2, 160)
+
+        create_transaction(2020, 3, 10)
+        create_transaction(2020, 3, 20)
+        create_transaction(2020, 3, 40)
+      end
+
+      it "includes the sum of the transaction values by quarter" do
+        expect(breakdown.combined_hash).to include(
+          "FQ2 2020-2021 actual spend" => "240.00",
+          "FQ2 2020-2021 actual refund" => "0.00",
+          "FQ2 2020-2021 actual net" => "240.00",
+
+          "FQ3 2020-2021 actual spend" => "70.00",
+          "FQ3 2020-2021 actual refund" => "0.00",
+          "FQ3 2020-2021 actual net" => "70.00",
+        )
+      end
+    end
+
+    context "with positive and negative transactions" do
+      before do
+        create_transaction(2020, 3, 10)
+        create_transaction(2020, 3, -20)
+        create_transaction(2020, 3, 40)
+      end
+
+      it "includes the sum of the transaction spend, refund, and net" do
+        expect(breakdown.combined_hash).to include(
+          "FQ3 2020-2021 actual spend" => "50.00",
+          "FQ3 2020-2021 actual refund" => "20.00",
+          "FQ3 2020-2021 actual net" => "30.00",
+        )
+      end
+    end
+
+    context "with net negative transactions" do
+      before do
+        create_transaction(2020, 3, 10)
+        create_transaction(2020, 3, 20)
+        create_transaction(2020, 3, -40)
+      end
+
+      it "includes the sum of the transaction spend, refund, and net" do
+        expect(breakdown.combined_hash).to include(
+          "FQ3 2020-2021 actual spend" => "30.00",
+          "FQ3 2020-2021 actual refund" => "40.00",
+          "FQ3 2020-2021 actual net" => "-10.00",
+        )
+      end
+    end
   end
 end

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ActivitySpendingBreakdown do
   end
 
   it "generates columns in the given order" do
+    breakdown = ActivitySpendingBreakdown.new(report: report)
+
     expect(breakdown.headers).to eq([
       "RODA identifier",
       "BEIS identifier",

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe ActivitySpendingBreakdown do
       "Programme status",
       "ODA eligibility",
 
+      "FQ4 2015-2016 actual net",
+      "FQ1 2016-2017 actual net",
+      "FQ2 2016-2017 actual net",
+      "FQ3 2016-2017 actual net",
+      "FQ4 2016-2017 actual net",
+      "FQ1 2017-2018 actual net",
+      "FQ2 2017-2018 actual net",
+      "FQ3 2017-2018 actual net",
+      "FQ4 2017-2018 actual net",
+      "FQ1 2018-2019 actual net",
+      "FQ2 2018-2019 actual net",
+      "FQ3 2018-2019 actual net",
+      "FQ4 2018-2019 actual net",
+
       "FQ1 2019-2020 actual spend", "FQ1 2019-2020 actual refund", "FQ1 2019-2020 actual net",
       "FQ2 2019-2020 actual spend", "FQ2 2019-2020 actual refund", "FQ2 2019-2020 actual net",
       "FQ3 2019-2020 actual spend", "FQ3 2019-2020 actual refund", "FQ3 2019-2020 actual net",
@@ -42,6 +56,58 @@ RSpec.describe ActivitySpendingBreakdown do
       "Programme status" => presenter.programme_status,
       "ODA eligibility" => presenter.oda_eligibility
     )
+  end
+
+  describe "net spending columns" do
+    context "with a positive transaction" do
+      before do
+        create_transaction(2018, 3, 50)
+      end
+
+      it "includes the transaction" do
+        expect(breakdown.combined_hash).to include(
+          "FQ3 2018-2019 actual net" => "50.00"
+        )
+      end
+
+      it "includes a zero value for quarters with no transactions" do
+        expect(breakdown.combined_hash).to include(
+          "FQ4 2018-2019 actual net" => "0.00"
+        )
+      end
+    end
+
+    context "with multiple positive transactions" do
+      before do
+        create_transaction(2018, 2, 80)
+        create_transaction(2018, 2, 160)
+
+        create_transaction(2018, 3, 10)
+        create_transaction(2018, 3, 20)
+        create_transaction(2018, 3, 40)
+      end
+
+      it "includes the sum of the transaction values by quarter" do
+        expect(breakdown.combined_hash).to include(
+          "FQ2 2018-2019 actual net" => "240.00",
+          "FQ3 2018-2019 actual net" => "70.00",
+        )
+      end
+    end
+
+    context "with positive and negative transactions" do
+      before do
+        create_transaction(2018, 3, 10)
+        create_transaction(2018, 3, -20)
+        create_transaction(2018, 3, 40)
+      end
+
+      it "includes the sum of the transaction values" do
+        expect(breakdown.combined_hash).to include(
+          "FQ3 2018-2019 actual net" => "30.00",
+        )
+      end
+    end
   end
 
   describe "detailed spending columns" do


### PR DESCRIPTION
## Changes in this PR

This introduces a new report export CSV with a spending breakdown showing spending, refunds, and net values as distinct amounts for recent quarters. Specifically for each activity in the report, it includes:

- RODA, BEIS and DP identifiers
- title and description
- programme status and ODA eligibility
- for the most recent 7 quarters, the total spend, total refund and net
- for 13 quarters before those, the total net spend
- for 5 quarters after the report date, the forecast spend
The final commit is a refactoring of some code I encountered that I thought I would need to complete this feature. It ended up not being relevant but I thought I'd include it here in case people want it included. I'm happy to remove it if not.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
