### PR TITLE
(1727) Extend Organisation model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,6 +638,7 @@
 - Merge Academies Collective Fund and Resilient Futures GCRF strategic areas into one
 - Show organisation short name on organisations index page
 - Total budget should only total budgets from a specific activity
+- Allow organisations of type "Matched Effort Provider" to be created
 
 ## [unreleased]
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -2,7 +2,7 @@
 
 class Staff::OrganisationsController < Staff::BaseController
   def index
-    @organisations = policy_scope(Organisation)
+    @organisations = policy_scope(Organisation).where(role: params[:role].singularize)
     authorize @organisations
   end
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -2,7 +2,8 @@
 
 class Staff::OrganisationsController < Staff::BaseController
   def index
-    @organisations = policy_scope(Organisation).where(role: params[:role].singularize)
+    @role = params[:role]
+    @organisations = policy_scope(Organisation).where(role: @role.singularize)
     authorize @organisations
   end
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -135,7 +135,7 @@ class Staff::OrganisationsController < Staff::BaseController
 
   private def organisation_params
     params.require(:organisation)
-      .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role)
+      .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role, :active)
   end
 
   private def level

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -60,7 +60,7 @@ class Staff::OrganisationsController < Staff::BaseController
   end
 
   def new
-    @organisation = Organisation.new
+    @organisation = Organisation.new(role: params[:role].singularize)
     authorize @organisation
   end
 
@@ -135,8 +135,7 @@ class Staff::OrganisationsController < Staff::BaseController
 
   private def organisation_params
     params.require(:organisation)
-      .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference)
-      .merge(role: "delivery_partner")
+      .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role)
   end
 
   private def level

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -133,7 +133,9 @@ class Staff::OrganisationsController < Staff::BaseController
   end
 
   private def organisation_params
-    params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference)
+    params.require(:organisation)
+      .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference)
+      .merge(role: "delivery_partner")
   end
 
   private def level

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -86,7 +86,7 @@ class Staff::UsersController < Staff::BaseController
   end
 
   private def service_owner
-    Organisation.find_by(service_owner: true)
+    Organisation.service_owner
   end
 
   private def delivery_partners

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -9,27 +9,28 @@ module FormHelper
   end
 
   def list_of_user_roles
-    @list_of_user_roles ||= begin
-      User.roles.map { |id, name| OpenStruct.new(id: id, name: t("activerecord.attributes.user.roles.#{name}")) }
-    end
+    @list_of_user_roles ||= User.roles.map { |id, name| OpenStruct.new(id: id, name: t("activerecord.attributes.user.roles.#{name}")) }
   end
 
   def list_of_financial_quarters
-    @list_of_financial_quarters ||= begin
-      FinancialQuarter::QUARTERS.map { |id| OpenStruct.new(id: id, name: "Q#{id}") }
-    end
+    @list_of_financial_quarters ||= FinancialQuarter::QUARTERS.map { |id| OpenStruct.new(id: id, name: "Q#{id}") }
   end
 
   def list_of_financial_years(years = FinancialYear.next_ten)
-    @list_of_financial_years ||= begin
-      years.map { |year| OpenStruct.new(id: year.to_i, name: year.to_s) }
-    end
+    @list_of_financial_years ||= years.map { |year| OpenStruct.new(id: year.to_i, name: year.to_s) }
   end
 
   def user_active_options
     [
       OpenStruct.new(id: "true", name: t("form.user.active.active")),
       OpenStruct.new(id: "false", name: t("form.user.active.inactive")),
+    ]
+  end
+
+  def organisation_active_options
+    [
+      OpenStruct.new(id: "true", name: t("form.label.organisation.active.true")),
+      OpenStruct.new(id: "false", name: t("form.label.organisation.active.false")),
     ]
   end
 end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -16,7 +16,7 @@ class ReportMailer < ApplicationMailer
 
     @role = if @user.organisation == @report_presenter.organisation
       :delivery_partner
-    elsif @user.organisation.service_owner
+    elsif @user.organisation.service_owner?
       :service_owner
     end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -388,7 +388,7 @@ class Activity < ApplicationRecord
   end
 
   def service_owner
-    Organisation.find_by(service_owner: true)
+    Organisation.service_owner
   end
 
   def parent_level

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -20,6 +20,7 @@ class Organisation < ApplicationRecord
   validates :iati_reference,
     uniqueness: {case_sensitive: false},
     presence: true,
+    unless: proc { |organisation| organisation.matched_effort_provider? },
     format: {with: /\A[a-zA-Z]{2,}-[a-zA-Z]{3}-.+\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")}
   validates :beis_organisation_reference, uniqueness: {case_sensitive: false}
   validates :beis_organisation_reference,

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,6 +7,11 @@ class Organisation < ApplicationRecord
   has_many :users
   has_many :funds
 
+  enum role: {
+    delivery_partner: 0,
+    service_owner: 99,
+  }
+
   validates_presence_of :organisation_type, :language_code, :default_currency
   validates :name,
     presence: true,
@@ -21,7 +26,7 @@ class Organisation < ApplicationRecord
     format: {with: /\A[A-Z]{2,10}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
 
   scope :sorted_by_name, -> { order(name: :asc) }
-  scope :delivery_partners, -> { sorted_by_name.where(service_owner: false) }
+  scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
 
   before_validation :ensure_beis_organisation_reference_is_uppercase
 
@@ -37,9 +42,5 @@ class Organisation < ApplicationRecord
 
   def self.service_owner
     find_by(iati_reference: SERVICE_OWNER_IATI_REFERENCE)
-  end
-
-  def delivery_partner?
-    !service_owner?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -21,10 +21,11 @@ class Organisation < ApplicationRecord
     uniqueness: {case_sensitive: false},
     presence: true,
     format: {with: /\A[a-zA-Z]{2,}-[a-zA-Z]{3}-.+\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")}
+  validates :beis_organisation_reference, uniqueness: {case_sensitive: false}
   validates :beis_organisation_reference,
     presence: true,
-    uniqueness: {case_sensitive: false},
-    format: {with: /\A[A-Z]{2,10}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
+    unless: proc { |organisation| organisation.matched_effort_provider? },
+    format: {with: /\A[A-Z]{2,5}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
 
   scope :sorted_by_name, -> { order(name: :asc) }
   scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,6 +9,7 @@ class Organisation < ApplicationRecord
 
   enum role: {
     delivery_partner: 0,
+    matched_effort_provider: 1,
     service_owner: 99,
   }
 

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -1,5 +1,6 @@
 class ActivityDefaults
   class InvalidParentActivity < RuntimeError; end
+
   class InvalidDeliveryPartnerOrganisation < RuntimeError; end
 
   attr_reader :parent_activity, :delivery_partner_organisation
@@ -27,7 +28,7 @@ class ActivityDefaults
   private
 
   def service_owner
-    @_service_owner ||= Organisation.find_by(service_owner: true)
+    @_service_owner ||= Organisation.service_owner
   end
 
   def level

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -15,7 +15,7 @@ class FindProgrammeActivities
       .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
-    return programmes if organisation.service_owner
+    return programmes if organisation.service_owner?
 
     query_conditions = {extending_organisation_id: organisation.id}
     query_conditions[:parent_id] = fund_id if fund_id.present?

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -14,7 +14,7 @@ class FindProjectActivities
       .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
-    projects = if organisation.service_owner
+    projects = if organisation.service_owner?
       projects.all
     else
       projects.where(organisation_id: organisation.id)

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -14,11 +14,10 @@ class FindThirdPartyProjectActivities
       .includes(:organisation, :extending_organisation, :implementing_organisations, :budgets, :parent)
       .order("created_at ASC")
 
-    third_party_projects = if organisation.service_owner
+    if organisation.service_owner?
       third_party_projects.all
     else
       third_party_projects.where(organisation_id: organisation.id)
     end
-    third_party_projects
   end
 end

--- a/app/services/planned_disbursement_history.rb
+++ b/app/services/planned_disbursement_history.rb
@@ -96,7 +96,7 @@ class PlannedDisbursementHistory
     attributes = series_attributes.merge(required_attributes).merge(
       planned_disbursement_type: :original,
       value: value,
-      report: report,
+      report: report
     )
 
     entry = PlannedDisbursement.create!(attributes)
@@ -109,7 +109,7 @@ class PlannedDisbursementHistory
     new_entry.update!(
       planned_disbursement_type: :revised,
       value: value,
-      report: report,
+      report: report
     )
     new_entry.create_activity(key: "planned_disbursement.create", owner: @user)
   end
@@ -133,7 +133,7 @@ class PlannedDisbursementHistory
 
   def required_attributes
     start_date, end_date = period_start_and_end_dates
-    service_owner = Organisation.find_by(service_owner: true)
+    service_owner = Organisation.service_owner
 
     {
       period_start_date: start_date,

--- a/app/services/report/send_state_change_emails.rb
+++ b/app/services/report/send_state_change_emails.rb
@@ -48,7 +48,7 @@ class Report
     end
 
     def service_owners
-      Organisation.find_by(service_owner: true).users.active
+      Organisation.service_owner.users.active
     end
   end
 end

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -7,8 +7,9 @@
                      organisation_type_options,
                      :code,
                      :name
-= f.govuk_text_field :iati_reference,
-                      hint: { text: t("form.hint.organisation.iati_reference_html", link: link_to_new_tab("See International Aid Transparency Initiative (IATI) for detailed documentation", "https://reference.iatistandard.org/organisation-identifiers/")) }
+- if f.object.role != "matched_effort_provider"
+  = f.govuk_text_field :iati_reference,
+                        hint: { text: t("form.hint.organisation.iati_reference_html", link: link_to_new_tab("See International Aid Transparency Initiative (IATI) for detailed documentation", "https://reference.iatistandard.org/organisation-identifiers/")) }
 = f.govuk_collection_select :language_code,
                      language_code_options,
                      :code,

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -1,4 +1,5 @@
 = f.govuk_error_summary
+= f.hidden_field :role
 = f.govuk_text_field :name
 .uppercase-input
   = f.govuk_text_field :beis_organisation_reference

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -17,4 +17,11 @@
                      default_currency_options,
                      :code,
                      :name
+- if f.object.role == "matched_effort_provider"
+  = f.govuk_collection_radio_buttons :active,
+    organisation_active_options,
+    :id,
+    :name,
+    inline: true,
+    legend: -> { tag.legend(t("form.legend.organisation.active"), class: "govuk-fieldset__legend") }
 = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -1,20 +1,35 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-tabs
+      %h2.govuk-tabs__title
+        Organisations
 
-%table.govuk-table.organisations
-  %thead.govuk-table__head
-    %tr.govuk-table__row
-      %th.govuk-table__header
-        =t("table.header.organisation.name")
-      %th.govuk-table__header
-        =t("table.header.organisation.beis_organisation_reference")
-      %th.govuk-table__header
+      %ul.govuk-tabs__list
+        - ["delivery_partners", "matched_effort_providers"].each do |role|
+          %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
+            = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: (role == @role) } }
 
-  %tbody.govuk-table__body
-    - organisations.each do |organisation|
-      %tr.govuk-table__row{id: organisation.id}
-        %td.govuk-table__cell= organisation.name
-        %td.govuk-table__cell= organisation.beis_organisation_reference
-        %td.govuk-table__cell
-          - if policy(organisation).show?
-            = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
-          - if policy(organisation).edit?
-            = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name)
+      .govuk-tabs__panel
+        %h2.govuk-heading-l
+          = t("page_title.organisations.#{@role}")
+
+        - unless organisations.empty?
+          %table.govuk-table.organisations
+            %thead.govuk-table__head
+              %tr.govuk-table__row
+                %th.govuk-table__header
+                  =t("table.header.organisation.name")
+                %th.govuk-table__header
+                  =t("table.header.organisation.beis_organisation_reference")
+                %th.govuk-table__header
+
+            %tbody.govuk-table__body
+              - organisations.each do |organisation|
+                %tr.govuk-table__row{id: organisation.id}
+                  %td.govuk-table__cell= organisation.name
+                  %td.govuk-table__cell= organisation.beis_organisation_reference
+                  %td.govuk-table__cell
+                    - if policy(organisation).show?
+                      = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
+                    - if policy(organisation).edit?
+                      = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name)

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -13,6 +13,9 @@
         %h2.govuk-heading-l
           = t("page_title.organisations.#{@role}")
 
+        - if policy(Organisation).new?
+          = link_to(t("page_content.organisations.#{@role}.button.create"), new_organisation_path(role: @role), class: "govuk-button")
+
         - unless organisations.empty?
           %table.govuk-table.organisations
             %thead.govuk-table__head

--- a/app/views/staff/organisations/index.html.haml
+++ b/app/views/staff/organisations/index.html.haml
@@ -6,8 +6,5 @@
       %h1.govuk-heading-xl
         = t("page_title.organisation.index")
 
-      - if policy(Organisation).new?
-        = link_to(t("page_content.organisations.button.create"), new_organisation_path, class: "govuk-button")
-
       - if @organisations
         = render partial: "staff/organisations/table", locals: { organisations: @organisations }

--- a/app/views/staff/organisations/new.html.haml
+++ b/app/views/staff/organisations/new.html.haml
@@ -1,10 +1,10 @@
-=content_for :page_title_prefix, t("page_title.organisation.new")
+=content_for :page_title_prefix, t("page_title.organisation.#{@organisation.role}.new")
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.organisation.new")
+        = t("page_title.organisation.#{@organisation.role}.new")
 
       = form_with model: @organisation, url: organisations_path do |f|
         = render partial: "form", locals: { f: f }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "3cf80b586f3e0c8a93c52132b54e6b1c401197f838a086bd63eba5a09efbd729",
+      "fingerprint": "e80a1115847632e735c8ffb37ac93551e98904cd2d90ce636b8b7cbb1c1c5353",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/staff/organisations_controller.rb",
       "line": 138,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role)",
+      "code": "params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role, :active)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -18,7 +18,7 @@
       },
       "user_input": ":role",
       "confidence": "Medium",
-      "note": "Role in this context does not give a user a specific role, so there is no risk of privilege escalation (which I think is what this warning is getting at)"
+      "note": ""
     },
     {
       "warning_type": "Mass Assignment",
@@ -41,6 +41,6 @@
       "note": "The only role that currently exists is administrator so there is no risk of privilege escalation at the moment."
     }
   ],
-  "updated": "2021-05-13 16:24:46 +0100",
+  "updated": "2021-05-13 16:42:16 +0100",
   "brakeman_version": "5.0.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,11 +3,31 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
+      "fingerprint": "3cf80b586f3e0c8a93c52132b54e6b1c401197f838a086bd63eba5a09efbd729",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/staff/organisations_controller.rb",
+      "line": 138,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Staff::OrganisationsController",
+        "method": "organisation_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "note": "Role in this context does not give a user a specific role, so there is no risk of privilege escalation (which I think is what this warning is getting at)"
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
       "fingerprint": "b26dcf9c3cbf7e8ddce1403a18b16facb7804a6b3bbea29f21912ff4a3a2eaa6",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/staff/users_controller.rb",
-      "line": 66,
+      "line": 73,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:user).permit(:name, :email, :role, :organisation_id)",
       "render_path": null,
@@ -21,6 +41,6 @@
       "note": "The only role that currently exists is administrator so there is no risk of privilege escalation at the moment."
     }
   ],
-  "updated": "2020-02-28 13:31:52 +0000",
-  "brakeman_version": "4.8.0"
+  "updated": "2021-05-13 16:24:46 +0100",
+  "brakeman_version": "5.0.1"
 }

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -15,8 +15,12 @@ en:
         default_currency: Default currency
         language_code: Language code
         beis_organisation_reference: Short name
+        active:
+          true: Active
+          false: Inactive
     legend:
       organisation:
+        active: What is the status of the organisation?
     hint:
       organisation:
         iati_reference_html: Machine-readable identification string for the organisation. %{link}.

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -43,8 +43,12 @@ en:
   page_content:
     organisation_details: Organisation details
     organisations:
-      button:
-        create: Add organisation
+      delivery_partners:
+        button:
+          create: Add delivery partner organisation
+      matched_effort_providers:
+        button:
+          create: Add matched effort provider organisation
     organisation:
       create_programme: Add level B activity
       button:
@@ -70,8 +74,11 @@ en:
     organisation:
       edit: Edit organisation
       index: Organisations
-      new: Create a new organisation
       show: Organisation %{name}
+      delivery_partner:
+        new: Create a new delivery partner organisation
+      matched_effort_provider:
+        new: Create a new matched effort provider organisation
     organisations:
       delivery_partners: Delivery partners
       matched_effort_providers: Matched effort providers

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -28,6 +28,10 @@ en:
         name: Name
         iati_reference: International Aid Transparency Initiative (IATI) reference
         beis_organisation_reference: Short name
+  tabs:
+    organisations:
+      delivery_partners: Delivery partners
+      matched_effort_providers: Matched effort providers
   summary:
     label:
       organisation:
@@ -68,6 +72,9 @@ en:
       index: Organisations
       new: Create a new organisation
       show: Organisation %{name}
+    organisations:
+      delivery_partners: Delivery partners
+      matched_effort_providers: Matched effort providers
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,13 +22,13 @@ Rails.application.routes.draw do
         get "historic" => "activities#historic"
       end
     end
-    resources :organisations, except: [:destroy, :index] do
-      constraints role: /delivery_partners|matched_effort_providers/o do
-        collection do
-          get "(:role)", to: "organisations#index", defaults: {role: "delivery_partners"}, as: ""
-        end
-      end
 
+    constraints role: /delivery_partners|matched_effort_providers/ do
+      get "organisations/(:role)", to: "organisations#index", defaults: {role: "delivery_partners"}, as: :organisations
+      get "organisations/(:role)/new", to: "organisations#new", as: :new_organisation
+    end
+
+    resources :organisations, except: [:destroy, :index, :new] do
       resources :activities, except: [:index, :create, :destroy] do
         get "financials" => "activity_financials#show"
         get "details" => "activity_details#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,13 @@ Rails.application.routes.draw do
         get "historic" => "activities#historic"
       end
     end
-    resources :organisations, except: [:destroy] do
+    resources :organisations, except: [:destroy, :index] do
+      constraints role: /delivery_partners|matched_effort_providers/o do
+        collection do
+          get "(:role)", to: "organisations#index", defaults: {role: "delivery_partners"}, as: ""
+        end
+      end
+
       resources :activities, except: [:index, :create, :destroy] do
         get "financials" => "activity_financials#show"
         get "details" => "activity_details#show"

--- a/db/migrate/20210309165233_remove_accountable_organisation_from_activity.rb
+++ b/db/migrate/20210309165233_remove_accountable_organisation_from_activity.rb
@@ -10,7 +10,7 @@ class RemoveAccountableOrganisationFromActivity < ActiveRecord::Migration[6.0]
     add_column :activities, :accountable_organisation_reference, :string
     add_column :activities, :accountable_organisation_type, :string
 
-    service_owner = Organisation.find_by(service_owner: true)
+    service_owner = Organisation.service_owner
 
     Activity.update_all(
       accountable_organisation_name: service_owner.name,

--- a/db/migrate/20210511091839_add_organisation_role_to_organisation.rb
+++ b/db/migrate/20210511091839_add_organisation_role_to_organisation.rb
@@ -1,0 +1,15 @@
+class AddOrganisationRoleToOrganisation < ActiveRecord::Migration[6.1]
+  def up
+    add_column :organisations, :role, :integer
+
+    Organisation.where(service_owner: true).update_all(role: 99)
+    Organisation.where(service_owner: false).update_all(role: 0)
+  end
+
+  def down
+    Organisation.where(role: 99).update_all(service_owner: true)
+    Organisation.where.not(role: 99).update_all(service_owner: false)
+
+    remove_column :organisations, :role
+  end
+end

--- a/db/migrate/20210511121941_remove_service_owner_boolean_from_organisation.rb
+++ b/db/migrate/20210511121941_remove_service_owner_boolean_from_organisation.rb
@@ -1,0 +1,5 @@
+class RemoveServiceOwnerBooleanFromOrganisation < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :organisations, :service_owner, :boolean
+  end
+end

--- a/db/migrate/20210513085444_add_active_flag_to_organisation.rb
+++ b/db/migrate/20210513085444_add_active_flag_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddActiveFlagToOrganisation < ActiveRecord::Migration[6.1]
+  def change
+    add_column :organisations, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_092826) do
+ActiveRecord::Schema.define(version: 2021_05_11_121941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -153,9 +153,9 @@ ActiveRecord::Schema.define(version: 2021_04_22_092826) do
     t.string "default_currency"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "service_owner", default: false
     t.string "iati_reference"
     t.string "beis_organisation_reference"
+    t.integer "role"
     t.index ["iati_reference"], name: "index_organisations_on_iati_reference", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_121941) do
+ActiveRecord::Schema.define(version: 2021_05_13_085444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -156,6 +156,7 @@ ActiveRecord::Schema.define(version: 2021_05_11_121941) do
     t.string "iati_reference"
     t.string "beis_organisation_reference"
     t.integer "role"
+    t.boolean "active", default: true
     t.index ["iati_reference"], name: "index_organisations_on_iati_reference", unique: true
   end
 

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -1,4 +1,4 @@
-beis = Organisation.find_by(service_owner: true)
+beis = Organisation.service_owner
 
 gcrf_fund_params = FactoryBot.build(:fund_activity,
   roda_identifier_fragment: "GCRF",

--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -10,7 +10,7 @@ delivery_partner = User.find_or_create_by(
   identifier: "auth0|5e5e1ee731555a0cb0ab5a75",
   role: :administrator
 )
-beis = Organisation.find_by(service_owner: true)
+beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 

--- a/db/seeds/pentest_users.rb
+++ b/db/seeds/pentest_users.rb
@@ -10,7 +10,7 @@ delivery_partner = User.find_or_create_by(
   identifier: "auth0|5e7e39e391c2560c6426bda9",
   role: :administrator
 )
-beis = Organisation.find_by(service_owner: true)
+beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 

--- a/db/seeds/staging_users.rb
+++ b/db/seeds/staging_users.rb
@@ -10,7 +10,7 @@ delivery_partner = User.find_or_create_by(
   identifier: "auth0|5e554c1b37de640d5dd3ea61",
   role: :administrator
 )
-beis = Organisation.find_by(service_owner: true)
+beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -33,8 +33,6 @@ FactoryBot.define do
 
     form_state { "complete" }
 
-    association :organisation, factory: :organisation
-
     before(:create) do |activity|
       activity.cache_roda_identifier
     end
@@ -113,6 +111,7 @@ FactoryBot.define do
       policy_marker_disaster_risk_reduction { "not_assessed" }
       policy_marker_nutrition { "not_assessed" }
 
+      association :organisation, factory: :delivery_partner_organisation
       association :extending_organisation, factory: :delivery_partner_organisation
 
       factory :project_activity_with_implementing_organisations do
@@ -156,6 +155,7 @@ FactoryBot.define do
       policy_marker_disaster_risk_reduction { "not_assessed" }
       policy_marker_nutrition { "not_assessed" }
 
+      association :organisation, factory: :delivery_partner_organisation
       association :extending_organisation, factory: :delivery_partner_organisation
 
       trait :newton_funded do

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :organisation do
+  factory :__organisation do
     sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
     beis_organisation_reference { Faker::Alphanumeric.alpha(number: 10).upcase! }
     iati_reference { "GB-GOV-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
@@ -8,7 +8,7 @@ FactoryBot.define do
     language_code { "en" }
 
     factory :delivery_partner_organisation do
-      service_owner { false }
+      role { "delivery_partner" }
 
       trait :non_government do
         organisation_type { "22" }
@@ -18,12 +18,13 @@ FactoryBot.define do
     factory :beis_organisation do
       name { "Department for Business, Energy and Industrial Strategy" }
       iati_reference { Organisation::SERVICE_OWNER_IATI_REFERENCE }
-      service_owner { true }
+      role { "service_owner" }
+
       initialize_with do
         Organisation.find_or_create_by(
           name: name,
           iati_reference: iati_reference,
-          service_owner: service_owner
+          role: role
         )
       end
     end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       end
     end
 
+    factory :matched_effort_provider do
+      role { "matched_effort_provider" }
+    end
+
     factory :beis_organisation do
       name { "Department for Business, Energy and Industrial Strategy" }
       iati_reference { Organisation::SERVICE_OWNER_IATI_REFERENCE }

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :__organisation do
     sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
-    beis_organisation_reference { Faker::Alphanumeric.alpha(number: 10).upcase! }
+    beis_organisation_reference { Faker::Alphanumeric.alpha(number: 5).upcase! }
     iati_reference { "GB-GOV-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
     organisation_type { "10" }
     default_currency { "GBP" }

--- a/spec/factories/report.rb
+++ b/spec/factories/report.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     state { :inactive }
 
     association :fund, factory: :fund_activity
-    association :organisation
+    association :organisation, factory: :delivery_partner_organisation
 
     trait :active do
       state { :active }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     role { :administrator }
     active { true }
 
-    organisation
+    organisation factory: :beis_organisation
 
     factory :beis_user do
       organisation factory: :beis_organisation

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Factory" do
         result = Organisation.where(
           name: "Department for Business, Energy and Industrial Strategy",
           iati_reference: Organisation::SERVICE_OWNER_IATI_REFERENCE,
-          service_owner: true
+          role: "service_owner"
         )
 
         expect(result.count).to eq(1)

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "BEIS users can create organisations" do
       click_button t("default.button.submit")
 
       expect(page).to have_content(t("action.organisation.create.success"))
+      expect(page).to_not have_field("organisation[active]", type: "radio")
 
       organisation = Organisation.order("created_at ASC").last
 
@@ -37,6 +38,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.language_code).to eq("cs")
       expect(organisation.default_currency).to eq("PLN")
       expect(organisation.role).to eq("delivery_partner")
+      expect(organisation.active).to eq(true)
     end
 
     scenario "successfully creating a matched effort provider organisation" do
@@ -47,11 +49,15 @@ RSpec.feature "BEIS users can create organisations" do
       click_link t("page_content.organisations.matched_effort_providers.button.create")
 
       expect(page).to have_content(t("page_title.organisation.matched_effort_provider.new"))
+      expect(page).to have_field("organisation[active]", type: "radio")
+
       fill_in "organisation[name]", with: "My New Organisation"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
+      choose t("form.label.organisation.active.true"), name: "organisation[active]"
+
       click_button t("default.button.submit")
 
       organisation = Organisation.order("created_at ASC").last
@@ -64,6 +70,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.language_code).to eq("cs")
       expect(organisation.default_currency).to eq("PLN")
       expect(organisation.role).to eq("matched_effort_provider")
+      expect(organisation.active).to eq(true)
     end
 
     scenario "organisation creation is tracked with public_activity" do

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -19,11 +19,22 @@ RSpec.feature "BEIS users can create organisations" do
 
       expect(page).to have_content(t("page_title.organisation.new"))
       fill_in "organisation[name]", with: "My New Organisation"
+      fill_in "organisation[beis_organisation_reference]", with: "MNO"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
       click_button t("default.button.submit")
+
+      organisation = Organisation.order("created_at ASC").last
+
+      expect(organisation.name).to eq("My New Organisation")
+      expect(organisation.beis_organisation_reference).to eq("MNO")
+      expect(organisation.iati_reference).to eq("CZH-GOV-1234")
+      expect(organisation.organisation_type).to eq("10")
+      expect(organisation.language_code).to eq("cs")
+      expect(organisation.default_currency).to eq("PLN")
+      expect(organisation.role).to eq("delivery_partner")
     end
 
     scenario "organisation creation is tracked with public_activity" do

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -26,6 +26,8 @@ RSpec.feature "BEIS users can create organisations" do
       select "Zloty", from: "organisation[default_currency]"
       click_button t("default.button.submit")
 
+      expect(page).to have_content(t("action.organisation.create.success"))
+
       organisation = Organisation.order("created_at ASC").last
 
       expect(organisation.name).to eq("My New Organisation")
@@ -46,7 +48,6 @@ RSpec.feature "BEIS users can create organisations" do
 
       expect(page).to have_content(t("page_title.organisation.matched_effort_provider.new"))
       fill_in "organisation[name]", with: "My New Organisation"
-      fill_in "organisation[beis_organisation_reference]", with: "MNO"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
@@ -55,8 +56,9 @@ RSpec.feature "BEIS users can create organisations" do
 
       organisation = Organisation.order("created_at ASC").last
 
+      expect(page).to have_content(t("action.organisation.create.success"))
+
       expect(organisation.name).to eq("My New Organisation")
-      expect(organisation.beis_organisation_reference).to eq("MNO")
       expect(organisation.iati_reference).to eq("CZH-GOV-1234")
       expect(organisation.organisation_type).to eq("10")
       expect(organisation.language_code).to eq("cs")

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -52,7 +52,6 @@ RSpec.feature "BEIS users can create organisations" do
       expect(page).to have_field("organisation[active]", type: "radio")
 
       fill_in "organisation[name]", with: "My New Organisation"
-      fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
@@ -65,7 +64,6 @@ RSpec.feature "BEIS users can create organisations" do
       expect(page).to have_content(t("action.organisation.create.success"))
 
       expect(organisation.name).to eq("My New Organisation")
-      expect(organisation.iati_reference).to eq("CZH-GOV-1234")
       expect(organisation.organisation_type).to eq("10")
       expect(organisation.language_code).to eq("cs")
       expect(organisation.default_currency).to eq("PLN")

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -12,12 +12,12 @@ RSpec.feature "BEIS users can create organisations" do
       authenticate!(user: user)
     end
 
-    scenario "successfully creating an organisation" do
+    scenario "successfully creating a delivery partner organisation" do
       visit organisation_path(user.organisation)
       click_link t("page_title.organisation.index")
-      click_link t("page_content.organisations.button.create")
+      click_link t("page_content.organisations.delivery_partners.button.create")
 
-      expect(page).to have_content(t("page_title.organisation.new"))
+      expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
       fill_in "organisation[name]", with: "My New Organisation"
       fill_in "organisation[beis_organisation_reference]", with: "MNO"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
@@ -37,13 +37,40 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.role).to eq("delivery_partner")
     end
 
+    scenario "successfully creating a matched effort provider organisation" do
+      visit organisation_path(user.organisation)
+      click_link t("page_title.organisation.index")
+      click_link t("tabs.organisations.matched_effort_providers")
+
+      click_link t("page_content.organisations.matched_effort_providers.button.create")
+
+      expect(page).to have_content(t("page_title.organisation.matched_effort_provider.new"))
+      fill_in "organisation[name]", with: "My New Organisation"
+      fill_in "organisation[beis_organisation_reference]", with: "MNO"
+      fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
+      select "Government", from: "organisation[organisation_type]"
+      select "Czech", from: "organisation[language_code]"
+      select "Zloty", from: "organisation[default_currency]"
+      click_button t("default.button.submit")
+
+      organisation = Organisation.order("created_at ASC").last
+
+      expect(organisation.name).to eq("My New Organisation")
+      expect(organisation.beis_organisation_reference).to eq("MNO")
+      expect(organisation.iati_reference).to eq("CZH-GOV-1234")
+      expect(organisation.organisation_type).to eq("10")
+      expect(organisation.language_code).to eq("cs")
+      expect(organisation.default_currency).to eq("PLN")
+      expect(organisation.role).to eq("matched_effort_provider")
+    end
+
     scenario "organisation creation is tracked with public_activity" do
       PublicActivity.with_tracking do
         visit organisation_path(user.organisation)
         click_link t("page_title.organisation.index")
-        click_link t("page_content.organisations.button.create")
+        click_link t("page_content.organisations.delivery_partners.button.create")
 
-        expect(page).to have_content(t("page_title.organisation.new"))
+        expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
         fill_in "organisation[name]", with: "My New Organisation"
         fill_in "organisation[beis_organisation_reference]", with: "mno"
         fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
@@ -63,9 +90,9 @@ RSpec.feature "BEIS users can create organisations" do
     scenario "presence validation works as expected" do
       visit organisation_path(user.organisation)
       click_link t("page_title.organisation.index")
-      click_link t("page_content.organisations.button.create")
+      click_link t("page_content.organisations.delivery_partners.button.create")
 
-      expect(page).to have_content(t("page_title.organisation.new"))
+      expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
       fill_in "organisation[name]", with: "My New Organisation"
 
       click_button t("default.button.submit")

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "BEIS users can editing other users" do
-  let!(:user) { create(:administrator, organisation: create(:organisation)) }
+  let!(:user) { create(:delivery_partner_user, organisation: create(:delivery_partner_organisation)) }
 
   before do
     stub_auth0_token_request
@@ -11,7 +11,7 @@ RSpec.feature "BEIS users can editing other users" do
     user = create(:beis_user)
     authenticate!(user: user)
 
-    target_user = create(:administrator, name: "Old Name", email: "old@example.com")
+    target_user = create(:delivery_partner_user, name: "Old Name", email: "old@example.com")
 
     visit organisation_path(user.organisation)
     click_on(t("page_title.users.index"))
@@ -26,14 +26,14 @@ RSpec.feature "BEIS users can editing other users" do
     user = create(:beis_user)
     authenticate!(user: user)
 
-    target_user = create(:administrator, name: "Old Name", email: "old@example.com")
+    target_user = create(:delivery_partner_user, name: "Old Name", email: "old@example.com")
 
     updated_name = "New Name"
 
     stub_auth0_update_user_request(
       auth0_identifier: target_user.identifier,
       name: updated_name,
-      email: target_user.email,
+      email: target_user.email
     )
 
     # Navigate from the landing page
@@ -91,7 +91,7 @@ RSpec.feature "BEIS users can editing other users" do
 
   scenario "an inactive user can be reactivated" do
     administrator_user = create(:beis_user)
-    user = create(:inactive_user)
+    user = create(:inactive_user, organisation: create(:delivery_partner_organisation))
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
@@ -107,14 +107,14 @@ RSpec.feature "BEIS users can editing other users" do
   scenario "user update is tracked with public_activity" do
     administrator_user = create(:beis_user)
     authenticate!(user: administrator_user)
-    target_user = create(:administrator, name: "Old Name", email: "old@example.com")
+    target_user = create(:delivery_partner_user, name: "Old Name", email: "old@example.com")
 
     updated_name = "New Name"
 
     stub_auth0_update_user_request(
       auth0_identifier: target_user.identifier,
       name: updated_name,
-      email: target_user.email,
+      email: target_user.email
     )
 
     PublicActivity.with_tracking do

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -21,8 +21,8 @@ RSpec.feature "BEIS users can invite new users to the service" do
       let(:user) { create(:beis_user) }
 
       scenario "a new user can be created" do
-        organisation = create(:organisation)
-        second_organisation = create(:organisation)
+        organisation = create(:delivery_partner_organisation)
+        second_organisation = create(:delivery_partner_organisation)
         new_user_name = "Foo Bar"
         new_user_email = "email@example.com"
         auth0_identifier = "auth0|00991122"
@@ -53,7 +53,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       scenario "user creation is tracked with public_activity" do
         PublicActivity.with_tracking do
-          organisation = create(:organisation)
+          organisation = create(:delivery_partner_organisation)
           new_user_name = "Foo Bar"
           new_user_email = "email@example.com"
           auth0_identifier = "auth0|00991122"
@@ -90,7 +90,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
           it "does not create the user and displays an error message" do
             stub_auth0_token_request
             new_email = "email@example.com"
-            organisation = create(:organisation)
+            organisation = create(:delivery_partner_organisation)
             stub_auth0_create_user_request_failure(email: new_email)
 
             visit new_user_path
@@ -111,7 +111,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
         context "when the email was invalid" do
           it "does not create the user and displays an invalid email message" do
             new_email = "tom"
-            organisation = create(:organisation)
+            organisation = create(:delivery_partner_organisation)
             stub_auth0_create_user_request_failure(email: new_email)
 
             visit new_user_path
@@ -151,7 +151,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
     # We expect to see BEIS separately on this page
     within(".user-organisations") do
-      beis_identifier = Organisation.find_by(service_owner: true).id
+      beis_identifier = Organisation.service_owner.id
       expect(page).to have_css("input[type='radio'][value='#{beis_identifier}']:first-child")
       expect(page).to have_css(".govuk-radios__divider:nth-child(2)")
     end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -6,6 +6,40 @@ RSpec.feature "BEIS users can view other organisations" do
     end
   end
 
+  RSpec.shared_examples "lists delivery partner organisations" do
+    scenario "it lists delivery partner organisations" do
+      expect(page).to have_content(t("page_title.organisation.index"))
+      expect(page).to have_content(t("page_title.organisations.delivery_partners"))
+
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.delivery_partners"))
+
+      delivery_partner_organisations.each do |organisation|
+        expect(page).to have_content(organisation.beis_organisation_reference)
+        expect(page).to have_content(organisation.name)
+      end
+
+      matched_effort_provider_organisations.each do |organisation|
+        expect(page).to_not have_content(organisation.name)
+      end
+    end
+  end
+
+  RSpec.shared_examples "lists matched effort provider organisations" do
+    scenario "it lists matched effort provider organisations" do
+      expect(page).to have_content(t("page_title.organisation.index"))
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.matched_effort_providers"))
+      expect(page).to have_content(t("page_title.organisations.matched_effort_providers"))
+
+      matched_effort_provider_organisations.each do |organisation|
+        expect(page).to have_content(organisation.name)
+      end
+
+      delivery_partner_organisations.each do |organisation|
+        expect(page).to_not have_content(organisation.name)
+      end
+    end
+  end
+
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
 
@@ -24,33 +58,28 @@ RSpec.feature "BEIS users can view other organisations" do
       context "the role is 'delivery_partners'" do
         let(:role) { "delivery_partners" }
 
-        scenario "it lists delivery partner organisations" do
-          expect(page).to have_content(t("page_title.organisation.index"))
+        include_examples "lists delivery partner organisations"
 
-          delivery_partner_organisations.each do |organisation|
-            expect(page).to have_content(organisation.name)
+        context "when viewing the matched effort providers tab" do
+          before do
+            click_on t("tabs.organisations.matched_effort_providers")
           end
 
-          matched_effort_provider_organisations.each do |organisation|
-            expect(page).to_not have_content(organisation.name)
-          end
+          include_examples "lists matched effort provider organisations"
         end
       end
 
       context "the role is 'matched_effort_providers'" do
         let(:role) { "matched_effort_providers" }
 
-        scenario "it lists matched effort provider organisations" do
-          expect(page).to have_content(t("page_title.organisation.index"))
+        include_examples "lists matched effort provider organisations"
 
-          matched_effort_provider_organisations.each do |organisation|
-            expect(page).to have_content(organisation.name)
-            expect(page).to have_content(organisation.beis_organisation_reference)
+        context "when viewing the delivery partner organisations tab" do
+          before do
+            click_on t("tabs.organisations.delivery_partners")
           end
 
-          delivery_partner_organisations.each do |organisation|
-            expect(page).to_not have_content(organisation.name)
-          end
+          include_examples "lists delivery partner organisations"
         end
       end
     end
@@ -60,18 +89,7 @@ RSpec.feature "BEIS users can view other organisations" do
         visit organisations_path
       end
 
-      scenario "it lists delivery partner organisations" do
-        expect(page).to have_content(t("page_title.organisation.index"))
-
-        delivery_partner_organisations.each do |organisation|
-          expect(page).to have_content(organisation.name)
-          expect(page).to have_content(organisation.beis_organisation_reference)
-        end
-
-        matched_effort_provider_organisations.each do |organisation|
-          expect(page).to_not have_content(organisation.name)
-        end
-      end
+      include_examples "lists delivery partner organisations"
     end
   end
 end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -9,16 +9,69 @@ RSpec.feature "BEIS users can view other organisations" do
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
 
-    scenario "all organisations can be viewed" do
-      another_organisation = create(:delivery_partner_organisation)
+    let!(:delivery_partner_organisations) { create_list(:delivery_partner_organisation, 3) }
+    let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
+
+    before do
       authenticate!(user: user)
+    end
 
-      visit organisations_path
+    context "when a role is provided" do
+      before do
+        visit organisations_path(role: role)
+      end
 
-      expect(page).to have_content(t("page_title.organisation.index"))
-      expect(page).to have_content(user.organisation.name)
-      expect(page).to have_content(another_organisation.name)
-      expect(page).to have_content(another_organisation.beis_organisation_reference)
+      context "the role is 'delivery_partners'" do
+        let(:role) { "delivery_partners" }
+
+        scenario "it lists delivery partner organisations" do
+          expect(page).to have_content(t("page_title.organisation.index"))
+
+          delivery_partner_organisations.each do |organisation|
+            expect(page).to have_content(organisation.name)
+          end
+
+          matched_effort_provider_organisations.each do |organisation|
+            expect(page).to_not have_content(organisation.name)
+          end
+        end
+      end
+
+      context "the role is 'matched_effort_providers'" do
+        let(:role) { "matched_effort_providers" }
+
+        scenario "it lists matched effort provider organisations" do
+          expect(page).to have_content(t("page_title.organisation.index"))
+
+          matched_effort_provider_organisations.each do |organisation|
+            expect(page).to have_content(organisation.name)
+            expect(page).to have_content(organisation.beis_organisation_reference)
+          end
+
+          delivery_partner_organisations.each do |organisation|
+            expect(page).to_not have_content(organisation.name)
+          end
+        end
+      end
+    end
+
+    context "when the role is not provided" do
+      before do
+        visit organisations_path
+      end
+
+      scenario "it lists delivery partner organisations" do
+        expect(page).to have_content(t("page_title.organisation.index"))
+
+        delivery_partner_organisations.each do |organisation|
+          expect(page).to have_content(organisation.name)
+          expect(page).to have_content(organisation.beis_organisation_reference)
+        end
+
+        matched_effort_provider_organisations.each do |organisation|
+          expect(page).to_not have_content(organisation.name)
+        end
+      end
     end
   end
 end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "BEIS users can view other organisations" do
     let(:user) { create(:beis_user) }
 
     scenario "all organisations can be viewed" do
-      another_organisation = create(:organisation)
+      another_organisation = create(:delivery_partner_organisation)
       authenticate!(user: user)
 
       visit organisations_path

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature "BEIS users can can view other users" do
     end
 
     scenario "users are grouped by their organisation name in alphabetical order" do
-      a_organisation = create(:organisation, name: "A Organisation")
-      b_organisation = create(:organisation, name: "B Organisation")
+      a_organisation = create(:delivery_partner_organisation, name: "A Organisation")
+      b_organisation = create(:delivery_partner_organisation, name: "B Organisation")
 
       a1_user = create(:administrator, organisation: a_organisation)
       a2_user = create(:administrator, organisation: a_organisation)

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can activate reports" do
   context "signed in as a BEIS user" do
     let(:beis_user) { create(:beis_user) }
-    let(:organisation) { create(:organisation, users: build_list(:administrator, 3)) }
+    let(:organisation) { create(:delivery_partner_organisation, users: build_list(:administrator, 3)) }
 
     before do
       authenticate!(user: beis_user)

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can approve reports" do
   context "signed in as a BEIS user" do
     let(:beis_user) { create(:beis_user) }
-    let(:organisation) { create(:organisation, users: create_list(:delivery_partner_user, 3)) }
+    let(:organisation) { create(:delivery_partner_organisation, users: create_list(:delivery_partner_user, 3)) }
 
     before do
       authenticate!(user: beis_user)

--- a/spec/features/staff/users_can_create_a_comment_spec.rb
+++ b/spec/features/staff/users_can_create_a_comment_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Users can create a comment" do
     end
 
     context "when the report is editable but does not belong to this user's organisation" do
-      let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:organisation)) }
+      let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
       scenario "the user cannot add a comment" do
         visit report_path(report)
         expect(page).to have_content t("not_authorised.default")

--- a/spec/features/staff/users_can_edit_a_comment_spec.rb
+++ b/spec/features/staff/users_can_edit_a_comment_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Users can edit a comment" do
       end
 
       context "when the report is editable but does not belong to this user's organisation" do
-        let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:organisation)) }
+        let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
         scenario "the user cannot edit a comment" do
           visit report_path(report)
           expect(page).to have_content t("not_authorised.default")

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature "Users can edit organisations" do
   let!(:beis_organisation) { create(:beis_organisation) }
-  let!(:another_organisation) { create(:organisation) }
+  let!(:another_organisation) { create(:delivery_partner_organisation) }
 
   context "when the user is not logged in" do
     it "redirects the user to the root path" do

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -46,6 +46,31 @@ RSpec.feature "Users can edit organisations" do
     expect(page).to have_content t("activerecord.errors.models.organisation.attributes.name.blank")
   end
 
+  context "when the organisation is a matched effort provider organisation" do
+    let!(:another_organisation) { create(:matched_effort_provider) }
+
+    scenario "it can be set to inactive" do
+      authenticate!(user: create(:administrator, organisation: beis_organisation))
+
+      visit organisation_path(beis_organisation)
+      click_link t("page_title.organisation.index")
+      click_link t("tabs.organisations.matched_effort_providers")
+
+      within("##{another_organisation.id}") do
+        click_link t("default.link.edit")
+      end
+
+      choose t("form.label.organisation.active.false"), name: "organisation[active]"
+      expect {
+        click_button t("default.button.submit")
+      }.to change {
+        another_organisation.reload.active
+      }.from(true).to(false)
+
+      expect(page).to have_content t("action.organisation.update.success")
+    end
+  end
+
   def successfully_edit_an_organisation(organisation_name: "My New Organisation")
     visit organisation_path(beis_organisation)
 

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature "Users can manage the implementing organisations" do
   context "when they are signed in as a delivery partner" do
-    let(:delivery_partner) { create(:organisation) }
+    let(:delivery_partner) { create(:delivery_partner_organisation) }
     let(:project) { create(:project_activity, organisation: delivery_partner) }
     let!(:report) { create(:report, state: :active, organisation: delivery_partner, fund: project.associated_fund) }
 
@@ -55,7 +55,7 @@ RSpec.feature "Users can manage the implementing organisations" do
   end
 
   context "when they are signed in as a BEIS user" do
-    let(:delivery_partner) { create(:organisation) }
+    let(:delivery_partner) { create(:delivery_partner_organisation) }
     let(:project) { create(:project_activity, organisation: delivery_partner) }
 
     before { authenticate!(user: create(:beis_user)) }

--- a/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can move reports into awaiting changes & view reports awaiting changes" do
   context "signed in as a BEIS user" do
     let(:beis_user) { create(:beis_user) }
-    let(:organisation) { create(:organisation, users: create_list(:delivery_partner_user, 3)) }
+    let(:organisation) { create(:delivery_partner_organisation, users: create_list(:delivery_partner_user, 3)) }
 
     before do
       authenticate!(user: beis_user)

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can submit a report" do
   context "as a Delivery partner user" do
     let!(:service_owner) { create(:beis_user) }
-    let(:organisation) { create(:organisation, users: create_list(:delivery_partner_user, 2)) }
+    let(:organisation) { create(:delivery_partner_organisation, users: create_list(:delivery_partner_user, 2)) }
     let(:delivery_partner_user) { create(:delivery_partner_user, organisation: organisation) }
 
     before do

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "users can upload activities" do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
   let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
   let!(:programme) { create(:programme_activity, :newton_funded, extending_organisation: organisation, roda_identifier_fragment: "B-PROG", parent: create(:fund_activity, roda_identifier_fragment: "A-FUND")) }
@@ -125,7 +125,7 @@ RSpec.feature "users can upload activities" do
   end
 
   context "uploading a set of activities the user doesn't have permission to modify" do
-    let(:another_organisation) { create(:organisation) }
+    let(:another_organisation) { create(:delivery_partner_organisation) }
     let!(:another_programme) { create(:programme_activity, parent: programme.associated_fund, extending_organisation: another_organisation, roda_identifier_fragment: "BB-PROG") }
     let!(:existing_activity) { create(:project_activity, parent: programme, roda_identifier_fragment: "EX42") }
 

--- a/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
+++ b/spec/features/staff/users_can_upload_planned_disbursements_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "users can upload planned disbursements" do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
   let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
   let!(:project) { create(:project_activity, organisation: organisation) }
@@ -87,7 +87,7 @@ RSpec.feature "users can upload planned disbursements" do
           "FC 2025/26 FY Q2" => "",
           "FC 2025/26 FY Q3" => "",
           "FC 2025/26 FY Q4" => "",
-          "FC 2026/27 FY Q1" => "",
+          "FC 2026/27 FY Q1" => ""
         )
       end
     end

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "users can upload transactions" do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
   let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
   let!(:project) { create(:project_activity, organisation: organisation) }

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can view an organisation" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
-      organisation = create(:organisation)
+      organisation = create(:delivery_partner_organisation)
       visit organisation_path(organisation)
       expect(current_path).to eq(root_path)
     end
@@ -28,7 +28,7 @@ RSpec.feature "Users can view an organisation" do
     end
 
     context "viewing another organisation" do
-      let!(:other_organisation) { create(:organisation) }
+      let!(:other_organisation) { create(:delivery_partner_organisation) }
 
       scenario "can see the other organisation's page" do
         visit organisation_path(user.organisation)
@@ -40,8 +40,8 @@ RSpec.feature "Users can view an organisation" do
       end
 
       scenario "does not see activities which belong to a different organisation" do
-        other_programme = create(:programme_activity, extending_organisation: create(:organisation))
-        other_project = create(:project_activity, organisation: create(:organisation))
+        other_programme = create(:programme_activity, extending_organisation: create(:delivery_partner_organisation))
+        other_project = create(:project_activity, organisation: create(:delivery_partner_organisation))
 
         visit organisation_path(user.organisation)
         click_link t("page_title.organisation.index")

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can view fund level activities" do
   context "when the user is not logged in" do
     it "redirects the user to the root path" do
-      organisation = create(:organisation)
+      organisation = create(:delivery_partner_organisation)
       visit organisation_path(organisation)
       expect(current_path).to eq(root_path)
     end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -337,7 +337,7 @@ RSpec.feature "Users can view reports" do
       end
 
       scenario "cannot view a report belonging to another delivery partner" do
-        another_report = create(:report, organisation: create(:organisation))
+        another_report = create(:report, organisation: create(:delivery_partner_organisation))
 
         visit report_path(another_report)
 

--- a/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Users can view third-party project level activities" do
 
       header = page.response_headers["Content-Disposition"]
       expect(header).to match(/^attachment/)
-      expect(header).to match(/filename=\"#{third_party_project.transparency_identifier}.xml\"$/)
+      expect(header).to match(/filename="#{third_party_project.transparency_identifier}.xml"$/)
     end
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ActivityHelper, type: :helper do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
 
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FormHelper, type: :helper do
 
   describe "#list_of_delivery_partners" do
     it "asks for a list of organisations that are not `service_owner`" do
-      delivery_partner = build_stubbed(:organisation, service_owner: false)
+      delivery_partner = build_stubbed(:delivery_partner_organisation)
       allow(Organisation).to receive(:delivery_partners).and_return([delivery_partner])
 
       expect(Organisation).to receive(:delivery_partners)

--- a/spec/helpers/organisation_helper_spec.rb
+++ b/spec/helpers/organisation_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe OrganisationHelper do
   describe "#organisation_page_back_link" do
-    let(:organisation) { create(:organisation) }
-    let(:other_organisation) { create(:organisation) }
+    let(:organisation) { create(:delivery_partner_organisation) }
+    let(:other_organisation) { create(:delivery_partner_organisation) }
 
     let(:user) { create(:administrator, organisation: organisation) }
 

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe UserHelper, type: :helper do
   describe "#organisation_check_box_options" do
     it "returns an array of all organisations in alphabetical order" do
-      first_organisation = create(:organisation, name: "A Organisation")
-      second_organisation = create(:organisation, name: "Z Organisation")
+      first_organisation = create(:delivery_partner_organisation, name: "A Organisation")
+      second_organisation = create(:delivery_partner_organisation, name: "Z Organisation")
 
       expect(helper.organisation_check_box_options)
         .to match([

--- a/spec/lib/tasks/import_activities_spec.rb
+++ b/spec/lib/tasks/import_activities_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "rake activities:import", type: :task do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
   let(:uploader) { create(:beis_user) }
 
   it "returns an error if the organisation is blank" do

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -9,7 +9,7 @@ class ReportMailerPreview < ActionMailer::Preview
   end
 
   def submitted_delivery_partner
-    organisation = FactoryBot.build(:organisation)
+    organisation = FactoryBot.build(:delivery_partner_organisation)
 
     ReportMailer.with(
       user: FactoryBot.build(:administrator, organisation: organisation),

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ReportMailer, type: :mailer do
   let(:fund) { create(:fund_activity, :gcrf) }
-  let(:organisation) { create(:organisation, beis_organisation_reference: "ABC") }
+  let(:organisation) { create(:delivery_partner_organisation, beis_organisation_reference: "ABC") }
   let(:user) { create(:administrator) }
   let(:report) { create(:report, financial_quarter: 4, financial_year: 2020, deadline: DateTime.parse("2021-01-01"), fund: fund, organisation: organisation) }
 
@@ -80,7 +80,7 @@ RSpec.describe ReportMailer, type: :mailer do
     end
 
     context "when the user is a delivery partner in a different organisation" do
-      let(:user) { create(:administrator) }
+      let(:user) { create(:administrator, organisation: build(:delivery_partner_organisation)) }
 
       it "should raise an error" do
         expect { mail.body }.to raise_error(ArgumentError, "User must either be a service owner or belong to the organisation making the report")

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -6,25 +6,29 @@ RSpec.describe Organisation, type: :model do
     it { should validate_presence_of(:organisation_type) }
     it { should validate_presence_of(:language_code) }
     it { should validate_presence_of(:default_currency) }
-    it { should validate_presence_of(:iati_reference) }
 
-    it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     it { should validate_uniqueness_of(:name).ignoring_case_sensitivity }
     it { should validate_uniqueness_of(:beis_organisation_reference).ignoring_case_sensitivity }
 
     context "when the organisation is a service owner" do
       subject { build(:beis_organisation) }
       it { should validate_presence_of(:beis_organisation_reference) }
+      it { should validate_presence_of(:iati_reference) }
+      it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     end
 
     context "when the organisation is a delivery partner" do
       subject { build(:delivery_partner_organisation) }
       it { should validate_presence_of(:beis_organisation_reference) }
+      it { should validate_presence_of(:iati_reference) }
+      it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     end
 
     context "when the organisation is a matched effort provider" do
       subject { build(:matched_effort_provider) }
       it { should_not validate_presence_of(:beis_organisation_reference) }
+      it { should_not validate_presence_of(:iati_reference) }
+      it { should_not validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     end
 
     describe "sanitation" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -19,31 +19,31 @@ RSpec.describe Organisation, type: :model do
 
     describe "#iati_reference" do
       it "returns true if it does matches a known structure XX-XXX-" do
-        organisation = build(:organisation, iati_reference: "GB-GOV-13")
+        organisation = build(:delivery_partner_organisation, iati_reference: "GB-GOV-13")
         result = organisation.valid?
         expect(result).to eq(true)
       end
 
       it "returns true if it does match an unexpected value of the same XX-XXX- structure" do
-        organisation = build(:organisation, iati_reference: "GB-COH-1234567asdfghj")
+        organisation = build(:delivery_partner_organisation, iati_reference: "GB-COH-1234567asdfghj")
         result = organisation.valid?
         expect(result).to eq(true)
       end
 
       it "returns true if the country code is 3 characters long" do
-        organisation = build(:organisation, iati_reference: "CZH-COH-111")
+        organisation = build(:delivery_partner_organisation, iati_reference: "CZH-COH-111")
         result = organisation.valid?
         expect(result).to eq(true)
       end
 
       it "returns false if it doesn't match the structure XX-XXX-" do
-        organisation = build(:organisation, iati_reference: "1234")
+        organisation = build(:delivery_partner_organisation, iati_reference: "1234")
         result = organisation.valid?
         expect(result).to eq(false)
       end
 
       it "returns an error message if it is invalid" do
-        organisation = build(:organisation, iati_reference: "1234")
+        organisation = build(:delivery_partner_organisation, iati_reference: "1234")
         organisation.valid?
         expect(organisation.errors.messages[:iati_reference]).to include(
           t("activerecord.errors.models.organisation.attributes.iati_reference.format")
@@ -69,7 +69,7 @@ RSpec.describe Organisation, type: :model do
 
     context "when an organisation is not flagged as BEIS" do
       it " should return false" do
-        other_organisation = create(:organisation, service_owner: false)
+        other_organisation = create(:delivery_partner_organisation)
 
         result = other_organisation.service_owner?
 
@@ -79,7 +79,7 @@ RSpec.describe Organisation, type: :model do
 
     context "when an organisation is not deliberately flagged as BEIS" do
       it "should default to false" do
-        new_organisation = create(:organisation)
+        new_organisation = create(:delivery_partner_organisation)
 
         result = new_organisation.service_owner?
 
@@ -97,9 +97,9 @@ RSpec.describe Organisation, type: :model do
 
   describe ".sorted_by_name" do
     it "should sort name name a->z" do
-      a_organisation = create(:organisation, name: "A", created_at: 3.days.ago)
-      b_organisation = create(:organisation, name: "B", created_at: 1.days.ago)
-      c_organisation = create(:organisation, name: "C", created_at: 2.days.ago)
+      a_organisation = create(:delivery_partner_organisation, name: "A", created_at: 3.days.ago)
+      b_organisation = create(:delivery_partner_organisation, name: "B", created_at: 1.days.ago)
+      c_organisation = create(:delivery_partner_organisation, name: "C", created_at: 2.days.ago)
 
       result = Organisation.sorted_by_name
 
@@ -122,24 +122,24 @@ RSpec.describe Organisation, type: :model do
 
   describe "#is_government?" do
     it "should be true for a Government organisation_type" do
-      organisation = create(:organisation, organisation_type: 10)
+      organisation = create(:delivery_partner_organisation, organisation_type: 10)
       expect(organisation.is_government?).to eq true
     end
 
     it "should be true for a Government organisation_type" do
-      organisation = create(:organisation, organisation_type: 11)
+      organisation = create(:delivery_partner_organisation, organisation_type: 11)
       expect(organisation.is_government?).to eq true
     end
 
     it "should be false for an NGO organisation_type" do
-      organisation = create(:organisation, organisation_type: 21)
+      organisation = create(:delivery_partner_organisation, organisation_type: 21)
       expect(organisation.is_government?).to eq false
     end
   end
 
   describe "#ensure_beis_organisation_reference_is_uppercase" do
     it "converts the value of beis_organisation_reference to uppercase" do
-      organisation = build(:organisation, beis_organisation_reference: "testme")
+      organisation = build(:delivery_partner_organisation, beis_organisation_reference: "testme")
 
       expect(organisation.valid?).to be_truthy
       expect(organisation.beis_organisation_reference).to eql "TESTME"

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Organisation, type: :model do
       end
     end
 
-    context "when an organisation is not flagged as BEIS" do
+    context "when an organisation is a delivery partner" do
       it " should return false" do
         other_organisation = create(:delivery_partner_organisation)
 
@@ -77,11 +77,11 @@ RSpec.describe Organisation, type: :model do
       end
     end
 
-    context "when an organisation is not deliberately flagged as BEIS" do
-      it "should default to false" do
-        new_organisation = create(:delivery_partner_organisation)
+    context "when an organisation is a matched effort provider" do
+      it "should return false" do
+        other_organisation = create(:matched_effort_provider)
 
-        result = new_organisation.service_owner?
+        result = other_organisation.service_owner?
 
         expect(result).to eq(false)
       end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -7,11 +7,25 @@ RSpec.describe Organisation, type: :model do
     it { should validate_presence_of(:language_code) }
     it { should validate_presence_of(:default_currency) }
     it { should validate_presence_of(:iati_reference) }
-    it { should validate_presence_of(:beis_organisation_reference) }
 
     it { should validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     it { should validate_uniqueness_of(:name).ignoring_case_sensitivity }
     it { should validate_uniqueness_of(:beis_organisation_reference).ignoring_case_sensitivity }
+
+    context "when the organisation is a service owner" do
+      subject { build(:beis_organisation) }
+      it { should validate_presence_of(:beis_organisation_reference) }
+    end
+
+    context "when the organisation is a delivery partner" do
+      subject { build(:delivery_partner_organisation) }
+      it { should validate_presence_of(:beis_organisation_reference) }
+    end
+
+    context "when the organisation is a matched effort provider" do
+      subject { build(:matched_effort_provider) }
+      it { should_not validate_presence_of(:beis_organisation_reference) }
+    end
 
     describe "sanitation" do
       it { should strip_attribute(:iati_reference) }
@@ -139,10 +153,10 @@ RSpec.describe Organisation, type: :model do
 
   describe "#ensure_beis_organisation_reference_is_uppercase" do
     it "converts the value of beis_organisation_reference to uppercase" do
-      organisation = build(:delivery_partner_organisation, beis_organisation_reference: "testme")
+      organisation = build(:delivery_partner_organisation, beis_organisation_reference: "test")
 
       expect(organisation.valid?).to be_truthy
-      expect(organisation.beis_organisation_reference).to eql "TESTME"
+      expect(organisation.beis_organisation_reference).to eql "TEST"
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Report, type: :model do
   end
 
   describe ".editable_for_activity" do
-    let!(:organisation) { create(:organisation) }
+    let!(:organisation) { create(:delivery_partner_organisation) }
     let!(:project) { create(:project_activity, organisation: organisation) }
     let!(:project_in_another_fund) { create(:project_activity, organisation: organisation) }
 
@@ -157,7 +157,7 @@ RSpec.describe Report, type: :model do
   end
 
   describe "reportable_activities" do
-    let!(:report) { create(:report) }
+    let!(:report) { create(:report, organisation: build(:delivery_partner_organisation)) }
     let!(:programme) { create(:programme_activity, parent: report.fund) }
     let!(:project_a) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe User, type: :model do
 
     context "when the user organisation is NOT a service owner" do
       it "returns false" do
-        organisation = build_stubbed(:organisation, service_owner: false)
+        organisation = build_stubbed(:delivery_partner_organisation)
         result = described_class.new(organisation: organisation).service_owner?
         expect(result).to be false
       end
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
 
     context "when the user organisation is NOT a service owner" do
       it "returns true" do
-        organisation = build_stubbed(:organisation, service_owner: false)
+        organisation = build_stubbed(:delivery_partner_organisation)
         result = described_class.new(organisation: organisation).delivery_partner?
         expect(result).to be true
       end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe OrganisationPolicy do
   subject { described_class.new(user, organisation) }
 
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
 
   context "as user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
@@ -29,7 +29,7 @@ RSpec.describe OrganisationPolicy do
     end
 
     context "when the user does NOT belong to that organisation" do
-      let(:user) { build_stubbed(:delivery_partner_user, organisation: create(:organisation)) }
+      let(:user) { build_stubbed(:delivery_partner_user, organisation: create(:delivery_partner_organisation)) }
 
       it { is_expected.to forbid_action(:index) }
       it { is_expected.to forbid_action(:show) }

--- a/spec/presenters/organisation_presenter_spec.rb
+++ b/spec/presenters/organisation_presenter_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe OrganisationPresenter do
-  let(:organisation) { FactoryBot.build(:organisation, language_code: "EN", default_currency: "GBP") }
+  let(:organisation) { FactoryBot.build(:delivery_partner_organisation, language_code: "EN", default_currency: "GBP") }
 
   describe "#language_code" do
     it "downcases the language_code" do

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ReportPresenter do
         financial_quarter: 1,
         financial_year: 2020,
         fund: build(:fund_activity, :gcrf),
-        organisation: build(:organisation, beis_organisation_reference: "BOR"),
+        organisation: build(:delivery_partner_organisation, beis_organisation_reference: "BOR"),
         description: "My report")
     }
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Activities::ImportFromCsv do
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
   let(:uploader) { create(:delivery_partner_user, organisation: organisation) }
   let(:parent_activity) { create(:programme_activity, :newton_funded, extending_organisation: organisation) }
 

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CreateUser do
     it "returns a successful result" do
       stub_auth0_create_user_request(email: user.email)
 
-      result = described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+      result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
 
       expect(result.success?).to eq(true)
       expect(result.failure?).to eq(false)
@@ -20,7 +20,7 @@ RSpec.describe CreateUser do
       stub_auth0_create_user_request(email: user.email)
 
       expect {
-        described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
       }.to have_enqueued_mail(UserMailer, :welcome).with(args: [user])
     end
 
@@ -28,7 +28,7 @@ RSpec.describe CreateUser do
       it "associates a user to an organisation" do
         stub_auth0_create_user_request(email: user.email)
 
-        organisation = create(:organisation)
+        organisation = create(:delivery_partner_organisation)
 
         described_class.new(
           user: user,
@@ -45,24 +45,24 @@ RSpec.describe CreateUser do
       end
 
       it "returns a failed result" do
-        result = described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
         expect(result.failure?).to eq(true)
       end
 
       it "does not save the user" do
-        described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
         expect(User.find_by(email: user.email)).to be_nil
       end
 
       it "logs a failure message" do
         expect(Rails.logger).to receive(:error)
           .with("Error adding user #{user.email} to Auth0 during CreateUser with: The user already exists.")
-        described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
       end
 
       it "does not email the user" do
         expect(SendWelcomeEmail).not_to receive(:new)
-        described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
       end
 
       context "when Auth0 returns an unparseable error message" do
@@ -73,7 +73,7 @@ RSpec.describe CreateUser do
         it "logs a generic failure message" do
           expect(Rails.logger).to receive(:error)
             .with("Error adding user #{user.email} to Auth0 during CreateUser with: Unknown error")
-          described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+          described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
         end
       end
     end

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FindProgrammeActivities do
   let(:user) { create(:beis_user) }
   let(:service_owner) { create(:beis_organisation) }
-  let(:other_organisation) { create(:organisation) }
+  let(:other_organisation) { create(:delivery_partner_organisation) }
 
   let!(:extending_organisation_programme) { create(:programme_activity, extending_organisation: other_organisation) }
   let!(:other_programme) { create(:programme_activity) }

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FindProjectActivities do
   let(:user) { create(:beis_user) }
   let(:service_owner) { create(:beis_organisation) }
-  let(:other_organisation) { create(:organisation) }
+  let(:other_organisation) { create(:delivery_partner_organisation) }
 
   let!(:organisation_project) { create(:project_activity, organisation: other_organisation) }
   let!(:other_project) { create(:project_activity) }

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FindThirdPartyProjectActivities do
   let(:user) { create(:beis_user) }
   let(:service_owner) { create(:beis_organisation) }
-  let(:other_organisation) { create(:organisation) }
+  let(:other_organisation) { create(:delivery_partner_organisation) }
 
   let!(:organisation_project) { create(:third_party_project_activity, organisation: other_organisation) }
   let!(:other_project) { create(:third_party_project_activity) }

--- a/spec/services/import_planned_disbursements_spec.rb
+++ b/spec/services/import_planned_disbursements_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ImportPlannedDisbursements do
   end
 
   context "when the reporter is not authorised to report on the Activity" do
-    let(:reporter_organisation) { create(:organisation) }
+    let(:reporter_organisation) { create(:delivery_partner_organisation) }
 
     before do
       importer.import([

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ImportTransactions do
         value: 50.0,
         receiving_organisation_name: "Example University",
         receiving_organisation_type: "80",
-        description: "FQ4 1999-2000 spend on Example Project",
+        description: "FQ4 1999-2000 spend on Example Project"
       )
     end
 
@@ -71,12 +71,12 @@ RSpec.describe ImportTransactions do
       expect(transaction).to have_attributes(
         providing_organisation_name: project.providing_organisation.name,
         providing_organisation_type: project.providing_organisation.organisation_type,
-        providing_organisation_reference: project.providing_organisation.iati_reference,
+        providing_organisation_reference: project.providing_organisation.iati_reference
       )
     end
 
     context "when the reporter is not authorised to report on the Activity" do
-      let(:reporter_organisation) { create(:organisation) }
+      let(:reporter_organisation) { create(:delivery_partner_organisation) }
 
       it "does not import any transactions" do
         expect(report.transactions.count).to eq(0)
@@ -319,7 +319,7 @@ RSpec.describe ImportTransactions do
           value: 50.0,
           receiving_organisation_name: nil,
           receiving_organisation_type: nil,
-          description: "FQ4 1999-2000 spend on Example Project",
+          description: "FQ4 1999-2000 spend on Example Project"
         )
       end
     end
@@ -380,7 +380,7 @@ RSpec.describe ImportTransactions do
       expect(report.transactions.pluck(:description)).to contain_exactly(
         "FQ4 1999-2000 spend on Example Project",
         "FQ4 1999-2000 spend on Sibling Project",
-        "FQ4 1999-2000 spend on Sibling Project",
+        "FQ4 1999-2000 spend on Sibling Project"
       )
     end
 

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UpdateUser do
     it "returns a successful result" do
       stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
 
-      result = described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+      result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
 
       expect(result.success?).to eq(true)
       expect(result.failure?).to eq(false)
@@ -24,7 +24,7 @@ RSpec.describe UpdateUser do
       it "associates the user to it" do
         stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
 
-        organisation = create(:organisation)
+        organisation = create(:delivery_partner_organisation)
 
         described_class.new(
           user: user,
@@ -42,13 +42,13 @@ RSpec.describe UpdateUser do
       end
 
       it "returns a failed result" do
-        result = described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
         expect(result.failure?).to eq(true)
       end
 
       it "does not save the user" do
         expect {
-          described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+          described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
         }.to_not change { user.reload }
       end
 
@@ -56,7 +56,7 @@ RSpec.describe UpdateUser do
         expect(Rails.logger).to receive(:error)
           .with("Error updating user #{user.email} to Auth0 during UpdateUser with .")
 
-        described_class.new(user: user, organisation: build_stubbed(:organisation)).call
+        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
       end
     end
   end


### PR DESCRIPTION
This PR extends the Organisation model to allow a new type of organisation - Matched Effort Providers. I've also added a tabbed navigation to filter by organisation type and also a button to create each type of organisation.

Matched effort providers can optionally have a `beis_organisation_reference`, and it doesn't have the same kind of constraints on length as with a delivery partner organisation. They can also be set to "inactive", which means they are only kept for reference, and won't show up in the UI when we come to adding them to activities.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/118145439-84c0dc00-b405-11eb-931f-55ba7a49eb5a.png)

![image](https://user-images.githubusercontent.com/109774/118145462-8ab6bd00-b405-11eb-9674-3764a41ddd5d.png)
