### PR TITLE
(1753) Hide upload buttons where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -647,6 +647,7 @@
 - Allow DP users to create transfers and associate them with the current report
 - Add some useful stats to our healthcheck endpoint
 - Prevent uploading transactions if the report is not editable
+- Prevent uploading activities, transactions and planned disbursements if the report is not editable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,7 @@
 - Update the request an account link
 - Allow DP users to create transfers and associate them with the current report
 - Add some useful stats to our healthcheck endpoint
+- Prevent uploading transactions if the report is not editable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/app/controllers/staff/activity_uploads_controller.rb
+++ b/app/controllers/staff/activity_uploads_controller.rb
@@ -6,21 +6,25 @@ class Staff::ActivityUploadsController < Staff::BaseController
   include Secured
   include StreamCsvDownload
 
-  before_action :authorize_report
-
   def new
-    @report_presenter = ReportPresenter.new(@report)
+    authorize report, :show?
+
+    @report_presenter = ReportPresenter.new(report)
   end
 
   def show
-    @report_presenter = ReportPresenter.new(@report)
+    authorize report, :show?
+
+    @report_presenter = ReportPresenter.new(report)
     filename = @report_presenter.filename_for_activities_template
 
     stream_csv_download(filename: filename, headers: csv_headers)
   end
 
   def update
-    @report_presenter = ReportPresenter.new(@report)
+    authorize report, :upload?
+
+    @report_presenter = ReportPresenter.new(report)
     upload = CsvFileUpload.new(params[:report], :activity_csv)
     @success = false
 
@@ -39,9 +43,8 @@ class Staff::ActivityUploadsController < Staff::BaseController
     end
   end
 
-  private def authorize_report
-    @report = Report.find(params[:report_id])
-    authorize @report, :show?
+  private def report
+    @_report ||= Report.find(params[:report_id])
   end
 
   private def csv_headers

--- a/app/controllers/staff/planned_disbursement_uploads_controller.rb
+++ b/app/controllers/staff/planned_disbursement_uploads_controller.rb
@@ -6,26 +6,30 @@ class Staff::PlannedDisbursementUploadsController < Staff::BaseController
   include Secured
   include StreamCsvDownload
 
-  before_action :authorize_report
-
   def new
-    @report_presenter = ReportPresenter.new(@report)
+    authorize report, :show?
+
+    @report_presenter = ReportPresenter.new(report)
   end
 
   def show
-    @report_presenter = ReportPresenter.new(@report)
-    generator = ImportPlannedDisbursements::Generator.new(@report)
+    authorize report, :show?
+
+    @report_presenter = ReportPresenter.new(report)
+    generator = ImportPlannedDisbursements::Generator.new(report)
     filename = @report_presenter.filename_for_forecasts_template
 
     stream_csv_download(filename: filename, headers: generator.column_headings) do |csv|
-      @report.reportable_activities.each do |activity|
+      report.reportable_activities.each do |activity|
         csv << generator.csv_row(activity)
       end
     end
   end
 
   def update
-    @report_presenter = ReportPresenter.new(@report)
+    authorize report, :upload?
+
+    @report_presenter = ReportPresenter.new(report)
     upload = CsvFileUpload.new(params[:report], :planned_disbursement_csv)
     @success = false
 
@@ -44,8 +48,7 @@ class Staff::PlannedDisbursementUploadsController < Staff::BaseController
     end
   end
 
-  private def authorize_report
-    @report = Report.find(params[:report_id])
-    authorize @report, :show?
+  private def report
+    @_report ||= Report.find(params[:report_id])
   end
 end

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -26,7 +26,7 @@ class Staff::TransactionUploadsController < Staff::BaseController
   end
 
   def update
-    authorize report, :show?
+    authorize report, :upload?
 
     @report_presenter = ReportPresenter.new(report)
     upload = CsvFileUpload.new(params[:report], :transaction_csv)

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -45,7 +45,7 @@ class ReportPolicy < ApplicationPolicy
   end
 
   def upload?
-    ["active", "awaiting_changes"].include?(record.state) && record.organisation == user.organisation
+    record.editable? && record.organisation == user.organisation
   end
 
   def download?
@@ -57,7 +57,7 @@ class ReportPolicy < ApplicationPolicy
   end
 
   def submit?
-    return change_state? if ["active", "awaiting_changes"].include? record.state
+    return change_state? if record.editable?
   end
 
   def review?

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -44,6 +44,10 @@ class ReportPolicy < ApplicationPolicy
     end
   end
 
+  def upload?
+    ["active", "awaiting_changes"].include?(record.state) && record.organisation == user.organisation
+  end
+
   def download?
     show?
   end

--- a/app/views/staff/activity_uploads/new.html.haml
+++ b/app/views/staff/activity_uploads/new.html.haml
@@ -14,11 +14,17 @@
       %p.govuk-body
         = t("action.activity.download.hint_html")
 
-      .govuk-body.upload-form
-        = form_for @report_presenter, url: report_activity_upload_path(@report_presenter) do |f|
+      - if policy(@report_presenter).upload?
+        .govuk-body.upload-form
+          = form_for @report_presenter, url: report_activity_upload_path(@report_presenter) do |f|
 
-          = f.govuk_file_field :activity_csv,
-            label: { text: t("form.label.activity.csv_file") },
-            hint: { text: t("form.hint.activity.csv_file") }
+            = f.govuk_file_field :activity_csv,
+              label: { text: t("form.label.activity.csv_file") },
+              hint: { text: t("form.hint.activity.csv_file") }
 
-          = f.govuk_submit t("action.activity.upload.button")
+            = f.govuk_submit t("action.activity.upload.button")
+      - else
+        %h2.govuk-heading-m= t("form.label.activity.csv_file")
+
+        %p.govuk-body
+          = "This report is #{@report_presenter.state.downcase}, so CSV upload is unavailable."

--- a/app/views/staff/planned_disbursement_uploads/new.html.haml
+++ b/app/views/staff/planned_disbursement_uploads/new.html.haml
@@ -17,11 +17,17 @@
       %p.govuk-body
         = t("action.planned_disbursement.download.hint_html")
 
-      .govuk-body.upload-form
-        = form_for @report_presenter, url: report_planned_disbursement_upload_path(@report_presenter) do |f|
+      - if policy(@report_presenter).upload?
+        .govuk-body.upload-form
+          = form_for @report_presenter, url: report_planned_disbursement_upload_path(@report_presenter) do |f|
 
-          = f.govuk_file_field :planned_disbursement_csv,
-            label: { text: t("form.label.planned_disbursement.csv_file") },
-            hint: { text: t("form.hint.planned_disbursement.csv_file") }
+            = f.govuk_file_field :planned_disbursement_csv,
+              label: { text: t("form.label.planned_disbursement.csv_file") },
+              hint: { text: t("form.hint.planned_disbursement.csv_file") }
 
-          = f.govuk_submit t("action.planned_disbursement.upload.button")
+            = f.govuk_submit t("action.planned_disbursement.upload.button")
+      - else
+        %h2.govuk-heading-m= t("form.label.planned_disbursement.csv_file")
+
+        %p.govuk-body
+          = "This report is #{@report_presenter.state.downcase}, so CSV upload is unavailable."

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -1,8 +1,9 @@
 .govuk-grid-row
   .govuk-grid-column-full.page-actions
-    = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-    = link_to t("action.planned_disbursement.upload.link"), new_report_planned_disbursement_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-    = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+    - if policy(@report_presenter).upload?
+      = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+      = link_to t("action.planned_disbursement.upload.link"), new_report_planned_disbursement_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+      = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
     - if policy(@report_presenter).activate?
       = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -6,6 +6,13 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
+      %dl.govuk-summary-list.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("form.label.report.state")
+          %dd.govuk-summary-list__value
+            = @report_presenter.state
+
     - if policy(@report_presenter).download?
       = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
 

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -6,6 +6,13 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
+      %dl.govuk-summary-list.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("form.label.report.state")
+          %dd.govuk-summary-list__value
+            = @report_presenter.state
+
     - if policy(@report_presenter).download?
       = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
 

--- a/app/views/staff/transaction_uploads/new.html.haml
+++ b/app/views/staff/transaction_uploads/new.html.haml
@@ -19,11 +19,17 @@
       %p.govuk-body
         = t("action.transaction.download.hint_html")
 
-      .govuk-body.upload-form
-        = form_for @report_presenter, url: report_transaction_upload_path(@report_presenter) do |f|
+      - if policy(@report_presenter).upload?
+        .govuk-body.upload-form
+          = form_for @report_presenter, url: report_transaction_upload_path(@report_presenter) do |f|
 
-          = f.govuk_file_field :transaction_csv,
-            label: { text: t("form.label.transaction.csv_file") },
-            hint: { text: t("form.hint.transaction.csv_file") }
+            = f.govuk_file_field :transaction_csv,
+              label: { text: t("form.label.transaction.csv_file") },
+              hint: { text: t("form.hint.transaction.csv_file") }
 
-          = f.govuk_submit t("action.transaction.upload.button")
+            = f.govuk_submit t("action.transaction.upload.button")
+      - else
+        %h2.govuk-heading-m= t("form.label.transaction.csv_file")
+
+        %p.govuk-body
+          = "This report is #{@report_presenter.state.downcase}, so CSV upload is unavailable."

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -52,9 +52,14 @@ en:
             </p>
   label:
     report:
-     state:
-       inactive: Inactive
-       active: Active
+      state:
+        active: Active
+        approved: Approved
+        awaiting_changes: Awaiting changes
+        in_review: In review
+        inactive: Inactive
+        submitted: Submitted
+
   form:
     label:
       report:

--- a/spec/controllers/staff/activity_uploads_controller_spec.rb
+++ b/spec/controllers/staff/activity_uploads_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Staff::ActivityUploadsController do
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
+  describe "#new" do
+    render_views
+
+    let(:report) { create(:report, organisation: organisation, state: state) }
+
+    context "with an active report" do
+      let(:state) { :active }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report awaiting changes" do
+      let(:state) { :awaiting_changes }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report in review" do
+      let(:state) { :in_review }
+
+      it "doesn't show the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to_not include(t("action.transaction.upload.button"))
+      end
+    end
+  end
+end

--- a/spec/controllers/staff/planned_disbursement_uploads_controller_spec.rb
+++ b/spec/controllers/staff/planned_disbursement_uploads_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Staff::PlannedDisbursementUploadsController do
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
+  describe "#new" do
+    render_views
+
+    let(:report) { create(:report, organisation: organisation, state: state) }
+
+    context "with an active report" do
+      let(:state) { :active }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report awaiting changes" do
+      let(:state) { :awaiting_changes }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report in review" do
+      let(:state) { :in_review }
+
+      it "doesn't show the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to_not include(t("action.transaction.upload.button"))
+      end
+    end
+  end
+end

--- a/spec/controllers/staff/transaction_uploads_controller_spec.rb
+++ b/spec/controllers/staff/transaction_uploads_controller_spec.rb
@@ -9,6 +9,66 @@ RSpec.describe Staff::TransactionUploadsController do
     allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
   end
 
+  describe "#new" do
+    render_views
+
+    let(:report) { create(:report, organisation: organisation, state: state) }
+
+    context "with an active report" do
+      let(:state) { :active }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report awaiting changes" do
+      let(:state) { :awaiting_changes }
+
+      it "shows the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "with a report in review" do
+      let(:state) { :in_review }
+
+      it "doesn't show the upload button" do
+        get :new, params: {report_id: report.id}
+
+        expect(response.body).to_not include(t("action.transaction.upload.button"))
+      end
+    end
+
+    context "as a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      context "with an active report" do
+        let(:state) { :active }
+
+        it "doesn't show the upload button" do
+          get :new, params: {report_id: report.id}
+
+          expect(response.body).to_not include(t("action.transaction.upload.button"))
+        end
+      end
+
+      context "with a report awaiting changes" do
+        let(:state) { :awaiting_changes }
+
+        it "doesn't show the upload button" do
+          get :new, params: {report_id: report.id}
+
+          expect(response.body).to_not include(t("action.transaction.upload.button"))
+        end
+      end
+    end
+  end
+
   describe "#show" do
     let(:report) { create(:report, organisation: organisation, state: :active, fund: fund) }
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -176,4 +176,26 @@ RSpec.describe Report, type: :model do
       expect(report.reportable_activities).not_to include(cancelled_project)
     end
   end
+
+  describe "#editable?" do
+    all_report_states = Report.states.keys
+    editable_states = Report::EDITABLE_STATES
+    readonly_states = all_report_states - editable_states
+
+    editable_states.each do |state|
+      it "is false when the report is #{state}", state: state do |example|
+        report = Report.new(state: example.metadata[:state])
+
+        expect(report.editable?).to be_truthy
+      end
+    end
+
+    readonly_states.each do |state|
+      it "is true when the report is #{state}", state: state do |example|
+        report = Report.new(state: example.metadata[:state])
+
+        expect(report.editable?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:review) }
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
     end
 
     context "when the report is active" do
@@ -43,6 +44,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:review) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
     end
 
     context "when the report is submitted" do
@@ -55,6 +57,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:submit) }
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
     end
 
     context "when the report is in review" do
@@ -67,6 +70,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:activate) }
       it { is_expected.to forbid_action(:submit) }
       it { is_expected.to forbid_action(:review) }
+      it { is_expected.to forbid_action(:upload) }
     end
 
     context "when the report is awaiting changes" do
@@ -78,6 +82,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:review) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
     end
 
     context "when the report is approved" do
@@ -89,6 +94,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:review) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
     end
   end
 
@@ -115,6 +121,7 @@ RSpec.describe ReportPolicy do
       it { is_expected.to forbid_action(:review) }
       it { is_expected.to forbid_action(:request_changes) }
       it { is_expected.to forbid_action(:approve) }
+      it { is_expected.to forbid_action(:upload) }
 
       it { is_expected.to permit_action(:index) }
     end
@@ -134,6 +141,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to forbid_action(:review) }
         it { is_expected.to forbid_action(:request_changes) }
         it { is_expected.to forbid_action(:approve) }
+        it { is_expected.to forbid_action(:upload) }
       end
 
       context "when the report is active" do
@@ -143,6 +151,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to permit_action(:download) }
         it { is_expected.to permit_action(:change_state) }
         it { is_expected.to permit_action(:submit) }
+        it { is_expected.to permit_action(:upload) }
 
         it { is_expected.to forbid_action(:activate) }
         it { is_expected.to forbid_action(:review) }
@@ -162,6 +171,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to forbid_action(:review) }
         it { is_expected.to forbid_action(:request_changes) }
         it { is_expected.to forbid_action(:approve) }
+        it { is_expected.to forbid_action(:upload) }
       end
 
       context "when the report is in review" do
@@ -176,6 +186,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to forbid_action(:review) }
         it { is_expected.to forbid_action(:request_changes) }
         it { is_expected.to forbid_action(:approve) }
+        it { is_expected.to forbid_action(:upload) }
       end
 
       context "when the report is awaiting changes" do
@@ -185,6 +196,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to permit_action(:download) }
         it { is_expected.to permit_action(:change_state) }
         it { is_expected.to permit_action(:submit) }
+        it { is_expected.to permit_action(:upload) }
 
         it { is_expected.to forbid_action(:activate) }
         it { is_expected.to forbid_action(:review) }
@@ -204,6 +216,7 @@ RSpec.describe ReportPolicy do
         it { is_expected.to forbid_action(:request_changes) }
         it { is_expected.to forbid_action(:review) }
         it { is_expected.to forbid_action(:approve) }
+        it { is_expected.to forbid_action(:upload) }
       end
     end
   end


### PR DESCRIPTION
The various upload controllers have been  relying on `ReportPolicy.show?` to determine whether to allow the user to upload, which caused:

- BEIS users were able to upload into any report at any time(!)
- Delivery partners could upload  as long as the current report belonged to them and wasn't inactive

This change introduces `ReportPolicy.upload?` which does the following:

- BEIS users can *never* upload
- Delivery partners can upload where the selected report is editable (i.e. has a state of 'active' or 'awaiting_changes')

## Active report (editable)

### Before
![Screenshot 2021-05-20 at 10 50 01](https://user-images.githubusercontent.com/3166/118958443-56895200-b959-11eb-9711-4597bc614034.png)

### After
![Screenshot 2021-05-20 at 10 49 08](https://user-images.githubusercontent.com/3166/118958531-6b65e580-b959-11eb-9e3c-aca301b7e404.png)

## Approved report (not editable)

### Before
![Screenshot 2021-05-20 at 10 49 48](https://user-images.githubusercontent.com/3166/118958451-59844280-b959-11eb-83b3-58065119ad5f.png)

### After
![Screenshot 2021-05-20 at 10 49 24](https://user-images.githubusercontent.com/3166/118958500-63a64100-b959-11eb-8b08-4203b61e00a7.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
