### PR TITLE
(1845) External Income Providers can be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -660,6 +660,7 @@
 - Only show Channel of delivery code for projects and third-party projects
 - Send approved report email notifications to BEIS users
 - Add "sdgs_apply" to CSV export
+- Allow organisations of type "External Income Provider" to be created
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...HEAD
 [release-51]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...release-51

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -46,6 +46,10 @@ class Organisation < ApplicationRecord
     %w[10 11].include?(organisation_type)
   end
 
+  def is_reporter?
+    service_owner? || delivery_partner?
+  end
+
   def self.service_owner
     find_by(iati_reference: SERVICE_OWNER_IATI_REFERENCE)
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -21,12 +21,12 @@ class Organisation < ApplicationRecord
   validates :iati_reference,
     uniqueness: {case_sensitive: false},
     presence: true,
-    unless: proc { |organisation| organisation.matched_effort_provider? },
+    if: proc { |organisation| organisation.is_reporter? },
     format: {with: /\A[a-zA-Z]{2,}-[a-zA-Z]{3}-.+\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.iati_reference.format")}
   validates :beis_organisation_reference, uniqueness: {case_sensitive: false}
   validates :beis_organisation_reference,
     presence: true,
-    unless: proc { |organisation| organisation.matched_effort_provider? },
+    if: proc { |organisation| organisation.is_reporter? },
     format: {with: /\A[A-Z]{2,5}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
 
   scope :sorted_by_name, -> { order(name: :asc) }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,6 +10,7 @@ class Organisation < ApplicationRecord
   enum role: {
     delivery_partner: 0,
     matched_effort_provider: 1,
+    external_income_provider: 2,
     service_owner: 99,
   }
 

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -7,7 +7,7 @@
                      organisation_type_options,
                      :code,
                      :name
-- if f.object.role != "matched_effort_provider"
+- if f.object.is_reporter?
   = f.govuk_text_field :iati_reference,
                         hint: { text: t("form.hint.organisation.iati_reference_html", link: link_to_new_tab("See International Aid Transparency Initiative (IATI) for detailed documentation", "https://reference.iatistandard.org/organisation-identifiers/")) }
 = f.govuk_collection_select :language_code,
@@ -18,7 +18,7 @@
                      default_currency_options,
                      :code,
                      :name
-- if f.object.role == "matched_effort_provider"
+- unless f.object.is_reporter?
   = f.govuk_collection_radio_buttons :active,
     organisation_active_options,
     :id,

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -5,7 +5,7 @@
         Organisations
 
       %ul.govuk-tabs__list
-        - ["delivery_partners", "matched_effort_providers"].each do |role|
+        - ["delivery_partners", "matched_effort_providers", "external_income_providers"].each do |role|
           %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
             = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: (role == @role) } }
 

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -36,6 +36,7 @@ en:
     organisations:
       delivery_partners: Delivery partners
       matched_effort_providers: Matched effort providers
+      external_income_providers: External income providers
   summary:
     label:
       organisation:
@@ -53,6 +54,9 @@ en:
       matched_effort_providers:
         button:
           create: Add matched effort provider organisation
+      external_income_providers:
+        button:
+          create: Add external income provider organisation
     organisation:
       create_programme: Add level B activity
       button:
@@ -83,9 +87,12 @@ en:
         new: Create a new delivery partner organisation
       matched_effort_provider:
         new: Create a new matched effort provider organisation
+      external_income_provider:
+        new: Create a new external income provider organisation
     organisations:
       delivery_partners: Delivery partners
       matched_effort_providers: Matched effort providers
+      external_income_providers: External income providers
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       end
     end
 
-    constraints role: /delivery_partners|matched_effort_providers/ do
+    constraints role: /delivery_partners|matched_effort_providers|external_income_providers/ do
       get "organisations/(:role)", to: "organisations#index", defaults: {role: "delivery_partners"}, as: :organisations
       get "organisations/(:role)/new", to: "organisations#new", as: :new_organisation
     end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       role { "matched_effort_provider" }
     end
 
+    factory :external_income_provider do
+      role { "external_income_provider" }
+    end
+
     factory :beis_organisation do
       name { "Department for Business, Energy and Industrial Strategy" }
       iati_reference { Organisation::SERVICE_OWNER_IATI_REFERENCE }

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -71,6 +71,36 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.active).to eq(true)
     end
 
+    scenario "successfully creating a external income provider organisation" do
+      visit organisation_path(user.organisation)
+      click_link t("page_title.organisation.index")
+      click_link t("tabs.organisations.external_income_providers")
+
+      click_link t("page_content.organisations.external_income_providers.button.create")
+
+      expect(page).to have_content(t("page_title.organisation.external_income_provider.new"))
+      expect(page).to have_field("organisation[active]", type: "radio")
+
+      fill_in "organisation[name]", with: "My New External Income Provider"
+      select "Other", from: "organisation[organisation_type]"
+      select "Russian", from: "organisation[language_code]"
+      select "Russian Ruble", from: "organisation[default_currency]"
+      choose t("form.label.organisation.active.true"), name: "organisation[active]"
+
+      click_button t("default.button.submit")
+
+      organisation = Organisation.order("created_at ASC").last
+
+      expect(page).to have_content(t("action.organisation.create.success"))
+
+      expect(organisation.name).to eq("My New External Income Provider")
+      expect(organisation.organisation_type).to eq("90")
+      expect(organisation.language_code).to eq("ru")
+      expect(organisation.default_currency).to eq("RUB")
+      expect(organisation.role).to eq("external_income_provider")
+      expect(organisation.active).to eq(true)
+    end
+
     scenario "organisation creation is tracked with public_activity" do
       PublicActivity.with_tracking do
         visit organisation_path(user.organisation)

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -40,11 +40,32 @@ RSpec.feature "BEIS users can view other organisations" do
     end
   end
 
+  RSpec.shared_examples "lists external income provider organisations" do
+    scenario "it lists external income provider organisations" do
+      expect(page).to have_content(t("page_title.organisation.index"))
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.external_income_providers"))
+      expect(page).to have_content(t("page_title.organisations.external_income_providers"))
+
+      matched_effort_provider_organisations.each do |organisation|
+        expect(page).to_not have_content(organisation.name)
+      end
+
+      delivery_partner_organisations.each do |organisation|
+        expect(page).to_not have_content(organisation.name)
+      end
+
+      external_income_provider_organisations.each do |organisation|
+        expect(page).to have_content(organisation.name)
+      end
+    end
+  end
+
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
 
     let!(:delivery_partner_organisations) { create_list(:delivery_partner_organisation, 3) }
     let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
+    let!(:external_income_provider_organisations) { create_list(:external_income_provider, 2) }
 
     before do
       authenticate!(user: user)
@@ -67,6 +88,14 @@ RSpec.feature "BEIS users can view other organisations" do
 
           include_examples "lists matched effort provider organisations"
         end
+
+        context "when viewing the external income providers tab" do
+          before do
+            click_on t("tabs.organisations.external_income_providers")
+          end
+
+          include_examples "lists external income provider organisations"
+        end
       end
 
       context "the role is 'matched_effort_providers'" do
@@ -80,6 +109,36 @@ RSpec.feature "BEIS users can view other organisations" do
           end
 
           include_examples "lists delivery partner organisations"
+        end
+
+        context "when viewing the external income providers tab" do
+          before do
+            click_on t("tabs.organisations.external_income_providers")
+          end
+
+          include_examples "lists external income provider organisations"
+        end
+      end
+
+      context "the role is 'external_income_providers'" do
+        let(:role) { "external_income_providers" }
+
+        include_examples "lists external income provider organisations"
+
+        context "when viewing the delivery partner organisations tab" do
+          before do
+            click_on t("tabs.organisations.delivery_partners")
+          end
+
+          include_examples "lists delivery partner organisations"
+        end
+
+        context "when viewing the matched effort providers tab" do
+          before do
+            click_on t("tabs.organisations.matched_effort_providers")
+          end
+
+          include_examples "lists matched effort provider organisations"
         end
       end
     end

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -71,6 +71,31 @@ RSpec.feature "Users can edit organisations" do
     end
   end
 
+  context "when the organisation is an external income provider organisation" do
+    let!(:another_organisation) { create(:external_income_provider) }
+
+    scenario "it can be set to inactive" do
+      authenticate!(user: create(:administrator, organisation: beis_organisation))
+
+      visit organisation_path(beis_organisation)
+      click_link t("page_title.organisation.index")
+      click_link t("tabs.organisations.external_income_providers")
+
+      within("##{another_organisation.id}") do
+        click_link t("default.link.edit")
+      end
+
+      choose t("form.label.organisation.active.false"), name: "organisation[active]"
+      expect {
+        click_button t("default.button.submit")
+      }.to change {
+        another_organisation.reload.active
+      }.from(true).to(false)
+
+      expect(page).to have_content t("action.organisation.update.success")
+    end
+  end
+
   def successfully_edit_an_organisation(organisation_name: "My New Organisation")
     visit organisation_path(beis_organisation)
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -174,6 +174,28 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
+  describe "#is_reporter?" do
+    it "should be true for delivery partners" do
+      organisation = build(:delivery_partner_organisation)
+      expect(organisation.is_reporter?).to eq true
+    end
+
+    it "should be true for BEIS" do
+      organisation = build(:beis_organisation)
+      expect(organisation.is_reporter?).to eq true
+    end
+
+    it "should be false for matched effort providers" do
+      organisation = build(:matched_effort_provider)
+      expect(organisation.is_reporter?).to eq false
+    end
+
+    it "should be false for external income providers" do
+      organisation = build(:external_income_provider)
+      expect(organisation.is_reporter?).to eq false
+    end
+  end
+
   describe "#ensure_beis_organisation_reference_is_uppercase" do
     it "converts the value of beis_organisation_reference to uppercase" do
       organisation = build(:delivery_partner_organisation, beis_organisation_reference: "test")

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Organisation, type: :model do
       it { should_not validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
     end
 
+    context "when the organisation is a external income provider" do
+      subject { build(:external_income_provider) }
+      it { should_not validate_presence_of(:beis_organisation_reference) }
+      it { should_not validate_presence_of(:iati_reference) }
+      it { should_not validate_uniqueness_of(:iati_reference).ignoring_case_sensitivity }
+    end
+
     describe "sanitation" do
       it { should strip_attribute(:iati_reference) }
     end


### PR DESCRIPTION
## Changes in this PR

- Allow organisations of type "External Income Provider" to be created

## Screenshots of UI changes

<img width="1030" alt="Screenshot 2021-05-26 at 16 47 07" src="https://user-images.githubusercontent.com/2804149/119691208-4afac700-be42-11eb-9cc3-23cc00b7ea61.png">
<img width="1013" alt="Screenshot 2021-05-26 at 16 46 50" src="https://user-images.githubusercontent.com/2804149/119691235-50f0a800-be42-11eb-804c-38cc571a25ec.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
