### PR TITLE
(1840) Improvements to single report view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,6 +664,8 @@
 - Move Aid type question before Collaboration type question
 - Report title no longer includes the description
 - A report description is no longer required
+- Reports show a more detailed summary, including deadline, organisation and
+  description (if one is supplied)
 
 ## [unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,6 +663,7 @@
 - Allow organisations of type "External Income Provider" to be created
 - Move Aid type question before Collaboration type question
 - Report title no longer includes the description
+- A report description is no longer required
 
 ## [unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,6 +662,7 @@
 - Add "sdgs_apply" to CSV export
 - Allow organisations of type "External Income Provider" to be created
 - Move Aid type question before Collaboration type question
+- Report title no longer includes the description
 
 ## [unreleased]
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,7 +6,6 @@ class Report < ApplicationRecord
 
   attr_readonly :financial_quarter, :financial_year
 
-  validates_presence_of :description, on: [:edit, :activate]
   validates_presence_of :state
 
   belongs_to :fund, -> { where(level: :fund) }, class_name: "Activity"

--- a/app/views/staff/reports/_summary.html.haml
+++ b/app/views/staff/reports/_summary.html.haml
@@ -1,0 +1,29 @@
+%dl.govuk-summary-list.govuk-summary-list
+  - if current_user.service_owner?
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("form.label.report.organisation")
+      %dd.govuk-summary-list__value
+        = @report_presenter.organisation.name
+  - if @report_presenter.description.present?
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("form.label.report.description")
+      %dd.govuk-summary-list__value
+        = @report_presenter.description
+  .govuk-summary-list__row
+    %dt.govuk-summary-list__key
+      = t("form.label.report.deadline")
+    %dd.govuk-summary-list__value
+      = @report_presenter.deadline
+  .govuk-summary-list__row
+    %dt.govuk-summary-list__key
+      = t("form.label.report.state")
+    %dd.govuk-summary-list__value
+      = @report_presenter.state
+  - if current_user.delivery_partner?
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("page_content.report.summary.editable.title")
+      %dd.govuk-summary-list__value
+        = t("page_content.report.summary.editable.#{@report_presenter.editable?}")

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+        = t("page_title.report.show", report_fund: @report_presenter.fund.source_fund.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
       %dl.govuk-summary-list.govuk-summary-list
         .govuk-summary-list__row

--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -6,17 +6,15 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_fund: @report_presenter.fund.source_fund.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
-      %dl.govuk-summary-list.govuk-summary-list
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
-            = t("form.label.report.state")
-          %dd.govuk-summary-list__value
-            = @report_presenter.state
-
     - if policy(@report_presenter).download?
       = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
 
-  = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
+    .govuk-grid-column-two-thirds
+      = render partial: "staff/reports/summary"
+
+    .govuk-grid-column-full
+
+      = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -6,17 +6,14 @@
       %h1.govuk-heading-xl
         = t("page_title.report.show", report_fund: @report_presenter.fund.source_fund.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
-      %dl.govuk-summary-list.govuk-summary-list
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
-            = t("form.label.report.state")
-          %dd.govuk-summary-list__value
-            = @report_presenter.state
-
     - if policy(@report_presenter).download?
       = render partial: "staff/reports/download", locals: { report_presenter: @report_presenter }
 
-  = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
+    .govuk-grid-column-two-thirds
+      = render partial: "staff/reports/summary"
+
+    .govuk-grid-column-full
+      = render partial: "staff/reports/actions", locals: { report_presenter: @report_presenter }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.report.show", report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+        = t("page_title.report.show", report_fund: @report_presenter.fund.source_fund.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
 
       %dl.govuk-summary-list.govuk-summary-list
         .govuk-summary-list__row

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -50,6 +50,11 @@ en:
             <p class="govuk-body">
             The Service Manager will send the delivery partner an email notifying them that RODA is now open and their reporting cycle has begun.  ODA PMO Finance Lead will send the commissioning email confirming the deadline and relevant service updates to DPs 2 weeks before the report submission deadline.
             </p>
+      summary:
+        editable:
+          title: Report can be changed
+          "true": "Yes"
+          "false": "No"
   label:
     report:
       state:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -84,7 +84,7 @@ en:
         complete: Report activation complete
       index: Reports
       edit: Edit report
-      show: "%{report_financial_quarter} %{report_description}"
+      show: "%{report_financial_quarter} %{report_fund} report"
       submit:
         confirm: Confirm submission of your %{report_financial_quarter} report
         complete: "%{report_financial_quarter} %{report_organisation} report submitted"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -170,8 +170,6 @@ en:
       models:
         report:
           attributes:
-            description:
-              blank: Report description cannot be blank
             fund:
               level: Activity must be a Fund (level A) activity
             deadline:

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -140,24 +140,6 @@ RSpec.feature "BEIS users can edit a report" do
       end
     end
 
-    scenario "the description (Reporting Period) cannot be blank" do
-      authenticate!(user: beis_user)
-      report = create(:report)
-
-      visit reports_path
-
-      within "##{report.id}" do
-        click_on t("default.link.edit")
-      end
-
-      fill_in "report[description]", with: ""
-
-      click_on t("default.button.submit")
-
-      expect(page).to_not have_content t("action.report.update.success")
-      expect(page).to have_content t("activerecord.errors.models.report.attributes.description.blank")
-    end
-
     scenario "they see the organisation, level A activity and financial quarter for the report" do
       authenticate!(user: beis_user)
       report = create(:report)

--- a/spec/features/staff/users_can_activate_reports_spec.rb
+++ b/spec/features/staff/users_can_activate_reports_spec.rb
@@ -26,19 +26,6 @@ RSpec.feature "Users can activate reports" do
       end
     end
 
-    scenario "they see a warning when the report is not valid i.e. has no description" do
-      organisation = create(:delivery_partner_organisation)
-      fund = create(:fund_activity)
-      report = Report.new(organisation: organisation, fund: fund)
-      report.save(validate: false)
-
-      visit report_path(report)
-      click_link t("action.report.activate.button")
-      click_button t("action.report.activate.confirm.button")
-
-      expect(page).to have_content t("action.report.activate.failure")
-    end
-
     context "when the report is already active" do
       scenario "it cannot be activated again" do
         report = create(:report, state: :active)

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -63,6 +63,31 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content report.fund.source_fund.name
     end
 
+    scenario "the report includes a summary" do
+      report = create(:report, :active, organisation: build(:delivery_partner_organisation))
+
+      visit reports_path
+
+      within "##{report.id}" do
+        click_on t("default.link.show")
+      end
+
+      expect(page).to have_content report.description
+      expect(page).to have_content l(report.deadline)
+      expect(page).not_to have_content t("page_content.report.summary.editable.#{report.editable?}")
+      expect(page).to have_content report.organisation.name
+    end
+
+    context "when there is no report descripiton" do
+      scenario "the summary does not include the empty value" do
+        report = create(:report, :active, organisation: build(:delivery_partner_organisation), description: nil)
+
+        visit report_path(report.id)
+
+        expect(page).not_to have_content t("form.label.report.description")
+      end
+    end
+
     scenario "they can view budgets in a report" do
       report = create(:report, :active)
       budget = create(:budget, report: report)
@@ -270,6 +295,21 @@ RSpec.feature "Users can view reports" do
 
         expect(page).to have_content report.financial_quarter
         expect(page).to have_content report.fund.source_fund.name
+      end
+
+      scenario "their own report includes a summary" do
+        report = create(:report, :active, organisation: delivery_partner_user.organisation)
+
+        visit reports_path
+
+        within "##{report.id}" do
+          click_on t("default.link.show")
+        end
+
+        expect(page).to have_content report.description
+        expect(page).to have_content l(report.deadline)
+        expect(page).to have_content t("page_content.report.summary.editable.#{report.editable?}")
+        expect(page).not_to have_content report.organisation.name
       end
 
       scenario "the report shows the total forecasted and actual spend and the variance" do

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -59,7 +59,8 @@ RSpec.feature "Users can view reports" do
         click_on t("default.link.show")
       end
 
-      expect(page).to have_content report.description
+      expect(page).to have_content report.financial_quarter
+      expect(page).to have_content report.fund.source_fund.name
     end
 
     scenario "they can view budgets in a report" do
@@ -250,14 +251,12 @@ RSpec.feature "Users can view reports" do
 
     context "when there is an active report" do
       scenario "they can view reports for their own organisation" do
-        report = create(:report, :active, organisation: delivery_partner_user.organisation)
-        other_organisation_report = create(:report, :active)
+        _report = create(:report, :active, organisation: delivery_partner_user.organisation)
+        _other_organisation_report = create(:report, :active)
 
         visit reports_path
 
         expect(page).to have_content t("page_title.report.index")
-        expect(page).to have_content report.description
-        expect(page).not_to have_content other_organisation_report.description
       end
 
       scenario "can view their own report" do
@@ -269,7 +268,8 @@ RSpec.feature "Users can view reports" do
           click_on t("default.link.show")
         end
 
-        expect(page).to have_content report.description
+        expect(page).to have_content report.financial_quarter
+        expect(page).to have_content report.fund.source_fund.name
       end
 
       scenario "the report shows the total forecasted and actual spend and the variance" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Report, type: :model do
   describe "validations" do
-    it { should validate_presence_of(:description).on([:edit, :activate]) }
     it { should validate_presence_of(:state) }
     it { should have_readonly_attribute(:financial_quarter) }
     it { should have_readonly_attribute(:financial_year) }

--- a/spec/views/staff/shared/message_spec.rb
+++ b/spec/views/staff/shared/message_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "layouts/_messages" do
   context "when passed a flash message with a hash" do
     it "renders a flash message with a hash that has a title and errors" do
       errors = ActiveModel::Errors.new(build(:report))
-      errors.add(:description, :blank)
+      errors.add(:deadline, "This is an error!")
       errors.add(:fund, :level)
 
       flash[:notice] = {title: "The title", errors: errors}
       render
 
       expect(response).to include "The title"
-      expect(response).to include "Report description cannot be blank"
+      expect(response).to include "This is an error!"
       expect(response).to include "Activity must be a Fund (level A) activity"
     end
 


### PR DESCRIPTION
## Changes in this PR
Previously, we used the report description to derive the title shown on a single report view.

So far we have only ever seen a single report per quarter and the description is designed to be used when more than one report occurs in the same quarter.

The descriptions of the reports we have seen have generally been `[financial quarter] [fund] report` which made the title repetative and unclear.

The report description was also required which meant a user had to fill it in before being able to activate a report. This PR introduces two changes to ease this:

- the single report page now creates the title from two known values so it can be rendered without the user providing a descripiton formalising the report page title to `[financial quarter] [fund name] report` and showing the description in a summary (see below)
- the report description has been made optional, which reduces the number of steps to activate a report.

When viewing a single report some context was lost as users could no longer see some important information, we were showing the report state in a summary, so this work extends that to include other useful information:

- report deadline
- report organisation (for BEIS users)
- report description, if one is available
- whether the report can be changed

This last value has been added to aid new users who may not understand the link between the report states and when the contents of the report can be changed, we felt this was a simple, unobtrusive way to achieve this.

More work is planned to further improve the report experience for users.

## Screenshots of UI changes

Delivery partner:

![Screenshot 2021-05-27 at 13-55-28 FQ1 2021-2022 A longish description like this so we can see how this looks variance — Rep](https://user-images.githubusercontent.com/480578/119837057-25c98f80-befa-11eb-82ed-dcfeb46b0ddb.png)

BEIS user:

![Screenshot 2021-05-27 at 13-55-58 FQ1 2021-2022 A longish description like this so we can see how this looks variance — Rep](https://user-images.githubusercontent.com/480578/119837076-295d1680-befa-11eb-9c84-c8acf5b4614f.png)
