### PR TITLE
(1772) Set autocomplete to `off` for activity search

### DIFF
--- a/app/views/staff/searches/_form.html.haml
+++ b/app/views/staff/searches/_form.html.haml
@@ -8,5 +8,6 @@
         name: :query,
         label: { text: t("form.activity_search.query") },
         hint: { text: t("form.activity_search.hint") },
-        width: 20
+        width: 20,
+        autocomplete: :off
       = f.govuk_submit t("form.activity_search.submit")


### PR DESCRIPTION
When usig the search in Firefox (v89) as the text field is not set to `autocomplete=off` the browser show historic
suggestions. these suggestion take a second to appear and  by that point the user is click the search button directly under the autocomplete list thereby selecting a possibly incorrect serach value and submitting the form.

This sets `autocomplete` to `off`, so the browser does not show the historic suggestions.