### PR TITLE
(1681) Rolled up forecasts must be calculated in IATI XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,6 +648,7 @@
 - Add some useful stats to our healthcheck endpoint
 - Prevent uploading transactions if the report is not editable
 - Prevent uploading activities, transactions and planned disbursements if the report is not editable
+- Sum programme and child activity forecasts by financial quarter in IATI XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -41,7 +41,7 @@ class Staff::OrganisationsController < Staff::BaseController
         @activities = case level
         when "programme"
           return [] unless fund_id.present?
-          @programmes_for_organisation_and_fund = publishable_programme_activities(
+          publishable_programme_activities(
             organisation: organisation,
             user: current_user,
             fund_id: fund_id

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -269,7 +269,6 @@ class Activity < ApplicationRecord
 
   def total_forecasted
     activity_ids = descendants.pluck(:id).append(id)
-    # PlannedDisbursement.where(parent_activity_id: activity_ids).sum(:value)
     overview = PlannedDisbursementOverview.new(activity_ids)
     overview.latest_values.sum(:value)
   end

--- a/app/models/financial_quarter.rb
+++ b/app/models/financial_quarter.rb
@@ -1,4 +1,6 @@
 class FinancialQuarter
+  include Comparable
+
   attr_reader :financial_year, :quarter
 
   QUARTERS = (1..4).to_a
@@ -25,6 +27,14 @@ class FinancialQuarter
       end
 
       new(year, quarter)
+    end
+  end
+
+  def <=>(other)
+    if financial_year == other.financial_year
+      quarter <=> other.quarter
+    else
+      financial_year <=> other.financial_year
     end
   end
 

--- a/app/models/financial_year.rb
+++ b/app/models/financial_year.rb
@@ -1,4 +1,6 @@
 class FinancialYear
+  include Comparable
+
   class InvalidYear < StandardError; end
 
   attr_reader :start_year, :end_year
@@ -32,6 +34,10 @@ class FinancialYear
 
       (first_year..this_financial_year).map { |year| new(year) }
     end
+  end
+
+  def <=>(other)
+    start_year <=> other.start_year
   end
 
   def ==(other)

--- a/app/presenters/planned_disbursement_aggregate.rb
+++ b/app/presenters/planned_disbursement_aggregate.rb
@@ -1,6 +1,5 @@
 class PlannedDisbursementAggregate
   delegate :start_date, :end_date, to: :@financial_quarter, prefix: :period
-  delegate :providing_organisation_type, :providing_organisation_name, :providing_organisation_reference, to: "@planned_disbursements.first"
 
   def initialize(financial_quarter, planned_disbursements)
     @financial_quarter = financial_quarter
@@ -17,5 +16,21 @@ class PlannedDisbursementAggregate
 
   def value
     @planned_disbursements.sum(&:value)
+  end
+
+  def providing_organisation_name
+    providing_organisation.name
+  end
+
+  def providing_organisation_type
+    providing_organisation.organisation_type
+  end
+
+  def providing_organisation_reference
+    providing_organisation.iati_reference
+  end
+
+  private def providing_organisation
+    @_providing_organisation ||= Organisation.service_owner
   end
 end

--- a/app/presenters/planned_disbursement_aggregate.rb
+++ b/app/presenters/planned_disbursement_aggregate.rb
@@ -1,0 +1,21 @@
+class PlannedDisbursementAggregate
+  delegate :start_date, :end_date, to: :@financial_quarter, prefix: :period
+  delegate :providing_organisation_type, :providing_organisation_name, :providing_organisation_reference, to: "@planned_disbursements.first"
+
+  def initialize(financial_quarter, planned_disbursements)
+    @financial_quarter = financial_quarter
+    @planned_disbursements = planned_disbursements
+  end
+
+  def planned_disbursement_type
+    "original"
+  end
+
+  def currency
+    @planned_disbursements.first.currency
+  end
+
+  def value
+    @planned_disbursements.sum(&:value)
+  end
+end

--- a/app/views/staff/organisations/show.xml.haml
+++ b/app/views/staff/organisations/show.xml.haml
@@ -2,5 +2,5 @@
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
-    = render partial: "staff/shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_transactions_for_level, budgets: activity.budgets, planned_disbursements: activity.latest_planned_disbursements }
+    = render partial: "staff/shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_transactions_for_level, budgets: activity.budgets, planned_disbursements: activity.reportable_planned_disbursements_for_level }
 

--- a/doc/xml-validation.md
+++ b/doc/xml-validation.md
@@ -1,9 +1,7 @@
 # IATI XML Validation
 
-We aim for all XML outputs from this app to be valid against the [IATI Standard](https://iatistandard.org/en/). 
+We aim for all XML outputs from this app to be valid against the [IATI Standard](https://iatistandard.org/en/).
 
-If you have made any changes to the XML outputs, validate them against the "new" [IATI XML validator](https://test-validator.iatistandard.org/)* before committing.
+If you have made any changes to the XML outputs, validate them against the [IATI XML validator](https://iativalidator.iatistandard.org) before committing.
 
 Critical failures in the validation should be addressed in your PR; or if that's not possible then a ticket should be opened to address the issues in Trello.
-
-*There is also the "old" [IATI validator](http://validator.iatistandard.org/) which the "new" validator will supersede. 

--- a/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_as_xml_spec.rb
@@ -181,23 +181,23 @@ RSpec.feature "Users can view an organisation as XML" do
           activity_projects = create_list(:project_activity, 2, parent: programme)
           activity_third_party_project = create(:third_party_project_activity, parent: activity_projects[0])
 
-          create(:transaction, value: 100, parent_activity: programme, financial_year: 2018, financial_quarter: 1)
-          create(:transaction, value: 100, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
-          create(:transaction, value: 100, parent_activity: other_programme, financial_year: 2019, financial_quarter: 3)
+          create(:transaction, value: 10, parent_activity: programme, financial_year: 2018, financial_quarter: 1)
+          create(:transaction, value: 20, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
+          create(:transaction, value: 40, parent_activity: other_programme, financial_year: 2019, financial_quarter: 3)
 
-          create(:transaction, value: 50, parent_activity: activity_projects[0], financial_year: 2018, financial_quarter: 1)
-          create(:transaction, value: 50, parent_activity: activity_projects[0], financial_year: 2020, financial_quarter: 1)
+          create(:transaction, value: 80, parent_activity: activity_projects[0], financial_year: 2018, financial_quarter: 1)
+          create(:transaction, value: 160, parent_activity: activity_projects[0], financial_year: 2020, financial_quarter: 1)
 
-          create(:transaction, value: 50, parent_activity: activity_projects[1], financial_year: 2018, financial_quarter: 1)
-          create(:transaction, value: 50, parent_activity: activity_projects[1], financial_year: 2020, financial_quarter: 1)
+          create(:transaction, value: 320, parent_activity: activity_projects[1], financial_year: 2018, financial_quarter: 1)
+          create(:transaction, value: 640, parent_activity: activity_projects[1], financial_year: 2020, financial_quarter: 1)
 
-          create(:transaction, value: 100, parent_activity: activity_third_party_project, financial_year: 2018, financial_quarter: 1)
-          create(:transaction, value: 100, parent_activity: activity_third_party_project, financial_year: 2020, financial_quarter: 1)
+          create(:transaction, value: 1280, parent_activity: activity_third_party_project, financial_year: 2018, financial_quarter: 1)
+          create(:transaction, value: 2560, parent_activity: activity_third_party_project, financial_year: 2020, financial_quarter: 1)
 
           visit organisation_path(organisation, format: :xml, level: :programme, fund_id: programme.associated_fund.id)
           xml = Nokogiri::XML::Document.parse(page.body)
 
-          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to eql(["200.0", "100.0", "300.0", "100.0"])
+          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to eql(["3360.0", "20.0", "1690.0", "40.0"])
           expect(xml.xpath("//iati-activity/transaction/transaction-date/@iso-date").map(&:text)).to eql(["2020-06-30", "2018-09-30", "2018-06-30", "2019-12-31"])
         end
       end

--- a/spec/models/financial_quarter_spec.rb
+++ b/spec/models/financial_quarter_spec.rb
@@ -131,4 +131,22 @@ RSpec.describe FinancialQuarter do
       expect(FinancialQuarter.for_date(march_date).to_s).to eq("FQ4 2020-2021")
     end
   end
+
+  describe "#==" do
+    it "is true for quarters with the same year and the same quarter" do
+      expect(FinancialQuarter.new(2020, 3)).to eq(FinancialQuarter.new(2020, 3))
+    end
+  end
+
+  describe "#<=>" do
+    let(:oldest_quarter) { FinancialQuarter.new(2019, 3) }
+    let(:middle_quarter) { FinancialQuarter.new(2019, 4) }
+    let(:latest_quarter) { FinancialQuarter.new(2020, 1) }
+
+    it "compares quarters chronologically" do
+      quarters = [middle_quarter, latest_quarter, oldest_quarter]
+
+      expect(quarters.sort).to match_array([oldest_quarter, middle_quarter, latest_quarter])
+    end
+  end
 end

--- a/spec/models/financial_year_spec.rb
+++ b/spec/models/financial_year_spec.rb
@@ -39,4 +39,16 @@ RSpec.describe FinancialYear do
       end
     end
   end
+
+  describe "#<=>" do
+    let(:oldest_year) { FinancialYear.new(2019) }
+    let(:middle_year) { FinancialYear.new(2020) }
+    let(:latest_year) { FinancialYear.new(2021) }
+
+    it "compares the years chronologically" do
+      years = [middle_year, latest_year, oldest_year]
+
+      expect(years.sort).to match_array([oldest_year, middle_year, latest_year])
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- Sum programme and child activity forecasts by financial quarter in IATI XML

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
