### PR TITLE
Use consistent naming for China

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,6 +651,7 @@
 - Sum programme and child activity forecasts by financial quarter in IATI XML
 - Remove unused 'role' from User model
 - Open external links in the footer in new tabs
+- Use consistent naming for China (People's Republic of) when selecting and showing recipient country and intended beneficiaries
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...HEAD
 [release-50]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-49...release-50

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -97,7 +97,7 @@ en:
       CK: Cook Islands (the)
       CL: Chile
       CM: Cameroon
-      CN: China
+      CN: China (People's Republic of)
       CO: Colombia
       CR: Costa Rica
       CU: Cuba

--- a/spec/features/staff/users_can_add_benefitting_countries_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
         click_button t("form.button.activity.submit")
         expect(page).to have_select(t("form.label.activity.recipient_country"))
 
-        select "Bolivia"
+        select "China (People's Republic of)"
         click_button t("form.button.activity.submit")
         expect(page).to have_content t("form.legend.activity.requires_additional_benefitting_countries")
         choose "Yes"
@@ -33,6 +33,7 @@ RSpec.feature "users can add benefitting countries as intended beneficiaries" do
         click_button t("form.button.activity.submit")
         expect(page).to have_current_path(activity_step_path(activity, :gdi))
       end
+
       scenario "the user has the option of selecting other intended beneficiaries based on the full list of all countries" do
         visit activity_step_path(activity, :geography)
         choose "Region"

--- a/spec/features/staff/users_can_choose_recipient_country_spec.rb
+++ b/spec/features/staff/users_can_choose_recipient_country_spec.rb
@@ -22,6 +22,18 @@ RSpec.feature "Users can choose a recipient country" do
         click_button I18n.t("form.button.activity.submit")
         expect(activity.reload.recipient_region).to eq("1029") # Southern Africa
       end
+
+      scenario "the select box uses the DAC designation for China" do
+        select "China (People's Republic of)"
+        click_button I18n.t("form.button.activity.submit")
+
+        expect(activity.reload.recipient_country).to eq("CN")
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+        within(".recipient_country dd.govuk-summary-list__value") do
+          expect(page).to have_content("China (People's Republic of)")
+        end
+      end
     end
 
     context "with JavaScript enabled", js: true do
@@ -38,6 +50,12 @@ RSpec.feature "Users can choose a recipient country" do
         expect(page).to have_selector "li.autocomplete__option", text: "Saint Vincent and the Grenadines", visible: true
 
         expect(page).not_to have_selector "li.autocomplete__option", text: "United Kingdom of Great Britain and Northern Ireland (the)", visible: true
+      end
+
+      scenario "the autocomplete uses the DAC designation for China" do
+        fill_in t("form.label.activity.recipient_country"), with: "china"
+
+        expect(page).to have_selector "li.autocomplete__option", text: "China (People's Republic of)", visible: true
       end
 
       scenario "clicking the autocomplete shows all available countries" do

--- a/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
+++ b/vendor/data/codelists/IATI/2_03/activity/recipient_country.yml
@@ -83,7 +83,7 @@ data:
   name: Chad
   status: active
 - code: CN
-  name: China
+  name: China (People's Republic of)
   status: active
 - code: CO
   name: Colombia


### PR DESCRIPTION
## Changes in this PR
The recipient country codelist is lifted from IATI codelists, and is the source for the select boxes used on the activity form to select the recipient countries.

However, in this case, we don’t want to create a BEIS-specific codelist file, and accept that if we ever replace this file with a new codelist release from IATI, we might have to do the change again.

The IATI locale file was compiled by us based on official IATI codelists, and is used to display country names in both recipient country and intended beneficiaries sections on the activity details page.

## Screenshots of UI changes

### Before
![Screenshot 2021-05-24 at 14 23 21](https://user-images.githubusercontent.com/579522/119369688-5caa6600-bcac-11eb-858c-8014e7780939.png)
![Screenshot 2021-05-24 at 14 24 08](https://user-images.githubusercontent.com/579522/119369693-5ddb9300-bcac-11eb-9579-507aa8d1ba3f.png)

### After
![Screenshot 2021-05-24 at 14 28 23](https://user-images.githubusercontent.com/579522/119369736-69c75500-bcac-11eb-842b-7f9f15c8cdce.png)
![Screenshot 2021-05-24 at 14 28 14](https://user-images.githubusercontent.com/579522/119369745-6af88200-bcac-11eb-9cc7-ba63786941d6.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
