### PR TITLE
(1694) Feature include implementing organisation in the csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,6 +614,7 @@
 - Show activities in an collapsable and expandable tree view table
 
 ## [unreleased]
+- implementing organisations are shown in the report csv file.
 
 - Remove Reporting Organisation from activities
 - Add new category to GCRF strategic area options

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -153,7 +153,7 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def report_activities_sorted_by_level(report)
-    Activity.includes(:organisation).projects_and_third_party_projects_for_report(report).sort_by { |a| a.level }
+    Activity.includes(:organisation, :implementing_organisations).projects_and_third_party_projects_for_report(report).sort_by { |a| a.level }
   end
 
   def reports_have_same_quarter?

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -12,4 +12,9 @@ class ActivityCsvPresenter < ActivityPresenter
     return if super.blank?
     super.join(" | ")
   end
+
+  def implementing_organisations
+    return if super.empty?
+    super.pluck(:name).join("|")
+  end
 end

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -10,7 +10,7 @@ class ActivityCsvPresenter < ActivityPresenter
 
   def country_delivery_partners
     return if super.blank?
-    super.join(" | ")
+    super.join("|")
   end
 
   def implementing_organisations

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -97,9 +97,7 @@ class ExportActivityToCsv
       "Free Standing Technical Cooperation" => -> { activity_presenter.fstc_applies },
       "Disaster Risk Reduction" => -> { activity_presenter.policy_marker_disaster_risk_reduction },
       "Nutrition policy" => -> { activity_presenter.policy_marker_nutrition },
-      # Implementing organisation name
-      # Implementing organisation reference
-      # Implementing organisation sector
+      "Implementing organisations" => -> { activity_presenter.implementing_organisations },
       "Tied status" => -> { activity_presenter.tied_status_with_code },
     }
   end

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -53,4 +53,22 @@ RSpec.describe ActivityCsvPresenter do
       end
     end
   end
+
+  describe "#implementing_organisations" do
+    it "is blank when there are no implementing organisations" do
+      activity = build(:project_activity)
+      result = described_class.new(activity).implementing_organisations
+
+      expect(result).to be_nil
+    end
+
+    it "shows a list of implementing organisations seperated by the pipe symbol" do
+      implementing_organisation_one = build(:implementing_organisation)
+      implementing_organisation_two = build(:implementing_organisation)
+      activity = create(:project_activity, implementing_organisations: [implementing_organisation_one, implementing_organisation_two])
+      result = described_class.new(activity).implementing_organisations
+
+      expect(result).to eql("#{implementing_organisation_one.name}|#{implementing_organisation_two.name}")
+    end
+  end
 end

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ActivityCsvPresenter do
                                                                           "Chinese Academy of Sciences",
                                                                           "National Research Foundation",])
         result = described_class.new(activity).country_delivery_partners
-        expect(result).to eql("National Council for the State Funding Agencies (CONFAP) | Chinese Academy of Sciences | National Research Foundation")
+        expect(result).to eql("National Council for the State Funding Agencies (CONFAP)|Chinese Academy of Sciences|National Research Foundation")
       end
     end
 


### PR DESCRIPTION
## Changes in this PR
Users want to see the implementing organisations in the report csv. As
there can be multiple implementing organisations for a given activity we
need a separator when outputting into a single csv cell. As with the
rest of the application we use a pipe "|" symbol to achieve this.

As a general pattern we use a presenter to change the way data is
presented in certain contexts, here the csv presenter does the job.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
