### PR TITLE
(1774) Allow users to add, edit and delete external income on activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -675,6 +675,8 @@
 
 ## [unreleased]
 
+- Allow users to add, edit and delete external income on activities
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...HEAD
 [release-53]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...release-53
 [release-52]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-51...release-52

--- a/app/controllers/staff/activity_other_funding_controller.rb
+++ b/app/controllers/staff/activity_other_funding_controller.rb
@@ -8,5 +8,6 @@ class Staff::ActivityOtherFundingController < Staff::BaseController
     authorize @activity
 
     @matched_efforts = @activity.matched_efforts.map { |e| MatchedEffortPresenter.new(e) }
+    @external_incomes = @activity.external_incomes.map { |e| ExternalIncomePresenter.new(e) }
   end
 end

--- a/app/controllers/staff/external_incomes_controller.rb
+++ b/app/controllers/staff/external_incomes_controller.rb
@@ -49,6 +49,19 @@ class Staff::ExternalIncomesController < Staff::BaseController
     end
   end
 
+  def destroy
+    @activity = Activity.find(params[:activity_id])
+    @external_income = ExternalIncome.find(params[:id])
+
+    authorize @external_income
+
+    @external_income.create_activity key: "external_income.destroy", owner: current_user
+    @external_income.destroy
+
+    flash[:notice] = t("action.external_income.destroy.success")
+    redirect_to organisation_activity_other_funding_path(@activity.organisation, @activity)
+  end
+
   private
 
   def external_income_params

--- a/app/controllers/staff/external_incomes_controller.rb
+++ b/app/controllers/staff/external_incomes_controller.rb
@@ -23,6 +23,32 @@ class Staff::ExternalIncomesController < Staff::BaseController
     end
   end
 
+  def edit
+    @activity = Activity.find(params[:activity_id])
+    @external_income = ExternalIncome.find(params[:id])
+
+    authorize @external_income
+  end
+
+  def update
+    @activity = Activity.find(params[:activity_id])
+    @external_income = ExternalIncome.find(params[:id])
+
+    authorize @external_income
+
+    @external_income.assign_attributes(external_income_params)
+
+    if @external_income.valid?
+      @external_income.save
+      @external_income.create_activity key: "external_income.update", owner: current_user
+
+      flash[:notice] = t("action.external_income.update.success")
+      redirect_to organisation_activity_other_funding_path(@activity.organisation, @activity)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def external_income_params

--- a/app/controllers/staff/external_incomes_controller.rb
+++ b/app/controllers/staff/external_incomes_controller.rb
@@ -1,0 +1,38 @@
+class Staff::ExternalIncomesController < Staff::BaseController
+  def new
+    @activity = Activity.find(params[:activity_id])
+    @external_income = ExternalIncome.new
+
+    authorize @activity
+  end
+
+  def create
+    @activity = Activity.find(params[:activity_id])
+    @external_income = ExternalIncome.new(external_income_params)
+
+    authorize @external_income
+
+    if @external_income.valid?
+      @external_income.save
+      @external_income.create_activity key: "external_income.create", owner: current_user
+
+      flash[:notice] = t("action.external_income.create.success")
+      redirect_to organisation_activity_other_funding_path(@activity.organisation, @activity)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def external_income_params
+    params.require(:external_income).permit(
+      :activity_id,
+      :organisation_id,
+      :amount,
+      :financial_quarter,
+      :financial_year,
+      :oda_funding,
+    )
+  end
+end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -11,6 +11,13 @@ module FormHelper
     ].flatten
   end
 
+  def list_of_external_income_providers
+    @list_of_external_income_providers ||= [
+      OpenStruct.new(name: "", id: ""),
+      Organisation.external_income_providers.active,
+    ].flatten
+  end
+
   def list_of_delivery_partners
     @list_of_delivery_partners ||= Organisation.delivery_partners
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -151,6 +151,7 @@ class Activity < ApplicationRecord
 
   has_many :comments
   has_many :matched_efforts
+  has_many :external_incomes
 
   enum level: {
     fund: "fund",

--- a/app/models/external_income.rb
+++ b/app/models/external_income.rb
@@ -4,4 +4,6 @@ class ExternalIncome < ApplicationRecord
 
   belongs_to :organisation
   belongs_to :activity
+
+  validates_presence_of :organisation_id, :financial_quarter, :financial_year, :amount
 end

--- a/app/models/external_income.rb
+++ b/app/models/external_income.rb
@@ -1,0 +1,6 @@
+class ExternalIncome < ApplicationRecord
+  include PublicActivity::Common
+
+  belongs_to :organisation
+  belongs_to :activity
+end

--- a/app/models/external_income.rb
+++ b/app/models/external_income.rb
@@ -1,5 +1,6 @@
 class ExternalIncome < ApplicationRecord
   include PublicActivity::Common
+  include HasFinancialQuarter
 
   belongs_to :organisation
   belongs_to :activity

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -32,6 +32,7 @@ class Organisation < ApplicationRecord
   scope :sorted_by_name, -> { order(name: :asc) }
   scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
   scope :matched_effort_providers, -> { sorted_by_name.where(role: "matched_effort_provider") }
+  scope :external_income_providers, -> { sorted_by_name.where(role: "external_income_provider") }
   scope :active, -> { where(active: true) }
 
   before_validation :ensure_beis_organisation_reference_is_uppercase

--- a/app/policies/external_income_policy.rb
+++ b/app/policies/external_income_policy.rb
@@ -1,0 +1,13 @@
+class ExternalIncomePolicy < ApplicationPolicy
+  def create?
+    Pundit.policy(user, record.activity).update?
+  end
+
+  def update?
+    create?
+  end
+
+  def destroy?
+    update?
+  end
+end

--- a/app/presenters/external_income_presenter.rb
+++ b/app/presenters/external_income_presenter.rb
@@ -1,0 +1,9 @@
+class ExternalIncomePresenter < SimpleDelegator
+  def amount
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+
+  def oda_funding
+    super ? "Yes" : "No"
+  end
+end

--- a/app/views/staff/activity_other_funding/show.html.haml
+++ b/app/views/staff/activity_other_funding/show.html.haml
@@ -27,5 +27,8 @@
           %h3.govuk-heading-m
             = t("page_title.external_income.index")
 
+          - if policy(@activity).create?
+            = link_to(t("page_content.external_income.button.create"), new_activity_external_income_path(@activity), class: "govuk-button")
+
           - if @external_incomes.present?
             = render partial: "staff/shared/external_income/table", locals: { external_incomes: @external_incomes }

--- a/app/views/staff/activity_other_funding/show.html.haml
+++ b/app/views/staff/activity_other_funding/show.html.haml
@@ -23,3 +23,9 @@
 
           - if @matched_efforts.present?
             = render partial: "staff/shared/matched_effort/table", locals: { matched_efforts: @matched_efforts }
+
+          %h3.govuk-heading-m
+            = t("page_title.external_income.index")
+
+          - if @external_incomes.present?
+            = render partial: "staff/shared/external_income/table", locals: { external_incomes: @external_incomes }

--- a/app/views/staff/external_incomes/_form.html.haml
+++ b/app/views/staff/external_incomes/_form.html.haml
@@ -1,0 +1,41 @@
+= form_with model: external_income, url: path do |f|
+  = f.hidden_field :activity_id, value: @activity.id
+  = f.govuk_fieldset legend: { text: nil } do
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        = f.govuk_collection_radio_buttons :financial_quarter,
+          list_of_financial_quarters,
+          :id,
+          :name,
+          inline: true,
+          legend: { text: "Financial quarter" }
+      .govuk-grid-column-one-third
+        = f.govuk_collection_select :financial_year,
+          list_of_financial_years,
+          :id,
+          :name,
+          label: { text: "Financial year", tag: :h2, size: "m" }
+
+  = f.govuk_collection_select :organisation_id,
+    list_of_external_income_providers,
+    :id,
+    :name,
+    { include_blank: true }
+
+  = f.govuk_text_field :amount, width: 10, prefix_text: '£'
+
+  = f.govuk_check_box :oda_funding,
+    true,
+    0,
+    multiple: false,
+    link_errors: true,
+    label: { text: "Funding is Official Development Assistance (ODA)" }
+
+  %div{class: "govuk-!-margin-top-7"}
+    = f.govuk_submit t("default.button.submit")
+
+    - if action_name == "new"
+      = link_to t("form.link.activity.back"), organisation_activity_other_funding_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"
+    - if action_name == "edit"
+      = link_to t("default.button.delete"), activity_external_income_path(@activity, @external_income), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this matched effort?" }
+

--- a/app/views/staff/external_incomes/edit.html.haml
+++ b/app/views/staff/external_incomes/edit.html.haml
@@ -1,0 +1,10 @@
+= content_for :page_title_prefix, t("page_title.external_income.edit")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.external_income.edit")
+
+      = render partial: "form", locals: { activity: @activity, external_income: @external_income, path: activity_external_income_path(@activity, @external_income) }
+

--- a/app/views/staff/external_incomes/new.html.haml
+++ b/app/views/staff/external_incomes/new.html.haml
@@ -1,0 +1,11 @@
+= content_for :page_title_prefix, t("page_title.external_income.new")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.external_income.new")
+
+      = render partial: "form", locals: { activity: @activity, external_income: @external_income, path: activity_external_incomes_path(@activity) }
+
+

--- a/app/views/staff/matched_efforts/edit.html.haml
+++ b/app/views/staff/matched_efforts/edit.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title_prefix, t("page_title.matched_effort.new")
+= content_for :page_title_prefix, t("page_title.matched_effort.edit")
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row

--- a/app/views/staff/shared/external_income/_table.html.haml
+++ b/app/views/staff/shared/external_income/_table.html.haml
@@ -19,3 +19,4 @@
         %td.govuk-table__cell= external_income.oda_funding
         %td.govuk-table__cell= external_income.amount
         %td.govuk-table__cell
+          = link_to t("default.link.edit"), edit_activity_external_income_path(@activity, external_income), class: "govuk-link"

--- a/app/views/staff/shared/external_income/_table.html.haml
+++ b/app/views/staff/shared/external_income/_table.html.haml
@@ -1,0 +1,21 @@
+%table.govuk-table.implementing_organisations
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("table.header.external_income.financial_quarter")
+      %th.govuk-table__header
+        =t("table.header.external_income.providing_organisation")
+      %th.govuk-table__header
+        =t("table.header.external_income.oda_funding")
+      %th.govuk-table__header
+        =t("table.header.matched_effort.amount")
+      %th.govuk-table__header
+
+  %tbody.govuk-table__body
+    - external_incomes.each do |external_income|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= external_income.financial_quarter_and_year
+        %td.govuk-table__cell= external_income.organisation.name
+        %td.govuk-table__cell= external_income.oda_funding
+        %td.govuk-table__cell= external_income.amount
+        %td.govuk-table__cell

--- a/config/locales/models/external_income.en.yml
+++ b/config/locales/models/external_income.en.yml
@@ -1,0 +1,30 @@
+---
+en:
+  page_title:
+    external_income:
+      index: External income
+      new: Add new external income
+      edit: Edit an external income
+  table:
+    header:
+      external_income:
+        providing_organisation: Providing organisation
+        financial_quarter: Financial quarter
+        oda_funding: Official development assistance
+        amount: Amount
+  form:
+    label:
+      external_income:
+        organisation_id: Providing organisation
+  page_content:
+    external_income:
+      button:
+        create: Add external income
+  action:
+    external_income:
+      create:
+        success: The external income has been successfully created
+      update:
+        success: The external income has been successfully updated
+      destroy:
+        success: The external income has been successfully deleted

--- a/config/locales/models/matched_effort.en.yml
+++ b/config/locales/models/matched_effort.en.yml
@@ -14,21 +14,12 @@ en:
       index: Matched effort
       new: Add new matched effort
       edit: Edit a matched effort
-    external_income:
-      index: External income
-      new: Add new external income
-      edit: Edit a external income
   table:
     header:
       matched_effort:
         providing_organisation: Providing organisation
         funding_type: Funding type
         category: Category
-        amount: Amount
-      external_income:
-        providing_organisation: Providing organisation
-        financial_quarter: Financial quarter
-        oda_funding: Official development assistance
         amount: Amount
   form:
     legend:
@@ -50,9 +41,6 @@ en:
     matched_effort:
       button:
         create: Add matched effort
-    external_income:
-      button:
-        create: Add external income
   action:
     matched_effort:
       create:
@@ -61,10 +49,3 @@ en:
         success: The matched effort has been successfully updated
       destroy:
         success: The matched effort has been successfully deleted
-    external_income:
-      create:
-        success: The external income has been successfully created
-      update:
-        success: The external income has been successfully updated
-      destroy:
-        success: The external income has been successfully deleted

--- a/config/locales/models/matched_effort.en.yml
+++ b/config/locales/models/matched_effort.en.yml
@@ -61,3 +61,10 @@ en:
         success: The matched effort has been successfully updated
       destroy:
         success: The matched effort has been successfully deleted
+    external_income:
+      create:
+        success: The external income has been successfully created
+      update:
+        success: The external income has been successfully updated
+      destroy:
+        success: The external income has been successfully deleted

--- a/config/locales/models/matched_effort.en.yml
+++ b/config/locales/models/matched_effort.en.yml
@@ -14,12 +14,21 @@ en:
       index: Matched effort
       new: Add new matched effort
       edit: Edit a matched effort
+    external_income:
+      index: External income
+      new: Add new external income
+      edit: Edit a external income
   table:
     header:
       matched_effort:
         providing_organisation: Providing organisation
         funding_type: Funding type
         category: Category
+        amount: Amount
+      external_income:
+        providing_organisation: Providing organisation
+        financial_quarter: Financial quarter
+        oda_funding: Official development assistance
         amount: Amount
   form:
     legend:
@@ -41,6 +50,9 @@ en:
     matched_effort:
       button:
         create: Add matched effort
+    external_income:
+      button:
+        create: Add external income
   action:
     matched_effort:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,11 @@ Rails.application.routes.draw do
       resources :matched_efforts
     end
 
-    resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable, :matched_effortable] do
+    concern :external_incomeable do
+      resources :external_incomes, only: [:new, :create]
+    end
+
+    resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable, :matched_effortable, :external_incomeable] do
       resource :redaction, only: [:edit, :update], controller: :activity_redactions
       resources :steps, controller: "activity_forms"
       resources :implementing_organisations, only: [:new, :create, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
     end
 
     concern :external_incomeable do
-      resources :external_incomes, only: [:new, :create]
+      resources :external_incomes, only: [:new, :create, :edit, :update]
     end
 
     resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable, :matched_effortable, :external_incomeable] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
     end
 
     concern :external_incomeable do
-      resources :external_incomes, only: [:new, :create, :edit, :update]
+      resources :external_incomes, only: [:new, :create, :edit, :update, :destroy]
     end
 
     resources :activities, only: [], concerns: [:transactionable, :budgetable, :disbursement_plannable, :matched_effortable, :external_incomeable] do

--- a/db/migrate/20210527130555_add_external_income.rb
+++ b/db/migrate/20210527130555_add_external_income.rb
@@ -1,0 +1,14 @@
+class AddExternalIncome < ActiveRecord::Migration[6.1]
+  def change
+    create_table :external_incomes, id: :uuid do |t|
+      t.belongs_to :activity, type: :uuid
+      t.belongs_to :organisation, type: :uuid
+      t.decimal :amount, precision: 13, scale: 2
+      t.integer :financial_quarter
+      t.integer :financial_year
+      t.boolean :oda_funding
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_134602) do
+ActiveRecord::Schema.define(version: 2021_05_27_130555) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -133,6 +134,19 @@ ActiveRecord::Schema.define(version: 2021_05_20_134602) do
     t.index ["activity_id"], name: "index_comments_on_activity_id"
     t.index ["owner_id"], name: "index_comments_on_owner_id"
     t.index ["report_id"], name: "index_comments_on_report_id"
+  end
+
+  create_table "external_incomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "activity_id"
+    t.uuid "organisation_id"
+    t.decimal "amount", precision: 13, scale: 2
+    t.integer "financial_quarter"
+    t.integer "financial_year"
+    t.boolean "oda_funding"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_external_incomes_on_activity_id"
+    t.index ["organisation_id"], name: "index_external_incomes_on_organisation_id"
   end
 
   create_table "implementing_organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/external_income.rb
+++ b/spec/factories/external_income.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :external_income do
+    amount { 1100.00 }
+    financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
+    financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
+    oda_funding { true }
+
+    association :activity, factory: :project_activity
+    association :organisation, factory: :external_income_provider
+  end
+end

--- a/spec/features/staff/users_can_create_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_create_an_external_income_spec.rb
@@ -54,5 +54,13 @@ RSpec.describe "Users can create a external income" do
         expect(auditable_event.owner_id).to eq user.id
       end
     end
+
+    scenario "they are shown errors when required fields are left blank" do
+      click_on t("default.button.submit")
+
+      expect(page).to have_content("Organisation can't be blank")
+      expect(page).to have_content("Financial quarter can't be blank")
+      expect(page).to have_content("Amount can't be blank")
+    end
   end
 end

--- a/spec/features/staff/users_can_create_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_create_an_external_income_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe "Users can create a external income" do
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    let(:programme) { create(:programme_activity, extending_organisation: user.organisation) }
+
+    let!(:project) { create(:project_activity, :with_report, organisation: user.organisation, parent: programme) }
+    let!(:external_income_provider) { create(:external_income_provider) }
+
+    before { authenticate!(user: user) }
+
+    before do
+      visit organisation_activity_path(project.organisation, project)
+
+      click_on "Other funding"
+      click_on t("page_content.external_income.button.create")
+    end
+
+    scenario "they can add an external income" do
+      template = build(:external_income,
+        organisation: external_income_provider,
+        amount: "2345",
+        financial_quarter: 1,
+        financial_year: 2021,
+        oda_funding: true)
+
+      fill_in_external_income_form(template)
+
+      expect(page).to have_content(t("action.external_income.create.success"))
+
+      external_income = ExternalIncome.order("created_at ASC").last
+
+      expect(external_income.organisation).to eq(external_income_provider)
+      expect(external_income.financial_quarter).to eq(1)
+      expect(external_income.financial_year).to eq(2021)
+      expect(external_income.amount).to eq(2345.00)
+      expect(external_income.oda_funding).to eq(true)
+
+      within("table.implementing_organisations") do
+        expect(page).to have_content(external_income_provider.name)
+        expect(page).to have_content("FQ1 2021-2022")
+        expect(page).to have_content("£2,345.00")
+        expect(page).to have_content("Yes")
+      end
+    end
+
+    scenario "creation is tracked with PublicActivity" do
+      template = build(:external_income, organisation: external_income_provider)
+
+      PublicActivity.with_tracking do
+        fill_in_external_income_form(template)
+
+        auditable_event = PublicActivity::Activity.last
+        expect(auditable_event.key).to eq "external_income.create"
+        expect(auditable_event.owner_id).to eq user.id
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_edit_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_edit_an_external_income_spec.rb
@@ -47,5 +47,19 @@ RSpec.describe "Users can edit an external income" do
 
       expect(page).to have_content("Organisation can't be blank")
     end
+
+    scenario "they can delete an external income" do
+      PublicActivity.with_tracking do
+        expect {
+          click_on t("default.button.delete")
+        }.to change { ExternalIncome.count }.by(-1)
+
+        expect(page).to have_content(t("action.external_income.destroy.success"))
+
+        auditable_event = PublicActivity::Activity.last
+        expect(auditable_event.key).to eq "external_income.destroy"
+        expect(auditable_event.owner_id).to eq user.id
+      end
+    end
   end
 end

--- a/spec/features/staff/users_can_edit_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_edit_an_external_income_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Users can edit an external income" do
+  context "when signed in as a delivery partner" do
+    let(:user) { create(:delivery_partner_user) }
+    let(:programme) { create(:programme_activity, extending_organisation: user.organisation) }
+
+    let!(:project) { create(:project_activity, :with_report, organisation: user.organisation, parent: programme) }
+    let!(:external_income_provider) { create(:external_income_provider) }
+    let!(:external_income) { create(:external_income, activity: project, financial_quarter: 1, oda_funding: true) }
+
+    before { authenticate!(user: user) }
+
+    before do
+      visit organisation_activity_path(project.organisation, project)
+      click_on "Other funding"
+      find("a[href='#{edit_activity_external_income_path(project, external_income)}']").click
+    end
+
+    scenario "they can edit a matched effort" do
+      external_income.organisation = external_income_provider
+      external_income.financial_quarter = 4
+      external_income.oda_funding = false
+
+      fill_in_external_income_form(external_income)
+
+      expect(page).to have_content(t("action.external_income.update.success"))
+
+      expect(external_income.reload.organisation).to eq(external_income_provider)
+      expect(external_income.financial_quarter).to eq(4)
+      expect(external_income.oda_funding).to eq(false)
+    end
+
+    scenario "updating is tracked with PublicActivity" do
+      PublicActivity.with_tracking do
+        fill_in_external_income_form(external_income)
+
+        auditable_event = PublicActivity::Activity.last
+        expect(auditable_event.key).to eq "external_income.update"
+        expect(auditable_event.owner_id).to eq user.id
+      end
+    end
+
+    scenario "they see errors when a required field is missing" do
+      select("", from: "external_income[organisation_id]")
+      click_on t("default.button.submit")
+
+      expect(page).to_not have_content(t("action.external_income.update.success"))
+
+      expect(page).to have_content("Organisation can't be blank")
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
@@ -1,12 +1,12 @@
 RSpec.feature "Users can view an activity's other funding" do
   let(:user) { create(:delivery_partner_user) }
-  let(:organisation) { create(:matched_effort_provider) }
+  let(:matched_effort_provider) { create(:matched_effort_provider) }
   let!(:activity) { create(:project_activity, organisation: user.organisation) }
 
   let!(:matched_effort) do
     create(:matched_effort,
       activity: activity,
-      organisation: organisation,
+      organisation: matched_effort_provider,
       funding_type: "in_kind",
       category: "staff_time",
       committed_amount: 200_000)
@@ -19,7 +19,7 @@ RSpec.feature "Users can view an activity's other funding" do
       visit organisation_activity_path(activity.organisation, activity)
       click_on t("tabs.activity.other_funding")
 
-      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(matched_effort_provider.name)
       expect(page).to have_content("In kind")
       expect(page).to have_content("Staff time")
       expect(page).to have_content("£200,000.00")
@@ -35,7 +35,7 @@ RSpec.feature "Users can view an activity's other funding" do
       visit organisation_activity_path(activity.organisation, activity)
       click_on t("tabs.activity.other_funding")
 
-      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(matched_effort_provider.name)
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.feature "Users can view an activity's other funding" do
     it "does not allow the user to view the funding" do
       visit organisation_activity_other_funding_path(activity.organisation, activity)
 
-      expect(page).to_not have_content(organisation.name)
+      expect(page).to_not have_content(matched_effort_provider.name)
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
@@ -1,6 +1,7 @@
 RSpec.feature "Users can view an activity's other funding" do
   let(:user) { create(:delivery_partner_user) }
   let(:matched_effort_provider) { create(:matched_effort_provider) }
+  let(:external_income_provider) { create(:external_income_provider) }
   let!(:activity) { create(:project_activity, organisation: user.organisation) }
 
   let!(:matched_effort) do
@@ -10,6 +11,15 @@ RSpec.feature "Users can view an activity's other funding" do
       funding_type: "in_kind",
       category: "staff_time",
       committed_amount: 200_000)
+  end
+
+  let!(:external_income) do
+    create(:external_income,
+      activity: activity,
+      organisation: external_income_provider,
+      financial_quarter: 1,
+      financial_year: 2021,
+      amount: 150_000)
   end
 
   context "when the user is signed in as a delivery partner" do
@@ -24,6 +34,15 @@ RSpec.feature "Users can view an activity's other funding" do
       expect(page).to have_content("Staff time")
       expect(page).to have_content("£200,000.00")
     end
+
+    it "lists the external incomes" do
+      visit organisation_activity_path(activity.organisation, activity)
+      click_on t("tabs.activity.other_funding")
+
+      expect(page).to have_content(external_income_provider.name)
+      expect(page).to have_content("Q1 2021-2022")
+      expect(page).to have_content("£150,000.00")
+    end
   end
 
   context "when the user is signed in as a BEIS user" do
@@ -37,6 +56,13 @@ RSpec.feature "Users can view an activity's other funding" do
 
       expect(page).to have_content(matched_effort_provider.name)
     end
+
+    it "lists the external incomes" do
+      visit organisation_activity_path(activity.organisation, activity)
+      click_on t("tabs.activity.other_funding")
+
+      expect(page).to have_content(external_income_provider.name)
+    end
   end
 
   context "when the user is not a member of the activity's organisation" do
@@ -46,6 +72,7 @@ RSpec.feature "Users can view an activity's other funding" do
       visit organisation_activity_other_funding_path(activity.organisation, activity)
 
       expect(page).to_not have_content(matched_effort_provider.name)
+      expect(page).to_not have_content(external_income_provider.name)
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -807,6 +807,7 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:source_transfers) }
     it { should have_many(:destination_transfers) }
     it { should have_many(:matched_efforts) }
+    it { should have_many(:external_incomes) }
   end
 
   describe "#parent_activities" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -154,6 +154,15 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
+  describe ".external_income_providers" do
+    it "should contain only organisations that are external income providers" do
+      create_list(:delivery_partner_organisation, 3)
+      matched_effort_providers = create_list(:matched_effort_provider, 2)
+
+      expect(Organisation.matched_effort_providers).to match_array(matched_effort_providers)
+    end
+  end
+
   describe ".active" do
     it "should contain only active organisations" do
       create_list(:delivery_partner_organisation, 3, active: false)

--- a/spec/policies/external_income_policy_spec.rb
+++ b/spec/policies/external_income_policy_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe ExternalIncomePolicy do
+  subject { described_class.new(user, external_income) }
+
+  let!(:report) { create(:report, organisation: user.organisation, fund: activity.associated_fund, state: :approved) }
+  let(:external_income) { build_stubbed(:external_income, activity: activity) }
+
+  context "as a user that belongs to BEIS" do
+    let(:user) { build_stubbed(:beis_user) }
+
+    context "when the activity is a programme activity owned by the organisation" do
+      let(:activity) { build_stubbed(:programme_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:create) }
+      it { is_expected.to permit_action(:update) }
+      it { is_expected.to permit_action(:destroy) }
+    end
+
+    context "when the activity is a project activity" do
+      let(:activity) { build_stubbed(:project_activity) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+  end
+
+  context "as a Delivery partner user" do
+    let(:user) { build_stubbed(:delivery_partner_user) }
+
+    context "when the external income belongs to an activity owned by the user" do
+      let(:activity) { build_stubbed(:project_activity, organisation: user.organisation) }
+
+      context "when there is an editable report for the organisation" do
+        before do
+          report.update(state: :active)
+        end
+
+        it { is_expected.to permit_action(:create) }
+        it { is_expected.to permit_action(:update) }
+        it { is_expected.to permit_action(:destroy) }
+      end
+
+      context "when there is no editable report for the organisation" do
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+    end
+
+    context "when the external income does not belong to an activity owned by the user" do
+      let(:activity) { build_stubbed(:project_activity) }
+
+      context "when there is an editable report for the organisation" do
+        before do
+          report.update(state: :active)
+        end
+
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+
+      context "when there is no editable report for the organisation" do
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+    end
+  end
+end

--- a/spec/presenters/external_income_presenter_spec.rb
+++ b/spec/presenters/external_income_presenter_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ExternalIncomePresenter do
+  let(:external_income) { build(:external_income) }
+  subject { described_class.new(external_income) }
+
+  describe "#amount" do
+    before { external_income.amount = 800_000.1 }
+
+    it "returns the amount in pounds and pence" do
+      expect(subject.amount).to eq("£800,000.10")
+    end
+  end
+
+  describe "#oda_funding" do
+    context "when true" do
+      before { external_income.oda_funding = true }
+
+      it "returns yes" do
+        expect(subject.oda_funding).to eq("Yes")
+      end
+    end
+
+    context "when false" do
+      before { external_income.oda_funding = false }
+
+      it "returns no" do
+        expect(subject.oda_funding).to eq("No")
+      end
+    end
+  end
+end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -519,6 +519,7 @@ module FormHelpers
     select template.organisation.name, from: "external_income[organisation_id]"
     fill_in "external_income[amount]", with: template.amount
     check "external_income[oda_funding]" if template.oda_funding
+    uncheck "external_income[oda_funding]" unless template.oda_funding
 
     click_on t("default.button.submit")
   end

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -513,6 +513,16 @@ module FormHelpers
     click_on t("default.button.submit")
   end
 
+  def fill_in_external_income_form(template = build(:external_income))
+    page.find(:xpath, "//input[@value='#{template.financial_quarter}']").set(true)
+    select template.financial_year, from: "external_income[financial_year]"
+    select template.organisation.name, from: "external_income[organisation_id]"
+    fill_in "external_income[amount]", with: template.amount
+    check "external_income[oda_funding]" if template.oda_funding
+
+    click_on t("default.button.submit")
+  end
+
   private def activity_level(level)
     t("page_content.activity.level.#{level}")
   end


### PR DESCRIPTION
## Changes in this PR

- Allow users to add, edit and delete external income on activities

## Screenshots of UI changes

<img width="1191" alt="Screenshot 2021-06-01 at 16 34 22" src="https://user-images.githubusercontent.com/2804149/120351975-3b72f680-c2f8-11eb-9550-988f9f01718d.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
