### PR TITLE
(1848) Change the email address given in email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -671,6 +671,7 @@
 
 - add spacing between view and edit links on Organisation index page
 - export complete transaction history per delivery partner for BEIS users
+- Change the email address given in email notifications
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...HEAD
 [release-52]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...release-52

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  SUPPORT_EMAIL_ADDRESS = "support@beisodahelp.zendesk.com"
+
   def l(object, options = {})
     super(object, options) if object
   end
@@ -23,5 +25,9 @@ module ApplicationHelper
 
   def link_to_new_tab(text, href, css_class: "govuk-link")
     link_to("#{text} (opens in new tab)", href, class: css_class, target: "_blank", rel: "noreferrer noopener")
+  end
+
+  def support_email_link
+    mail_to(SUPPORT_EMAIL_ADDRESS, nil, class: "govuk-link")
   end
 end

--- a/app/views/pages/accessibility_statement.html.haml
+++ b/app/views/pages/accessibility_statement.html.haml
@@ -27,7 +27,8 @@
       %h2.govuk-heading-m
         What to do if you can’t access parts of this service
       %p.govuk-body
-        If you need information for this service in a different format or cannot use the service and would like to report an accessibility problem, contact us at <a href="mailto:support@beisodahelp.zendesk.com" class="govuk-link">support@beisodahelp.zendesk.com</a>
+        If you need information for this service in a different format or cannot use the service and would like to report an accessibility problem, contact us at
+        = support_email_link
       %p.govuk-body
         We’ll consider your request and get back to you in 5 days.
       %h2.govuk-heading-m

--- a/app/views/pages/accessibility_statement.html.haml
+++ b/app/views/pages/accessibility_statement.html.haml
@@ -27,7 +27,7 @@
       %h2.govuk-heading-m
         What to do if you can’t access parts of this service
       %p.govuk-body
-        If you need information for this service in a different format or cannot use the service and would like to report an accessibility problem, contact us at <a href="mailto:RODAsupport@odamanagement.org" class="govuk-link">RODAsupport@odamanagement.org</a>
+        If you need information for this service in a different format or cannot use the service and would like to report an accessibility problem, contact us at <a href="mailto:support@beisodahelp.zendesk.com" class="govuk-link">support@beisodahelp.zendesk.com</a>
       %p.govuk-body
         We’ll consider your request and get back to you in 5 days.
       %h2.govuk-heading-m

--- a/app/views/pages/terms_of_service.html.haml
+++ b/app/views/pages/terms_of_service.html.haml
@@ -29,7 +29,7 @@
         This Service is operated by
         = link_to "the Department for Business, Energy and Industrial Strategy", "https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy", class: "govuk-link"
         ('we', 'our', or 'us'). You can contact us using the following email address:
-        = link_to "RODAsupport@odamanagement.org", "mailto:RODAsupport@odamanagement.org", class: "govuk-link"
+        = link_to "support@beisodahelp.zendesk.com", "mailto:support@beisodahelp.zendesk.com", class: "govuk-link"
 
       %h3.govuk-heading-s
         Validity of these General Terms
@@ -68,7 +68,7 @@
 
       %p.govuk-body
         If you know or suspect that anyone other than you knows your user identification code or password, you must promptly notify us at
-        = link_to "RODAsupport@odamanagement.org", "mailto:RODAsupport@odamanagement.org", class: "govuk-link"
+        = link_to "support@beisodahelp.zendesk.com", "mailto:support@beisodahelp.zendesk.com", class: "govuk-link"
 
       %p.govuk-body
         We reserve the right to restrict or deny you access to all or some parts of the Service if, in our opinion, you have failed to comply with these General Terms.

--- a/app/views/pages/terms_of_service.html.haml
+++ b/app/views/pages/terms_of_service.html.haml
@@ -29,7 +29,7 @@
         This Service is operated by
         = link_to "the Department for Business, Energy and Industrial Strategy", "https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy", class: "govuk-link"
         ('we', 'our', or 'us'). You can contact us using the following email address:
-        = link_to "support@beisodahelp.zendesk.com", "mailto:support@beisodahelp.zendesk.com", class: "govuk-link"
+        = support_email_link
 
       %h3.govuk-heading-s
         Validity of these General Terms
@@ -68,7 +68,8 @@
 
       %p.govuk-body
         If you know or suspect that anyone other than you knows your user identification code or password, you must promptly notify us at
-        = link_to "support@beisodahelp.zendesk.com", "mailto:support@beisodahelp.zendesk.com", class: "govuk-link"
+        = support_email_link
+
 
       %p.govuk-body
         We reserve the right to restrict or deny you access to all or some parts of the Service if, in our opinion, you have failed to comply with these General Terms.

--- a/app/views/report_mailer/_footer.text.erb
+++ b/app/views/report_mailer/_footer.text.erb
@@ -2,7 +2,7 @@
 
 If you need assistance please contact RODA support at:
 
-support@beisodahelp.zendesk.com
+<%= ApplicationHelper::SUPPORT_EMAIL_ADDRESS %>
 
 Or visit the BEIS ODA Help centre:
 

--- a/app/views/report_mailer/_footer.text.erb
+++ b/app/views/report_mailer/_footer.text.erb
@@ -2,7 +2,7 @@
 
 If you need assistance please contact RODA support at:
 
-RODAsupport@odamanagement.org
+support@beisodahelp.zendesk.com
 
 Or visit the BEIS ODA Help centre:
 

--- a/app/views/shared/_help_and_support.html.haml
+++ b/app/views/shared/_help_and_support.html.haml
@@ -6,4 +6,4 @@
       If you have any questions or have any problems, please contact the RODA support team
 
     %p.govuk-body
-      = mail_to "support@beisodahelp.zendesk.com", "support@beisodahelp.zendesk.com", class: "govuk-link"
+      = support_email_link

--- a/app/views/shared/_help_and_support.html.haml
+++ b/app/views/shared/_help_and_support.html.haml
@@ -6,4 +6,4 @@
       If you have any questions or have any problems, please contact the RODA support team
 
     %p.govuk-body
-      = mail_to "RODAsupport@odamanagement.org", "RODAsupport@odamanagement.org", class: "govuk-link"
+      = mail_to "support@beisodahelp.zendesk.com", "support@beisodahelp.zendesk.com", class: "govuk-link"


### PR DESCRIPTION
This replaces all the mentions of the old support email (RODAsupport@odamanagement.org) with the new one (support@beisodahelp.zendesk.com), and adds a helper the generate a link to the support email.