### PR TITLE
Use `pg_restore` to restore the dump

### DIFF
--- a/bin/db-restore
+++ b/bin/db-restore
@@ -32,7 +32,7 @@ exit_code=0
 
 # Create a unique filename, so we can delete it later
 timestamp=$(date +"%Y%m%d%I%M%S")
-filename="/tmp/dump-$timestamp.sql"
+filename="/tmp/dump-$timestamp.tar"
 
 # Cleanup on exit, no matter what happens
 cleanup () {
@@ -58,6 +58,7 @@ cf conduit "$service" -- \
         --file "$filename" \
         --no-acl \
         --no-owner \
+        --format=t \
         --exclude-table-data="users" \
         --exclude-table="ar_internal_metadata" \
         --exclude-table="spatial_ref_sys"
@@ -74,7 +75,7 @@ if [ "$delete_data" == "y" ]; then
     psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
 
     echo "==> Restoring the data from the backup..."
-    psql -d roda-development -f "$filename"
+    pg_restore -d roda-development --no-owner --clean "$filename"
 
     echo "==> Removing extraneous Postgres extensions..."
     psql -d roda-development -c 'DROP extension citext; DROP extension postgis; DROP extension "uuid-ossp";'


### PR DESCRIPTION
There has recently been a row introduced into the database, which had a `%` literal in the title, which has caused issues with the database restore. To get around this, and give us a more reliable restore process, I've set the format to be a `.tar` file, which can be restored via `pg_restore`, rather than a plain text SQL dump.