### PR TITLE
Fix typo in email notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -627,6 +627,7 @@
 - Validate that activities have the correct organisation
 - Deleting a forecast doesn't delete data from approved reports
 - Handle the case of forecasts for past financial quarters during bulk importing
+- Fix a typo in the email notification sent to BEIS when a DP submits a report
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...HEAD
 [release-48]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...release-48

--- a/app/views/report_mailer/_submitted_service_owner.text.erb
+++ b/app/views/report_mailer/_submitted_service_owner.text.erb
@@ -4,4 +4,4 @@ A delivery partner has submitted a report.
 
 # What happens next?
 
-This report ready to assure.
+This report is ready to assure.


### PR DESCRIPTION
## Changes in this PR
- Fix a typo in the email notification sent to BEIS when a DP submits a report

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
