### PR TITLE
Infer the value of `sdgs_apply` when importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -628,6 +628,7 @@
 - Deleting a forecast doesn't delete data from approved reports
 - Handle the case of forecasts for past financial quarters during bulk importing
 - Fix a typo in the email notification sent to BEIS when a DP submits a report
+- Infer the value of `sdgs_apply` when importing new or existing activities from CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...HEAD
 [release-48]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-47...release-48

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -105,6 +105,10 @@ module Activities
 
         @activity.assign_attributes(@converter.to_h)
 
+        if @activity.sdg_1 || @activity.sdg_2 || @activity.sdg_3
+          @activity.sdgs_apply = true
+        end
+
         if row["Implementing organisation name"].present? || row["Implementing organisation sector"].present?
           implementing_organisation_builder = ImplementingOrganisationBuilder.new(@activity, row)
           implementing_organisation = implementing_organisation_builder.organisation
@@ -161,6 +165,10 @@ module Activities
         }
         @activity.assign_attributes(@converter.to_h)
         @activity.cache_roda_identifier
+
+        if @activity.sdg_1 || @activity.sdg_2 || @activity.sdg_3
+          @activity.sdgs_apply = true
+        end
 
         implementing_organisation_builder = ImplementingOrganisationBuilder.new(@activity, row)
         if row["Implementing organisation name"].present? || row["Implementing organisation sector"].present?

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives (DP Definition)"])
       expect(existing_activity.beis_identifier).to eq(existing_activity_attributes["BEIS ID"])
       expect(existing_activity.uk_dp_named_contact).to eq(existing_activity_attributes["UK DP Named Contact"])
+      expect(existing_activity.sdgs_apply).to eql(true)
 
       expect(existing_activity.implementing_organisations.count).to eql(1)
       expect(existing_activity.implementing_organisations.first.name).to eq(existing_activity_attributes["Implementing organisation name"])
@@ -437,6 +438,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(new_activity.beis_identifier).to eq(new_activity_attributes["BEIS ID"])
       expect(new_activity.uk_dp_named_contact).to eq(new_activity_attributes["UK DP Named Contact"])
       expect(new_activity.country_delivery_partners).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
+      expect(new_activity.sdgs_apply).to eql(true)
     end
 
     context "with a parent activity that is incomplete" do


### PR DESCRIPTION
## Changes in this PR

By default `sdgs_apply` is `false`.

Set it to `true` if at least one Sustainable Development Goal is populated during import.

NB: We don’t have a way to remove attributes during import, which is why we can’t currently detect if the goals are entirely removed in order to set it to `false`.

## UI changes

### Before

The goals themselves were set, but not correctly reflected in the interface. The interface said "Not applicable".

### After

The goals are set and they are reflected in the interface.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
