### PR TITLE
(1712) Include organisation short name and fund name in report CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -633,6 +633,7 @@
 ## [unreleased]
 
 - Replace the broken sector code hint link with an easier to maintain BEIS Zendesk link
+- Include 'source fund' in CSV export
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...HEAD
 [release-49]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...release-49

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -633,7 +633,7 @@
 ## [unreleased]
 
 - Replace the broken sector code hint link with an easier to maintain BEIS Zendesk link
-- Include 'source fund' in CSV export
+- Include 'source fund' and 'delivery partner short name' in CSV export
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...HEAD
 [release-49]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...release-49

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -153,7 +153,10 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def report_activities_sorted_by_level(report)
-    Activity.includes(:organisation, :implementing_organisations).projects_and_third_party_projects_for_report(report).sort_by { |a| a.level }
+    Activity
+      .includes(:organisation, :extending_organisation, :implementing_organisations)
+      .projects_and_third_party_projects_for_report(report)
+      .sort_by { |a| a.level }
   end
 
   def reports_have_same_quarter?

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -114,6 +114,7 @@ class ExportActivityToCsv
       "VAR #{report_financial_quarter}" => -> { activity_presenter.variance_for_report_financial_quarter(report: report) },
       "Comment" => -> { activity_presenter.comment_for_report(report_id: report.id)&.comment },
       "Source fund" => -> { activity_presenter.source_fund&.name },
+      "Delivery partner short name" => -> { activity_presenter.extending_organisation&.beis_organisation_reference },
       "Link to activity in RODA" => -> { activity_presenter.link_to_roda },
     }
   end

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -113,6 +113,7 @@ class ExportActivityToCsv
       # Additional headers specific to export CSV =============================
       "VAR #{report_financial_quarter}" => -> { activity_presenter.variance_for_report_financial_quarter(report: report) },
       "Comment" => -> { activity_presenter.comment_for_report(report_id: report.id)&.comment },
+      "Source fund" => -> { activity_presenter.source_fund&.name },
       "Link to activity in RODA" => -> { activity_presenter.link_to_roda },
     }
   end

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe ExportActivityToCsv do
     expect(export_service.call[column_position]).to eql("GCRF")
   end
 
+  it "includes the delivery partner's short_name in the export" do
+    expect(export_service.headers).to include("Delivery partner short name")
+
+    column_position = export_service.headers.index("Delivery partner short name")
+    expect(export_service.call[column_position]).to eql project.extending_organisation.beis_organisation_reference
+  end
+
   context "when the project has a BEIS identifier" do
     before do
       project.update!(beis_identifier: "GCRF_AHRC_NS_AH1001")

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe ExportActivityToCsv do
-  let(:project) { travel_to_quarter(1, 2020) { create(:project_activity, :with_report) } }
+  let(:project) { travel_to_quarter(1, 2020) { create(:project_activity, :gcrf_funded, :with_report) } }
   let(:report) { Report.for_activity(project).in_historical_order.first }
   let(:export_service) { ExportActivityToCsv.new(activity: project, report: report) }
 
@@ -65,6 +65,13 @@ RSpec.describe ExportActivityToCsv do
       expect(export_service.headers.drop(15).take(20)).to eq(next_twenty_quarter_forecast_headers)
       expect(export_service.call.drop(15).take(20)).to eq(next_twenty_quarter_forecast_values)
     end
+  end
+
+  it "includes the source fund name in the export" do
+    expect(export_service.headers).to include("Source fund")
+
+    column_position = export_service.headers.index("Source fund")
+    expect(export_service.call[column_position]).to eql("GCRF")
   end
 
   context "when the project has a BEIS identifier" do


### PR DESCRIPTION
Although of little value to delivery partners, having these columns in the report CSV file allows BEIS users to sort and filter the "all reports" CSV file by Delivery partner and/or fund name.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
