### PR TITLE
Remote shell improvements

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,41 @@
+# Define prompt colours
+ANSI_FG_RED = "\u001b[31m"
+ANSI_FG_YELLOW = "\u001b[33m"
+ANSI_RESET = "\u001b[0m"
+
+if defined?(Rails)
+  hostname = ENV.fetch("CANONICAL_HOSTNAME", "").split(".").first
+
+  case hostname
+  when "www"
+    environment_colour = ANSI_FG_RED
+    environment_name = "production"
+  when "staging", "sandbox", "training", "pentest"
+    environment_colour = ANSI_FG_YELLOW
+    environment_name = hostname
+  else
+    environment_colour = ""
+    environment_name = Rails.env
+  end
+
+  sandbox_status = "(writable)"
+  sandbox_status = "(sandbox)" if Rails.application.sandbox
+
+  if Rails.application.sandbox == false && environment_name == "production"
+    puts
+    puts ANSI_FG_RED + "*******************************************************************" + ANSI_RESET
+    puts ANSI_FG_RED + "Warning: You are using the production console in non-sandboxed mode" + ANSI_RESET
+    puts ANSI_FG_RED + "*******************************************************************" + ANSI_RESET
+  end
+
+  puts
+
+  Pry.config.prompt_name = [
+    environment_colour,
+    environment_name,
+    " ",
+    ANSI_RESET,
+    sandbox_status,
+    " ",
+  ].join
+end

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ARG RAILS_ENV
 ENV RAILS_ENV ${RAILS_ENV:-production}
 ENV NODE_ENV ${RAILS_ENV:-production}
 
+RUN echo "\nexport PATH=/usr/local/bin:\$PATH\n\n# Stop here if non-interactive shell\n[[ \$- == *i* ]] || return\n\ncd /app" >> ~/.bashrc
+
 # ------------------------------------------------------------------------------
 # dependencies
 # ------------------------------------------------------------------------------

--- a/doc/console-access.md
+++ b/doc/console-access.md
@@ -22,17 +22,13 @@ You must have have been given 'Space developer' access to the intended space, fo
     ```
     $ cf ssh beis-roda-prod
     ```
-3. Navigate to the application
+3. Run the intended commands
     ```
-    $ cd /app
-    ```
-4. Run the intended commands
-    ```
-    $ /usr/local/bin/ruby bin/rails c
+    $ bin/rails c
     ```
 
     or
 
     ```
-    $ /usr/local/bin/ruby bin/rake db:seed
+    $ bin/rails db:seed
     ```

--- a/doc/importing-new-delivery-partner-data.md
+++ b/doc/importing-new-delivery-partner-data.md
@@ -88,7 +88,7 @@ cf ssh beis-roda-prod
 - run a rails console
 
 ```
-cd /app && /usr/local/bin/ruby bin/rails console --sandbox
+bin/rails console --sandbox
 ```
 
 - locate your account
@@ -109,10 +109,10 @@ me.update(organisation_id: "organisation_id")
 ```
 - quit the console
 
-- run the import 
+- run the import
 
 ```
-cd /app && /usr/local/bin/ruby bin/rails activities:import CSV=FILENAME ORGANISATION_ID=ORGANISATION_ID UPLOADER_EMAIL=youremail
+bin/rails activities:import CSV=FILENAME ORGANISATION_ID=ORGANISATION_ID UPLOADER_EMAIL=youremail
 ```
 
 - smoke test the activities in production after each level is imported
@@ -137,7 +137,7 @@ cf ssh beis-roda-prod
 - run a rails console
 
 ```
-cd /app && /usr/local/bin/ruby bin/rails console
+bin/rails console
 ```
 
 - get the `organisation` id for the delivery partner
@@ -232,17 +232,17 @@ cf login
 cf ssh beis-roda-prod
 ```
 
-- run the import 
+- run the import
 
 ```
-cd /app && /usr/local/bin/ruby script/import_forecasts.rb  -f FUND NAME -o ORGANISATION NAME -q 3 -y 2020 -i FILENAME.csv
+script/import_forecasts.rb  -f FUND NAME -o ORGANISATION NAME -q 3 -y 2020 -i FILENAME.csv
 ```
 
 FUND NAME and ORGANISATION NAME are the strings used for
 `Activity.roda_identifier` and
 `Organisation.name` e.g. "NF" and "Academy of Medical Science".
 
-## Actual spend 
+## Actual spend
 
 We only import actual data:
 
@@ -286,7 +286,7 @@ cf ssh beis-roda-prod
 - run a rails console
 
 ```
-cd /app && /usr/local/bin/ruby bin/rails console
+bin/rails console
 ```
 
 - locate your account


### PR DESCRIPTION
## Improvements when connecting to production instances

- Added `/usr/local/bin` to the `PATH`
- Automatically change into the `/app` directory on login

This means you can run `bin/rails c` rather than `cd /app; /usr/local/bin/ruby bin/rails c` 🎉 

## Rails Console

- When running locally, prepend the Rails console prompt with `Rails.env`
- Make it super obvious you're connected to a production environment _(including warning banner when starting a non-sandboxed console in prod)_
- Show that you're running in `--sandbox` mode or not

### Examples

Local development:

![Screenshot 2021-04-15 at 18 58 35](https://user-images.githubusercontent.com/3166/114916379-9fab2b00-9e1c-11eb-9fa1-fc16fc29ac25.png)

Staging (in sandbox mode):

![Screenshot 2021-04-15 at 19 01 39](https://user-images.githubusercontent.com/3166/114916723-09c3d000-9e1d-11eb-99d1-b7eee22e14ba.png)

Production:

![Screenshot 2021-04-15 at 19 00 59](https://user-images.githubusercontent.com/3166/114916648-f44ea600-9e1c-11eb-9be8-5d0152008375.png)






