### PR TITLE
Allow reports without financial year to be accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,10 +614,10 @@
 - Show activities in an collapsable and expandable tree view table
 
 ## [unreleased]
-- implementing organisations are shown in the report csv file.
-
+- Implementing organisations are shown in the report csv file
 - Remove Reporting Organisation from activities
 - Add new category to GCRF strategic area options
+- Fix bug that prevented historical reports from being accessed
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...HEAD
 [release-47]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-46...release-47

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -228,17 +228,17 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    return if super.blank?
+    return if report.own_financial_quarter.blank? || super.blank?
     "%.2f" % super
   end
 
   def forecasted_total_for_report_financial_quarter(report:)
-    return if super.blank?
+    return if report.own_financial_quarter.blank? || super.blank?
     "%.2f" % super
   end
 
   def variance_for_report_financial_quarter(report:)
-    return if super.blank?
+    return if report.own_financial_quarter.blank? || super.blank?
     "%.2f" % super
   end
 

--- a/app/services/activity_spending_breakdown.rb
+++ b/app/services/activity_spending_breakdown.rb
@@ -117,11 +117,15 @@ class ActivitySpendingBreakdown
   end
 
   def previous_quarters
+    return [] if financial_quarter.nil?
+
     count = RECENT_QUARTERS + OLDER_QUARTERS
     financial_quarter.preceding(count - 1) + [financial_quarter]
   end
 
   def upcoming_quarters
+    return [] if financial_quarter.nil?
+
     financial_quarter.following(UPCOMING_QUARTERS)
   end
 

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -23,6 +23,8 @@ class ExportActivityToCsv
   end
 
   def previous_twelve_quarter_actuals
+    return [] if report.own_financial_quarter.nil?
+
     transaction_quarters = TransactionOverview.new(activity_presenter, report_presenter).all_quarters
 
     previous_report_quarters.map do |quarter|
@@ -32,6 +34,8 @@ class ExportActivityToCsv
   end
 
   def next_twenty_quarter_forecasts
+    return [] if report.own_financial_quarter.nil?
+
     forecast_quarters = PlannedDisbursementOverview.new(activity_presenter).snapshot(report_presenter).all_quarters
 
     following_report_quarters.map do |quarter|
@@ -103,6 +107,8 @@ class ExportActivityToCsv
   end
 
   private def variance_columns
+    return {} if report.own_financial_quarter.nil?
+
     @_variance_columns ||= {
       # Additional headers specific to export CSV =============================
       "VAR #{report_financial_quarter}" => -> { activity_presenter.variance_for_report_financial_quarter(report: report) },
@@ -132,11 +138,15 @@ class ExportActivityToCsv
   end
 
   def previous_report_quarters
+    return [] if report.own_financial_quarter.nil?
+
     quarter = report.own_financial_quarter
     quarter.preceding(11) + [quarter]
   end
 
   def following_report_quarters
+    return [] if report.own_financial_quarter.nil?
+
     quarter = report.own_financial_quarter
     [quarter] + quarter.following(19)
   end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -211,6 +211,34 @@ RSpec.feature "Users can view reports" do
         expect(page).to have_content t("table.body.report.no_reports")
       end
     end
+
+    context "when there are legacy ingested reports" do
+      let(:activity) { create(:project_activity) }
+      let!(:report) { create(:report, :active, fund: activity.associated_fund, organisation: activity.organisation, financial_quarter: nil, financial_year: nil) }
+
+      before do
+        visit reports_path
+        within "##{report.id}" do
+          click_on t("default.link.show")
+        end
+      end
+
+      it "they can be viewed" do
+        expect(page).to have_content "Variance"
+
+        visit report_budgets_path(report)
+
+        expect(page).to have_content "Budgets"
+      end
+
+      it "they can be downloaded as CSV" do
+        click_on "Download report as CSV file"
+      end
+
+      it "the spending breakdown can be downloaded" do
+        click_on "Download spending breakdown as CSV file"
+      end
+    end
   end
 
   context "as a delivery partner user" do


### PR DESCRIPTION
## Changes in this PR

Historical “ingested” reports don’t have any financial year and quarter.

Many of the features built around a report rely on the report having a financial quarter and year, and break if the report doesn’t.

In order to allow the historical reports to be accessed and downloaded, we need to add a lot of guards against the lack of financial year and quarter.

(Any reports being created now enforce the presence of a FY/FQ by assigning default values at creation, and the fields are readonly at database level.)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
