### PR TITLE
Fix transaction export spec array assertion

### DIFF
--- a/spec/services/quarterly_transaction_export_spec.rb
+++ b/spec/services/quarterly_transaction_export_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe QuarterlyTransactionExport do
 
     expect(quarter_headers).to eq ["FQ1 2014-2015", "FQ2 2014-2015", "FQ3 2014-2015", "FQ4 2014-2015", "FQ1 2015-2016", "FQ2 2015-2016"]
 
-    expect(transaction_data).to eq([
+    expect(transaction_data).to match_array([
       [project.roda_identifier, "10.00", "0.00", "0.00", "0.00", "0.00", "0.00"],
       [third_party_project.roda_identifier, "0.00", "0.00", "0.00", "0.00", "0.00", "20.00"],
     ])
@@ -70,7 +70,7 @@ RSpec.describe QuarterlyTransactionExport do
 
     expect(quarter_headers).to eq ["FQ1 2014-2015"]
 
-    expect(transaction_data).to eq([
+    expect(transaction_data).to match_array([
       [project.roda_identifier, "10.00"],
       [third_party_project.roda_identifier, "0.00"],
     ])


### PR DESCRIPTION
This test always fails for me, but it doesn't appear to fail on CI or
on other people's machines. It could be because I'm running a newer
version of Postgres (13.2) -- in any case, we don't specify the return
order for the transaction data, so we can use `match_array` instead.