### PR TITLE
(1717) Validate that activities have the correct organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,6 +624,7 @@
 ## [unreleased]
 
 - Add BEIS contact info to the IATI XML
+- Validate that activities have the correct organisation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...HEAD
 [release-48]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...release-48

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -83,7 +83,7 @@ class Activity < ApplicationRecord
   validates :level, presence: true
   validates :parent, absence: true, if: proc { |activity| activity.fund? }
   validates :parent, presence: true, unless: proc { |activity| activity.fund? }
-  validates :organisation, service_owner: true, if: proc { |activity| activity.fund? }
+  validates_with OrganisationValidator
   validates :delivery_partner_identifier, presence: true, on: :identifier_step
   validates_with RodaIdentifierValidator, on: :roda_identifier_step
   validates :title, :description, presence: true, on: :purpose_step

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -83,6 +83,7 @@ class Activity < ApplicationRecord
   validates :level, presence: true
   validates :parent, absence: true, if: proc { |activity| activity.fund? }
   validates :parent, presence: true, unless: proc { |activity| activity.fund? }
+  validates :organisation, service_owner: true, if: proc { |activity| activity.fund? }
   validates :delivery_partner_identifier, presence: true, on: :identifier_step
   validates_with RodaIdentifierValidator, on: :roda_identifier_step
   validates :title, :description, presence: true, on: :purpose_step

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -38,4 +38,8 @@ class Organisation < ApplicationRecord
   def self.service_owner
     find_by(iati_reference: SERVICE_OWNER_IATI_REFERENCE)
   end
+
+  def delivery_partner?
+    !service_owner?
+  end
 end

--- a/app/validators/organisation_validator.rb
+++ b/app/validators/organisation_validator.rb
@@ -5,6 +5,10 @@ class OrganisationValidator < ActiveModel::Validator
       activity.errors.add(error_message(level: "fund")) unless activity.organisation.service_owner?
     when "programme"
       activity.errors.add(error_message(level: "programme")) unless activity.organisation.service_owner?
+    when "project"
+      activity.errors.add(error_message(level: "project")) unless activity.organisation.delivery_partner?
+    when "third_party_project"
+      activity.errors.add(error_message(level: "third_party_project")) unless activity.organisation.delivery_partner?
     end
   end
 

--- a/app/validators/organisation_validator.rb
+++ b/app/validators/organisation_validator.rb
@@ -1,0 +1,14 @@
+class OrganisationValidator < ActiveModel::Validator
+  def validate(activity)
+    case activity.level
+    when "fund"
+      activity.errors.add(error_message(level: "fund")) unless activity.organisation.service_owner?
+    when "programme"
+      activity.errors.add(error_message(level: "programme")) unless activity.organisation.service_owner?
+    end
+  end
+
+  private def error_message(level:)
+    I18n.t("activerecord.errors.models.activity.attributes.organisation_id.#{level}.invalid")
+  end
+end

--- a/app/validators/service_owner_validator.rb
+++ b/app/validators/service_owner_validator.rb
@@ -1,0 +1,8 @@
+class ServiceOwnerValidator < ActiveModel::Validator
+  def validate(activity)
+    unless activity.organisation.service_owner?
+      activity.errors.add(:organisation,
+        I18n.t("activerecord.errors.models.activity.attributes.organisation_id.invalid"))
+    end
+  end
+end

--- a/app/validators/service_owner_validator.rb
+++ b/app/validators/service_owner_validator.rb
@@ -1,8 +1,0 @@
-class ServiceOwnerValidator < ActiveModel::Validator
-  def validate(activity)
-    unless activity.organisation.service_owner?
-      activity.errors.add(:organisation,
-        I18n.t("activerecord.errors.models.activity.attributes.organisation_id.invalid"))
-    end
-  end
-end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -475,7 +475,10 @@ en:
             channel_of_delivery_code:
               invalid: Please select a valid Channel of delivery code
             organisation_id:
-              invalid: Funds must be associated with the Service Owner Organisation
+              fund:
+                invalid: Funds must be associated with the Service Owner Organisation
+              programme:
+                invalid: Programmes must be associated with the Service Owner Organisation
   importer:
     errors:
       activity:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -474,6 +474,8 @@ en:
               blank: Select a GCRF challenge area
             channel_of_delivery_code:
               invalid: Please select a valid Channel of delivery code
+            organisation_id:
+              invalid: Funds must be associated with the Service Owner Organisation
   importer:
     errors:
       activity:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -479,6 +479,10 @@ en:
                 invalid: Funds must be associated with the Service Owner Organisation
               programme:
                 invalid: Programmes must be associated with the Service Owner Organisation
+              project:
+                invalid: Projects must be associated with a Delivery Partner Organisation
+              third_party_project:
+                invalid: Third Party Projects must be associated with a Delivery Partner Organisation
   importer:
     errors:
       activity:

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe Staff::ActivityFormsController do
 
   describe "#show" do
     context "when editing a programme" do
+      let(:user) { create(:beis_user) }
+
       let(:fund) { create(:fund_activity) }
-      let(:activity) { create(:programme_activity, organisation: organisation, parent: fund) }
+      let(:activity) { create(:programme_activity, parent: fund) }
 
       context "gcrf_challenge_area step" do
         subject { get_step :gcrf_challenge_area }

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -10,22 +10,6 @@ RSpec.describe Staff::ActivityFormsController do
   end
 
   describe "#show" do
-    context "when editing a fund" do
-      let(:activity) { create(:fund_activity, organisation: organisation) }
-
-      context "gcrf_challenge_area step" do
-        subject { get_step :gcrf_challenge_area }
-
-        it { is_expected.to skip_to_next_step }
-
-        context "when activity is the GCRF fund" do
-          let(:activity) { create(:fund_activity, :gcrf, organisation: organisation) }
-
-          it { is_expected.to skip_to_next_step }
-        end
-      end
-    end
-
     context "when editing a programme" do
       let(:fund) { create(:fund_activity) }
       let(:activity) { create(:programme_activity, organisation: organisation, parent: fund) }

--- a/spec/controllers/staff/transactions_uploads_controller_spec.rb
+++ b/spec/controllers/staff/transactions_uploads_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Staff::TransactionUploadsController do
     let(:report) { create(:report, organisation: organisation, state: :active, fund: fund) }
 
     let!(:fund) { create(:fund_activity, roda_identifier_fragment: "A") }
-    let!(:programme_a) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "A", created_at: rand(0..60).minutes.ago) }
-    let!(:programme_b) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "B", created_at: rand(0..60).minutes.ago) }
+    let!(:programme_a) { create(:programme_activity, parent: fund, roda_identifier_fragment: "A", created_at: rand(0..60).minutes.ago) }
+    let!(:programme_b) { create(:programme_activity, parent: fund, roda_identifier_fragment: "B", created_at: rand(0..60).minutes.ago) }
     let!(:project_c) { create(:project_activity, parent: programme_a, organisation: report.organisation, roda_identifier_fragment: "C", created_at: rand(0..60).minutes.ago) }
     let!(:project_d) { create(:project_activity, parent: programme_b, organisation: report.organisation, roda_identifier_fragment: "D", created_at: rand(0..60).minutes.ago) }
     let!(:third_party_project_e) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier_fragment: "E", created_at: rand(0..60).minutes.ago) }

--- a/spec/controllers/staff/transactions_uploads_controller_spec.rb
+++ b/spec/controllers/staff/transactions_uploads_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Staff::TransactionUploadsController do
   describe "#show" do
     let(:report) { create(:report, organisation: organisation, state: :active, fund: fund) }
 
-    let!(:fund) { create(:fund_activity, organisation: organisation, roda_identifier_fragment: "A") }
+    let!(:fund) { create(:fund_activity, roda_identifier_fragment: "A") }
     let!(:programme_a) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "A", created_at: rand(0..60).minutes.ago) }
     let!(:programme_b) { create(:programme_activity, parent: fund, organisation: report.organisation, roda_identifier_fragment: "B", created_at: rand(0..60).minutes.ago) }
     let!(:project_c) { create(:project_activity, parent: programme_a, organisation: report.organisation, roda_identifier_fragment: "C", created_at: rand(0..60).minutes.ago) }

--- a/spec/controllers/staff/transfers_controller_spec.rb
+++ b/spec/controllers/staff/transfers_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Staff::TransfersController do
     allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
   end
 
-  let(:activity) { create(:activity) }
+  let(:activity) { create(:programme_activity) }
   let(:transfer) { create(:transfer) }
 
   context "when loggged in as a beis user" do

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :activity do
+  factory :__activity do
     title { Faker::Lorem.sentence }
     delivery_partner_identifier { "GCRF-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     roda_identifier_fragment { Faker::Alphanumeric.alpha(number: 5) }

--- a/spec/factories/budget.rb
+++ b/spec/factories/budget.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     value { BigDecimal("110.01") }
     currency { "gbp" }
     ingested { false }
-    association :parent_activity, factory: :activity
+    association :parent_activity, factory: :project_activity
     association :report, factory: :report
 
     trait :direct_newton do

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     receiving_organisation_reference { "GB-COH-{#{Faker::Number.number(digits: 6)}}" }
     receiving_organisation_type { "70" }
 
-    association :parent_activity, factory: :activity
+    association :parent_activity, factory: :project_activity
     association :report
 
     trait :without_receiving_organisation do

--- a/spec/factories/transfer.rb
+++ b/spec/factories/transfer.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :transfer do
-    association :source, factory: :activity
-    association :destination, factory: :activity
+    association :source, factory: :project_activity
+    association :destination, factory: :project_activity
 
     financial_quarter { 1 }
     financial_year { Date.today.year }

--- a/spec/features/staff/beis_users_can_create_a_transfer_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_transfer_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "BEIS users can create a transfer" do
   let(:user) { create(:beis_user) }
   before { authenticate!(user: user) }
 
-  let(:source_activity) { create(:activity) }
+  let(:source_activity) { create(:project_activity) }
   let(:created_transfer) { Transfer.last }
 
   before do
@@ -79,7 +79,7 @@ RSpec.feature "BEIS users can create a transfer" do
   end
 
   scenario "show an error when the destination RODA ID is incorrect" do
-    non_existent_activity = build(:activity)
+    non_existent_activity = build(:project_activity)
 
     roda_identifier = "GCRF-BLOB-424434434"
     allow(non_existent_activity).to receive(:roda_identifier) { roda_identifier }

--- a/spec/features/staff/beis_users_can_edit_a_transfer_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_transfer_spec.rb
@@ -2,8 +2,8 @@ RSpec.feature "BEIS users can edit a transfer" do
   let(:user) { create(:beis_user) }
   before { authenticate!(user: user) }
 
-  let(:source_activity) { create(:activity) }
-  let(:destination_activity) { create(:activity) }
+  let(:source_activity) { create(:project_activity) }
+  let(:destination_activity) { create(:project_activity) }
 
   let!(:transfer) { create(:transfer, source: source_activity, destination: destination_activity) }
 

--- a/spec/features/staff/beis_users_can_edit_a_transfer_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_transfer_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "BEIS users can edit a transfer" do
   end
 
   scenario "the user can see validation errors" do
-    non_existent_activity = build(:activity)
+    non_existent_activity = build(:project_activity)
 
     roda_identifier = "GCRF-BLOB-424434434"
     allow(non_existent_activity).to receive(:roda_identifier) { roda_identifier }

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -1,8 +1,9 @@
 RSpec.feature "users can add benefitting countries as intended beneficiaries" do
-  context "when the user is signed as a BEIS user" do
-    let(:user) { create(:beis_user) }
+  context "when the user is signed as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
     before { authenticate!(user: user) }
     let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation, intended_beneficiaries: nil) }
+    let!(:report) { create(:report, :active, fund: activity.associated_fund, organisation: user.organisation) }
 
     context "after choosing either country or region on the geography step" do
       scenario "the user will be asked if there are other benefitting countries to be added" do

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
   context "when the user is signed as a BEIS user" do
     let(:user) { create(:beis_user) }
     before { authenticate!(user: user) }
-    let(:activity) { create(:activity, :at_geography_step, organisation: user.organisation, intended_beneficiaries: nil) }
+    let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation, intended_beneficiaries: nil) }
 
     context "after choosing either country or region on the geography step" do
       scenario "the user will be asked if there are other benefitting countries to be added" do

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -1,10 +1,10 @@
 RSpec.feature "Users can choose a recipient country" do
   include CodelistHelper
 
-  context "when the user is signed as a BEIS user" do
-    let(:user) { create(:beis_user) }
+  context "when the user is signed as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
     before { authenticate!(user: user) }
-    let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation) }
+    let(:activity) { create(:project_activity, :with_report, :at_geography_step, organisation: user.organisation) }
 
     before do
       visit activity_step_path(activity, :geography)

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Users can choose a recipient country" do
   context "when the user is signed as a BEIS user" do
     let(:user) { create(:beis_user) }
     before { authenticate!(user: user) }
-    let(:activity) { create(:activity, :at_geography_step, organisation: user.organisation) }
+    let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation) }
 
     before do
       visit activity_step_path(activity, :geography)

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can create a project" do
 
     context "when viewing a programme" do
       scenario "a new project cannot be added to the programme when a report does not exist" do
-        programme = create(:programme_activity, :newton_funded, organisation: user.organisation, extending_organisation: user.organisation)
+        programme = create(:programme_activity, :newton_funded, extending_organisation: user.organisation)
 
         visit activities_path
         click_on programme.title
@@ -15,7 +15,7 @@ RSpec.feature "Users can create a project" do
       end
 
       scenario "a new project can be added to the programme" do
-        programme = create(:programme_activity, :newton_funded, organisation: user.organisation, extending_organisation: user.organisation)
+        programme = create(:programme_activity, :newton_funded, extending_organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 
         visit activities_path

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature "Users can create a project" do
       end
 
       context "when creating a project that is Newton funded" do
-        let(:newton_fund) { create(:fund_activity, :newton, organisation: user.organisation) }
+        let(:newton_fund) { create(:fund_activity, :newton) }
 
         scenario "'country_delivery_partners' can be present" do
           newton_programme = create(:programme_activity, extending_organisation: user.organisation, parent: newton_fund)

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -281,7 +281,6 @@ RSpec.feature "Users can create a transaction" do
       fund_activity = create(:fund_activity, :with_report)
       programme_activity = create(:programme_activity,
         parent: fund_activity,
-        organisation: user.organisation,
         extending_organisation: user.organisation)
 
       visit organisation_activity_path(programme_activity.organisation, programme_activity)

--- a/spec/features/staff/users_can_create_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_create_a_transaction_spec.rb
@@ -275,9 +275,10 @@ RSpec.feature "Users can create a transaction" do
   context "when they are a government delivery partner organisation user" do
     before { authenticate!(user: user) }
     let(:user) { create(:delivery_partner_user) }
+    let(:beis_user) { create(:beis_user) }
 
     scenario "they cannot create transactions on a programme" do
-      fund_activity = create(:fund_activity, :with_report, organisation: user.organisation)
+      fund_activity = create(:fund_activity, :with_report)
       programme_activity = create(:programme_activity,
         parent: fund_activity,
         organisation: user.organisation,

--- a/spec/features/staff/users_can_delete_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_delete_a_transaction_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "Users can delete a transaction" do
   let(:delivery_partner_user) { create(:delivery_partner_user) }
   let(:beis_user) { create(:beis_user) }
 
-  let!(:activity) { create(:programme_activity, organisation: delivery_partner_user.organisation) }
+  let!(:activity) { create(:programme_activity) }
   let!(:report) { create(:report, :active, organisation: delivery_partner_user.organisation, fund: activity.associated_fund) }
   let!(:transaction) { create(:transaction, parent_activity: activity, report: report) }
 
@@ -33,7 +33,9 @@ RSpec.feature "Users can delete a transaction" do
   context "when signed in as a delivery partner" do
     before { authenticate!(user: delivery_partner_user) }
 
-    scenario "deleting a transaction on a programme" do
+    let!(:activity) { create(:project_activity, organisation: delivery_partner_user.organisation) }
+
+    scenario "deleting a transaction on a project" do
       PublicActivity.with_tracking do
         visit organisation_activity_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -249,7 +249,7 @@ RSpec.feature "Users can edit an activity" do
       end
 
       scenario "it does not show the Publish to Iati field" do
-        activity = create(:programme_activity, organisation: user.organisation)
+        activity = create(:programme_activity)
 
         visit organisation_activity_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can edit an activity" do
     before { authenticate!(user: user) }
 
     it "shows the Publish to Iati field" do
-      activity = create(:third_party_project_activity, organisation: user.organisation)
+      activity = create(:third_party_project_activity)
 
       visit organisation_activity_path(activity.organisation, activity)
       click_on t("tabs.activity.details")
@@ -15,7 +15,7 @@ RSpec.feature "Users can edit an activity" do
     end
 
     it "allows the user to redact the activity from Iati" do
-      activity = create(:third_party_project_activity, organisation: user.organisation)
+      activity = create(:third_party_project_activity)
 
       visit organisation_activity_path(activity.organisation, activity)
       click_on t("tabs.activity.details")
@@ -34,8 +34,8 @@ RSpec.feature "Users can edit an activity" do
     end
 
     it "also redacts any child third-party projects when a project is redacted" do
-      project_activity = create(:project_activity, organisation: user.organisation)
-      third_party_project_activity = create(:third_party_project_activity, parent: project_activity, organisation: user.organisation)
+      project_activity = create(:project_activity)
+      third_party_project_activity = create(:third_party_project_activity, parent: project_activity)
 
       visit organisation_activity_path(project_activity.organisation, project_activity)
       click_on t("tabs.activity.details")

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -1,8 +1,8 @@
 RSpec.feature "Users can provide the geography for an activity" do
-  context "when the user belongs to BEIS" do
-    let(:user) { create(:beis_user) }
+  context "when the user is a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
     before { authenticate!(user: user) }
-    let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation) }
+    let(:activity) { create(:project_activity, :with_report, :at_geography_step, organisation: user.organisation) }
 
     scenario "they are asked to choose the geography" do
       visit activity_step_path(activity, :geography)
@@ -60,6 +60,7 @@ RSpec.feature "Users can provide the geography for an activity" do
     context "with a completed activity" do
       scenario "they can change the geography from region to country" do
         activity = create(:project_activity,
+          :with_report,
           geography: :recipient_region,
           recipient_country: nil,
           organisation: user.organisation)
@@ -87,6 +88,7 @@ RSpec.feature "Users can provide the geography for an activity" do
 
       scenario "they can change the geography from country to region" do
         activity = create(:project_activity,
+          :with_report,
           geography: :recipient_country,
           recipient_region: nil,
           recipient_country: "AG",

--- a/spec/features/staff/users_can_manage_activity_geography_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_geography_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "Users can provide the geography for an activity" do
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
     before { authenticate!(user: user) }
-    let(:activity) { create(:activity, :at_geography_step, organisation: user.organisation) }
+    let(:activity) { create(:project_activity, :at_geography_step, organisation: user.organisation) }
 
     scenario "they are asked to choose the geography" do
       visit activity_step_path(activity, :geography)
@@ -59,7 +59,7 @@ RSpec.feature "Users can provide the geography for an activity" do
 
     context "with a completed activity" do
       scenario "they can change the geography from region to country" do
-        activity = create(:activity,
+        activity = create(:project_activity,
           geography: :recipient_region,
           recipient_country: nil,
           organisation: user.organisation)
@@ -86,7 +86,7 @@ RSpec.feature "Users can provide the geography for an activity" do
       end
 
       scenario "they can change the geography from country to region" do
-        activity = create(:activity,
+        activity = create(:project_activity,
           geography: :recipient_country,
           recipient_region: nil,
           recipient_country: "AG",

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can manage Sectors" do
 
     context "with a new activity" do
       scenario "they can provide the sector category" do
-        activity = create(:activity, :at_identifier_step, delivery_partner_identifier: "GCRF", organisation: user.organisation)
+        activity = create(:fund_activity, :at_identifier_step, delivery_partner_identifier: "GCRF", organisation: user.organisation)
         visit activity_step_path(activity, :sector_category)
         choose "Basic Education"
         click_button t("form.button.activity.submit")
@@ -16,7 +16,7 @@ RSpec.feature "Users can manage Sectors" do
     end
 
     context "with an existing activity" do
-      let(:activity) { create(:activity, organisation: user.organisation) }
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
 
       scenario "they can edit the sector by changing the sector category and sector and retruning to the summary" do
         visit organisation_activity_details_path(user.organisation, activity)

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can view activities" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
-      activity = create(:activity)
+      activity = create(:programme_activity)
       visit organisation_activity_path(activity.organisation, activity)
       expect(current_path).to eq(root_path)
     end

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -131,7 +131,6 @@ RSpec.feature "Users can view an activity as XML" do
       context "when the activity has policy markers" do
         let(:activity) {
           create(:project_activity,
-            organisation: organisation,
             delivery_partner_identifier: "IND-ENT-IFIER",
             policy_marker_gender: "not_targeted",
             policy_marker_biodiversity: "significant_objective",
@@ -216,14 +215,14 @@ RSpec.feature "Users can view an activity as XML" do
       end
 
       context "when the activity is a project activity" do
-        let(:activity) { create(:project_activity_with_implementing_organisations, :with_transparency_identifier, organisation: organisation) }
+        let(:activity) { create(:project_activity_with_implementing_organisations, :with_transparency_identifier) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it_behaves_like "valid activity XML"
       end
 
       context "when the activity has budgets" do
-        let(:activity) { create(:project_activity, organisation: organisation) }
+        let(:activity) { create(:project_activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it "only includes budgets which belong to the activity" do
@@ -247,7 +246,7 @@ RSpec.feature "Users can view an activity as XML" do
       end
 
       context "when the activity has transactions" do
-        let(:activity) { create(:project_activity, organisation: organisation) }
+        let(:activity) { create(:project_activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it "only includes transactions which belong to the activity" do
@@ -281,7 +280,7 @@ RSpec.feature "Users can view an activity as XML" do
       end
 
       context "when the activity has planned disbursements" do
-        let(:activity) { create(:project_activity, organisation: organisation) }
+        let(:activity) { create(:project_activity) }
         let(:xml) { Nokogiri::XML::Document.parse(page.body) }
 
         it "only includes planned disbursements which belong to the activity" do

--- a/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_as_xml_spec.rb
@@ -228,7 +228,7 @@ RSpec.feature "Users can view an activity as XML" do
 
         it "only includes budgets which belong to the activity" do
           _budget = create(:budget, parent_activity: activity)
-          _other_budget = create(:budget, parent_activity: create(:activity))
+          _other_budget = create(:budget)
 
           visit organisation_activity_path(organisation, activity, format: :xml)
 
@@ -252,7 +252,7 @@ RSpec.feature "Users can view an activity as XML" do
 
         it "only includes transactions which belong to the activity" do
           _transaction = create(:transaction, parent_activity: activity)
-          _other_transaction = create(:transaction, parent_activity: create(:activity))
+          _other_transaction = create(:transaction)
 
           visit organisation_activity_path(organisation, activity, format: :xml)
 
@@ -286,7 +286,7 @@ RSpec.feature "Users can view an activity as XML" do
 
         it "only includes planned disbursements which belong to the activity" do
           _planned_disbursement = create(:planned_disbursement, parent_activity: activity)
-          _other_planned_disbursement = create(:planned_disbursement, parent_activity: create(:activity))
+          _other_planned_disbursement = create(:planned_disbursement)
 
           visit organisation_activity_path(organisation, activity, format: :xml)
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "the activity child activities can be viewed in a tab" do
-      activity = create(:project_activity, organisation: user.organisation)
+      activity = create(:project_activity)
 
       visit organisation_activity_children_path(activity.organisation, activity)
 
@@ -153,7 +153,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "the activity details tab can be viewed" do
-      activity = create(:project_activity, organisation: user.organisation)
+      activity = create(:project_activity)
 
       visit organisation_activity_details_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can view an activity" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
-      activity = create(:activity)
+      activity = create(:project_activity)
       visit organisation_activity_path(activity.organisation, activity)
       expect(current_path).to eq(root_path)
     end
@@ -182,10 +182,11 @@ RSpec.feature "Users can view an activity" do
 
     scenario "a fund activity has human readable date format" do
       travel_to Time.zone.local(2020, 1, 29) do
-        activity = create(:activity, planned_start_date: Date.new(2020, 2, 3),
-                                     planned_end_date: Date.new(2024, 6, 22),
-                                     actual_start_date: Date.new(2020, 1, 2),
-                                     actual_end_date: Date.new(2020, 1, 29))
+        activity = create(:project_activity,
+          planned_start_date: Date.new(2020, 2, 3),
+          planned_end_date: Date.new(2024, 6, 22),
+          actual_start_date: Date.new(2020, 1, 2),
+          actual_end_date: Date.new(2020, 1, 29))
 
         visit organisation_activity_path(user.organisation, activity)
         click_on t("tabs.activity.details")

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Users can view an activity" do
     before { authenticate!(user: user) }
 
     scenario "a programme activity does not link to its parent activity" do
-      activity = create(:programme_activity, organisation: user.organisation)
+      activity = create(:programme_activity, extending_organisation: user.organisation)
       parent_activity = activity.parent
 
       visit organisation_activity_details_path(activity.organisation, activity)

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "the activity child activities can be viewed in a tab" do
-      activity = create(:activity, organisation: user.organisation)
+      activity = create(:project_activity, organisation: user.organisation)
 
       visit organisation_activity_children_path(activity.organisation, activity)
 
@@ -153,7 +153,7 @@ RSpec.feature "Users can view an activity" do
     end
 
     scenario "the activity details tab can be viewed" do
-      activity = create(:activity, organisation: user.organisation)
+      activity = create(:project_activity, organisation: user.organisation)
 
       visit organisation_activity_details_path(activity.organisation, activity)
 

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can view an organisation as XML" do
     context "when the user is viewing the BEIS organisation show page" do
       scenario "they cannot download the organisation's projects as XML" do
         beis = user.organisation
-        _project = create(:project_activity, organisation: beis)
+        _programme = create(:programme_activity, organisation: beis)
 
         visit organisation_path(beis)
 

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -140,7 +140,8 @@ RSpec.feature "Users can view an organisation as XML" do
       end
 
       scenario "the XML file does not contain fund or programme activities in the organisation" do
-        _fund = create(:fund_activity, organisation: organisation)
+        beis = create(:beis_organisation)
+        _fund = create(:fund_activity, organisation: beis)
         _programme = create(:programme_activity, extending_organisation: organisation)
 
         visit organisation_path(organisation, format: :xml)
@@ -218,7 +219,7 @@ RSpec.feature "Users can view an organisation as XML" do
           visit organisation_path(organisation, format: :xml, level: :project)
           xml = Nokogiri::XML::Document.parse(page.body)
 
-          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to eql(["100.0", "150.0", "200.0"])
+          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to match_array(["100.0", "150.0", "200.0"])
           expect(xml.xpath("//iati-activity/transaction/transaction-date/@iso-date").map(&:text)).to eql(["2018-06-30", "2018-06-30", "2019-12-31"])
         end
       end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
     context "when the activity is project level" do
       scenario "budget information is shown on the page" do
-        programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
+        programme_activity = create(:programme_activity, extending_organisation: user.organisation)
         project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
         budget = create(:budget, parent_activity: project_activity)
@@ -149,7 +149,7 @@ RSpec.feature "Users can view budgets on an activity page" do
       end
 
       scenario "a delivery partner can edit/create a budget" do
-        programme_activity = create(:programme_activity, extending_organisation: user.organisation, organisation: user.organisation)
+        programme_activity = create(:programme_activity, extending_organisation: user.organisation)
         report = create(:report, state: :active, organisation: user.organisation, fund: programme_activity.associated_fund)
         project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can view fund level activities" do
     before { authenticate!(user: user) }
 
     scenario "can view a fund level activity" do
-      fund_activity = create(:activity, level: :fund, organisation: user.organisation)
+      fund_activity = create(:fund_activity)
       create(:programme_activity, parent: fund_activity)
 
       visit activities_path

--- a/spec/features/staff/users_can_view_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_view_planned_disbursements_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Users can view planned disbursements" do
     before { authenticate!(user: beis_user) }
 
     scenario "they can view planned disbursements on projects" do
-      project = create(:project_activity, organisation: beis_user.organisation)
+      project = create(:project_activity)
       planned_disbursement = create(:planned_disbursement, parent_activity: project)
 
       visit organisation_activity_path(beis_user.organisation, project)
@@ -39,7 +39,7 @@ RSpec.describe "Users can view planned disbursements" do
     end
 
     scenario "they can view planned disbursements on third-party projects" do
-      third_party_project = create(:third_party_project_activity, organisation: beis_user.organisation)
+      third_party_project = create(:third_party_project_activity)
       planned_disbursement = create(:planned_disbursement, parent_activity: third_party_project)
 
       visit organisation_activity_path(beis_user.organisation, third_party_project)

--- a/spec/features/staff/users_can_view_programme_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_programme_level_activities_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature "Users can view programme level activities" do
 
       fund_activity = create(:fund_activity)
       programme_activity = create(:programme_activity,
-        organisation: user.organisation,
         parent: fund_activity,
         extending_organisation: user.organisation)
       project = create(:project_activity, parent: programme_activity, organisation: user.organisation)

--- a/spec/features/staff/users_can_view_programme_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_programme_level_activities_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Users can view programme level activities" do
     it "shows the programme level activity" do
       authenticate!(user: user)
 
-      fund_activity = create(:fund_activity, organisation: user.organisation)
+      fund_activity = create(:fund_activity)
       programme_activity = create(:programme_activity,
         organisation: user.organisation,
         parent: fund_activity,

--- a/spec/features/staff/users_can_view_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_project_level_activities_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Users can view project level activities" do
       fund = create(:fund_activity)
       programme = create(:programme_activity)
       fund.child_activities << programme
-      project = create(:project_activity, organisation: user.organisation, transparency_identifier: "GB-GOV-13-PROJECT")
+      project = create(:project_activity, transparency_identifier: "GB-GOV-13-PROJECT")
       programme.child_activities << project
 
       visit organisation_activity_path(project.organisation, project)

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can view the site navigation" do
   context "when the user is not signed in" do
     it "does not show the navigation" do
-      activity = create(:activity)
+      activity = create(:project_activity)
 
       visit organisation_path(activity.organisation)
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe ActivityHelper, type: :helper do
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do
       it "returns true for the purpose fields" do
-        activity = build(:activity, :at_roda_identifier_step)
+        activity = build(:project_activity, :at_roda_identifier_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "purpose")).to be(true)
       end
 
       it "returns false for the next fields following the purpose field" do
-        activity = build(:activity, :at_identifier_step)
+        activity = build(:project_activity, :at_identifier_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "sector")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "programme_status")).to be(false)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "dates")).to be(false)
@@ -23,7 +23,7 @@ RSpec.describe ActivityHelper, type: :helper do
 
     context "when the activity has passed the region step" do
       it "returns true for the previous field and only for the next field" do
-        activity = build(:activity, :at_region_step)
+        activity = build(:project_activity, :at_region_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "purpose")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "sector")).to be(true)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "programme_status")).to be(true)
@@ -33,14 +33,14 @@ RSpec.describe ActivityHelper, type: :helper do
       end
 
       it "returns false for the next fields" do
-        activity = build(:activity, :at_region_step)
+        activity = build(:project_activity, :at_region_step)
         expect(helper.step_is_complete_or_next?(activity: activity, step: "aid_type")).to be(false)
       end
     end
 
     context "when the activity form has been completed" do
       it "shows all steps" do
-        activity = build(:activity, form_state: "complete")
+        activity = build(:project_activity, form_state: "complete")
         all_steps = Activity::FORM_STEPS
 
         all_steps.each do |step|

--- a/spec/lib/roda_form_builder/form_builder_spec.rb
+++ b/spec/lib/roda_form_builder/form_builder_spec.rb
@@ -4,7 +4,7 @@ class TestHelper < ActionView::Base; end
 
 RSpec.describe RodaFormBuilder::FormBuilder do
   let(:helper) { TestHelper.new(ActionView::LookupContext.new(nil), {}, nil) }
-  let(:resource) { build(:activity) }
+  let(:resource) { build(:project_activity) }
   let(:builder) { described_class.new :activity, resource, helper, {} }
   let(:guidance) { double("GuidanceUrl", to_s: url) }
 

--- a/spec/lib/tasks/import_activities_spec.rb
+++ b/spec/lib/tasks/import_activities_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "rake activities:import", type: :task do
 
     context "When there are no errors from the importer" do
       let(:importer) do
-        double(:importer, errors: [], created: build_list(:activity, 3), updated: build_list(:activity, 2))
+        double(:importer, errors: [], created: build_list(:project_activity, 3), updated: build_list(:project_activity, 2))
       end
 
       it "outputs the number of activities imported and updated" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Activity, type: :model do
 
     context "overall activity state" do
       context "when the activity form is final" do
-        subject { build(:activity, :at_identifier_step, form_state: "complete") }
+        subject { build(:project_activity, :at_identifier_step, form_state: "complete") }
         it { should be_invalid }
       end
     end
@@ -174,7 +174,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when delivery_partner_identifier is blank" do
-      subject(:activity) { build(:activity, delivery_partner_identifier: nil) }
+      subject(:activity) { build(:project_activity, delivery_partner_identifier: nil) }
       it "should not be valid" do
         expect(activity.valid?(:identifier_step)).to be_falsey
       end
@@ -365,14 +365,14 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when title is blank" do
-      subject(:activity) { build(:activity, title: nil) }
+      subject(:activity) { build(:project_activity, title: nil) }
       it "should not be valid" do
         expect(activity.valid?(:purpose_step)).to be_falsey
       end
     end
 
     context "when description is blank" do
-      subject(:activity) { build(:activity, description: nil) }
+      subject(:activity) { build(:project_activity, description: nil) }
       it "should not be valid" do
         expect(activity.valid?(:purpose_step)).to be_falsey
       end
@@ -386,21 +386,21 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when sector category is blank" do
-      subject(:activity) { build(:activity, sector_category: nil) }
+      subject(:activity) { build(:project_activity, sector_category: nil) }
       it "should not be valid" do
         expect(activity.valid?(:sector_category_step)).to be_falsey
       end
     end
 
     context "when sector is blank" do
-      subject(:activity) { build(:activity, sector: nil) }
+      subject(:activity) { build(:project_activity, sector: nil) }
       it "should not be valid" do
         expect(activity.valid?(:sector_step)).to be_falsey
       end
     end
 
     context "when planned start and actual start dates are blank" do
-      subject(:activity) { build(:activity, planned_start_date: nil, actual_start_date: nil) }
+      subject(:activity) { build(:project_activity, planned_start_date: nil, actual_start_date: nil) }
       it "should not be valid" do
         expect(activity.valid?(:dates_step)).to be_falsey
       end
@@ -452,7 +452,7 @@ RSpec.describe Activity, type: :model do
       let(:activity) { build(:project_activity) }
 
       it "does not allow planned_end_date to be earlier than planned_start_date" do
-        activity = build(:activity, planned_start_date: Date.today, planned_end_date: Date.yesterday)
+        activity = build(:project_activity, planned_start_date: Date.today, planned_end_date: Date.yesterday)
         expect(activity.valid?).to be_falsey
         expect(activity.errors[:planned_end_date]).to include "Planned end date must be after planned start date"
       end
@@ -585,14 +585,14 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when fstc applies is blank" do
-      subject(:activity) { build(:activity, fstc_applies: nil) }
+      subject(:activity) { build(:project_activity, fstc_applies: nil) }
       it "should not be valid" do
         expect(activity.valid?(:fstc_applies_step)).to be_falsey
       end
     end
 
     context "when Covid19-related research is blank" do
-      subject(:activity) { build(:activity, covid19_related: nil) }
+      subject(:activity) { build(:project_activity, covid19_related: nil) }
       it "should not be valid" do
         expect(activity.valid?(:covid19_related_step)).to be_falsey
       end
@@ -666,7 +666,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when oda_eligibility is blank" do
-      subject(:activity) { build(:activity, oda_eligibility: nil) }
+      subject(:activity) { build(:project_activity, oda_eligibility: nil) }
       it "should not be valid" do
         expect(activity.valid?(:oda_eligibility_step)).to be_falsey
       end
@@ -674,34 +674,34 @@ RSpec.describe Activity, type: :model do
 
     context "when saving in the oda_eligibility_lead_step context" do
       context "and the activity is a fund" do
-        subject { build(:activity, level: :fund) }
+        subject { build(:project_activity, level: :fund) }
         it { should_not validate_presence_of(:oda_eligibility_lead).on(:oda_eligibility_lead_step) }
       end
 
       context "and the activity is a programme" do
-        subject { build(:activity, level: :programme) }
+        subject { build(:project_activity, level: :programme) }
         it { should_not validate_presence_of(:oda_eligibility_lead).on(:oda_eligibility_lead_step) }
       end
 
       context "and the activity is a project" do
-        subject { build(:activity, level: :project) }
+        subject { build(:project_activity, level: :project) }
         it { should validate_presence_of(:oda_eligibility_lead).on(:oda_eligibility_lead_step) }
       end
 
       context "and the activity is a third party project" do
-        subject { build(:activity, level: :third_party_project) }
+        subject { build(:project_activity, level: :third_party_project) }
         it { should validate_presence_of(:oda_eligibility_lead).on(:oda_eligibility_lead_step) }
       end
     end
 
     context "when saving in the uk_dp_named_contact context" do
       context "and the activity is a fund" do
-        subject { build(:activity, level: :fund) }
+        subject { build(:project_activity, level: :fund) }
         it { should_not validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
       end
 
       context "and the activity is a programme" do
-        subject { build(:activity, level: :programme) }
+        subject { build(:project_activity, level: :programme) }
         it { should_not validate_presence_of(:uk_dp_named_contact).on(:uk_dp_named_contact_step) }
       end
 
@@ -912,19 +912,19 @@ RSpec.describe Activity, type: :model do
 
   describe "#form_steps_completed?" do
     it "is true when a user has completed all of the form steps" do
-      activity = build(:activity, form_state: :complete)
+      activity = build(:project_activity, form_state: :complete)
 
       expect(activity.form_steps_completed?).to be_truthy
     end
 
     it "is false when a user is still completing one of the form steps" do
-      activity = build(:activity, form_state: :purpose)
+      activity = build(:project_activity, form_state: :purpose)
 
       expect(activity.form_steps_completed?).to be_falsey
     end
 
     it "is false when the form_state is nil" do
-      activity = build(:activity, form_state: nil)
+      activity = build(:project_activity, form_state: nil)
 
       expect(activity.form_steps_completed?).to be_falsey
     end
@@ -939,7 +939,7 @@ RSpec.describe Activity, type: :model do
   end
 
   it "returns false if all extending_organisation fields are not present" do
-    activity = build(:activity)
+    activity = build(:project_activity, extending_organisation: nil)
 
     expect(activity.has_extending_organisation?).to be false
   end
@@ -1536,7 +1536,7 @@ RSpec.describe Activity, type: :model do
 
   describe "#source_fund" do
     context "for a Newton fund activity" do
-      let(:activity) { build(:activity, source_fund_code: Fund::MAPPINGS["NF"]) }
+      let(:activity) { build(:project_activity, source_fund_code: Fund::MAPPINGS["NF"]) }
 
       it "returns a Newton fund" do
         expect(activity.source_fund).to be_a(Fund)
@@ -1546,7 +1546,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context "for a GCRF activity" do
-      let(:activity) { build(:activity, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+      let(:activity) { build(:project_activity, source_fund_code: Fund::MAPPINGS["GCRF"]) }
 
       it "returns a GCRF fund" do
         expect(activity.source_fund).to be_a(Fund)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe Activity, type: :model do
     describe ".projects_and_third_party_projects_for_report" do
       it "only returns projects and third party projects that are for the reports organisation and fund" do
         organisation = create(:delivery_partner_organisation)
-        fund = create(:fund_activity, organisation: organisation)
+        fund = create(:fund_activity)
         programme = create(:programme_activity, parent: fund, organisation: organisation)
         project = create(:project_activity, parent: programme, organisation: organisation)
         third_party_project = create(:third_party_project_activity, parent: project, organisation: organisation)
         report = create(:report, organisation: third_party_project.organisation, fund: fund)
 
-        another_fund = create(:fund_activity, organisation: organisation)
+        another_fund = create(:fund_activity)
         another_programme = create(:programme_activity, parent: another_fund, organisation: organisation)
         another_project = create(:project_activity, parent: another_programme, organisation: organisation)
         another_third_party_project = create(:third_party_project_activity, parent: another_project, organisation: organisation)
@@ -134,23 +134,39 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when activity is a fund" do
+      subject { build(:fund_activity, organisation: organisation) }
+
+      context "when the organisation is a delivery partner" do
+        let(:organisation) { build(:delivery_partner_organisation) }
+
+        it { should be_invalid }
+      end
+
+      context "when the organisation is the service owner" do
+        let(:organisation) { build(:beis_organisation) }
+
+        it { should be_valid }
+      end
+    end
+
     context "#form_state" do
       context "when the form_state is set to a value we expect" do
-        subject(:activity) { build(:activity) }
+        subject(:activity) { build(:project_activity) }
         it "should be valid" do
           expect(activity.valid?).to be_truthy
         end
       end
 
       context "when form_state is set to a value not included in the validation list" do
-        subject(:activity) { build(:activity, form_state: "completed") }
+        subject(:activity) { build(:project_activity, form_state: "completed") }
         it "should not be valid" do
           expect(activity.valid?).to be_falsey
         end
       end
 
       context "when form_state is set to a value included in the validation list" do
-        subject(:activity) { build(:activity, form_state: "purpose") }
+        subject(:activity) { build(:project_activity, form_state: "purpose") }
         it "should be valid" do
           expect(activity.valid?).to be_truthy
         end
@@ -391,49 +407,49 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when programme status is blank" do
-      subject(:activity) { build(:activity, programme_status: nil) }
+      subject(:activity) { build(:project_activity, programme_status: nil) }
       it "should not be valid" do
         expect(activity.valid?(:programme_status_step)).to be_falsey
       end
     end
 
     context "when planned_start_date is blank but actual_start_date is not nil" do
-      subject(:activity) { build(:activity, planned_start_date: nil) }
+      subject(:activity) { build(:project_activity, planned_start_date: nil) }
       it "should be valid" do
         expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when actual_start_date is blank but planned_start_date is not nil" do
-      subject(:activity) { build(:activity, actual_start_date: nil) }
+      subject(:activity) { build(:project_activity, actual_start_date: nil) }
       it "should be valid" do
         expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when planned_end_date is blank" do
-      subject(:activity) { build(:activity, planned_end_date: nil) }
+      subject(:activity) { build(:project_activity, planned_end_date: nil) }
       it "should be valid" do
         expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when actual_start_date is blank" do
-      subject(:activity) { build(:activity, actual_start_date: nil) }
+      subject(:activity) { build(:project_activity, actual_start_date: nil) }
       it "should be valid" do
         expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when actual_end_date is blank" do
-      subject(:activity) { build(:activity, actual_end_date: nil) }
+      subject(:activity) { build(:project_activity, actual_end_date: nil) }
       it "should be valid" do
         expect(activity.valid?(:dates_step)).to be_truthy
       end
     end
 
     context "when planned_end_date is not blank" do
-      let(:activity) { build(:activity) }
+      let(:activity) { build(:project_activity) }
 
       it "does not allow planned_end_date to be earlier than planned_start_date" do
         activity = build(:activity, planned_start_date: Date.today, planned_end_date: Date.yesterday)
@@ -467,7 +483,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when geography is blank" do
-      subject(:activity) { build(:activity, geography: nil) }
+      subject(:activity) { build(:project_activity, geography: nil) }
       it "should not be valid" do
         expect(activity.valid?(:geography_step)).to be_falsey
       end
@@ -475,7 +491,7 @@ RSpec.describe Activity, type: :model do
 
     context "when geography is recipient_region" do
       context "and recipient_region and recipient_contry are blank" do
-        subject { build(:activity) }
+        subject { build(:project_activity) }
         it { should validate_presence_of(:recipient_region).on(:region_step) }
         it { should_not validate_presence_of(:recipient_country).on(:country_step) }
       end
@@ -483,28 +499,28 @@ RSpec.describe Activity, type: :model do
 
     context "when geography is recipient_country" do
       context "and recipient_region and recipient_country are blank" do
-        subject { build(:activity, geography: :recipient_country) }
+        subject { build(:project_activity, geography: :recipient_country) }
         it { should validate_presence_of(:recipient_country).on(:country_step) }
         it { should_not validate_presence_of(:recipient_region).on(:region_step) }
       end
     end
 
     context "when requires_additional_benefitting_countries is blank when required" do
-      subject(:activity) { build(:activity, geography: :recipient_country, requires_additional_benefitting_countries: nil) }
+      subject(:activity) { build(:project_activity, geography: :recipient_country, requires_additional_benefitting_countries: nil) }
       it "should not be valid" do
         expect(activity.valid?(:requires_additional_benefitting_countries_step)).to be_falsey
       end
     end
 
     context "when intended_beneficiaries is blank" do
-      subject(:activity) { build(:activity, intended_beneficiaries: nil) }
+      subject(:activity) { build(:project_activity, intended_beneficiaries: nil) }
       it "should not be valid" do
         expect(activity.valid?(:intended_beneficiaries_step)).to be_falsey
       end
     end
 
     context "when gdi is blank" do
-      subject(:activity) { build(:activity, gdi: nil) }
+      subject(:activity) { build(:project_activity, gdi: nil) }
       it "should not be valid" do
         expect(activity.valid?(:gdi_step)).to be_falsey
       end
@@ -548,7 +564,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it "is not required if the activity is a fund" do
-        activity = build(:activity, level: :fund, fund_pillar: nil)
+        activity = build(:fund_activity, fund_pillar: nil)
 
         expect(activity.valid?(:fund_pillar_step)).to be_truthy
       end
@@ -763,9 +779,11 @@ RSpec.describe Activity, type: :model do
     end
 
     describe "parent association" do
-      subject { Activity.new(level: level) }
+      let(:organisation) { build(:delivery_partner_organisation) }
+      subject { Activity.new(level: level, organisation: organisation) }
 
       context "with a fund" do
+        let(:organisation) { build(:beis_organisation) }
         let(:level) { "fund" }
 
         it { is_expected.to validate_absence_of :parent }
@@ -1215,12 +1233,12 @@ RSpec.describe Activity, type: :model do
 
   describe "#iati_identifier" do
     it "returns the previous_identifier if it exists" do
-      activity = create(:activity, previous_identifier: "previous-id", transparency_identifier: "transparency-id")
+      activity = create(:project_activity, previous_identifier: "previous-id", transparency_identifier: "transparency-id")
       expect(activity.iati_identifier).to eq("previous-id")
     end
 
     it "returns the transparency_identifier if previous_identifier is not set" do
-      activity = create(:activity, previous_identifier: nil, transparency_identifier: "transparency-id")
+      activity = create(:project_activity, previous_identifier: nil, transparency_identifier: "transparency-id")
       expect(activity.iati_identifier).to eq("transparency-id")
     end
   end
@@ -1540,7 +1558,7 @@ RSpec.describe Activity, type: :model do
 
   describe "#source_fund=" do
     it "sets the source fund code" do
-      activity = build(:activity)
+      activity = build(:project_activity)
       activity.source_fund = Fund.new(Fund::MAPPINGS["GCRF"])
       activity.save
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -134,38 +134,6 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    context "when activity is a fund" do
-      subject { build(:fund_activity, organisation: organisation) }
-
-      context "when the organisation is a delivery partner" do
-        let(:organisation) { build(:delivery_partner_organisation) }
-
-        it { should be_invalid }
-      end
-
-      context "when the organisation is the service owner" do
-        let(:organisation) { build(:beis_organisation) }
-
-        it { should be_valid }
-      end
-    end
-
-    context "when activity is a programme" do
-      subject { build(:fund_activity, organisation: organisation) }
-
-      context "when the organisation is a delivery partner" do
-        let(:organisation) { build(:delivery_partner_organisation) }
-
-        it { should be_invalid }
-      end
-
-      context "when the organisation is the service owner" do
-        let(:organisation) { build(:beis_organisation) }
-
-        it { should be_valid }
-      end
-    end
-
     context "#form_state" do
       context "when the form_state is set to a value we expect" do
         subject(:activity) { build(:project_activity) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe Activity, type: :model do
       it "only returns projects and third party projects that are for the reports organisation and fund" do
         organisation = create(:delivery_partner_organisation)
         fund = create(:fund_activity)
-        programme = create(:programme_activity, parent: fund, organisation: organisation)
+        programme = create(:programme_activity, parent: fund)
         project = create(:project_activity, parent: programme, organisation: organisation)
         third_party_project = create(:third_party_project_activity, parent: project, organisation: organisation)
         report = create(:report, organisation: third_party_project.organisation, fund: fund)
 
         another_fund = create(:fund_activity)
-        another_programme = create(:programme_activity, parent: another_fund, organisation: organisation)
+        another_programme = create(:programme_activity, parent: another_fund)
         another_project = create(:project_activity, parent: another_programme, organisation: organisation)
         another_third_party_project = create(:third_party_project_activity, parent: another_project, organisation: organisation)
 
@@ -135,6 +135,22 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when activity is a fund" do
+      subject { build(:fund_activity, organisation: organisation) }
+
+      context "when the organisation is a delivery partner" do
+        let(:organisation) { build(:delivery_partner_organisation) }
+
+        it { should be_invalid }
+      end
+
+      context "when the organisation is the service owner" do
+        let(:organisation) { build(:beis_organisation) }
+
+        it { should be_valid }
+      end
+    end
+
+    context "when activity is a programme" do
       subject { build(:fund_activity, organisation: organisation) }
 
       context "when the organisation is a delivery partner" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Budget do
 
     context "when the activity belongs to a delivery partner" do
       it "should validate that the report association exists" do
-        activity = build(:activity, organisation: build_stubbed(:delivery_partner_organisation))
+        activity = build(:project_activity, organisation: build_stubbed(:delivery_partner_organisation))
         report_for_activity = build_stubbed(:report, organisation: activity.organisation, fund: activity.associated_fund)
         budget = build(:budget, parent_activity: activity, report: nil)
 
@@ -118,7 +118,7 @@ RSpec.describe Budget do
 
     context "when the activity belongs to BEIS" do
       it "should validate that the report association exists" do
-        activity = build(:activity, organisation: build_stubbed(:beis_organisation))
+        activity = build(:project_activity, organisation: build_stubbed(:beis_organisation))
         budget = build(:budget, parent_activity: activity, report: nil)
 
         expect(budget).to be_valid

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Organisation, type: :model do
   describe "service_owner?" do
     context "when an organisation is has been flagged as BEIS" do
       it "should return true" do
-        beis_organisation = create(:organisation, service_owner: true)
+        beis_organisation = create(:beis_organisation)
 
         result = beis_organisation.service_owner?
 

--- a/spec/models/planned_disbursement_spec.rb
+++ b/spec/models/planned_disbursement_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PlannedDisbursement, type: :model do
-  let(:activity) { build(:activity) }
+  let(:activity) { build(:project_activity) }
 
   describe "validations" do
     it { should validate_presence_of(:planned_disbursement_type) }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Report, type: :model do
 
   describe "reportable_activities" do
     let!(:report) { create(:report) }
-    let!(:programme) { create(:programme_activity, parent: report.fund, organisation: report.organisation) }
+    let!(:programme) { create(:programme_activity, parent: report.fund) }
     let!(:project_a) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:third_party_project) { create(:third_party_project_activity, parent: project_b, organisation: report.organisation) }

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Transaction, type: :model do
-  let(:activity) { build(:activity) }
+  let(:activity) { build(:project_activity) }
 
   describe "validations" do
     it { should validate_presence_of(:value) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe User, type: :model do
   describe "#service_owner?" do
     context "when the user organisation is a service owner" do
       it "returns true" do
-        organisation = build_stubbed(:organisation, service_owner: true)
+        organisation = build_stubbed(:beis_organisation)
         result = described_class.new(organisation: organisation).service_owner?
         expect(result).to be true
       end
@@ -49,7 +49,7 @@ RSpec.describe User, type: :model do
   describe "#delivery_partner?" do
     context "when the user organisation is a service owner" do
       it "returns false" do
-        organisation = build_stubbed(:organisation, service_owner: true)
+        organisation = build_stubbed(:beis_organisation)
         result = described_class.new(organisation: organisation).delivery_partner?
         expect(result).to be false
       end

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -57,10 +57,9 @@ RSpec.describe BudgetPolicy do
     let(:user) { create(:delivery_partner_user) }
 
     context "when the activity is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -67,10 +67,9 @@ RSpec.describe BudgetPolicy do
     end
 
     context "when the activity is a programme" do
-      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      let(:activity) { create(:programme_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe BudgetPolicy do
     end
 
     context "when the activity is a project" do
-      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      let(:activity) { create(:project_activity) }
 
       it { is_expected.to permit_action(:show) }
 
@@ -42,7 +42,7 @@ RSpec.describe BudgetPolicy do
     end
 
     context "when the activity is a third party project" do
-      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
+      let(:activity) { create(:third_party_project_activity) }
 
       it { is_expected.to permit_action(:show) }
 

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CommentPolicy do
-  let(:activity) { create(:fund_activity, organisation: user.organisation) }
+  let(:activity) { create(:fund_activity) }
   let(:report) { create(:report, :active, fund: activity, organisation: user.organisation) }
   let(:comment) { create(:comment, activity: activity, report: report, owner: user) }
 

--- a/spec/policies/fund_policy_spec.rb
+++ b/spec/policies/fund_policy_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe FundPolicy do
   subject { described_class.new(user, activity) }
 
-  let(:organisation) { create(:organisation) }
-  let(:activity) { create(:fund_activity, organisation: organisation) }
+  let(:activity) { create(:fund_activity) }
 
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -56,10 +56,9 @@ RSpec.describe PlannedDisbursementPolicy do
     let(:user) { create(:delivery_partner_user) }
 
     context "when the activity is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PlannedDisbursementPolicy do
     end
 
     context "when the activity is a project" do
-      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      let(:activity) { create(:project_activity) }
 
       it { is_expected.to permit_action(:show) }
 
@@ -41,7 +41,7 @@ RSpec.describe PlannedDisbursementPolicy do
     end
 
     context "when the activity is a third party project" do
-      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
+      let(:activity) { create(:third_party_project_activity) }
 
       it { is_expected.to permit_action(:show) }
 

--- a/spec/policies/planned_disbursement_policy_spec.rb
+++ b/spec/policies/planned_disbursement_policy_spec.rb
@@ -66,10 +66,9 @@ RSpec.describe PlannedDisbursementPolicy do
     end
 
     context "when the activity is a programme" do
-      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      let(:activity) { create(:programme_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -66,10 +66,9 @@ RSpec.describe TransactionPolicy do
     end
 
     context "when the activity is a programme" do
-      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      let(:activity) { create(:programme_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe TransactionPolicy do
     end
 
     context "when the activity is a project" do
-      let(:activity) { create(:project_activity, organisation: user.organisation) }
+      let(:activity) { create(:project_activity, organisation: create(:delivery_partner_organisation)) }
 
       it { is_expected.to permit_action(:show) }
 
@@ -41,7 +41,7 @@ RSpec.describe TransactionPolicy do
     end
 
     context "when the activity is a third party project" do
-      let(:activity) { create(:third_party_project_activity, organisation: user.organisation) }
+      let(:activity) { create(:third_party_project_activity, organisation: create(:delivery_partner_organisation)) }
 
       it { is_expected.to permit_action(:show) }
 

--- a/spec/policies/transaction_policy_spec.rb
+++ b/spec/policies/transaction_policy_spec.rb
@@ -56,10 +56,9 @@ RSpec.describe TransactionPolicy do
     let(:user) { create(:delivery_partner_user) }
 
     context "when the activity is a fund" do
-      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+      let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to permit_action(:show) }
-
+      it { is_expected.to forbid_action(:show) }
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ActivityCsvPresenter do
   describe "#intended_beneficiaries" do
     context "when there are other benefiting countries" do
       it "returns the benefiting countries separated by semicolons" do
-        activity = build(:activity, intended_beneficiaries: ["AR", "EC", "BR"])
+        activity = build(:project_activity, intended_beneficiaries: ["AR", "EC", "BR"])
         result = described_class.new(activity).intended_beneficiaries
         expect(result).to eql("Argentina; Ecuador; Brazil")
       end
@@ -12,7 +12,7 @@ RSpec.describe ActivityCsvPresenter do
 
     context "when there are no other benefiting countries" do
       it "returns nil" do
-        activity = build(:activity, intended_beneficiaries: nil)
+        activity = build(:project_activity, intended_beneficiaries: nil)
         result = described_class.new(activity).intended_beneficiaries
         expect(result).to be_nil
       end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe ActivityPresenter do
 
   describe "#flow_with_code" do
     it "returns the default flow string & code number" do
-      fund = create(:activity)
+      fund = create(:project_activity)
       expect(described_class.new(fund).flow_with_code).to eql("ODA (10)")
     end
   end
@@ -524,7 +524,7 @@ RSpec.describe ActivityPresenter do
   describe "#display_title" do
     context "when the title is nil" do
       it "returns a default display_title" do
-        activity = create(:activity, :at_purpose_step, title: nil)
+        activity = create(:project_activity, :at_purpose_step, title: nil)
         expect(described_class.new(activity).display_title).to eql("Untitled (#{activity.id})")
       end
     end
@@ -586,14 +586,14 @@ RSpec.describe ActivityPresenter do
 
   describe "#tied_status_with_code" do
     it "returns the tied status string & code number" do
-      fund = create(:activity)
+      fund = create(:project_activity)
       expect(described_class.new(fund).tied_status_with_code).to eql("Untied (5)")
     end
   end
 
   describe "#finance_with_code" do
     it "returns the finance string & code number" do
-      fund = create(:activity)
+      fund = create(:project_activity)
       expect(described_class.new(fund).finance_with_code).to eql("Standard grant (110)")
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ActivityPresenter do
 
     it "has translations for all of the codes" do
       Codelist.new(**args).each do |code|
-        activity = build(:activity)
+        activity = build(:project_activity)
         code = cast_code_to_field(code["code"])
         activity.write_attribute(field, code)
 
@@ -30,13 +30,13 @@ RSpec.describe ActivityPresenter do
 
     context "when the aid_type exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, aid_type: "a01")
+        activity = build(:project_activity, aid_type: "a01")
         result = described_class.new(activity).aid_type
         expect(result).to eql("General budget support")
       end
 
       it "returns the locale value when the code is upper case" do
-        activity = build(:activity, aid_type: "A01")
+        activity = build(:project_activity, aid_type: "A01")
         result = described_class.new(activity).aid_type
         expect(result).to eql("General budget support")
       end
@@ -44,7 +44,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have an aid_type set" do
       it "returns nil" do
-        activity = build(:activity, :at_identifier_step)
+        activity = build(:project_activity, :at_identifier_step)
         result = described_class.new(activity)
         expect(result.aid_type).to be_nil
       end
@@ -54,7 +54,7 @@ RSpec.describe ActivityPresenter do
   describe "#aid_type_with_code" do
     context "when the aid_type exists" do
       it "returns the locale value for the code with the code in brackets" do
-        activity = build(:activity, aid_type: "A01")
+        activity = build(:project_activity, aid_type: "A01")
         result = described_class.new(activity).aid_type_with_code
         expect(result).to eql("General budget support (A01)")
       end
@@ -62,7 +62,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have an aid_type set" do
       it "returns nil" do
-        activity = build(:activity, :at_identifier_step)
+        activity = build(:project_activity, :at_identifier_step)
         result = described_class.new(activity)
         expect(result.aid_type_with_code).to be_nil
       end
@@ -73,7 +73,7 @@ RSpec.describe ActivityPresenter do
     it_behaves_like "a code translator", "covid19_related", {type: "covid19_related_research", source: "beis"}
 
     it "returns the locale value for the code" do
-      activity = build(:activity, covid19_related: 3)
+      activity = build(:project_activity, covid19_related: 3)
       result = described_class.new(activity).covid19_related
       expect(result).to eql("New activity that will somewhat focus on COVID-19")
     end
@@ -84,7 +84,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the sector exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, sector: "11110")
+        activity = build(:project_activity, sector: "11110")
         result = described_class.new(activity).sector
         expect(result).to eql("Education policy and administrative management")
       end
@@ -92,7 +92,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a sector set" do
       it "returns nil" do
-        activity = build(:activity, sector: nil)
+        activity = build(:project_activity, sector: nil)
         result = described_class.new(activity)
         expect(result.sector).to be_nil
       end
@@ -102,7 +102,7 @@ RSpec.describe ActivityPresenter do
   describe "#sector_with_code" do
     context "when the sector exists" do
       it "returns the locale value for the code with the code in brackets" do
-        activity = build(:activity, sector: "11110")
+        activity = build(:project_activity, sector: "11110")
         result = described_class.new(activity).sector_with_code
         expect(result).to eql("Education policy and administrative management (11110)")
       end
@@ -110,7 +110,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a sector set" do
       it "returns nil" do
-        activity = build(:activity, sector: nil)
+        activity = build(:project_activity, sector: nil)
         result = described_class.new(activity)
         expect(result.sector_with_code).to be_nil
       end
@@ -176,7 +176,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the programme status exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, programme_status: "spend_in_progress")
+        activity = build(:project_activity, programme_status: "spend_in_progress")
         result = described_class.new(activity).programme_status
         expect(result).to eql("Spend in progress")
       end
@@ -184,7 +184,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a programme status set" do
       it "returns nil" do
-        activity = build(:activity, programme_status: nil)
+        activity = build(:project_activity, programme_status: nil)
         result = described_class.new(activity)
         expect(result.programme_status).to be_nil
       end
@@ -194,7 +194,7 @@ RSpec.describe ActivityPresenter do
   describe "#planned_start_date" do
     context "when the planned start date exists" do
       it "returns a human readable date" do
-        activity = build(:activity, planned_start_date: "2020-02-25")
+        activity = build(:project_activity, planned_start_date: "2020-02-25")
         result = described_class.new(activity).planned_start_date
         expect(result).to eql("25 Feb 2020")
       end
@@ -202,7 +202,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the planned start date does not exist" do
       it "returns nil" do
-        activity = build(:activity, planned_start_date: nil)
+        activity = build(:project_activity, planned_start_date: nil)
         result = described_class.new(activity)
         expect(result.planned_start_date).to be_nil
       end
@@ -212,7 +212,7 @@ RSpec.describe ActivityPresenter do
   describe "#planned_end_date" do
     context "when the planned end date exists" do
       it "returns a human readable date" do
-        activity = build(:activity, planned_end_date: "2021-04-03")
+        activity = build(:project_activity, planned_end_date: "2021-04-03")
         result = described_class.new(activity).planned_end_date
         expect(result).to eql("3 Apr 2021")
       end
@@ -220,7 +220,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the planned end date does not exist" do
       it "returns nil" do
-        activity = build(:activity, planned_end_date: nil)
+        activity = build(:project_activity, planned_end_date: nil)
         result = described_class.new(activity)
         expect(result.planned_end_date).to be_nil
       end
@@ -230,7 +230,7 @@ RSpec.describe ActivityPresenter do
   describe "#actual_start_date" do
     context "when the actual start date exists" do
       it "returns a human readable date" do
-        activity = build(:activity, actual_start_date: "2020-11-06")
+        activity = build(:project_activity, actual_start_date: "2020-11-06")
         result = described_class.new(activity).actual_start_date
         expect(result).to eql("6 Nov 2020")
       end
@@ -238,7 +238,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the actual start date does not exist" do
       it "returns nil" do
-        activity = build(:activity, actual_start_date: nil)
+        activity = build(:project_activity, actual_start_date: nil)
         result = described_class.new(activity)
         expect(result.actual_start_date).to be_nil
       end
@@ -248,7 +248,7 @@ RSpec.describe ActivityPresenter do
   describe "#actual_end_date" do
     context "when the actual end date exists" do
       it "returns a human readable date" do
-        activity = build(:activity, actual_end_date: "2029-05-27")
+        activity = build(:project_activity, actual_end_date: "2029-05-27")
         result = described_class.new(activity).actual_end_date
         expect(result).to eql("27 May 2029")
       end
@@ -256,7 +256,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the actual end date does not exist" do
       it "returns nil" do
-        activity = build(:activity, actual_end_date: nil)
+        activity = build(:project_activity, actual_end_date: nil)
         result = described_class.new(activity)
         expect(result.actual_end_date).to be_nil
       end
@@ -268,7 +268,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the aid_type recipient_region" do
       it "returns the locale value for the code" do
-        activity = build(:activity, recipient_region: "489")
+        activity = build(:project_activity, recipient_region: "489")
         result = described_class.new(activity).recipient_region
         expect(result).to eql("South America, regional")
       end
@@ -276,7 +276,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a recipient_region set" do
       it "returns nil" do
-        activity = build(:activity, recipient_region: nil)
+        activity = build(:project_activity, recipient_region: nil)
         result = described_class.new(activity)
         expect(result.recipient_region).to be_nil
       end
@@ -288,7 +288,7 @@ RSpec.describe ActivityPresenter do
 
     context "when there is a recipient_country" do
       it "returns the locale value for the code" do
-        activity = build(:activity, recipient_country: "CL")
+        activity = build(:project_activity, recipient_country: "CL")
         result = described_class.new(activity).recipient_country
         expect(result).to eq t("activity.recipient_country.#{activity.recipient_country}")
       end
@@ -296,7 +296,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a recipient_country set" do
       it "returns nil" do
-        activity = build(:activity, recipient_country: nil)
+        activity = build(:project_activity, recipient_country: nil)
         result = described_class.new(activity)
         expect(result.recipient_country).to be_nil
       end
@@ -326,7 +326,7 @@ RSpec.describe ActivityPresenter do
 
     context "when there are other benefitting countries" do
       it "returns the locale value for the codes of the countries" do
-        activity = build(:activity, intended_beneficiaries: ["AR", "EC", "BR"])
+        activity = build(:project_activity, intended_beneficiaries: ["AR", "EC", "BR"])
         result = described_class.new(activity).intended_beneficiaries
         expect(result).to eql("Argentina, Ecuador, and Brazil")
       end
@@ -338,7 +338,7 @@ RSpec.describe ActivityPresenter do
 
     context "when gdi exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, gdi: "3")
+        activity = build(:project_activity, gdi: "3")
         result = described_class.new(activity).gdi
         expect(result).to eql("Yes - China and India")
       end
@@ -346,7 +346,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a gdi set" do
       it "returns nil" do
-        activity = build(:activity, gdi: nil)
+        activity = build(:project_activity, gdi: nil)
         result = described_class.new(activity)
         expect(result.gdi).to be_nil
       end
@@ -358,7 +358,7 @@ RSpec.describe ActivityPresenter do
 
     context "when collaboration_type exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, collaboration_type: "1")
+        activity = build(:project_activity, collaboration_type: "1")
         result = described_class.new(activity).collaboration_type
         expect(result).to eql("Bilateral")
       end
@@ -366,7 +366,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a collaboration_type set" do
       it "returns nil" do
-        activity = build(:activity, collaboration_type: nil)
+        activity = build(:project_activity, collaboration_type: nil)
         result = described_class.new(activity)
         expect(result.collaboration_type).to be_nil
       end
@@ -375,7 +375,7 @@ RSpec.describe ActivityPresenter do
 
   describe "#flow" do
     it "returns the locale value for the default ODA code" do
-      activity = build(:activity)
+      activity = build(:project_activity)
       result = described_class.new(activity).flow
       expect(result).to eql("ODA")
     end
@@ -393,7 +393,7 @@ RSpec.describe ActivityPresenter do
 
     context "when gender exists" do
       it "returns the locale value for the code" do
-        activity = build(:activity, policy_marker_gender: "not_targeted")
+        activity = build(:project_activity, policy_marker_gender: "not_targeted")
         result = described_class.new(activity).policy_marker_gender
         expect(result).to eql("Not targeted")
       end
@@ -401,7 +401,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the value is the BEIS custom value" do
       it "returns the locale value for the custom code" do
-        activity = build(:activity, policy_marker_gender: "not_assessed")
+        activity = build(:project_activity, policy_marker_gender: "not_assessed")
         result = described_class.new(activity).policy_marker_gender
         expect(result).to eql("Not assessed")
       end
@@ -409,7 +409,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the activity does not have a gender set" do
       it "returns nil" do
-        activity = build(:activity, policy_marker_gender: nil)
+        activity = build(:project_activity, policy_marker_gender: nil)
         result = described_class.new(activity)
         expect(result.policy_marker_gender).to be_nil
       end
@@ -418,21 +418,21 @@ RSpec.describe ActivityPresenter do
 
   describe "#sustainable_development_goals" do
     it "returns 'Not applicable' when the user selects that SDGs do not apply (sdgs_apply is false)" do
-      activity = build(:activity, sdgs_apply: false)
+      activity = build(:project_activity, sdgs_apply: false)
       result = described_class.new(activity).sustainable_development_goals
 
       expect(result).to eq("Not applicable")
     end
 
     it "leaves the field blank when the SDG form step has not been filled yet" do
-      activity = build(:activity, sdgs_apply: false, form_state: nil)
+      activity = build(:project_activity, sdgs_apply: false, form_state: nil)
       result = described_class.new(activity).sustainable_development_goals
 
       expect(result).to be_nil
     end
 
     it "when there is a single SDG, return its name" do
-      activity = build(:activity, sdgs_apply: true, sdg_1: 5)
+      activity = build(:project_activity, sdgs_apply: true, sdg_1: 5)
       result = described_class.new(activity)
 
       items = Nokogiri::HTML(result.sustainable_development_goals).css("ol > li")
@@ -440,7 +440,7 @@ RSpec.describe ActivityPresenter do
     end
 
     it "when there are multiple SDGs, return their names, separated by a slash" do
-      activity = build(:activity, sdgs_apply: true, sdg_1: 5, sdg_2: 1)
+      activity = build(:project_activity, sdgs_apply: true, sdg_1: 5, sdg_2: 1)
       result = described_class.new(activity)
 
       items = Nokogiri::HTML(result.sustainable_development_goals).css("ol > li")
@@ -449,7 +449,7 @@ RSpec.describe ActivityPresenter do
     end
 
     it "when there are no SDGs return nil" do
-      activity = build(:activity, sdgs_apply: true, sdg_1: nil, sdg_2: nil, sdg_3: nil)
+      activity = build(:project_activity, sdgs_apply: true, sdg_1: nil, sdg_2: nil, sdg_3: nil)
       result = described_class.new(activity)
 
       expect(result.sustainable_development_goals).to be_nil
@@ -458,7 +458,7 @@ RSpec.describe ActivityPresenter do
 
   describe "#gcrf_strategic_area" do
     it "returns the code list description values for the stored integers" do
-      activity = build(:activity, gcrf_strategic_area: %w[1 3])
+      activity = build(:project_activity, gcrf_strategic_area: %w[1 3])
       result = described_class.new(activity)
 
       expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Resilient Futures"
@@ -469,7 +469,7 @@ RSpec.describe ActivityPresenter do
     it_behaves_like "a code translator", "gcrf_challenge_area", {type: "gcrf_challenge_area", source: "beis"}, "Integer"
 
     it "returns the locale value for the stored integer" do
-      activity = build(:activity, gcrf_challenge_area: 2)
+      activity = build(:project_activity, gcrf_challenge_area: 2)
       result = described_class.new(activity)
 
       expect(result.gcrf_challenge_area).to eql "Sustainable health and well being"
@@ -506,17 +506,17 @@ RSpec.describe ActivityPresenter do
 
   describe "#call_to_action" do
     it "returns 'edit' if the desired attribute is present" do
-      activity = build(:activity, title: "My title")
+      activity = build(:project_activity, title: "My title")
       expect(described_class.new(activity).call_to_action(:title)).to eql("edit")
     end
 
     it "returns 'edit' if the desired attribute is 'false'" do
-      activity = build(:activity, fstc_applies: false)
+      activity = build(:project_activity, fstc_applies: false)
       expect(described_class.new(activity).call_to_action(:title)).to eql("edit")
     end
 
     it "returns 'add' if the desired attribute is not present" do
-      activity = build(:activity, title: nil)
+      activity = build(:project_activity, title: nil)
       expect(described_class.new(activity).call_to_action(:title)).to eql("add")
     end
   end
@@ -531,7 +531,7 @@ RSpec.describe ActivityPresenter do
 
     context "when the title is present" do
       it "returns the title" do
-        activity = build(:activity)
+        activity = build(:project_activity)
         expect(described_class.new(activity).display_title).to eql(activity.title)
       end
     end

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Activities::ImportFromCsv do
 
   # NB: 'let!' to prevent `to change { Activity.count }` from giving confusing results
   let!(:existing_activity) do
-    create(:activity) do |activity|
+    create(:project_activity) do |activity|
       activity.implementing_organisations = [
         create(:implementing_organisation, activity: activity),
       ]
@@ -229,7 +229,7 @@ RSpec.describe Activities::ImportFromCsv do
     end
 
     it "has an error and does not update any other activities if a region does not exist" do
-      activity_2 = create(:activity)
+      activity_2 = create(:project_activity)
       invalid_activity_attributes = existing_activity_attributes.merge({
         "RODA ID" => activity_2.roda_identifier_compound,
         "Recipient Region" => "111111",

--- a/spec/services/create_budget_spec.rb
+++ b/spec/services/create_budget_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CreateBudget do
   let!(:service_owner) { create(:beis_organisation) }
-  let(:activity) { create(:activity) }
+  let(:activity) { create(:project_activity) }
 
   describe "#call" do
     it "sets the activity as the one this budget belongs to" do

--- a/spec/services/create_transaction_spec.rb
+++ b/spec/services/create_transaction_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CreateTransaction do
   let!(:service_owner) { create(:beis_organisation) }
-  let(:activity) { create(:activity) }
+  let(:activity) { create(:project_activity) }
 
   describe "#call" do
     it "sets the parent activity as the one this transaction belongs to" do
@@ -61,7 +61,7 @@ RSpec.describe CreateTransaction do
 
     context "when the description is blank" do
       it "sets a default description" do
-        activity = create(:activity, title: "Some activity")
+        activity = create(:project_activity, title: "Some activity")
         attributes = ActionController::Parameters.new(financial_quarter: 1, financial_year: 2020).permit!
 
         result = described_class.new(activity: activity).call(attributes: attributes)

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ExportActivityToCsv do
     it "uses the current report financial quarter to generate the actuals total column" do
       report = travel_to(Date.parse("1 April 2020")) { Report.new }
 
-      headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+      headers = ExportActivityToCsv.new(activity: build(:project_activity), report: report).headers
 
       expect(headers).to include "ACT FQ1 2020-2021"
     end
@@ -175,7 +175,7 @@ RSpec.describe ExportActivityToCsv do
     it "uses the current report financial quarter to generate the forecast total column" do
       report = travel_to_quarter(1, 2020) { Report.new }
 
-      headers = ExportActivityToCsv.new(activity: build(:activity), report: report).headers
+      headers = ExportActivityToCsv.new(activity: build(:project_activity), report: report).headers
 
       expect(headers).to include "FC FQ1 2020-2021"
     end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -475,7 +475,7 @@ module FormHelpers
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
   end
 
-  def fill_in_transfer_form(destination: create(:activity), financial_quarter: FinancialQuarter.for_date(Date.today).to_i, financial_year: FinancialYear.for_date(Date.today).to_i, value: 1234)
+  def fill_in_transfer_form(destination: create(:project_activity), financial_quarter: FinancialQuarter.for_date(Date.today).to_i, financial_year: FinancialYear.for_date(Date.today).to_i, value: 1234)
     transfer = build(
       :transfer,
       destination: destination,

--- a/spec/validators/end_date_after_start_date_validator_spec.rb
+++ b/spec/validators/end_date_after_start_date_validator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe EndDateAfterStartDateValidator do
-  subject { build(:activity) }
+  subject { build(:fund_activity) }
 
   context "when the planned start date is the same as the planned end date" do
     it "is valid" do

--- a/spec/validators/organisation_validator_spec.rb
+++ b/spec/validators/organisation_validator_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe OrganisationValidator do
+  context "when activity is a fund" do
+    subject { build(:fund_activity, organisation: organisation) }
+
+    context "when the organisation is a delivery partner" do
+      let(:organisation) { build(:delivery_partner_organisation) }
+
+      it { should be_invalid }
+    end
+
+    context "when the organisation is the service owner" do
+      let(:organisation) { build(:beis_organisation) }
+
+      it { should be_valid }
+    end
+  end
+
+  context "when activity is a programme" do
+    subject { build(:fund_activity, organisation: organisation) }
+
+    context "when the organisation is a delivery partner" do
+      let(:organisation) { build(:delivery_partner_organisation) }
+
+      it { should be_invalid }
+    end
+
+    context "when the organisation is the service owner" do
+      let(:organisation) { build(:beis_organisation) }
+
+      it { should be_valid }
+    end
+  end
+
+  context "when activity is a project" do
+    subject { build(:project_activity, organisation: organisation) }
+
+    context "when the organisation is a delivery partner" do
+      let(:organisation) { build(:delivery_partner_organisation) }
+
+      it { should be_valid }
+    end
+
+    context "when the organisation is the service owner" do
+      let(:organisation) { build(:beis_organisation) }
+
+      it { should be_invalid }
+    end
+  end
+
+  context "when activity is a third party project" do
+    subject { build(:third_party_project_activity, organisation: organisation) }
+
+    context "when the organisation is a delivery partner" do
+      let(:organisation) { build(:delivery_partner_organisation) }
+
+      it { should be_valid }
+    end
+
+    context "when the organisation is the service owner" do
+      let(:organisation) { build(:beis_organisation) }
+
+      it { should be_invalid }
+    end
+  end
+end


### PR DESCRIPTION
This adds a validation to make sure activities are owned by the correct organisation with the following rules:

* Funds should be owned by BEIS
* Programmes should be owned by BEIS
* Projects should be owned by a delivery partner
* Third Party Projects should be owned by a delivery partner

We have business logic in the app which forces this to happen anyway, but we have A LOT of tests that don't reflect this reality, and mean making changes to how we handle organisations is quite brittle.

I've also renamed the generic `activity` factory to `__activity`, to reflect the fact that its purpose is to set up defaults, and shouldn't be used on its own - in the app an activity is either a Fund, a Programme, a Project, or a Third-party Project, so we should be using these.