### PR TITLE
(1677) Sum programme and child activity transactions by financial quarter in IATI XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,7 @@
 - Remove Reporting Organisation from activities
 - Add new category to GCRF strategic area options
 - Fix bug that prevented historical reports from being accessed
+- Sum programme and child activity transactions by financial quarter in IATI XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...HEAD
 [release-47]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-46...release-47

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -111,21 +111,21 @@ class Staff::OrganisationsController < Staff::BaseController
       organisation: organisation,
       user: current_user,
       fund_id: fund_id
-    ).call(eager_load_parent: false)
+    ).call
   end
 
   private def iati_publishable_project_activities(organisation:, user:)
     FindProjectActivities.new(
       organisation: organisation,
       user: current_user
-    ).call(eager_load_parent: false).publishable_to_iati
+    ).call.publishable_to_iati
   end
 
   private def iati_publishable_third_party_project_activities(organisation:, user:)
     FindThirdPartyProjectActivities.new(
       organisation: organisation,
       user: current_user
-    ).call(eager_load_parent: false).publishable_to_iati
+    ).call.publishable_to_iati
   end
 
   private def id

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -250,9 +250,7 @@ class Activity < ApplicationRecord
   end
 
   def total_spend(financial_quarter = nil)
-    activity_ids = descendants.pluck(:id).append(id)
-
-    transactions = Transaction.where(parent_activity_id: activity_ids)
+    transactions = own_and_descendants_transactions
 
     if financial_quarter
       transactions = transactions.where(
@@ -272,6 +270,11 @@ class Activity < ApplicationRecord
   def total_forecasted
     activity_ids = descendants.pluck(:id).append(id)
     PlannedDisbursement.where(parent_activity_id: activity_ids).sum(:value)
+  end
+
+  def own_and_descendants_transactions
+    activity_ids = descendants.pluck(:id).append(id)
+    Transaction.where(parent_activity_id: activity_ids)
   end
 
   def valid?(context = nil)

--- a/app/models/financial_quarter.rb
+++ b/app/models/financial_quarter.rb
@@ -32,6 +32,14 @@ class FinancialQuarter
     quarter == other.quarter && financial_year == other.financial_year
   end
 
+  def eql?(other)
+    self == other
+  end
+
+  def hash
+    to_s.hash
+  end
+
   def start_date
     @start_date ||= Date.new(calendar_year, start_month, 1)
   end

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -9,13 +9,10 @@ class FindProgrammeActivities
     @fund_id = fund_id
   end
 
-  def call(eager_load_parent: true)
-    eager_load_associations = [:organisation]
-    eager_load_associations << :parent if eager_load_parent
-
+  def call
     programmes = ProgrammePolicy::Scope.new(user, Activity.programme)
       .resolve
-      .includes(eager_load_associations)
+      .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
     return programmes if organisation.service_owner

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -8,13 +8,10 @@ class FindProjectActivities
     @user = user
   end
 
-  def call(eager_load_parent: true)
-    eager_load_associations = [:organisation]
-    eager_load_associations << :parent if eager_load_parent
-
+  def call
     projects = ProjectPolicy::Scope.new(user, Activity.project)
       .resolve
-      .includes(eager_load_associations)
+      .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
     projects = if organisation.service_owner

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -8,13 +8,10 @@ class FindThirdPartyProjectActivities
     @user = user
   end
 
-  def call(eager_load_parent: true)
-    eager_load_associations = [:organisation]
-    eager_load_associations << :parent if eager_load_parent
-
+  def call
     third_party_projects = ThirdPartyProjectPolicy::Scope.new(user, Activity.third_party_project)
       .resolve
-      .includes(eager_load_associations)
+      .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
     third_party_projects = if organisation.service_owner

--- a/app/views/staff/organisations/show.xml.haml
+++ b/app/views/staff/organisations/show.xml.haml
@@ -2,5 +2,5 @@
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
-    = render partial: "staff/shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.transactions, budgets: activity.budgets, planned_disbursements: activity.latest_planned_disbursements }
+    = render partial: "staff/shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_transactions_for_level, budgets: activity.budgets, planned_disbursements: activity.latest_planned_disbursements }
 

--- a/app/views/staff/shared/xml/_transaction.xml.haml
+++ b/app/views/staff/shared/xml/_transaction.xml.haml
@@ -2,10 +2,12 @@
   %transaction-type{"code" => transaction.transaction_type}
   %transaction-date{"iso-date" => transaction.date}
   %value{"currency" => transaction.currency, "value-date" => transaction.date}=transaction.value
-  %description
-    %narrative=transaction.description
-  %provider-org{"provider-activity-id" => "", "type" => transaction.providing_organisation_type, "ref" => transaction.providing_organisation_reference}
-    %narrative=transaction.providing_organisation_name
+  - if transaction.description.present?
+    %description
+      %narrative=transaction.description
+  - if transaction.providing_organisation_name.present?
+    %provider-org{"provider-activity-id" => "", "type" => transaction.providing_organisation_type, "ref" => transaction.providing_organisation_reference}
+      %narrative=transaction.providing_organisation_name
   - if transaction.receiving_organisation_name.present?
     %receiver-org{"receiver-activity-id" => "", "type" => transaction.receiving_organisation_type, "ref" => transaction.receiving_organisation_reference}
       %narrative=transaction.receiving_organisation_name

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -82,6 +82,9 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :extending_organisation
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :implementing_organisations
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :budgets
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Report", association: :fund
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Budget", association: :providing_organisation
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1824,5 +1824,31 @@ RSpec.describe Activity, type: :model do
         expect(programme2_projects[1].total_forecasted).to eq(programme2_project_1_forecasted)
       end
     end
+
+    describe "#own_and_descendants_transactions" do
+      let!(:fund_transaction) { create(:transaction, value: 100, parent_activity: fund) }
+      let!(:programme1_transaction) { create(:transaction, value: 100, parent_activity: programme1) }
+      let!(:programme2_transaction) { create(:transaction, value: 100, parent_activity: programme2) }
+      let!(:programme1_projects1_transaction) { create(:transaction, value: 50, parent_activity: programme1_projects[0]) }
+      let!(:programme1_projects2_transaction) { create(:transaction, value: 50, parent_activity: programme1_projects[1]) }
+      let!(:programme2_projects1_transaction) { create(:transaction, value: 100, parent_activity: programme2_projects[0]) }
+      let!(:programme2_projects2_transaction) { create(:transaction, value: 100, parent_activity: programme2_projects[1]) }
+      let!(:programme1_tpp_transaction) { create(:transaction, value: 100, parent_activity: programme1_third_party_project) }
+      let!(:programme2_tpp_transaction) { create(:transaction, value: 100, parent_activity: programme2_third_party_project) }
+
+      it "returns all the transactions belonging to the activity and to the descendant activities" do
+        expect(fund.own_and_descendants_transactions.pluck(:id)).to match_array([
+          fund_transaction.id,
+          programme1_transaction.id,
+          programme2_transaction.id,
+          programme1_projects1_transaction.id,
+          programme1_projects2_transaction.id,
+          programme2_projects1_transaction.id,
+          programme2_projects2_transaction.id,
+          programme1_tpp_transaction.id,
+          programme2_tpp_transaction.id,
+        ])
+      end
+    end
   end
 end

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -9,27 +9,6 @@ RSpec.describe FindProgrammeActivities do
   let!(:other_programme) { create(:programme_activity) }
 
   describe "#call" do
-    it "eager loads the organisation and parent activity" do
-      expect_any_instance_of(ActiveRecord::Relation)
-        .to receive(:includes)
-        .with([:organisation, :parent])
-        .and_call_original
-
-      described_class.new(organisation: service_owner, user: user).call
-    end
-
-    context "when eager loading parent activities is turned off" do
-      it "does not eager load parent" do
-        expect_any_instance_of(ActiveRecord::Relation)
-          .to receive(:includes)
-          .with([:organisation])
-          .and_call_original
-
-        described_class.new(organisation: service_owner, user: user)
-          .call(eager_load_parent: false)
-      end
-    end
-
     context "when the organisation is the service owner" do
       it "returns all programme activities" do
         result = described_class.new(organisation: service_owner, user: user).call

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -9,27 +9,6 @@ RSpec.describe FindProjectActivities do
   let!(:other_project) { create(:project_activity) }
 
   describe "#call" do
-    it "eager loads the organisation and parent activity" do
-      expect_any_instance_of(ActiveRecord::Relation)
-        .to receive(:includes)
-        .with([:organisation, :parent])
-        .and_call_original
-
-      described_class.new(organisation: service_owner, user: user).call
-    end
-
-    context "when eager loading parent activities is turned off" do
-      it "does not eager load parent" do
-        expect_any_instance_of(ActiveRecord::Relation)
-          .to receive(:includes)
-          .with([:organisation])
-          .and_call_original
-
-        described_class.new(organisation: service_owner, user: user)
-          .call(eager_load_parent: false)
-      end
-    end
-
     context "when the organisation is the service owner" do
       it "returns all project activities" do
         result = described_class.new(organisation: service_owner, user: user).call

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -9,27 +9,6 @@ RSpec.describe FindThirdPartyProjectActivities do
   let!(:other_project) { create(:third_party_project_activity) }
 
   describe "#call" do
-    it "eager loads the organisation and parent activity" do
-      expect_any_instance_of(ActiveRecord::Relation)
-        .to receive(:includes)
-        .with([:organisation, :parent])
-        .and_call_original
-
-      described_class.new(organisation: service_owner, user: user).call
-    end
-
-    context "when eager loading parent activities is turned off" do
-      it "does not eager load parent" do
-        expect_any_instance_of(ActiveRecord::Relation)
-          .to receive(:includes)
-          .with([:organisation])
-          .and_call_original
-
-        described_class.new(organisation: service_owner, user: user)
-          .call(eager_load_parent: false)
-      end
-    end
-
     context "when the organisation is the service owner" do
       it "returns all third party project activities" do
         result = described_class.new(organisation: service_owner, user: user).call


### PR DESCRIPTION
## Changes in this PR

When reporting programme level activities to IATI we want to include transactions belonging to all child activities as well. We don't want an entry for each transaction rather we want to group them by financial quarter.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
