### PR TITLE
CSV export of all actual spend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,6 +670,7 @@
 ## [unreleased]
 
 - add spacing between view and edit links on Organisation index page
+- export complete transaction history per delivery partner for BEIS users
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...HEAD
 [release-52]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...release-52

--- a/app/controllers/concerns/stream_csv_download.rb
+++ b/app/controllers/concerns/stream_csv_download.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 module StreamCsvDownload
   extend ActiveSupport::Concern
   include ActionController::Live

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -2,16 +2,18 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
   include Secured
   include StreamCsvDownload
 
-  after_action :verify_authorized, except: [:show, :transactions]
+  before_action do
+    @organisation = Organisation.find(params[:id])
+    authorize :export, :show?
+  end
 
   def show
-    @organisation = organisation
   end
 
   def transactions
     respond_to do |format|
       format.csv do
-        activities = Activity.where(organisation: organisation)
+        activities = Activity.where(organisation: @organisation)
         export = QuarterlyTransactionExport.new(activities)
 
         stream_csv_download(filename: "transactions.csv", headers: export.headers) do |csv|
@@ -19,9 +21,5 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
         end
       end
     end
-  end
-
-  private def organisation
-    @_organisation ||= Organisation.find(params[:id])
   end
 end

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -1,0 +1,27 @@
+class Staff::Exports::OrganisationsController < Staff::BaseController
+  include Secured
+  include StreamCsvDownload
+
+  after_action :verify_authorized, except: [:show, :transactions]
+
+  def show
+    @organisation = organisation
+  end
+
+  def transactions
+    respond_to do |format|
+      format.csv do
+        activities = Activity.where(organisation: organisation)
+        export = QuarterlyTransactionExport.new(activities)
+
+        stream_csv_download(filename: "transactions.csv", headers: export.headers) do |csv|
+          export.rows.each { |row| csv << row }
+        end
+      end
+    end
+  end
+
+  private def organisation
+    @_organisation ||= Organisation.find(params[:id])
+  end
+end

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -2,6 +2,7 @@ class Staff::ExportsController < Staff::BaseController
   include Secured
 
   def index
+    authorize :export
     @organisations = policy_scope(Organisation).delivery_partner
   end
 end

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -1,0 +1,7 @@
+class Staff::ExportsController < Staff::BaseController
+  include Secured
+
+  def index
+    @organisations = policy_scope(Organisation).delivery_partner
+  end
+end

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -1,0 +1,9 @@
+class ExportPolicy < ApplicationPolicy
+  def index?
+    user.service_owner?
+  end
+
+  def show?
+    user.service_owner?
+  end
+end

--- a/app/services/quarterly_transaction_export.rb
+++ b/app/services/quarterly_transaction_export.rb
@@ -1,0 +1,57 @@
+class QuarterlyTransactionExport
+  HEADERS = [
+    "Activity RODA Identifier",
+    "Activity BEIS Identifier",
+  ]
+
+  def initialize(activities)
+    @activities = activities.to_a
+    load_transactions
+  end
+
+  def headers
+    return HEADERS if @transactions.empty?
+
+    HEADERS + financial_quarter_range.map(&:to_s)
+  end
+
+  def rows
+    @activities.map do |activity|
+      [activity.roda_identifier, activity.beis_identifier] + transaction_row(activity)
+    end
+  end
+
+  private
+
+  def transaction_row(activity)
+    return [] if @transactions.empty?
+
+    financial_quarter_range.map do |quarter|
+      value = @transactions[[activity.id, quarter]]&.value || 0
+      "%.2f" % value
+    end
+  end
+
+  def load_transactions
+    group_columns = "parent_activity_id, financial_year, financial_quarter"
+
+    txn_relation = Transaction
+      .where(parent_activity: @activities)
+      .group(group_columns)
+      .select("#{group_columns}, SUM(value) AS value")
+
+    @transactions = {}
+    @financial_quarters = Set.new
+
+    txn_relation.each do |txn|
+      key = [txn.parent_activity_id, txn.own_financial_quarter]
+      @transactions[key] = txn
+
+      @financial_quarters.add(txn.own_financial_quarter)
+    end
+  end
+
+  def financial_quarter_range
+    @_financial_quarter_range ||= Range.new(*@financial_quarters.minmax)
+  end
+end

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -12,8 +12,9 @@
       %li{ class: navigation_item_class(activities_path(organisation_id: current_user.organisation_id)) }
         = link_to t("page_title.activity.index"), activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
 
-      %li{ class: navigation_item_class(exports_path) }
-        = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"
+      - if policy(:export).index?
+        %li{ class: navigation_item_class(exports_path) }
+          = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"
 
       - if policy(Organisation).index?
         %li{ class: navigation_item_class(organisations_path) }

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -12,6 +12,9 @@
       %li{ class: navigation_item_class(activities_path(organisation_id: current_user.organisation_id)) }
         = link_to t("page_title.activity.index"), activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
 
+      %li{ class: navigation_item_class(exports_path) }
+        = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"
+
       - if policy(Organisation).index?
         %li{ class: navigation_item_class(organisations_path) }
           = link_to t("page_title.organisation.index"), organisations_path, class: "govuk-header__link"

--- a/app/views/staff/exports/index.html.haml
+++ b/app/views/staff/exports/index.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("document_title.export.index")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_title.export.index")
+
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "col"} Delivery partner
+        %tbody.govuk-table__body
+          - @organisations.each do |organisation|
+            %tr.govuk-table__row
+              %td.govuk-table__cell
+                = link_to organisation.name, exports_organisation_path(organisation), class: "govuk-link"

--- a/app/views/staff/exports/organisations/show.html.haml
+++ b/app/views/staff/exports/organisations/show.html.haml
@@ -1,0 +1,20 @@
+= content_for :page_title_prefix, @organisation.name
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = t("page_title.export.organisation.show", name: @organisation.name)
+
+  .govuk-grid-row.activity-page
+    .govuk-grid-column-full
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "col"}= t("table.export.organisation.report")
+            %th.govuk-table__header{scope: "col"}= t("table.export.organisation.actions")
+        %tbody.govuk-table__body
+          %tr.govuk-table__row
+            %td.govuk-table__cell All transactions
+            %td.govuk-table__cell
+              = link_to t("table.export.organisation.download"), transactions_exports_organisation_path(@organisation, format: "csv"), class: "govuk-link"

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -1,0 +1,16 @@
+---
+en:
+  document_title:
+    export:
+      index: Exports
+  page_title:
+    export:
+      index: Exports
+      organisation:
+        show: Exports for %{name}
+  table:
+    export:
+      organisation:
+        report: Report
+        actions: Actions
+        download: Download

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,14 @@ Rails.application.routes.draw do
       get "organisations/(:role)/new", to: "organisations#new", as: :new_organisation
     end
 
+    resources :exports, only: [:index]
+
+    namespace :exports do
+      resources :organisations, only: [:show] do
+        get "transactions", on: :member
+      end
+    end
+
     resources :organisations, except: [:destroy, :index, :new] do
       resources :activities, except: [:index, :create, :destroy] do
         get "financials" => "activity_financials#show"

--- a/script/test
+++ b/script/test
@@ -28,6 +28,9 @@ else
   echo "==> Linting our shellscripts"
   bundle exec rake shellcheck
 
+  echo "==> Running Brakeman"
+  bundle exec brakeman
+
   echo "==> Running the tests..."
 
   if [ -n "$CI" ]; then
@@ -35,7 +38,4 @@ else
   else
     bundle exec rspec
   fi
-
-  echo "==> Running Brakeman"
-  bundle exec brakeman
 fi

--- a/spec/features/staff/beis_users_can_download_exports_spec.rb
+++ b/spec/features/staff/beis_users_can_download_exports_spec.rb
@@ -1,0 +1,24 @@
+RSpec.feature "BEIS users can download exports" do
+  before do
+    authenticate! user: create(:beis_user)
+  end
+
+  scenario "downloading the transactions for a delivery partner" do
+    delivery_partner = create(:delivery_partner_organisation)
+    project = create(:project_activity, organisation: delivery_partner)
+    create(:transaction, parent_activity: project, financial_year: 2019, financial_quarter: 3, value: 150)
+
+    visit exports_path
+    click_link delivery_partner.name
+    click_link t("table.export.organisation.download")
+    document = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
+
+    expect(document).to match_array([
+      {
+        "Activity RODA Identifier" => project.roda_identifier,
+        "Activity BEIS Identifier" => project.beis_identifier,
+        "FQ3 2019-2020" => "150.00",
+      },
+    ])
+  end
+end

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ExportPolicy do
+  subject { described_class.new(user, :export) }
+
+  context "for a BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+  end
+
+  context "for a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+
+    it { is_expected.to forbid_action(:index) }
+    it { is_expected.to forbid_action(:show) }
+  end
+end

--- a/spec/services/quarterly_transaction_export_spec.rb
+++ b/spec/services/quarterly_transaction_export_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe QuarterlyTransactionExport do
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+  let(:activities) { Activity.where(organisation: delivery_partner) }
+  let(:export) { QuarterlyTransactionExport.new(activities) }
+
+  let :quarter_headers do
+    export.headers.drop(2)
+  end
+
+  let :transaction_data do
+    export.rows.map { |row| row.take(1) + row.drop(2) }
+  end
+
+  it "exports an empty data set" do
+    project = create(:project_activity, organisation: delivery_partner)
+
+    expect(quarter_headers).to eq []
+
+    expect(transaction_data).to eq([
+      [project.roda_identifier],
+    ])
+  end
+
+  it "exports one quarter of spend for a single project" do
+    project = create(:project_activity, organisation: delivery_partner)
+
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 1, value: 10)
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 1, value: 20)
+
+    expect(quarter_headers).to eq ["FQ1 2014-2015"]
+
+    expect(transaction_data).to eq([
+      [project.roda_identifier, "30.00"],
+    ])
+  end
+
+  it "exports two quarters of spend for a single project with zeros for intervening quarters" do
+    project = create(:project_activity, organisation: delivery_partner)
+
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 1, value: 10)
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 4, value: 20)
+
+    expect(quarter_headers).to eq ["FQ1 2014-2015", "FQ2 2014-2015", "FQ3 2014-2015", "FQ4 2014-2015"]
+
+    expect(transaction_data).to eq([
+      [project.roda_identifier, "10.00", "0.00", "0.00", "20.00"],
+    ])
+  end
+
+  it "exports actual spend for two activities across different quarters" do
+    project = create(:project_activity, organisation: delivery_partner)
+    third_party_project = create(:third_party_project_activity, organisation: delivery_partner)
+
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 1, value: 10)
+    create(:transaction, parent_activity: third_party_project, financial_year: 2015, financial_quarter: 2, value: 20)
+
+    expect(quarter_headers).to eq ["FQ1 2014-2015", "FQ2 2014-2015", "FQ3 2014-2015", "FQ4 2014-2015", "FQ1 2015-2016", "FQ2 2015-2016"]
+
+    expect(transaction_data).to eq([
+      [project.roda_identifier, "10.00", "0.00", "0.00", "0.00", "0.00", "0.00"],
+      [third_party_project.roda_identifier, "0.00", "0.00", "0.00", "0.00", "0.00", "20.00"],
+    ])
+  end
+
+  it "includes activities that do not have any transactions recorded" do
+    project = create(:project_activity, organisation: delivery_partner)
+    third_party_project = create(:third_party_project_activity, organisation: delivery_partner)
+
+    create(:transaction, parent_activity: project, financial_year: 2014, financial_quarter: 1, value: 10)
+
+    expect(quarter_headers).to eq ["FQ1 2014-2015"]
+
+    expect(transaction_data).to eq([
+      [project.roda_identifier, "10.00"],
+      [third_party_project.roda_identifier, "0.00"],
+    ])
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This adds the ability for BEIS users to download all the transactions for each delivery partner as a CSV file that lists all the partner's activities with their total spending by quarter.

The main points of note here are that we probably want to iterate the design here -- do we want this split up by delivery partner, or should we have one big download? Do we need it more granular and split up by fund, etc.

The permissions here are very coarse, I've just limited this to only BEIS users. I'd expect this to change as iterating the design would probably mean changing the routes/resources/controllers we have here so I didn't want to get too into modelling permissions over those until we've a better idea of what we really want.

## Screenshots of UI changes

All these changes are only visible to BEIS users. A new item is added to the top-level navigation:

<img width="570" alt="Screenshot 2021-05-28 at 16 26 15" src="https://user-images.githubusercontent.com/9265/120007329-b32be300-bfd1-11eb-822e-1f1d5fd05f01.png">

This links to a list of all delivery partner organisations:

<img width="1139" alt="Screenshot 2021-05-28 at 16 26 39" src="https://user-images.githubusercontent.com/9265/120007335-b45d1000-bfd1-11eb-9bdd-a57d6ed005fa.png">

Each organisation links through to a list of exports for that organisation:

<img width="1135" alt="Screenshot 2021-05-28 at 16 26 58" src="https://user-images.githubusercontent.com/9265/120007340-b4f5a680-bfd1-11eb-8335-0de775b58620.png">

Clicking "Download" provides the user with a CSV file containing all the transaction totals per quarter for all that organisation's activities. All activities are included even if they have no spend in any of the listed quarters. The set of quarter columns covers every quarter from the earliest to the most recent transaction in the set.

<img width="444" alt="Screenshot 2021-05-28 at 16 27 24" src="https://user-images.githubusercontent.com/9265/120007343-b58e3d00-bfd1-11eb-8d81-2fc514605c28.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
