### PR TITLE
Add new category to GCRF strategic area options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,6 +616,7 @@
 ## [unreleased]
 
 - Remove Reporting Organisation from activities
+- Add new category to GCRF strategic area options
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...HEAD
 [release-47]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-46...release-47

--- a/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
+++ b/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
@@ -13,3 +13,5 @@ data:
     description: International Partnerships
   - code: 6
     description: Innovation and Commercialisation
+  - code: 7
+    description: Agile response in emergencies


### PR DESCRIPTION
This adds a new `Agile response in emergencies` option to the GCRF Strategic Area options

![image](https://user-images.githubusercontent.com/109774/116066771-4c3ca680-a680-11eb-92bb-322888211179.png)
