### PR TITLE
Deleting a forecast is non-destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,7 @@
 
 - Add BEIS contact info to the IATI XML
 - Validate that activities have the correct organisation
+- Deleting a forecast doesn't delete data from approved reports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...HEAD
 [release-48]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...release-48

--- a/app/controllers/staff/planned_disbursements_controller.rb
+++ b/app/controllers/staff/planned_disbursements_controller.rb
@@ -68,7 +68,7 @@ class Staff::PlannedDisbursementsController < Staff::BaseController
     history = history_for_update
     authorize history.latest_entry
 
-    history.clear!
+    history.clear
 
     flash[:notice] = t("action.planned_disbursement.destroy.success")
     redirect_to organisation_activity_path(@activity.organisation, @activity)

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -24,11 +24,8 @@ class PlannedDisbursementHistory
     end
   end
 
-  def clear!
-    entries.each do |entry|
-      entry.create_activity(key: "planned_disbursement.destroy", owner: @user, parameters: {associated_activity_id: @activity.id})
-      entry.destroy
-    end
+  def clear
+    set_value(0)
   end
 
   def all_entries

--- a/spec/features/staff/users_can_delete_a_planned_disbursement_spec.rb
+++ b/spec/features/staff/users_can_delete_a_planned_disbursement_spec.rb
@@ -17,19 +17,12 @@ RSpec.describe "Users can delete a planned disbursement" do
           click_on "Edit"
         end
 
-        expect {
-          click_on t("default.button.delete")
-        }.to change {
-          PlannedDisbursement.count
-        }.by(-1)
+        click_on t("default.button.delete")
 
         expect(page).to have_title t("document_title.activity.financials", name: project.title)
         expect(page).to have_content t("action.planned_disbursement.destroy.success")
 
         expect(page).to_not have_selector "##{planned_disbursement.id}"
-
-        auditable_event = PublicActivity::Activity.find_by(trackable_id: planned_disbursement.id, parameters: {associated_activity_id: project.id})
-        expect(auditable_event).to_not be_nil
       end
     end
   end

--- a/spec/services/planned_disbursement_overview_spec.rb
+++ b/spec/services/planned_disbursement_overview_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe PlannedDisbursementOverview do
       expect { overview.snapshot(Report.new).all_quarters }.to raise_error(TypeError)
     end
 
-    context "when a forecast has been revised with a zero value" do
+    context "when a forecast has been deleted" do
       before do
-        histories[[2017, 2]].set_value(0)
+        histories[[2017, 2]].clear
       end
 
       it "omits that forecast from the result set" do
@@ -112,9 +112,9 @@ RSpec.describe PlannedDisbursementOverview do
       ])
     end
 
-    context "when a forecast has been revised with a zero value" do
+    context "when a forecast has been deleted" do
       before do
-        histories[[2018, 4]].set_value(0)
+        histories[[2018, 4]].clear
       end
 
       it "omits that forecast from the result set" do


### PR DESCRIPTION
## Changes in this PR

Deleting a forecast is equivalent to setting the latest revision to 0.

Rather than plainly deleting all revisions, different things need to happen depending on whether the forecast is pinned to a report, like in the case of level C and D activities, or not pinned, like in the case of levels A and B.

The forecast history already takes care of all these cases when setting a value to 0, whether through the interface or via bulk upload.

Deletion is a nicer way for users to express the intent to remove that forecast, while the history mechanism remains invisible from the outside.

Co-authored-by: jcoglan <james.coglan@dxw.com>

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
