### PR TITLE
(1825) Fix roles in database seeds

### DIFF
--- a/bin/db-restore
+++ b/bin/db-restore
@@ -54,26 +54,23 @@ fi
 # Set the Postgres service name, depending on our environment
 service="beis-roda-${ENVIRONMENT_NAME}-postgres"
 
-echo "==> Running pg_dump on ${service} on ${ENVIRONMENT_NAME}"
-
-cf conduit "$service" -- \
-    pg_dump \
-        --file "$filename" \
-        --no-acl \
-        --no-owner \
-        --format=t \
-        --exclude-table-data="users" \
-        --exclude-table="ar_internal_metadata" \
-        --exclude-table="spatial_ref_sys"
-
-echo "==> Destroying the existing local database"
-
 # Check the user wants to continue before blowing away the development data
 echo "THIS WILL DELETE ALL DATA IN YOUR DEVELOPMENT ENVIRONMENT."
 echo "Are you sure you want to continue? (y to continue)"
 read -p "" -r delete_data
 
 if [ "$delete_data" == "y" ]; then
+    echo "==> Running pg_dump on ${service} on ${ENVIRONMENT_NAME}"
+    cf conduit "$service" -- \
+        pg_dump \
+            --file "$filename" \
+            --no-acl \
+            --no-owner \
+            --format=t \
+            --exclude-table-data="users" \
+            --exclude-table="ar_internal_metadata" \
+            --exclude-table="spatial_ref_sys"
+
     echo "==> Dropping and recreating the roda-development database..."
     psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
 

--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -14,6 +14,6 @@ beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 
-other_organisation = Organisation.where(service_owner: false).first
+other_organisation = Organisation.find_by(role: :delivery_partner)
 delivery_partner.organisation = other_organisation
 delivery_partner.save

--- a/db/seeds/organisations.rb
+++ b/db/seeds/organisations.rb
@@ -8,7 +8,7 @@ organisations.each do |organisation|
     organisation_type: organisation["type"],
     language_code: "en",
     default_currency: "gbp",
-    service_owner: organisation["service_owner"],
+    role: organisation["role"],
   }
   Organisation.find_or_create_by(iati_reference: organisation["reference"]).update!(organisation_params)
 end

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -2,39 +2,39 @@
   short_name: BEIS
   reference: GB-GOV-13
   type: 10
-  service_owner: true
+  role: service_owner
 - name: UK Space Agency
   short_name: UKSA
   reference: GB-GOV-EA31
   type: 10
-  service_owner: false
+  role: delivery_partner
 - name: Met Office
   short_name: MO
   reference: GB-GOV-EA46
   type: 10
-  service_owner: false
+  role: delivery_partner
 - name: British Council
   short_name: BC
   reference: GB-GOV-OT313
   type: 10
-  service_owner: false
+  role: delivery_partner
 - name: Academy of Medical Sciences
   short_name: AMS
   reference: GB-COH-03520281
   type: 22
-  service_owner: false
+  role: delivery_partner
 - name: Royal Society
   short_name: RS
   reference: GB-COH-RC000519
   type: 22
-  service_owner: false
+  role: delivery_partner
 - name: British Academy
   short_name: BA
   reference: GB-COH-RC000053
   type: 22
-  service_owner: false
+  role: delivery_partner
 - name: Royal Academy of Engineering
   short_name: RAE
   reference: GB-CHC-293074
   type: 22
-  service_owner: false
+  role: delivery_partner

--- a/db/seeds/pentest_users.rb
+++ b/db/seeds/pentest_users.rb
@@ -14,6 +14,6 @@ beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 
-other_organisation = Organisation.where(service_owner: false).first
+other_organisation = Organisation.find_by(role: :delivery_partner)
 delivery_partner.organisation = other_organisation
 delivery_partner.save

--- a/db/seeds/staging_users.rb
+++ b/db/seeds/staging_users.rb
@@ -14,6 +14,6 @@ beis = Organisation.service_owner
 administrator.organisation = beis
 administrator.save
 
-other_organisation = Organisation.where(service_owner: false).first
+other_organisation = Organisation.find_by(role: :delivery_partner)
 delivery_partner.organisation = other_organisation
 delivery_partner.save


### PR DESCRIPTION
Update the database seed files to reflect the recent changes to the organisation model.

Also, I've moved the confirmation message for destroying the local development database earlier, so the remote database dump only happens when the developer responds positively.
