### PR TITLE
(1713) Open footer external links in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -650,6 +650,7 @@
 - Prevent uploading activities, transactions and planned disbursements if the report is not editable
 - Sum programme and child activity forecasts by financial quarter in IATI XML
 - Remove unused 'role' from User model
+- Open external links in the footer in new tabs
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
     end
   end
 
-  def link_to_new_tab(text, href)
-    link_to("#{text} (opens in new tab)", href, class: "govuk-link", target: "_blank", rel: "noreferrer noopener")
+  def link_to_new_tab(text, href, css_class: "govuk-link")
+    link_to("#{text} (opens in new tab)", href, class: css_class, target: "_blank", rel: "noreferrer noopener")
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -75,9 +75,9 @@
               %li.govuk-footer__inline-list-item
                 = link_to t("footer.link.terms_of_service"), page_path("terms_of_service"), class: "govuk-footer__link"
               %li.govuk-footer__inline-list-item
-                = link_to t("footer.link.service_performance"), "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance", class: "govuk-footer__link"
+                = link_to_new_tab t("footer.link.service_performance"), "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance", css_class: "govuk-footer__link"
               %li.govuk-footer__inline-list-item
-                = link_to t("footer.link.support_site"), "https://beisodahelp.zendesk.com/", class: "govuk-footer__link"
+                = link_to_new_tab t("footer.link.support_site"), "https://beisodahelp.zendesk.com/", css_class: "govuk-footer__link"
 
             %svg.govuk-footer__licence-logo{focusable: "false", height: "17", role: "presentation", viewbox: "0 0 483.2 195.7", width: "41", xmlns: "http://www.w3.org/2000/svg"}
               %path{d: "M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145", fill: "currentColor"}


### PR DESCRIPTION
## Changes in this PR
- Extend the `link_to_new_tab` pattern to allow specifying the CSS class, while using the default `govuk-link` to keep existing usages as they are.

## Screenshots of UI changes

### Before
![Screenshot 2021-05-24 at 12 50 11](https://user-images.githubusercontent.com/579522/119343676-af752500-bc8e-11eb-9316-85b83414c5de.png)

### After
![Screenshot 2021-05-24 at 12 49 58](https://user-images.githubusercontent.com/579522/119343693-b6039c80-bc8e-11eb-92cc-2bbfcb159fa0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
