### PR TITLE
(1792) Do not show channel of delivery code on level B activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -656,6 +656,7 @@
 ## [unreleased]
 
 - Sort the users list by name within each organisation
+- Only show Channel of delivery code for projects and third-party projects
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...HEAD
 [release-51]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...release-51

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -406,14 +406,15 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :covid19_related)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:covid19_related)}"), activity_step_path(activity_presenter, :covid19_related), t("summary.label.activity.covid19_related"))
 
-  .govuk-summary-list__row.channel_of_delivery_code
-    %dt.govuk-summary-list__key
-      = t("summary.label.activity.channel_of_delivery_code")
-    %dd.govuk-summary-list__value
-      = activity_presenter.channel_of_delivery_code
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :channel_of_delivery_code)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:channel_of_delivery_code)}"), activity_step_path(activity_presenter, :channel_of_delivery_code), t("summary.label.activity.channel_of_delivery_code"))
+  - if @activity.is_project?
+    .govuk-summary-list__row.channel_of_delivery_code
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.channel_of_delivery_code")
+      %dd.govuk-summary-list__value
+        = activity_presenter.channel_of_delivery_code
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :channel_of_delivery_code)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:channel_of_delivery_code)}"), activity_step_path(activity_presenter, :channel_of_delivery_code), t("summary.label.activity.channel_of_delivery_code"))
 
   .govuk-summary-list__row.oda_eligibility
     %dt.govuk-summary-list__key

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Users can edit an activity" do
       it "does not show the Publish to Iati field" do
         activity = create(:fund_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
@@ -227,7 +227,7 @@ RSpec.feature "Users can edit an activity" do
       it "does not show the Publish to Iati field" do
         activity = create(:programme_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
@@ -251,7 +251,7 @@ RSpec.feature "Users can edit an activity" do
       scenario "it does not show the Publish to Iati field" do
         activity = create(:programme_activity)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
@@ -286,7 +286,7 @@ RSpec.feature "Users can edit an activity" do
       it "does not show the Publish to Iati field" do
         activity = create(:project_activity, organisation: user.organisation)
 
-        visit organisation_activity_path(activity.organisation, activity)
+        visit organisation_activity_details_path(activity.organisation, activity)
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -231,6 +231,14 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
+
+      it "does not show the Channel of delivery code field" do
+        activity = create(:programme_activity, organisation: user.organisation)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        expect(page).to_not have_content(t("summary.label.activity.channel_of_delivery_code"))
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR
- Only show Channel of delivery code for projects and third-party projects

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
