### PR TITLE
(1824) Address some policy inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -649,6 +649,7 @@
 - Prevent uploading transactions if the report is not editable
 - Prevent uploading activities, transactions and planned disbursements if the report is not editable
 - Sum programme and child activity forecasts by financial quarter in IATI XML
+- Remove unused 'role' from User model
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -70,7 +70,7 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :role, :organisation_id)
+    params.require(:user).permit(:name, :email, :organisation_id)
   end
 
   def id

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -8,10 +8,6 @@ module FormHelper
     @list_of_delivery_partners ||= Organisation.delivery_partners
   end
 
-  def list_of_user_roles
-    @list_of_user_roles ||= User.roles.map { |id, name| OpenStruct.new(id: id, name: t("activerecord.attributes.user.roles.#{name}")) }
-  end
-
   def list_of_financial_quarters
     @list_of_financial_quarters ||= FinancialQuarter::QUARTERS.map { |id| OpenStruct.new(id: id, name: "Q#{id}") }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,13 +22,7 @@ class User < ApplicationRecord
     I18n.t("activerecord.attributes.user.roles.#{role}")
   end
 
-  def service_owner?
-    organisation.service_owner?
-  end
-
-  def delivery_partner?
-    !service_owner?
-  end
+  delegate :service_owner?, :delivery_partner?, to: :organisation
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,21 +6,11 @@ class User < ApplicationRecord
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :email, with: :email_cannot_be_changed_after_create, on: :update
 
-  enum role: {
-    administrator: "administrator",
-  }
-
-  attribute :role, :string, default: "administrator"
-
   FORM_FIELD_TRANSLATIONS = {
     organisation_id: :organisation,
   }.freeze
 
   scope :active, -> { where(active: true) }
-
-  def role_name
-    I18n.t("activerecord.attributes.user.roles.#{role}")
-  end
 
   delegate :service_owner?, :delivery_partner?, to: :organisation
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -32,10 +32,10 @@ class ApplicationPolicy
   end
 
   protected def beis_user?
-    user.organisation.service_owner?
+    user.service_owner?
   end
 
   protected def delivery_partner_user?
-    !beis_user?
+    user.delivery_partner?
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,32 +8,12 @@ class ApplicationPolicy
     @record = record
   end
 
-  def index?
-    user.administrator?
-  end
-
-  def show?
-    user.administrator?
-  end
-
-  def create?
-    user.administrator?
-  end
-
   def new?
     create?
   end
 
-  def update?
-    user.administrator?
-  end
-
   def edit?
     update?
-  end
-
-  def destroy?
-    user.administrator?
   end
 
   class Scope

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -27,14 +27,4 @@ class OrganisationPolicy < ApplicationPolicy
   private def associated_user?
     user.organisation.eql?(record)
   end
-
-  class Scope < Scope
-    def resolve
-      if user.administrator?
-        scope.all
-      else
-        scope.where(id: user.organisation_id)
-      end
-    end
-  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -8,11 +8,11 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def create?
-    !beis_user?
+    delivery_partner_user?
   end
 
   def update?
-    !beis_user?
+    delivery_partner_user?
   end
 
   def destroy?

--- a/app/policies/third_party_project_policy.rb
+++ b/app/policies/third_party_project_policy.rb
@@ -1,14 +1,11 @@
 class ThirdPartyProjectPolicy < ProjectPolicy
   def create?
-    !beis_user? && editable_report?
+    delivery_partner_user? && editable_report?
   end
 
   private
 
   def editable_report?
-    # FIXME: Remove once 'level' form_step removed
-    return false if record.is_a?(Symbol)
-
     Report.editable.exists?(organisation: record.organisation, fund: record.associated_fund)
   end
 end

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -4,8 +4,6 @@
       %th.govuk-table__header
         = t("table.header.user.name")
       %th.govuk-table__header
-        = t("table.header.user.role")
-      %th.govuk-table__header
         = t("table.header.user.email")
       %th.govuk-table__header
         = t("table.header.user.organisation")
@@ -17,7 +15,6 @@
     - users.each do |user|
       %tr.govuk-table__row
         %td.govuk-table__cell= user.name
-        %td.govuk-table__cell= user.role_name
         %td.govuk-table__cell= user.email
         %td.govuk-table__cell.organisation= user.organisation.name
         %td.govuk-table__cell= t("form.user.active.#{user.active}")

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -3,11 +3,6 @@
 
   = f.govuk_text_field :name
   = f.govuk_email_field :email, disabled: (action_name == "edit")
-  = f.govuk_collection_radio_buttons :role,
-      list_of_user_roles,
-      :id,
-      :name,
-      legend: { tag: :h2 }
 
   - if @service_owner.present?
     = f.govuk_radio_buttons_fieldset :organisation_id, classes: "user-organisations" do

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -22,11 +22,6 @@
             = @user.email
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            = t("summary.label.user.role")
-          %dd.govuk-summary-list__value
-            = @user.role_name
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
             = t("summary.label.user.organisation")
           %dd.govuk-summary-list__value
             = @user.organisation.name

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -21,7 +21,6 @@ en:
       user:
         active: What is the user's status?
         organisation_id: What organisation does this user belong to?
-        role: Role
     hint:
       user:
         active: Deactivated users cannot log in
@@ -36,7 +35,6 @@ en:
     header:
       user:
         name: Full name
-        role: Role
         email: Email address
         organisation: Organisation
         active: Active?
@@ -44,7 +42,6 @@ en:
     label:
       user:
         name: Full name
-        role: Role
         email: Email address
         identifier: Identifier
         organisation: Organisation
@@ -67,10 +64,6 @@ en:
     attributes:
       user:
         organisation_ids: Organisations
-        roles:
-          administrator: Administrator
-          delivery_partner: Delivery partner
-          fund_manager: Fund manager
     errors:
       models:
         user:

--- a/db/migrate/20210520134602_remove_role_from_users.rb
+++ b/db/migrate/20210520134602_remove_role_from_users.rb
@@ -1,0 +1,10 @@
+class RemoveRoleFromUsers < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :users, :role
+  end
+
+  def down
+    add_column :users, :role, :string, index: true
+    User.update_all(role: :administrator)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_171318) do
+ActiveRecord::Schema.define(version: 2021_05_20_134602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -244,12 +244,10 @@ ActiveRecord::Schema.define(version: 2021_05_18_171318) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "role"
     t.uuid "organisation_id"
     t.boolean "active", default: true
     t.index ["identifier"], name: "index_users_on_identifier"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
-    t.index ["role"], name: "index_users_on_role"
   end
 
   add_foreign_key "activities", "activities", column: "parent_id", on_delete: :restrict

--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -2,13 +2,11 @@ administrator = User.find_or_create_by(
   name: "Administrator",
   email: "roda@dxw.com",
   identifier: "auth0|5dc53e4b85758e0e95b062f0",
-  role: :administrator
 )
 delivery_partner = User.find_or_create_by(
   name: "Delivery Partner",
   email: "roda+dp@dxw.com",
   identifier: "auth0|5e5e1ee731555a0cb0ab5a75",
-  role: :administrator
 )
 beis = Organisation.service_owner
 administrator.organisation = beis

--- a/db/seeds/pentest_users.rb
+++ b/db/seeds/pentest_users.rb
@@ -2,13 +2,11 @@ administrator = User.find_or_create_by(
   name: "Administrator",
   email: "roda@dxw.com",
   identifier: "auth0|5e7e3a08c888910c634232b3",
-  role: :administrator
 )
 delivery_partner = User.find_or_create_by(
   name: "Delivery Partner",
   email: "roda+dp@dxw.com",
   identifier: "auth0|5e7e39e391c2560c6426bda9",
-  role: :administrator
 )
 beis = Organisation.service_owner
 administrator.organisation = beis

--- a/db/seeds/staging_users.rb
+++ b/db/seeds/staging_users.rb
@@ -2,13 +2,11 @@ administrator = User.find_or_create_by(
   name: "Administrator",
   email: "roda@dxw.com",
   identifier: "auth0|5dc54a826560de0e885bb41b",
-  role: :administrator
 )
 delivery_partner = User.find_or_create_by(
   name: "Delivery Partner",
   email: "roda+dp@dxw.com",
   identifier: "auth0|5e554c1b37de640d5dd3ea61",
-  role: :administrator
 )
 beis = Organisation.service_owner
 administrator.organisation = beis

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     identifier { SecureRandom.uuid }
     name { Faker::Name.name }
     email { Faker::Internet.email }
-    role { :administrator }
     active { true }
 
     organisation factory: :beis_organisation

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -58,23 +58,6 @@ RSpec.feature "BEIS users can editing other users" do
     expect(page).to have_content(updated_name)
   end
 
-  scenario "the role can be changed" do
-    administrator_user = create(:beis_user)
-    authenticate!(user: administrator_user)
-
-    visit organisation_path(administrator_user.organisation)
-    click_on t("page_title.users.index")
-
-    expect(page).to have_content(user.name)
-
-    find("tr", text: user.name).click_link("Edit")
-
-    choose "Administrator"
-    click_on "Submit"
-
-    expect(user.reload.role).to eql("administrator")
-  end
-
   scenario "an active user can be deactivated" do
     administrator_user = create(:beis_user)
     authenticate!(user: administrator_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,47 +20,16 @@ RSpec.describe User, type: :model do
     it { is_expected.to belong_to(:organisation) }
   end
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:service_owner?).to(:organisation) }
+    it { is_expected.to delegate_method(:delivery_partner?).to(:organisation) }
+  end
+
   describe "#role_name" do
     it "returns the human readable role name of the user" do
       user = described_class.new(role: :administrator)
 
       expect(user.role_name).to eql "Administrator"
-    end
-  end
-
-  describe "#service_owner?" do
-    context "when the user organisation is a service owner" do
-      it "returns true" do
-        organisation = build_stubbed(:beis_organisation)
-        result = described_class.new(organisation: organisation).service_owner?
-        expect(result).to be true
-      end
-    end
-
-    context "when the user organisation is NOT a service owner" do
-      it "returns false" do
-        organisation = build_stubbed(:delivery_partner_organisation)
-        result = described_class.new(organisation: organisation).service_owner?
-        expect(result).to be false
-      end
-    end
-  end
-
-  describe "#delivery_partner?" do
-    context "when the user organisation is a service owner" do
-      it "returns false" do
-        organisation = build_stubbed(:beis_organisation)
-        result = described_class.new(organisation: organisation).delivery_partner?
-        expect(result).to be false
-      end
-    end
-
-    context "when the user organisation is NOT a service owner" do
-      it "returns true" do
-        organisation = build_stubbed(:delivery_partner_organisation)
-        result = described_class.new(organisation: organisation).delivery_partner?
-        expect(result).to be true
-      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,12 +24,4 @@ RSpec.describe User, type: :model do
     it { is_expected.to delegate_method(:service_owner?).to(:organisation) }
     it { is_expected.to delegate_method(:delivery_partner?).to(:organisation) }
   end
-
-  describe "#role_name" do
-    it "returns the human readable role name of the user" do
-      user = described_class.new(role: :administrator)
-
-      expect(user.role_name).to eql "Administrator"
-    end
-  end
 end


### PR DESCRIPTION
- Remove roles from users. All users were 'administrators', with their access determined by the organisation they belong to
- Update `delivery_partner?` to use the organisation role instead of assuming "NOT a service owner" means the same thing

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
