### PR TITLE
(1748) Merge two GCRF strategic areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -635,6 +635,7 @@
 - Replace the broken sector code hint link with an easier to maintain BEIS Zendesk link
 - Include 'source fund' and 'delivery partner short name' in CSV export
 - Prevent report mailer from sending emails to inactive users
+- Merge Academies Collective Fund and Resilient Futures GCRF strategic areas into one
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...HEAD
 [release-49]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-48...release-49

--- a/db/data/20210514141445_change_gcrf_strategic_area_code_2_to_3.rb
+++ b/db/data/20210514141445_change_gcrf_strategic_area_code_2_to_3.rb
@@ -1,0 +1,6 @@
+# Run me with `rails runner db/data/20210514141445_change_gcrf_strategic_area_code_2_to_3.rb`
+
+Activity.where("gcrf_strategic_area @> '{2}'::integer[]").each do |activity|
+  gcrf_strategic_areas = activity.gcrf_strategic_area.map { |i| i == 2 ? 3 : i }
+  activity.update_column(:gcrf_strategic_area, gcrf_strategic_areas)
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe ActivityPresenter do
       activity = build(:project_activity, gcrf_strategic_area: %w[1 3])
       result = described_class.new(activity)
 
-      expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Resilient Futures"
+      expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Academies Collective Fund: Resilient Futures"
     end
   end
 

--- a/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
+++ b/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
@@ -3,10 +3,8 @@ data:
     description: Core
   - code: 1
     description: UKRI Collective Fund (2017 allocation)
-  - code: 2
-    description: Academies Collective Fund
   - code: 3
-    description: Resilient Futures
+    description: "Academies Collective Fund: Resilient Futures"
   - code: 4
     description: Coherence and Impact
   - code: 5


### PR DESCRIPTION
`Academies Collective Fund` and `Resilient Futures` should have been one single strategic area, so we're merging them into one, with code `3`. I've also added a data migration to change any activities with code `2` to a code `3`

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/118291207-3841d300-b4cf-11eb-8c40-4300ba8f955e.png)

## After

![image](https://user-images.githubusercontent.com/109774/118291170-2f510180-b4cf-11eb-9c58-3eea8941d8ee.png)