### PR TITLE
(1767) Verify and improve fstc_applies question logic and experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,7 @@
 - add spacing between view and edit links on Organisation index page
 - export complete transaction history per delivery partner for BEIS users
 - Change the email address given in email notifications
+- Update the logic to auto populate the FSTC applies field
 
 ## [unreleased]
 

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -49,7 +49,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step unless @activity.is_project?
     when :fstc_applies
       skip_step if can_infer_fstc?(@activity.aid_type)
-      assign_default_fstc_applies_value_if_aid_type_c01
+      assign_default_fstc_applies_value
     end
 
     render_wizard
@@ -114,7 +114,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
   end
 
-  def assign_default_fstc_applies_value_if_aid_type_c01
-    @activity.fstc_applies = true if @activity.aid_type == "C01"
+  def assign_default_fstc_applies_value
+    @activity.fstc_applies = fstc_from_aid_type(@activity.aid_type)
   end
 end

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -82,11 +82,9 @@ module CodelistHelper
   end
 
   def aid_type_radio_options
-    options = Codelist.new(type: "aid_type").to_objects_with_description(
+    Codelist.new(type: "aid_type", source: "beis").to_objects_with_description(
       code_displayed_in_name: true,
     )
-
-    options.select { |a| ALLOWED_AID_TYPE_CODES.include?(a.code) }
   end
 
   def fstc_from_aid_type(aid_type_code)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -2,11 +2,6 @@
 
 module CodelistHelper
   DEVELOPING_COUNTRIES_CODE = "998"
-  FSTC_FROM_AID_TYPE_CODE = {
-    "D02" => true,
-    "E01" => true,
-    "G01" => false,
-  }
 
   def default_currency_options
     Codelist.new(type: "default_currency").to_objects
@@ -89,7 +84,7 @@ module CodelistHelper
   end
 
   def can_infer_fstc?(aid_type_code)
-    FSTC_FROM_AID_TYPE_CODE.key?(aid_type_code)
+    !fstc_from_aid_type(aid_type_code).nil?
   end
 
   def policy_markers_radio_options

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -2,15 +2,6 @@
 
 module CodelistHelper
   DEVELOPING_COUNTRIES_CODE = "998"
-  ALLOWED_AID_TYPE_CODES = [
-    "B02",
-    "B03",
-    "C01",
-    "D01",
-    "D02",
-    "E01",
-    "G01",
-  ]
   FSTC_FROM_AID_TYPE_CODE = {
     "D02" => true,
     "E01" => true,
@@ -81,14 +72,20 @@ module CodelistHelper
     Codelist.new(type: "sector").to_objects_with_categories(include_withdrawn: true)
   end
 
+  def aid_types
+    @aid_types ||= Codelist.new(type: "aid_type", source: "beis")
+  end
+
   def aid_type_radio_options
-    Codelist.new(type: "aid_type", source: "beis").to_objects_with_description(
+    aid_types.to_objects_with_description(
       code_displayed_in_name: true,
     )
   end
 
   def fstc_from_aid_type(aid_type_code)
-    FSTC_FROM_AID_TYPE_CODE[aid_type_code]
+    item = aid_types.find_item_by_code(aid_type_code) || {}
+
+    item["ftsc_applies"]
   end
 
   def can_infer_fstc?(aid_type_code)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -87,6 +87,13 @@ module CodelistHelper
     !fstc_from_aid_type(aid_type_code).nil?
   end
 
+  def fstc_applies_radio_options
+    [
+      OpenStruct.new(value: 0, label: I18n.t("form.label.activity.fstc_applies.false")),
+      OpenStruct.new(value: 1, label: I18n.t("form.label.activity.fstc_applies.true")),
+    ]
+  end
+
   def policy_markers_radio_options
     options = Codelist.new(type: "policy_significance", source: "beis")
       .to_objects_with_description

--- a/app/models/codelist.rb
+++ b/app/models/codelist.rb
@@ -113,6 +113,12 @@ class Codelist
     values
   end
 
+  def find_item_by_code(code)
+    return nil unless list.first.key?("code")
+
+    list.find { |c| c["code"] == code }
+  end
+
   private def fetch_codelist
     codelist = self.class.codelists[source][type]
 

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -10,7 +10,7 @@ class Fund
   }
 
   def initialize(id)
-    @code = self.class.codelist.find { |c| c["code"] == id.to_i }
+    @code = self.class.codelist.find_item_by_code(id.to_i)
 
     raise InvalidFund if @code.nil?
   end

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -530,7 +530,7 @@ module Activities
 
       def get_sector_category(sector_code)
         codelist = Codelist.new(type: "sector")
-        sector = codelist.find { |list_item| list_item["code"] == sector_code }
+        sector = codelist.find_item_by_code(sector_code)
 
         sector["category"] if sector
       end

--- a/app/views/staff/activity_forms/fstc_applies.html.haml
+++ b/app/views/staff/activity_forms/fstc_applies.html.haml
@@ -1,6 +1,3 @@
 = render layout: "wrapper" do |f|
   = f.govuk_error_summary
-  = f.govuk_radio_buttons_fieldset(:fstc_applies, legend: { text: t("form.legend.activity.fstc_applies"), size: "xl", tag: "h1" }, hint: -> { t("form.hint.activity.fstc_applies", aid_type: @activity.aid_type).html_safe }) do
-    = f.hidden_field :fstc_applies, value: nil
-    = f.govuk_radio_button :fstc_applies, :true, label: { text: t("form.label.activity.fstc_applies.true") }
-    = f.govuk_radio_button :fstc_applies, :false, label: { text: t("form.label.activity.fstc_applies.false") }
+  = f.govuk_collection_radio_buttons :fstc_applies, fstc_applies_radio_options, :value, :label, legend: { text: t("form.legend.activity.fstc_applies"), size: "xl", tag: "h1" }, hint: -> { t("form.hint.activity.fstc_applies").html_safe }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -107,8 +107,8 @@ en:
         total_applications: How many applications have you had?
         total_awards: How many awards have you made?
         fstc_applies:
-          "true": "Yes"
-          "false": "No"
+          "true": "Yes (1)"
+          "false": "No (0)"
         uk_dp_named_contact: Who is the UK delivery partner named contact for this activity?
         csv_file: Upload CSV spreadsheet
         csv_file_recover_from_error: Re-upload CSV spreadsheet
@@ -209,7 +209,7 @@ en:
           nutrition: This activity is intended to address the immediate or underlying determinants of malnutrition
         total_applications: You can enter 0 if this field is not applicable at the moment
         total_awards: You can enter 0 if this field is not applicable at the moment
-        fstc_applies: "<p>Free-standing technical co-operation is defined as financing of activities whose primary purpose is to augment the level of knowledge, skills, technical know-how or productive aptitudes of the population of developing countries.</p><ul><li>If aid type C01, please select Yes except in unusual circumstances</li><li>If aid type G01, please select No as the activity cannot have FTC.</li><li>If aid types E01 and D02, please select Yes as the activity must have Free-Standing Technical Co-operation.</li></ul><p>This activity's aid type is <strong>%{aid_type}</strong></p>"
+        fstc_applies: "Free-standing technical co-operation is defined as financing of activities whose primary purpose is to augment the level of knowledge, skills, technical know-how or productive aptitudes of the population of developing countries."
         options:
           aid_type:
             "B02": "These funds are classified as multilateral ODA. All other categories fall under bilateral ODA"

--- a/db/data/20210527151650_update_fstc_applies_based_on_aid_type.rb
+++ b/db/data/20210527151650_update_fstc_applies_based_on_aid_type.rb
@@ -1,0 +1,20 @@
+# Run me with `rails runner db/data/20210527151650_update_fstc_applies_based_on_aid_type.rb`
+require "csv"
+
+aid_types = Codelist.new(type: "aid_type", source: "beis")
+
+aid_type_codes_where_ftsc_applies_should_be_true = aid_types.select { |a| a["ftsc_applies"] == true }.pluck("code")
+activities_where_ftsc_applies_is_false_instead_of_true = Activity.where(
+  aid_type: aid_type_codes_where_ftsc_applies_should_be_true,
+  fstc_applies: false
+)
+
+activities_where_ftsc_applies_is_false_instead_of_true.update_all(fstc_applies: true)
+
+aid_type_codes_where_ftsc_applies_should_be_false = aid_types.select { |a| a["ftsc_applies"] == false }.pluck("code")
+activities_where_ftsc_applies_is_true_instead_of_false = Activity.where(
+  aid_type: aid_type_codes_where_ftsc_applies_should_be_false,
+  fstc_applies: true
+)
+
+activities_where_ftsc_applies_is_true_instead_of_false.update_all(fstc_applies: false)

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -195,7 +195,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       click_button t("form.button.activity.submit")
       expect(page).to have_content t("activerecord.errors.models.activity.attributes.aid_type.blank")
 
-      choose("activity[aid_type]", option: "B02")
+      choose("activity[aid_type]", option: "C01")
       click_button t("form.button.activity.submit")
 
       # Collaboration type question

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -222,7 +222,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       click_button t("form.button.activity.submit")
       expect(page).to have_content t("activerecord.errors.models.activity.attributes.fstc_applies.inclusion")
 
-      choose("activity[fstc_applies]", option: true)
+      choose("activity[fstc_applies]", option: 1)
       click_button t("form.button.activity.submit")
 
       # Covid19-related has a default and can't be set to blank so we skip

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature "Users can create a project" do
       end
 
       context "when the aid type is 'C01'" do
-        it "pre-selects Yes for the FSTC applies step but lets the user choose" do
+        it "lets the user choose the FSTC applies option" do
           programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)
           _report = create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -1,5 +1,6 @@
 RSpec.feature "Users can edit an activity" do
   include ActivityHelper
+  include CodelistHelper
 
   context "when signed in as a BEIS user" do
     let(:user) { create(:beis_user) }
@@ -590,7 +591,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   click_on(t("default.link.back"))
   click_on t("tabs.activity.details")
 
-  if activity.aid_type.in?(["D02", "E01", "G01"])
+  if can_infer_fstc?(activity.aid_type)
     within(".fstc_applies") do
       expect(page).to_not have_link(t("default.link.edit"))
     end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe CodelistHelper, type: :helper do
       it "returns the aid type with the code appended to the name" do
         options = helper.aid_type_radio_options
 
-        expect(options.length).to eq 7
+        expect(options.length).to eq 8
         expect(options.first.name).to eq "Core contributions to multilateral institutions (B02)"
         expect(options.last.name).to eq "Administrative costs not included elsewhere (G01)"
       end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -123,42 +123,35 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
-    describe "#fstc_from_aid_type" do
-      it "returns nil if the aid type is not set" do
-        expect(helper.fstc_from_aid_type(nil)).to be_nil
+    context "When using aid types to infer Free Standing Technical Cooperation" do
+      let(:codelist) { double("Codelist", list: list) }
+      let(:list) do
+        [
+          {"code" => "A", "ftsc_applies" => true},
+          {"code" => "B", "ftsc_applies" => false},
+          {"code" => "C"},
+        ]
       end
 
-      it "returns true for D02" do
-        expect(helper.fstc_from_aid_type("D02")).to eql true
+      before do
+        allow_any_instance_of(Codelist).to receive(:list).and_return(list)
       end
 
-      it "returns true for E01" do
-        expect(helper.fstc_from_aid_type("E01")).to eql true
-      end
-
-      it "returns false for G01" do
-        expect(helper.fstc_from_aid_type("G01")).to eql false
-      end
-
-      it "returns nil for any other aid type" do
-        expect(helper.fstc_from_aid_type("B02")).to be_nil
-      end
-    end
-
-    describe "#can_infer_fstc?" do
-      it "returns false if the aid type is not set" do
-        expect(helper.can_infer_fstc?(nil)).to eql false
-      end
-
-      it "returns true for aid types 'D02', 'E01', 'G01'" do
-        %w[D02 E01 G01].each do |at|
-          expect(helper.can_infer_fstc?(at)).to eql true
+      describe "#fstc_from_aid_type" do
+        it "returns nil if the aid type is not set" do
+          expect(helper.fstc_from_aid_type(nil)).to be_nil
         end
-      end
 
-      it "returns false for any other aid type" do
-        (CodelistHelper::ALLOWED_AID_TYPE_CODES - %w[D02 E01 G01]).each do |at|
-          expect(helper.can_infer_fstc?(at)).to eql false
+        it "returns true if ftsc_applies is true" do
+          expect(helper.fstc_from_aid_type("A")).to eql true
+        end
+
+        it "returns false if ftsc_applies is false" do
+          expect(helper.fstc_from_aid_type("B")).to eql false
+        end
+
+        it "returns nil if ftsc_applies is nil" do
+          expect(helper.fstc_from_aid_type("C")).to be_nil
         end
       end
     end

--- a/spec/models/codelist_spec.rb
+++ b/spec/models/codelist_spec.rb
@@ -155,4 +155,49 @@ RSpec.describe Codelist do
       expect { codelist.values_for("words") }.to raise_error "Codelist::KeyNotFound"
     end
   end
+
+  describe "#find_item_by_code" do
+    let(:codelist) { Codelist.new(type: "aid_type") }
+
+    subject { codelist.find_item_by_code("A01") }
+
+    context "when there is no key called `code` in the codelist" do
+      before do
+        allow(codelist).to receive(:list) do
+          [
+            {"foo" => "bar"},
+            {"foo" => "baz"},
+          ]
+        end
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is a key called `code` in the codelist" do
+      before do
+        allow(codelist).to receive(:list) do
+          [
+            {"code" => "A01"},
+            {"code" => "B01"},
+          ]
+        end
+      end
+
+      it { is_expected.to eq({"code" => "A01"}) }
+    end
+
+    context "when no key exists" do
+      before do
+        allow(codelist).to receive(:list) do
+          [
+            {"code" => "B01"},
+            {"code" => "C01"},
+          ]
+        end
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -231,15 +231,9 @@ module FormHelpers
       click_button t("form.button.activity.submit")
     end
 
-    if aid_type.in?(["B02", "B03", "D01"])
+    if aid_type.in?(["C01", "B03"])
       expect(page).to have_content t("form.legend.activity.fstc_applies")
       expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
-      choose("activity[fstc_applies]", option: fstc_applies)
-      click_button t("form.button.activity.submit")
-    elsif aid_type == "C01"
-      expect(page).to have_content t("form.legend.activity.fstc_applies")
-      expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
-      expect(find_field("activity-fstc-applies-true-field")).to be_checked
       choose("activity[fstc_applies]", option: fstc_applies)
       click_button t("form.button.activity.submit")
     end
@@ -351,11 +345,11 @@ module FormHelpers
     expect(page).to have_content t("activity.aid_type.#{aid_type.downcase}")
 
     within(".govuk-summary-list__row.fstc_applies") do
-      if aid_type.in?(["B02", "B03", "C01", "D01"])
+      if aid_type.in?(["B03", "C01"])
         expect(page).to have_content t("summary.label.activity.fstc_applies.#{fstc_applies}")
-      elsif aid_type.in?(["D02", "E01"])
+      elsif aid_type.in?(["D01", "D02", "E01", "E02"])
         expect(page).to have_content "Yes"
-      elsif aid_type == "G01"
+      elsif aid_type.in?(["G01", "B02"])
         expect(page).to have_content "No"
       end
     end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -233,8 +233,8 @@ module FormHelpers
 
     if aid_type.in?(["C01", "B03"])
       expect(page).to have_content t("form.legend.activity.fstc_applies")
-      expect(page.body).to include t("form.hint.activity.fstc_applies", aid_type: aid_type)
-      choose("activity[fstc_applies]", option: fstc_applies)
+      expect(page.body).to include t("form.hint.activity.fstc_applies")
+      choose("activity[fstc_applies]", option: fstc_applies ? "1" : "0")
       click_button t("form.button.activity.submit")
     end
 

--- a/vendor/data/codelists/BEIS/aid_type.yml
+++ b/vendor/data/codelists/BEIS/aid_type.yml
@@ -1,0 +1,96 @@
+---
+attributes:
+  category-codelist: AidType-category
+  name: AidType
+  complete: "1"
+data:
+  - category: B
+    code: B02
+    name: Core contributions to multilateral institutions
+    description:
+      These funds are classified as multilateral ODA (all other categories
+      fall under bilateral ODA). The recipient multilateral institution pools contributions
+      so that they lose their identity and become an integral part of its financial
+      assets. See Annex 2 of the DAC Directives for a comprehensive list of agencies
+      core contributions to which may be reported under B02 (Section I. Multilateral
+      institutions).
+    ftsc_applies: false
+  - category: B
+    code: B03
+    name:
+      Contributions to specific-purpose programmes and funds managed by international
+      organisations (multilateral, INGO)
+    description:
+      In addition to their core-funded operations, international organisations
+      set up and raise funds for specific programmes and funds with clearly identified
+      sectoral, thematic or geographical focus. Donors’ bilateral contributions to such
+      programmes and funds are recorded here, e.g. “UNICEF girls’ education”, “Education
+      For All Fast Track Initiative”, various trust funds, including for reconstruction
+      (e.g. Afghanistan Reconstruction Trust Fund).
+  - category: C
+    code: C01
+    name: Project-type interventions
+    description:
+      A project is a set of inputs, activities and outputs, agreed with the
+      partner country*, to reach specific objectives/outcomes within a defined time
+      frame, with a defined budget and a defined geographical area. Projects can vary
+      significantly in terms of objectives, complexity, amounts involved and duration.
+      There are smaller projects that might involve modest financial resources and last
+      only a few months, whereas large projects might involve more significant amounts,
+      entail successive phases and last for many years. A large project with a number
+      of different components is sometimes referred to as a programme, but should nevertheless
+      be recorded here. Feasibility studies, appraisals and evaluations are included
+      (whether designed as part of projects/programmes or dedicated funding arrangements).
+      Aid channelled through NGOs or multilaterals is also recorded here. This includes
+      payments for NGOs and multilaterals to implement donors’ projects and programmes,
+      and funding of specified NGOs projects. By contrast, core funding of NGOs and
+      multilaterals as well as contributions to specific-purpose funds managed by international
+      organisations are recorded under B. * In the cases of equity investments, humanitarian
+      aid or aid channelled through NGOs, projects are recorded here even if there was
+      no direct agreement between the donor and the partner country.
+  - category: D
+    code: D01
+    name: Donor country personnel
+    description:
+      Experts, consultants, teachers, academics, researchers, volunteers
+      and contributions to public and private bodies for sending experts to developing
+      countries.
+    ftsc_applies: true
+  - category: D
+    code: D02
+    name: Other technical assistance
+    description:
+      Provision, outside projects as described in category C01, of technical
+      assistance in recipient countries (excluding technical assistance performed by
+      donor experts reported under D01, and scholarships/training in donor country reported
+      under E01). This includes training and research; language training; south-south
+      studies; research studies; collaborative research between donor and recipient
+      universities and organisations); local scholarships; development-oriented social
+      and cultural programmes. This category also covers ad hoc contributions such as
+      conferences, seminars and workshops, exchange visits, publications, etc.
+    ftsc_applies: true
+  - category: E
+    code: E01
+    name: Scholarships/training in donor country
+    description: Financial aid awards for individual students and contributions to trainees.
+    ftsc_applies: true
+  - category: E
+    code: E02
+    name: Imputed student costs
+    description: Indirect (“imputed”) costs of tuition in donor countries.
+    ftsc_applies: true
+  - category: G
+    code: G01
+    name: Administrative costs not included elsewhere
+    description:
+      Administrative costs of development assistance programmes not already
+      included under other ODA items as an integral part of the costs of delivering
+      or implementing the aid provided. This category covers situation analyses and
+      auditing activities. As regards the salaries component of administrative costs,
+      it relates to in-house agency staff and contractors only; costs associated with
+      donor experts/consultants are to be reported under category C or D01.
+    ftsc_applies: false
+metadata:
+  url: http://www.oecd.org/dac/stats/dacandcrscodelists.htm
+  name: Aid Type
+  description: ""


### PR DESCRIPTION
This updates the logic in the `fstc_applies` question step to set it automatically in most cases based on the the Aid Type. Before we were only setting the value of `fstc_applies` in one particular case, now we can set it in virtually all cases, except in a couple where we need to ask.

We do this by creating a new BEIS Aid Type codelist which has a `ftsc_applies` value in the YAML that tells us whether to set it to true or false. If the value is not true or false, we ask.

There is also a data migration that we'll need to run that will set historical activities to the value we expect. BEIS are aware and will tell DPs this is happening. We'll also need to tell BEIS when this is done.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/119985940-33931980-bfbb-11eb-8d04-2373789047cc.png)

