### PR TITLE
(1812) Only show activities with relevant statuses in the actuals upload template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -676,6 +676,7 @@
 ## [unreleased]
 
 - Allow users to add, edit and delete external income on activities
+- Only show activities with relevant statuses in the actuals upload template
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...HEAD
 [release-53]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...release-53

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -180,6 +180,9 @@ class Activity < ApplicationRecord
     paused: 12,
   }
 
+  NON_CURRENT_PROGRAMME_STATUSES = ["completed", "stopped", "cancelled"]
+  UNREPORTABLE_PROGRAMME_STATUSES = NON_CURRENT_PROGRAMME_STATUSES + ["paused"]
+
   enum policy_marker_gender: POLICY_MARKER_CODES, _prefix: :gender
 
   enum policy_marker_climate_change_adaptation: POLICY_MARKER_CODES, _prefix: :climate_change_adaptation
@@ -217,8 +220,12 @@ class Activity < ApplicationRecord
   }
 
   scope :current, -> {
-                    where.not(programme_status: ["completed", "stopped", "cancelled"]).or(where(programme_status: nil))
+                    where.not(programme_status: NON_CURRENT_PROGRAMME_STATUSES).or(where(programme_status: nil))
                   }
+
+  scope :reportable, -> {
+    where(oda_eligibility: "eligible").where.not(programme_status: UNREPORTABLE_PROGRAMME_STATUSES)
+  }
 
   scope :historic, -> {
     where(programme_status: ["completed", "stopped", "cancelled"])

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -79,6 +79,6 @@ class Report < ApplicationRecord
   end
 
   def reportable_activities
-    Activity.current.projects_and_third_party_projects_for_report(self).with_roda_identifier
+    Activity.reportable.projects_and_third_party_projects_for_report(self).with_roda_identifier
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -115,6 +115,28 @@ RSpec.describe Activity, type: :model do
         expect(result).not_to include another_third_party_project
       end
     end
+
+    describe ".reportable" do
+      it "does not return any unreportable activities" do
+        completed_project = create(:project_activity, programme_status: "completed")
+        paused_project = create(:project_activity, programme_status: "paused")
+        ineligible_project = create(:project_activity, oda_eligibility: "never_eligible")
+
+        eligible_project = create(:project_activity, oda_eligibility: "eligible")
+        project_in_delivery = create(:project_activity, programme_status: "delivery")
+        project_spend_in_progress = create(:project_activity, programme_status: "spend_in_progress")
+
+        reportable_activities = Activity.reportable
+
+        expect(reportable_activities).to include(eligible_project)
+        expect(reportable_activities).to include(project_in_delivery)
+        expect(reportable_activities).to include(project_spend_in_progress)
+
+        expect(reportable_activities).to_not include(completed_project)
+        expect(reportable_activities).to_not include(paused_project)
+        expect(reportable_activities).to_not include(ineligible_project)
+      end
+    end
   end
 
   describe "sanitisation" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -162,6 +162,9 @@ RSpec.describe Report, type: :model do
     let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }
     let!(:third_party_project) { create(:third_party_project_activity, parent: project_b, organisation: report.organisation) }
     let!(:cancelled_project) { create(:project_activity, parent: programme, organisation: report.organisation, programme_status: "cancelled") }
+    let!(:paused_project) { create(:project_activity, parent: programme, organisation: report.organisation, programme_status: "paused") }
+    let!(:ineligible_project) { create(:project_activity, parent: programme, organisation: report.organisation, oda_eligibility: "never_eligible") }
+
     let!(:project_in_another_fund) { create(:project_activity, organisation: report.organisation) }
 
     it "returns the level C and D activities belonging to the report's fund and organisation" do
@@ -173,6 +176,8 @@ RSpec.describe Report, type: :model do
       expect(report.reportable_activities).not_to include(programme)
       expect(report.reportable_activities).not_to include(project_in_another_fund)
       expect(report.reportable_activities).not_to include(cancelled_project)
+      expect(report.reportable_activities).not_to include(paused_project)
+      expect(report.reportable_activities).not_to include(ineligible_project)
     end
   end
 


### PR DESCRIPTION
This updates the Report `reportable_activities` method to only return Activities that have an ODA Status of "eligible" and are do not have a programme status of "completed", "stopped", "cancelled" or "paused". I've done a bit of refactoring on the way too, and added some extra tests.

