### PR TITLE
Make sure activity fields have all translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,7 @@
 
 - Bump Ruby and Rails versions
 - Update Rails configuration files with v6.1 settings
+- Add tests to guard against missing Activity field translations
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-45...HEAD
 [release-45]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-44...release-45

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -6,7 +6,7 @@ class ActivityPresenter < SimpleDelegator
 
   def aid_type
     return if super.blank?
-    I18n.t("activity.aid_type.#{super.downcase}")
+    translate("activity.aid_type.#{super.downcase}")
   end
 
   def aid_type_with_code
@@ -15,12 +15,12 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def covid19_related
-    I18n.t("activity.covid19_related.#{super}")
+    translate("activity.covid19_related.#{super}")
   end
 
   def sector
     return if super.blank?
-    I18n.t("activity.sector.#{super}")
+    translate("activity.sector.#{super}")
   end
 
   def sector_with_code
@@ -30,7 +30,7 @@ class ActivityPresenter < SimpleDelegator
 
   def call_present
     return if super.nil?
-    I18n.t("activity.call_present.#{super}")
+    translate("activity.call_present.#{super}")
   end
 
   def call_open_date
@@ -45,7 +45,7 @@ class ActivityPresenter < SimpleDelegator
 
   def programme_status
     return if super.blank?
-    I18n.t("activity.programme_status.#{super}")
+    translate("activity.programme_status.#{super}")
   end
 
   def planned_start_date
@@ -70,41 +70,41 @@ class ActivityPresenter < SimpleDelegator
 
   def geography
     return if super.blank?
-    I18n.t("activity.geography.#{super}")
+    translate("activity.geography.#{super}")
   end
 
   def recipient_region
     return if super.blank?
-    I18n.t("activity.recipient_region.#{super}")
+    translate("activity.recipient_region.#{super}")
   end
 
   def recipient_country
     return if super.blank?
-    I18n.t("activity.recipient_country.#{super}")
+    translate("activity.recipient_country.#{super}")
   end
 
   def requires_additional_benefitting_countries
     return if super.nil?
-    I18n.t("activity.requires_additional_benefitting_countries.#{super}")
+    translate("activity.requires_additional_benefitting_countries.#{super}")
   end
 
   def intended_beneficiaries
     return if super.blank?
-    super.map { |item| I18n.t("activity.recipient_country.#{item}") }.to_sentence
+    super.map { |item| translate("activity.recipient_country.#{item}") }.to_sentence
   end
 
   def gdi
     return if super.blank?
-    I18n.t("activity.gdi.#{super}")
+    translate("activity.gdi.#{super}")
   end
 
   def collaboration_type
     return if super.blank?
-    I18n.t("activity.collaboration_type.#{super}")
+    translate("activity.collaboration_type.#{super}")
   end
 
   def flow
-    I18n.t("activity.flow.#{super}")
+    translate("activity.flow.#{super}")
   end
 
   def flow_with_code
@@ -113,42 +113,42 @@ class ActivityPresenter < SimpleDelegator
 
   def policy_marker_gender
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_climate_change_adaptation
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_climate_change_mitigation
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_biodiversity
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_desertification
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_disability
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_disaster_risk_reduction
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def policy_marker_nutrition
     return if super.blank?
-    I18n.t("activity.policy_markers.#{super}")
+    translate("activity.policy_markers.#{super}")
   end
 
   def sustainable_development_goals
@@ -161,7 +161,7 @@ class ActivityPresenter < SimpleDelegator
       html = "<ol class=\"govuk-list govuk-list--number\">"
 
       goals.each do |goal|
-        html += "<li>" + I18n.t("form.label.activity.sdg_options.#{goal}") + "</li>"
+        html += "<li>" + translate("form.label.activity.sdg_options.#{goal}") + "</li>"
       end
 
       html += "</ol>"
@@ -183,7 +183,7 @@ class ActivityPresenter < SimpleDelegator
 
   def oda_eligibility
     return if super.blank?
-    I18n.t("activity.oda_eligibility.#{super}")
+    translate("activity.oda_eligibility.#{super}")
   end
 
   def call_to_action(attribute)
@@ -206,21 +206,21 @@ class ActivityPresenter < SimpleDelegator
 
   def level
     return if super.blank?
-    activity_level = I18n.t("page_content.activity.level.#{super}")
+    activity_level = translate("page_content.activity.level.#{super}")
     custom_capitalisation(activity_level)
   end
 
   def tied_status_with_code
-    "#{I18n.t("activity.tied_status.#{tied_status}")} (#{tied_status})"
+    "#{translate("activity.tied_status.#{tied_status}")} (#{tied_status})"
   end
 
   def finance_with_code
-    "#{I18n.t("activity.finance.#{finance}")} (#{finance})"
+    "#{translate("activity.finance.#{finance}")} (#{finance})"
   end
 
   def fund_pillar
     return if super.blank?
-    I18n.t("page_content.activity.fund_pillar.#{super}")
+    translate("page_content.activity.fund_pillar.#{super}")
   end
 
   def link_to_roda
@@ -256,5 +256,11 @@ class ActivityPresenter < SimpleDelegator
 
   def total_budget
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+
+  private
+
+  def translate(reference)
+    I18n.t(reference)
   end
 end

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -340,6 +340,7 @@ en:
       "11182": Educational research
       "11220": Primary education
       "11230": Basic life skills for youth and adults
+      "11260": Lower secondary education"
       "11231": Basic life skills for youth
       "11232": Primary education equivalent for adults
       "11240": Early childhood education
@@ -354,6 +355,7 @@ en:
       "12181": Medical education/training
       "12182": Medical research
       "12191": Medical services
+      "12196": Health statistics and data
       "12220": Basic health care
       "12230": Basic health infrastructure
       "12240": Basic nutrition
@@ -361,6 +363,7 @@ en:
       "12261": Health education
       "12262": Malaria control
       "12263": Tuberculosis control
+      "12264": COVID-19 control
       "12281": Health personnel development
       "12310": NCDs control, general
       "12320": Tobacco use control
@@ -373,6 +376,7 @@ en:
       "13030": Family planning
       "13040": STD control including HIV/AIDS
       "13081": Personnel development for population and reproductive health
+      "13096": Population statistics and data
       "14010": Water sector policy and administrative management
       "14015": Water resources conservation (including data collection)
       "14020": Water supply and sanitation - large systems
@@ -431,6 +435,7 @@ en:
       "15180": Ending violence against women and girls
       "15185": Local government administration
       "15190": Facilitation of orderly, safe, regular and responsible migration and mobility
+      "15196": Government and civil society statistics and data
       "15210": Security system management and reform
       "15220": Civilian peace-building, conflict prevention and resolution
       "15230": Participation in international peacekeeping operations
@@ -502,6 +507,8 @@ en:
       "23210": Energy generation, renewable sources - multiple technologies
       "23220": Hydro-electric power plants
       "23230": Solar energy
+      "23231": Solar energy for isolated grids and standalone systems
+      "23232": Solar energy - thermal applications
       "23240": Wind energy
       "23250": Marine energy
       "23260": Geothermal energy
@@ -517,7 +524,10 @@ en:
       "23610": Heat plants
       "23620": District heating and cooling
       "23630": Electric power transmission and distribution
+      "23631": Electric power transmission and distribution (isolated mini-grids)
       "23640": Gas distribution
+      "23641": Retail distribution of liquid or solid fossil fuels
+      "23642": Electric mobility infrastructures
       "24010": Financial policy and administrative management
       "24020": Monetary institutions
       "24030": Formal sector financial intermediaries
@@ -573,6 +583,8 @@ en:
       "32170": Non-ferrous metal industries
       "32171": Engineering
       "32172": Transport equipment industry
+      "32173": Modern biofuels manufacturing
+      "32174": Clean cooking appliances manufacturing
       "32182": Technological research and development
       "32210": Mineral/mining policy and administrative management
       "32220": Mineral prospection and exploration
@@ -625,6 +637,8 @@ en:
       "60062": Other debt swap
       "60063": Debt buy-back
       "72010": Material relief assistance and services
+      "72011": Basic Health Care Services in Emergencies
+      "72012": Education in emergencies
       "72040": Emergency food assistance
       "72050": Relief co-ordination and support services
       "73010": Immediate post-emergency reconstruction and rehabilitation


### PR DESCRIPTION
This adds a shared example that covers all presenter fields that have a translation. It runs through all the codes in a given codelist and checks that the output does not match the `/translation missing/` regex. I did consider raising an error, but I was concerned that might cause issues with legacy data. This at least makes sure any data that we add with the codelists we have now (and any codelists that change going forward) are covered by the translations.