### PR TITLE
(1697) Automatically rebase when PR is set to auto merge

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,23 +2,64 @@ name: Automatic Rebase
 on:
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [auto_merge_enabled]
+env:
+  AUTO_REBASE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
 jobs:
-  rebase:
-    name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+  check_token:
+    if: ${{ (github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '/rebase')) || github.event_name ==
+      'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Add reaction
+      - name: Prompt user to add a token
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number || github.event.number }}
+          body: |
+            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN`
+            to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
+            Once this is done, you can try the `/rebase` command again.
+        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' }}
+      - name: Add -1 reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: "-1"
+        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' &&
+          github.event.comment }}
+      - name: Add +1 reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: "+1"
+        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' &&
+          github.event.comment }}
+  rebase:
+    if: ${{ github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '/rebase') || github.event_name ==
+      'pull_request_target' }}
+    name: Rebase
+    needs: check_token
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
+        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
+      - name: Send failure message
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number || github.event.number }}
+          body: |
+            Automatic rebasing for this issue has failed :disappointed:
+            You'll have to rebase this one manually, I'm afraid.
+        if: ${{ failure() }}


### PR DESCRIPTION
This tweaks the auto rebase action to automatically run the rebase action when a PR is set to automatically merge. This means that when a dev has approved a PR that is not up to date with the develop branch and set it to auto merge, this action will automatically bring it up to date (if possible), and it will then merge itself. As with the `/rebase` command, it adds a message to the PR if an automatic rebase is not possible.

We also check if the `AUTO_REBASE_PERSONAL_ACCESS_TOKEN` secret has been added, and add a message to the PR if it hasn't been added. I've added this secret coming from the dxw Rails user (who now has access to the project), so we can keep track with people rolling off the project for whatever reason. I'll delete the old, legacy `GH_ACCESS_TOKEN` secret (which is under my name) once this PR has been approved and merged.