### PR TITLE
Link to the Service performance article in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,6 +607,8 @@
 
 ## [unreleased]
 
+- Link to the Service performance Zendesk article in the footer
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-46...HEAD
 [release-46]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-45...release-46
 [release-45]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-44...release-45

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -75,6 +75,8 @@
               %li.govuk-footer__inline-list-item
                 = link_to t("footer.link.terms_of_service"), page_path("terms_of_service"), class: "govuk-footer__link"
               %li.govuk-footer__inline-list-item
+                = link_to t("footer.link.service_performance"), "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance", class: "govuk-footer__link"
+              %li.govuk-footer__inline-list-item
                 = link_to t("footer.link.support_site"), "https://beisodahelp.zendesk.com/", class: "govuk-footer__link"
 
             %svg.govuk-footer__licence-logo{focusable: "false", height: "17", role: "presentation", viewbox: "0 0 483.2 195.7", width: "41", xmlns: "http://www.w3.org/2000/svg"}

--- a/config/locales/views/footer.en.yml
+++ b/config/locales/views/footer.en.yml
@@ -7,3 +7,4 @@ en:
       accessibility_statement: Accessibility statement
       support_site: Support
       terms_of_service: Terms of service
+      service_performance: Service performance

--- a/spec/features/user_can_view_static_pages_spec.rb
+++ b/spec/features/user_can_view_static_pages_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Users can view the static pages" do
       expect(page).to have_link t("footer.link.cookie_statement"), href: page_path("cookie_statement")
       expect(page).to have_link t("footer.link.accessibility_statement"), href: page_path("accessibility_statement")
       expect(page).to have_link t("footer.link.terms_of_service"), href: page_path("terms_of_service")
+      expect(page).to have_link t("footer.link.service_performance"), href: "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance"
       expect(page).to have_link t("footer.link.support_site"), href: "https://beisodahelp.zendesk.com/"
     end
   end


### PR DESCRIPTION
## Changes in this PR
- Link to the Service performance Zendesk article in the footer

I have chosen to link to the generic article that will collect all service performance reports for each quarter, rather than to the specific link for the current quarter.

My thinking was that we don’t want to have to update the link during every quarter, but anyone disagrees this can be discussed.

## Screenshots of UI changes

### Before
![Screenshot 2021-04-20 at 17 34 35](https://user-images.githubusercontent.com/579522/115432797-b37cd580-a1fe-11eb-8bab-027cf54e2754.png)

### After
![Screenshot 2021-04-20 at 17 34 23](https://user-images.githubusercontent.com/579522/115432815-b972b680-a1fe-11eb-9470-d6b87b4c6050.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
