### PR TITLE
(1816) Approved reports are displayed in historical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -677,6 +677,7 @@
 
 - Allow users to add, edit and delete external income on activities
 - Only show activities with relevant statuses in the actuals upload template
+- Approved reports are displayed in historical order
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...HEAD
 [release-53]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...release-53

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -126,7 +126,7 @@ class Staff::ReportsController < Staff::BaseController
   end
 
   def approved_reports(including: [])
-    approved_reports = policy_scope(Report.approved).includes([:fund] + including)
+    approved_reports = policy_scope(Report.approved.in_historical_order).includes([:fund] + including)
     authorize approved_reports
     @approved_report_presenters = approved_reports.map { |report| ReportPresenter.new(report) }
   end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -441,6 +441,18 @@ RSpec.feature "Users can view reports" do
         expect(page).to have_content t("table.title.report.approved")
         expect(page).to have_content report.description
       end
+
+      scenario "they are displayed in historical order" do
+        old_report = create(:report, organisation: delivery_partner_user.organisation, state: :approved, financial_year: 2020)
+        new_report = create(:report, organisation: delivery_partner_user.organisation, state: :approved, financial_year: 2021)
+        oldest_report = create(:report, organisation: delivery_partner_user.organisation, state: :approved, financial_year: 2019)
+
+        visit reports_path
+
+        expect(page.find(:xpath, "//table[@id = 'approved-reports']/tbody/tr[1]")[:id]).to eq(new_report.id)
+        expect(page.find(:xpath, "//table[@id = 'approved-reports']/tbody/tr[2]")[:id]).to eq(old_report.id)
+        expect(page.find(:xpath, "//table[@id = 'approved-reports']/tbody/tr[3]")[:id]).to eq(oldest_report.id)
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

- Approved reports are displayed in historical order

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
