### PR TITLE
(1826) organisations index page view and edit links dont run into each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,6 +669,8 @@
 
 ## [unreleased]
 
+- add spacing between view and edit links on Organisation index page
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...HEAD
 [release-52]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...release-52
 [release-51]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-50...release-51

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,12 +11,13 @@ module ApplicationHelper
     classes.join(" ")
   end
 
-  def a11y_action_link(text, href, context = "")
+  def a11y_action_link(text, href, context = "", classes = [])
+    css_classes = classes.append("govuk-link")
     if context.blank?
-      link_to(text, href, class: "govuk-link")
+      link_to(text, href, class: css_classes)
     else
       span = content_tag :span, context, class: "govuk-visually-hidden"
-      link_to("#{text} #{raw(span)}".html_safe, href, class: "govuk-link")
+      link_to("#{text} #{raw(span)}".html_safe, href, class: css_classes)
     end
   end
 

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -35,4 +35,4 @@
                     - if policy(organisation).show?
                       = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
                     - if policy(organisation).edit?
-                      = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name)
+                      = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name, ["govuk-!-margin-left-3"])

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.a11y_action_link("Edit", "pear.com", "Pear")).to eql accessible_action_link
     end
 
+    it "merges any supplied css classes" do
+      span = content_tag :span, "Pear", class: "govuk-visually-hidden"
+      accessible_action_link = link_to("Edit #{raw(span)}".html_safe, "pear.com", class: "pear govuk-link")
+      expect(helper.a11y_action_link("Edit", "pear.com", "Pear", ["pear"])).to eql accessible_action_link
+    end
+
     context "when there is no context as a third argument" do
       it "creates the link and doesn't include the span" do
         expect(helper.a11y_action_link("Edit", "pear.com", "")).to eql(link_to("Edit", "pear.com", class: "govuk-link"))


### PR DESCRIPTION
## Changes in this PR
Extended the `a11y_action_link` to allow additonal css classes to be passed in.

Then used this to pass in a standard GOVUK margin override to the link in question.

## Screenshots of UI changes

### Before

![Screenshot 2021-05-28 at 15-08-54 Organisations — Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/119996492-ba99bf00-bfc6-11eb-80bd-4e93cb1add92.png)

### After

![Screenshot 2021-05-28 at 15-08-38 Organisations — Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/119996511-bec5dc80-bfc6-11eb-9723-a97a362104f1.png)
