### PR TITLE
(1674) Activity search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -608,6 +608,7 @@
 ## [unreleased]
 
 - Link to the Service performance Zendesk article in the footer
+- Add functionality to search for activities by identifiers and title
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-46...HEAD
 [release-46]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-45...release-46

--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -1,0 +1,8 @@
+class Staff::SearchesController < Staff::BaseController
+  include Secured
+
+  def show
+    skip_authorization
+    @activity_search = ActivitySearch.new(user: current_user, query: params[:query])
+  end
+end

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -4,7 +4,7 @@ class ActivityCsvPresenter < ActivityPresenter
     to_model.intended_beneficiaries.map { |item| I18n.t("activity.recipient_country.#{item}") }.join("; ")
   end
 
-  def beis_id
+  def beis_identifier
     super.to_s
   end
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -273,7 +273,7 @@ module Activities
         aid_type: "Aid type",
         fstc_applies: "Free Standing Technical Cooperation",
         objectives: "Aims/Objectives (DP Definition)",
-        beis_id: "BEIS ID",
+        beis_identifier: "BEIS ID",
         uk_dp_named_contact: "UK DP Named Contact",
         country_delivery_partners: "NF Partner Country DP",
       }

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -1,5 +1,9 @@
 class ActivitySearch
-  def initialize(user:, query:)
+  include ActiveModel::Model
+
+  attr_reader :query
+
+  def initialize(user: nil, query: nil)
     @user = user
     @query = query.to_s.strip
   end

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -14,7 +14,7 @@ class ActivitySearch
     ]
 
     search_fields
-      .map { |field| activities.where(field => @query) }
+      .map { |field| activities.where("LOWER(#{field}) = ?", @query.downcase) }
       .reduce { |a, b| a.or(b) }
   end
 

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -5,15 +5,17 @@ class ActivitySearch
   end
 
   def results
-    activities.where(roda_identifier_compound: @query).or(
-      activities.where(roda_identifier_fragment: @query)
-    ).or(
-      activities.where(delivery_partner_identifier: @query)
-    ).or(
-      activities.where(beis_identifier: @query)
-    ).or(
-      activities.where(previous_identifier: @query)
-    )
+    search_fields = [
+      :roda_identifier_compound,
+      :roda_identifier_fragment,
+      :delivery_partner_identifier,
+      :beis_identifier,
+      :previous_identifier,
+    ]
+
+    search_fields
+      .map { |field| activities.where(field => @query) }
+      .reduce { |a, b| a.or(b) }
   end
 
   private

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -7,6 +7,12 @@ class ActivitySearch
   def results
     activities.where(roda_identifier_compound: @query).or(
       activities.where(roda_identifier_fragment: @query)
+    ).or(
+      activities.where(delivery_partner_identifier: @query)
+    ).or(
+      activities.where(beis_identifier: @query)
+    ).or(
+      activities.where(previous_identifier: @query)
     )
   end
 

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -1,0 +1,22 @@
+class ActivitySearch
+  def initialize(user:, query:)
+    @user = user
+    @query = query.to_s.strip
+  end
+
+  def results
+    activities.where(roda_identifier_compound: @query).or(
+      activities.where(roda_identifier_fragment: @query)
+    )
+  end
+
+  private
+
+  def activities
+    @_activities ||= if @user.service_owner?
+      Activity.all
+    else
+      Activity.where(organisation: @user.organisation)
+    end
+  end
+end

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -16,6 +16,7 @@ class ActivitySearch
     search_fields
       .map { |field| activities.where("LOWER(#{field}) = ?", @query.downcase) }
       .reduce { |a, b| a.or(b) }
+      .or(activities.where("LOWER(title) LIKE ?", "%#{@query.downcase}%"))
   end
 
   private

--- a/app/services/activity_spending_breakdown.rb
+++ b/app/services/activity_spending_breakdown.rb
@@ -41,7 +41,7 @@ class ActivitySpendingBreakdown
   def identifiers
     {
       "RODA identifier" => -> { @activity.roda_identifier },
-      "BEIS identifier" => -> { @activity.beis_id },
+      "BEIS identifier" => -> { @activity.beis_identifier },
       "Delivery partner identifier" => -> { @activity.delivery_partner_identifier },
     }
   end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -46,7 +46,7 @@ class ExportActivityToCsv
       # RODA ID fragment
       # Parent RODA ID
       "Transparency identifier" => -> { activity_presenter.transparency_identifier },
-      "BEIS identifier" => -> { activity_presenter.beis_id },
+      "BEIS identifier" => -> { activity_presenter.beis_identifier },
       "Level" => -> { activity_presenter.level },
       # Other UK DPs
       # DP 'Brand'

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -8,6 +8,8 @@
       %h1.govuk-heading-xl
         = @organisation_presenter.name
 
+  = render partial: "staff/searches/form"
+
   - if @funds.any? { |fund| policy(fund).create_child? }
     .govuk-grid-row
       .govuk-grid-column-full

--- a/app/views/staff/searches/_form.html.haml
+++ b/app/views/staff/searches/_form.html.haml
@@ -1,0 +1,12 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("form.activity_search.heading")
+
+    = form_with model: ActivitySearch.new, url: search_path, method: "get" do |f|
+      = f.govuk_text_field :query,
+        name: :query,
+        label: { text: t("form.activity_search.query") },
+        hint: { text: t("form.activity_search.hint") },
+        width: 20
+      = f.govuk_submit t("form.activity_search.submit")

--- a/app/views/staff/searches/show.html.haml
+++ b/app/views/staff/searches/show.html.haml
@@ -1,0 +1,33 @@
+= content_for :page_title_prefix, t("page_title.activity_search.show")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_content.activity_search.heading", query: @activity_search.query)
+
+      - if @activity_search.results.any?
+        %table.govuk-table
+          %thead.govuk-table__head
+            %tr.govuk-table__row
+              %th.govuk-table__header{scope: "col"}
+                = t("page_content.activity_search.table.title")
+              %th.govuk-table__header{scope: "col"}
+                = t("page_content.activity_search.table.roda_identifier")
+              %th.govuk-table__header{scope: "col"}
+                = t("page_content.activity_search.table.delivery_partner_identifier")
+          %tbody.govuk-table__body
+            - @activity_search.results.each do |activity|
+              %tr.govuk-table__row
+                %td.govuk-table__cell
+                  = a11y_action_link activity.title,
+                    organisation_activity_path(activity.organisation_id, activity)
+                %td.govuk-table__cell
+                  = activity.roda_identifier
+                %td.govuk-table__cell
+                  = activity.delivery_partner_identifier
+      - else
+        %p.govuk-body
+          = t("page_content.activity_search.no_results")
+
+  = render partial: "form"

--- a/config/locales/views/activity_search.en.yml
+++ b/config/locales/views/activity_search.en.yml
@@ -1,0 +1,19 @@
+---
+en:
+  page_title:
+    activity_search:
+      show: Search results
+  page_content:
+    activity_search:
+      heading: Search results for “%{query}”
+      table:
+        title: Title
+        roda_identifier: RODA Identifier
+        delivery_partner_identifier: Delivery Partner Identifier
+      no_results: No results.
+  form:
+    activity_search:
+      query: Enter your search query
+      hint: You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title
+      heading: Search for activities
+      submit: Search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
       resources :comments, only: [:new, :create, :edit, :update]
       resources :transfers, except: [:index]
     end
+
+    resource :search, only: [:show]
   end
 
   # Static pages

--- a/db/migrate/20210416123920_rename_beis_id_to_beis_identifier.rb
+++ b/db/migrate/20210416123920_rename_beis_id_to_beis_identifier.rb
@@ -1,0 +1,5 @@
+class RenameBeisIdToBeisIdentifier < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :activities, :beis_id, :beis_identifier
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_06_094816) do
+ActiveRecord::Schema.define(version: 2021_04_16_123920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2021_04_06_094816) do
     t.boolean "sdgs_apply", default: false, null: false
     t.text "objectives"
     t.string "oda_eligibility_lead"
-    t.string "beis_id"
+    t.string "beis_identifier"
     t.string "uk_dp_named_contact"
     t.string "country_delivery_partners", array: true
     t.integer "gcrf_challenge_area"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     delivery_partner_identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     roda_identifier_fragment { Faker::Alphanumeric.alpha(number: 5) }
     roda_identifier_compound { nil }
-    beis_id { nil }
+    beis_identifier { nil }
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -151,8 +151,8 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
     # We expect to see BEIS separately on this page
     within(".user-organisations") do
-      beis_id = Organisation.find_by(service_owner: true).id
-      expect(page).to have_css("input[type='radio'][value='#{beis_id}']:first-child")
+      beis_identifier = Organisation.find_by(service_owner: true).id
+      expect(page).to have_css("input[type='radio'][value='#{beis_identifier}']:first-child")
       expect(page).to have_css(".govuk-radios__divider:nth-child(2)")
     end
 

--- a/spec/features/staff/users_can_search_for_activities_spec.rb
+++ b/spec/features/staff/users_can_search_for_activities_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe "Users can search for activities" do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  let!(:project) { create(:programme_activity, roda_identifier_fragment: "roda-id", title: "Project A") }
+  let!(:third_party_project) { create(:third_party_project_activity, roda_identifier_fragment: "roda-id", title: "Third-party Project B") }
+
+  scenario "searching by RODA identifier fragment" do
+    visit "/"
+    fill_in :query, with: "roda-id"
+    click_button t("form.activity_search.submit")
+
+    expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
+    expect(page).to have_link third_party_project.title, href: organisation_activity_path(third_party_project.organisation, third_party_project)
+  end
+end

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe ActivityCsvPresenter do
     end
   end
 
-  describe "#beis_id" do
+  describe "#beis_identifier" do
     it "returns an empty string if the BEIS ID is nil otherwise the value" do
-      activity = Activity.new(beis_id: nil)
-      result = described_class.new(activity).beis_id
+      activity = Activity.new(beis_identifier: nil)
+      result = described_class.new(activity).beis_identifier
 
       expect(result).to eq ""
 
-      fake_beis_id = "GCRF_AHRC_NS_AH1001"
-      activity.beis_id = fake_beis_id
-      result = described_class.new(activity).beis_id
+      fake_beis_identifier = "GCRF_AHRC_NS_AH1001"
+      activity.beis_identifier = fake_beis_identifier
+      result = described_class.new(activity).beis_identifier
 
-      expect(result).to eq fake_beis_id
+      expect(result).to eq fake_beis_identifier
     end
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
       expect(existing_activity.fstc_applies).to eq(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
-      expect(existing_activity.beis_id).to eq(existing_activity_attributes["BEIS ID"])
+      expect(existing_activity.beis_identifier).to eq(existing_activity_attributes["BEIS ID"])
       expect(existing_activity.uk_dp_named_contact).to eq(existing_activity_attributes["UK DP Named Contact"])
 
       expect(existing_activity.implementing_organisations.count).to eql(1)
@@ -434,7 +434,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
       expect(new_activity.fstc_applies).to eq(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives (DP Definition)"])
-      expect(new_activity.beis_id).to eq(new_activity_attributes["BEIS ID"])
+      expect(new_activity.beis_identifier).to eq(new_activity_attributes["BEIS ID"])
       expect(new_activity.uk_dp_named_contact).to eq(new_activity_attributes["UK DP Named Contact"])
       expect(new_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
     end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe ActivitySearch do
+  let(:beis_user) { create(:beis_user) }
+  let(:alice) { create(:delivery_partner_user) }
+  let(:bob) { create(:delivery_partner_user) }
+
+  let!(:fund) { create(:fund_activity) }
+  let!(:programme) { create(:programme_activity, parent: fund) }
+
+  let!(:alice_project) { create(:project_activity, parent: programme, organisation: alice.organisation, roda_identifier_fragment: "fragment") }
+  let!(:alice_third_party_project) { create(:third_party_project_activity, parent: alice_project, organisation: alice.organisation) }
+
+  let!(:bob_project) { create(:project_activity, parent: programme, organisation: bob.organisation) }
+  let!(:bob_third_party_project) { create(:third_party_project_activity, parent: bob_project, organisation: bob.organisation, roda_identifier_fragment: "fragment") }
+
+  let(:activity_search) { ActivitySearch.new(user: user, query: query) }
+
+  context "for BEIS users" do
+    let(:user) { beis_user }
+
+    describe "searching for a fund's RODA identifier" do
+      let(:query) { fund.roda_identifier }
+
+      it "returns the matching fund" do
+        expect(activity_search.results).to match_array [fund]
+      end
+    end
+
+    describe "searching for RODA identifier fragments" do
+      let(:query) { "fragment" }
+
+      it "returns all activities with that fragment" do
+        expect(activity_search.results).to match_array [alice_project, bob_third_party_project]
+      end
+    end
+  end
+
+  context "for delivery partners" do
+    let(:user) { alice }
+
+    describe "searching for a fund's RODA identifier" do
+      let(:query) { fund.roda_identifier }
+
+      it "returns nothing" do
+        expect(activity_search.results).to match_array []
+      end
+    end
+
+    describe "searching for a RODA identifier fragments" do
+      let(:query) { "fragment" }
+
+      it "returns only the user's own activities" do
+        expect(activity_search.results).to match_array [alice_project]
+      end
+    end
+  end
+end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -32,6 +32,38 @@ RSpec.describe ActivitySearch do
         expect(activity_search.results).to match_array [alice_project, bob_third_party_project]
       end
     end
+
+    describe "searching for delivery partner identifiers" do
+      let(:query) { alice_project.delivery_partner_identifier }
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [alice_project]
+      end
+    end
+
+    describe "searching for BEIS identifiers" do
+      let(:query) { programme.beis_identifier }
+
+      before do
+        programme.update!(beis_identifier: "programme-id")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [programme]
+      end
+    end
+
+    describe "searching for previous identifiers" do
+      let(:query) { programme.previous_identifier }
+
+      before do
+        programme.update!(previous_identifier: "programme-id")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [programme]
+      end
+    end
   end
 
   context "for delivery partners" do
@@ -50,6 +82,46 @@ RSpec.describe ActivitySearch do
 
       it "returns only the user's own activities" do
         expect(activity_search.results).to match_array [alice_project]
+      end
+    end
+
+    describe "searching for their own delivery partner identifiers" do
+      let(:query) { alice_project.delivery_partner_identifier }
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [alice_project]
+      end
+    end
+
+    describe "searching for another delivery partner's identifiers" do
+      let(:query) { bob_project.delivery_partner_identifier }
+
+      it "returns nothing" do
+        expect(activity_search.results).to match_array []
+      end
+    end
+
+    describe "searching for their own project's BEIS identifiers" do
+      let(:query) { alice_project.beis_identifier }
+
+      before do
+        alice_project.update!(beis_identifier: "programme-id")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [alice_project]
+      end
+    end
+
+    describe "searching for a programme's BEIS identifiers" do
+      let(:query) { programme.beis_identifier }
+
+      before do
+        programme.update!(beis_identifier: "programme-id")
+      end
+
+      it "returns nothing" do
+        expect(activity_search.results).to match_array []
       end
     end
   end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe ActivitySearch do
         expect(activity_search.results).to match_array [programme]
       end
     end
+
+    describe "searching by title" do
+      let(:query) { "Search" }
+
+      before do
+        alice_third_party_project.update!(title: "Research and development")
+        bob_project.update!(title: "Search and rescue")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [alice_third_party_project, bob_project]
+      end
+    end
   end
 
   context "for delivery partners" do
@@ -130,6 +143,19 @@ RSpec.describe ActivitySearch do
 
       it "returns nothing" do
         expect(activity_search.results).to match_array []
+      end
+    end
+
+    describe "searching by title" do
+      let(:query) { "Search" }
+
+      before do
+        alice_third_party_project.update!(title: "Research and development")
+        bob_project.update!(title: "Search and rescue")
+      end
+
+      it "returns only the user's own activities" do
+        expect(activity_search.results).to match_array [alice_third_party_project]
       end
     end
   end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe ActivitySearch do
       end
     end
 
+    describe "searching for RODA identifier fragment ignoring case" do
+      let(:query) { "FRAGMENT" }
+
+      it "returns all activities with that fragment" do
+        expect(activity_search.results).to match_array [alice_project, bob_third_party_project]
+      end
+    end
+
     describe "searching for delivery partner identifiers" do
       let(:query) { alice_project.delivery_partner_identifier }
 

--- a/spec/services/activity_spending_breakdown_spec.rb
+++ b/spec/services/activity_spending_breakdown_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ActivitySpendingBreakdown do
 
     expect(breakdown.combined_hash).to include(
       "RODA identifier" => project.roda_identifier,
-      "BEIS identifier" => project.beis_id,
+      "BEIS identifier" => project.beis_identifier,
       "Delivery partner identifier" => project.delivery_partner_identifier,
       "Title" => project.title,
       "Description" => project.description,

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ExportActivityToCsv do
 
   context "when the project has a BEIS identifier" do
     before do
-      project.update!(beis_id: "GCRF_AHRC_NS_AH1001")
+      project.update!(beis_identifier: "GCRF_AHRC_NS_AH1001")
     end
 
     it "includes the BEIS identifier" do


### PR DESCRIPTION
## Changes in this PR

This adds a search function to the site, capable of searching for activities on the following fields:

- RODA identifier (both the complete ID and the activity-specific fragment)
- BEIS identifier
- Delivery partner identifier
- Previous identifier
- Title

All the identifier fields are case-insensitive complete matches -- you cannot search for a substring of an activity's ID. The title is also case-insensitive but supports partial matches, so you can find an activity without remember its complete title.

We could extend this partial matching to IDs, and perform word splitting on the query, and so on, but I'd rather put this in front of users and test it before adding such complexity.

## Screenshots of UI changes

This shows the search box on the home page:

<img width="1194" alt="Screenshot 2021-04-16 at 18 01 03" src="https://user-images.githubusercontent.com/9265/115059001-d2692800-9edd-11eb-81d7-656695ff5bad.png">

Results for searching for an activity's RODA ID fragment:

<img width="1197" alt="Screenshot 2021-04-16 at 18 01 27" src="https://user-images.githubusercontent.com/9265/115059002-d432eb80-9edd-11eb-8d28-858b3fb38830.png">

Results for searching for a substring of some activities' titles:

<img width="1198" alt="Screenshot 2021-04-16 at 18 04 10" src="https://user-images.githubusercontent.com/9265/115059235-2bd15700-9ede-11eb-9593-a4dbd0d41bd7.png">



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
