### PR TITLE
(1738) Only send report-related emails to active users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -634,6 +634,7 @@
 
 - Replace the broken sector code hint link with an easier to maintain BEIS Zendesk link
 - Include 'source fund' and 'delivery partner short name' in CSV export
+- Prevent report mailer from sending emails to inactive users
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...HEAD
 [release-49]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...release-49

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -2,6 +2,7 @@ class ReportMailer < ApplicationMailer
   def activated
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
+    raise_unless_active_user
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: @user.email,
@@ -11,6 +12,7 @@ class ReportMailer < ApplicationMailer
   def submitted
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
+    raise_unless_active_user
 
     @role = if @user.organisation == @report_presenter.organisation
       :delivery_partner
@@ -30,6 +32,7 @@ class ReportMailer < ApplicationMailer
   def approved
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
+    raise_unless_active_user
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: @user.email,
@@ -39,9 +42,14 @@ class ReportMailer < ApplicationMailer
   def awaiting_changes
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
+    raise_unless_active_user
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: @user.email,
       subject: t("mailer.report.awaiting_changes.subject", application_name: t("app.title")))
+  end
+
+  private def raise_unless_active_user
+    raise ArgumentError, "User must be active to receive report-related emails" unless @user.active
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
     organisation_id: :organisation,
   }.freeze
 
+  scope :active, -> { where(active: true) }
+
   def role_name
     I18n.t("activerecord.attributes.user.roles.#{role}")
   end

--- a/app/services/report/send_state_change_emails.rb
+++ b/app/services/report/send_state_change_emails.rb
@@ -44,11 +44,11 @@ class Report
     end
 
     def delivery_partners
-      @report.organisation.users
+      @report.organisation.users.active
     end
 
     def service_owners
-      Organisation.find_by(service_owner: true).users
+      Organisation.find_by(service_owner: true).users.active
     end
   end
 end

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe ReportMailer, type: :mailer do
       expect(mail.body).to include("Deadline for submission: 1 Jan 2021")
       expect(mail.body).to include("Link to report: http://test.local/reports/#{report.id}")
     end
+
+    context "when the user is inactive" do
+      before do
+        user.update!(active: false)
+      end
+
+      it "should raise an error" do
+        expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
+      end
+    end
   end
 
   describe "#submitted" do
@@ -76,6 +86,14 @@ RSpec.describe ReportMailer, type: :mailer do
         expect { mail.body }.to raise_error(ArgumentError, "User must either be a service owner or belong to the organisation making the report")
       end
     end
+
+    context "when the user is inactive" do
+      let(:user) { create(:administrator, organisation: organisation, active: false) }
+
+      it "should raise an error" do
+        expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
+      end
+    end
   end
 
   describe "#approved" do
@@ -97,6 +115,16 @@ RSpec.describe ReportMailer, type: :mailer do
     it "contains the expected body" do
       expect(mail.body).to include("BEIS have approved your report.")
     end
+
+    context "when the user is inactive" do
+      before do
+        user.update!(active: false)
+      end
+
+      it "should raise an error" do
+        expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
+      end
+    end
   end
 
   describe "#awaiting_changes" do
@@ -117,6 +145,16 @@ RSpec.describe ReportMailer, type: :mailer do
 
     it "contains the expected body" do
       expect(mail.body).to include("BEIS have reviewed your report and requested changes.")
+    end
+
+    context "when the user is inactive" do
+      before do
+        user.update!(active: false)
+      end
+
+      it "should raise an error" do
+        expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
+      end
     end
   end
 end

--- a/spec/services/report/send_state_change_emails_spec.rb
+++ b/spec/services/report/send_state_change_emails_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe Report::SendStateChangeEmails do
 
   let!(:report) { create(:report, state: state) }
   let!(:delivery_partners) { create_list(:administrator, 5, organisation: report.organisation) }
+  let!(:inactive_dp_user) { create(:administrator, organisation: report.organisation, active: false) }
   let!(:service_owners) { create_list(:beis_user, 2) }
+  let!(:inactive_service_owner) { create(:beis_user, active: false) }
 
   let(:recipients) { ActionMailer::Base.deliveries.map { |delivery| delivery.to }.flatten }
 
   context "when the state is active" do
     let(:state) { "active" }
 
-    it "sends the activation emails to the delivery partners" do
+    it "sends the activation emails to the active delivery partners" do
       expect { subject.send! }.to have_enqueued_mail(ReportMailer, :activated).exactly(delivery_partners.count).times
 
       perform_enqueued_jobs
@@ -24,7 +26,7 @@ RSpec.describe Report::SendStateChangeEmails do
   context "when the state is submitted" do
     let(:state) { "submitted" }
 
-    it "sends the activation emails to the delivery partners and service owners" do
+    it "sends the activation emails to the active delivery partners and service owners" do
       expect { subject.send! }.to have_enqueued_mail(ReportMailer, :submitted)
         .exactly((service_owners + delivery_partners).count).times
 
@@ -37,7 +39,7 @@ RSpec.describe Report::SendStateChangeEmails do
   context "when the state is awaiting_changes" do
     let(:state) { "awaiting_changes" }
 
-    it "sends the activation emails to the delivery partners" do
+    it "sends the activation emails to the active delivery partners" do
       expect { subject.send! }.to have_enqueued_mail(ReportMailer, :awaiting_changes).exactly(delivery_partners.count).times
 
       perform_enqueued_jobs
@@ -49,7 +51,7 @@ RSpec.describe Report::SendStateChangeEmails do
   context "when the state is approved" do
     let(:state) { "approved" }
 
-    it "sends the activation emails to the delivery partners" do
+    it "sends the activation emails to the active delivery partners" do
       expect { subject.send! }.to have_enqueued_mail(ReportMailer, :approved).exactly(delivery_partners.count).times
 
       perform_enqueued_jobs

--- a/spec/support/custom_email_matchers.rb
+++ b/spec/support/custom_email_matchers.rb
@@ -1,5 +1,5 @@
 module CustomEmailMatchers
-  class HaveRecievedEmail
+  class HaveReceivedEmail
     def matches?(user)
       @user = user
       email_sent? && has_subject? && has_personalisations?
@@ -52,6 +52,6 @@ module CustomEmailMatchers
   end
 
   def have_received_email
-    HaveRecievedEmail.new
+    HaveReceivedEmail.new
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Prevent report mailer from sending emails to inactive users

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
