### PR TITLE
(1678) Improvements to totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -602,6 +602,8 @@
 - Update Rails configuration files with v6.1 settings
 - Add tests to guard against missing Activity field translations
 - Provide a breakdown of spend, refund and net values as a report CSV download
+- Only include transferred and direct budget in budget calculations
+- Show an activity's total forecasted spend to date against an activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-45...HEAD
 [release-45]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-44...release-45

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -270,6 +270,11 @@ class Activity < ApplicationRecord
     Budget.direct_or_transferred.where(parent_activity_id: activity_ids).sum(:value)
   end
 
+  def total_forecasted
+    activity_ids = descendants.pluck(:id).append(id)
+    PlannedDisbursement.where(parent_activity_id: activity_ids).sum(:value)
+  end
+
   def valid?(context = nil)
     context = VALIDATION_STEPS if context.nil? && form_steps_completed?
     super(context)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -267,7 +267,7 @@ class Activity < ApplicationRecord
 
   def total_budget
     activity_ids = descendants.pluck(:id).append(id)
-    Budget.where(parent_activity_id: activity_ids).sum(:value)
+    Budget.direct_or_transferred.where(parent_activity_id: activity_ids).sum(:value)
   end
 
   def valid?(context = nil)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -5,9 +5,15 @@ class Budget < ApplicationRecord
   IATI_STATUSES = Codelist.new(type: "budget_status", source: "iati").hash_of_coded_names
   BUDGET_TYPES = Codelist.new(type: "budget_type", source: "beis").hash_of_coded_names
   DIRECT_BUDGET_TYPES = [BUDGET_TYPES["direct_newton_fund"], BUDGET_TYPES["direct_global_challenges_research_fund"]]
+  TRANSFERRED_BUDGET_TYPE = BUDGET_TYPES["transferred"]
 
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
+
+  scope :direct_or_transferred, -> {
+    budget_types = DIRECT_BUDGET_TYPES + [TRANSFERRED_BUDGET_TYPE]
+    where(budget_type: budget_types)
+  }
 
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :value,

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -258,6 +258,10 @@ class ActivityPresenter < SimpleDelegator
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
 
+  def total_forecasted
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+
   private
 
   def translate(reference)

--- a/app/views/staff/activity_financials/show.html.haml
+++ b/app/views/staff/activity_financials/show.html.haml
@@ -36,6 +36,11 @@
                     Total spend to date
                   %dd.govuk-summary-list__value
                     = @activity.total_spend
+                .govuk-summary-list__row
+                  %dt.govuk-summary-list__key
+                    Total forecasted spend to date
+                  %dd.govuk-summary-list__value
+                    = @activity.total_forecasted
 
           - if @activity.fund? && policy(:fund).create?
             = render partial: "staff/shared/activities/budgets",

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -7,5 +7,27 @@ FactoryBot.define do
     ingested { false }
     association :parent_activity, factory: :activity
     association :report, factory: :report
+
+    trait :direct_newton do
+      budget_type { Budget::BUDGET_TYPES["direct_newton_fund"] }
+      association :parent_activity, factory: [:fund_activity, :newton]
+    end
+
+    trait :direct_gcrf do
+      budget_type { Budget::BUDGET_TYPES["direct_global_challenges_research_fund"] }
+      association :parent_activity, factory: [:fund_activity, :gcrf]
+    end
+
+    trait :transferred do
+      budget_type { Budget::BUDGET_TYPES["transferred"] }
+    end
+
+    trait :external_official_development_assistance do
+      budget_type { Budget::BUDGET_TYPES["external_official_development_assistance"] }
+    end
+
+    trait :external_non_official_development_assistance do
+      budget_type { Budget::BUDGET_TYPES["external_non_official_development_assistance"] }
+    end
   end
 end

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -126,6 +126,7 @@ RSpec.feature "Users can view an activity" do
 
       create(:transaction, parent_activity: activity, value: 50)
       create(:budget, parent_activity: activity, value: 55)
+      create(:planned_disbursement, parent_activity: activity, value: 70)
 
       visit organisation_activity_financials_path(activity.organisation, activity)
       within ".govuk-tabs__list-item--selected" do
@@ -134,6 +135,7 @@ RSpec.feature "Users can view an activity" do
       within ".financial-summary" do
         expect(page).to have_content "Total spend to date £60.00"
         expect(page).to have_content "Total budget to date £65.00"
+        expect(page).to have_content "Total forecasted spend to date £70.00"
       end
       expect(page).to have_content transaction.value
       expect(page).to have_content budget.value

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1727,5 +1727,86 @@ RSpec.describe Activity, type: :model do
         expect(programme2_projects[1].total_budget).to eq(programme2_project_1_total_budget)
       end
     end
+
+    describe "#total_forecasted" do
+      def create_forecast(parent_activity:)
+        create(:planned_disbursement, value: rand(100..200), parent_activity: parent_activity)
+      end
+
+      let!(:fund_forecast) { create_forecast(parent_activity: fund) }
+      let!(:programme1_forecast) do
+        [
+          create_forecast(parent_activity: programme1),
+          create_forecast(parent_activity: programme1),
+        ]
+      end
+      let!(:programme2_forecast) do
+        [
+          create_forecast(parent_activity: programme2),
+          create_forecast(parent_activity: programme2),
+        ]
+      end
+      let!(:programme1_project_0_forecast) { create_forecast(parent_activity: programme1_projects[0]) }
+      let!(:programme1_project_1_forecast) { create_forecast(parent_activity: programme1_projects[1]) }
+      let!(:programme2_project_0_forecast) { create_forecast(parent_activity: programme2_projects[0]) }
+      let!(:programme2_project_1_forecast) { create_forecast(parent_activity: programme2_projects[1]) }
+      let!(:programme1_project_0_third_party_project_forecast) { create_forecast(parent_activity: programme1_third_party_project) }
+      let!(:programme2_project_1_third_party_project_forecast) { create_forecast(parent_activity: programme2_third_party_project) }
+
+      it "returns the total forecasted spend for a fund" do
+        total_forecasted = [
+          fund_forecast,
+          *programme1_forecast,
+          *programme2_forecast,
+          programme1_project_0_forecast,
+          programme1_project_1_forecast,
+          programme2_project_0_forecast,
+          programme2_project_1_forecast,
+          programme1_project_0_third_party_project_forecast,
+          programme2_project_1_third_party_project_forecast,
+        ].sum(&:value)
+
+        expect(fund.total_forecasted).to eq(total_forecasted)
+      end
+
+      it "returns total forecasted spend for a programme" do
+        programme1_total_forecasted = [
+          *programme1_forecast,
+          programme1_project_0_forecast,
+          programme1_project_1_forecast,
+          programme1_project_0_third_party_project_forecast,
+        ].sum(&:value)
+
+        programme2_total_forecasted = [
+          *programme2_forecast,
+          programme2_project_0_forecast,
+          programme2_project_1_forecast,
+          programme2_project_1_third_party_project_forecast,
+        ].sum(&:value)
+
+        expect(programme1.total_forecasted).to eq(programme1_total_forecasted)
+        expect(programme2.total_forecasted).to eq(programme2_total_forecasted)
+      end
+
+      it "returns foral forecasted spend for a project" do
+        programme1_project_0_forecasted = [
+          programme1_project_0_forecast,
+          programme1_project_0_third_party_project_forecast,
+        ].sum(&:value)
+
+        programme1_project_1_forecasted = programme1_project_1_forecast.value
+        programme2_project_0_forecasted = programme2_project_0_forecast.value
+
+        programme2_project_1_forecasted = [
+          programme2_project_1_forecast,
+          programme2_project_1_third_party_project_forecast,
+        ].sum(&:value)
+
+        expect(programme1_projects[0].total_forecasted).to eq(programme1_project_0_forecasted)
+        expect(programme1_projects[1].total_forecasted).to eq(programme1_project_1_forecasted)
+        expect(programme2_projects[0].total_forecasted).to eq(programme2_project_0_forecasted)
+        expect(programme2_projects[1].total_forecasted).to eq(programme2_project_1_forecasted)
+      end
+    end
   end
 end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -64,6 +64,21 @@ RSpec.describe Budget do
     end
   end
 
+  describe "scopes" do
+    describe ".direct_or_transferred" do
+      it "returns only direct or transferred Budgets" do
+        newton_fund_budget = create(:budget, :direct_newton)
+        gcrf_fund_budget = create(:budget, :direct_gcrf)
+        transferred_budget = create(:budget, :transferred)
+
+        _external_oda_budget = create(:budget, :external_official_development_assistance)
+        _external_non_oda_budget = create(:budget, :external_non_official_development_assistance)
+
+        expect(Budget.direct_or_transferred).to match_array([newton_fund_budget, gcrf_fund_budget, transferred_budget])
+      end
+    end
+  end
+
   context "value must be between 0.01 and 99,999,999,999.00 (100 billion minus one)" do
     it "allows the maximum possible value" do
       budget = build(:budget, value: 99_999_999_999.00)

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -676,4 +676,12 @@ RSpec.describe ActivityPresenter do
       expect(described_class.new(activity).total_budget).to eq("£50.00")
     end
   end
+
+  describe "#total_forecasted" do
+    it "returns the value to two decimal places with a currency symbol" do
+      activity = build(:programme_activity)
+      create(:planned_disbursement, parent_activity: activity, value: 50)
+      expect(described_class.new(activity).total_forecasted).to eq("£50.00")
+    end
+  end
 end


### PR DESCRIPTION
This tweaks the budget total calculation to only include transferred and direct budget, as well as showing to total forecast to date, as shown below:

![image](https://user-images.githubusercontent.com/109774/115242092-74c11f80-a119-11eb-91c5-97d89b8d90a5.png)
