### PR TITLE
Add some useful stats to our healthcheck endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -645,6 +645,7 @@
 - Stop forecast totals double-counting multiple versions of the same forecast
 - Update the request an account link
 - Allow DP users to create transfers and associate them with the current report
+- Add some useful stats to our healthcheck endpoint
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,12 @@ RUN \
 # create tmp/pids
 RUN mkdir -p tmp/pids
 
+ARG current_sha
+ARG time_of_build
+
+ENV CURRENT_SHA=$current_sha
+ENV TIME_OF_BUILD=$time_of_build
+
 # db setup
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/app/controllers/public/base_controller.rb
+++ b/app/controllers/public/base_controller.rb
@@ -1,5 +1,9 @@
 class Public::BaseController < ApplicationController
   def health_check
-    render json: {rails: "OK"}, status: :ok
+    render json: {
+      rails: "OK",
+      git_sha: ENV.fetch("CURRENT_SHA", nil),
+      built_at: ENV.fetch("TIME_OF_BUILD", nil),
+    }, status: :ok
   end
 end

--- a/script/docker-push
+++ b/script/docker-push
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build --target web -t "thedxw/beis-report-official-development-assistance:$DOCKER_TAG" .
+docker build --target web \
+  --build-arg current_sha="$GITHUB_SHA" \
+  --build-arg time_of_build="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  -t "thedxw/beis-report-official-development-assistance:$DOCKER_TAG" \
+  .
 docker push "thedxw/beis-report-official-development-assistance:$DOCKER_TAG"

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -2,8 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Health Check", type: :request do
   it "returns an ok HTTP status code without requiring authentication" do
-    get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
-    expect(response).to have_http_status(:ok)
-    expect(JSON.parse(response.body)).to eql("rails" => "OK")
+    ClimateControl.modify CURRENT_SHA: "b9c73f88", TIME_OF_BUILD: "2020-01-01T00:00:00Z" do
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eql(
+        "rails" => "OK",
+        "git_sha" => "b9c73f88",
+        "built_at" => "2020-01-01T00:00:00Z",
+      )
+    end
   end
 end


### PR DESCRIPTION
This sets the current Git sha and the time the image was built as env vars in our Docker file, which we then expose via the healthcheck endpoint, which will be useful for checking deploy throughput, as well as letting us know exactly what version of the code is deployed.