### PR TITLE
(1837) Users can no longer update the delivery partner identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -682,6 +682,8 @@
 
 ## [unreleased]
 
+- Users can no longer update the delivery partner identifier
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-54...HEAD
 [release-54]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...release-54
 [release-53]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-52...release-53

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -50,6 +50,8 @@ class Staff::ActivityFormsController < Staff::BaseController
     when :fstc_applies
       skip_step if can_infer_fstc?(@activity.aid_type)
       assign_default_fstc_applies_value
+    when :identifier
+      skip_step if @activity.delivery_partner_identifier.present?
     end
 
     render_wizard

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -68,6 +68,8 @@ module Activities
         add_error(index, :roda_identifier_fragment, row["RODA ID Fragment"], I18n.t("importer.errors.activity.cannot_update.fragment_present")) && return
       elsif row["Parent RODA ID"].present?
         add_error(index, :parent_id, row["Parent RODA ID"], I18n.t("importer.errors.activity.cannot_update.parent_present")) && return
+      elsif row["Delivery Partner Identifier"].present?
+        add_error(index, :delivery_partner_identifier, row["Delivery Partner Identifier"], I18n.t("importer.errors.activity.cannot_update.delivery_partner_identifier_present")) && return
       else
         updater = ActivityUpdater.new(row: row, uploader: @uploader, delivery_partner_organisation: @delivery_partner_organisation)
         updater.update

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -31,8 +31,8 @@
     %dd.govuk-summary-list__value
       = activity_presenter.delivery_partner_identifier
     %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :identifier)
-        = a11y_action_link(t("default.link.edit"), activity_step_path(activity_presenter, :identifier), t("summary.label.activity.delivery_partner_identifier").downcase)
+      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :identifier) && activity_presenter.delivery_partner_identifier.blank?
+        = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :identifier), t("summary.label.activity.delivery_partner_identifier").downcase)
 
   .govuk-summary-list__row.roda_identifier
     %dt.govuk-summary-list__key

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -168,7 +168,7 @@ en:
         call_close_date: (Enter as dd/mm/yyyy) - This is not the same as IATI Activity End date! Date call will be/was closed. Estimate sufficient until Activity Status is 'Decided'. Where there will be calls for outline and then full proposals, the closing date of the first call (outline) only is sufficient
         country_delivery_partners: "Please provide up to ten country delivery partners. A name is required, provide a acronym where applicable, for example: 'National Council for the State Funding Agencies (CONFAP)'"
         fund_pillar: The Newton Fund largely comprises three pillar activities, which all activities must fall under. Use 'Not applicable' for delivery, other non-programme/project lines.
-        delivery_partner_identifier: This could be the reference you use in your internal systems
+        delivery_partner_identifier: This should be the reference you use to identify this activity in your internal systems and other third-party services. Once set, this value cannot be changed, see the guidance below for more information and support.
         gcrf_strategic_area: Select no more than two areas.
         gcrf_challenge_area: Select the most relevant GCRF challenge area for this activity. For broad programme calls, please select the challenge area most commonly represented across the individual projects within the programme. If the activity is a delivery line, you may select 'Not applicable'.
         gdi: Global Development Impact policy refocuses the way we use our ODA funding when partnering with certain countries, seeking to promote the global development impact over the local or domestic. Current GDI-Applicable countries include China and India

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -516,7 +516,7 @@ en:
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:
-          fragment_present: There is an existing RODA ID present, but there is a fragment specified too, which will overwrite the existing fragment. Please remove the fragement from this row and try again.
+          fragment_present: There is an existing RODA ID present, but there is a fragment specified too, which will overwrite the existing fragment. Please remove the fragment from this row and try again.
           parent_present: There is an existing RODA ID present, but there is a parent activity specified too, which will overwrite the existing parent. Please remove the parent ID from this row and try again.
           delivery_partner_identifier_present: The delivery partner identifier cannot be changed. Please remove the DP identifier from this row and try again.
         unauthorised: You are not authorised to report against this activity

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -518,4 +518,5 @@ en:
         cannot_update:
           fragment_present: There is an existing RODA ID present, but there is a fragment specified too, which will overwrite the existing fragment. Please remove the fragement from this row and try again.
           parent_present: There is an existing RODA ID present, but there is a parent activity specified too, which will overwrite the existing parent. Please remove the parent ID from this row and try again.
+          delivery_partner_identifier_present: The delivery partner identifier cannot be changed. Please remove the DP identifier from this row and try again.
         unauthorised: You are not authorised to report against this activity

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -300,6 +300,30 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
 
+      scenario "the delivery partner identifier can’t be changed" do
+        activity = create(:project_activity, organisation: user.organisation)
+        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within(".identifier") do
+          expect(page).not_to have_content(t("default.link.edit"))
+        end
+      end
+
+      context "when the project does not have a delivery partner identifier" do
+        scenario "the delivery partner identifier can be added" do
+          activity = create(:project_activity, :at_identifier_step, organisation: user.organisation)
+          _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+
+          visit organisation_activity_details_path(activity.organisation, activity)
+
+          within(".identifier") do
+            expect(page).to have_content(t("default.link.add"))
+          end
+        end
+      end
+
       context "when the project does not have a RODA identifier" do
         let(:fund) { create(:fund_activity, roda_identifier_fragment: "AAA") }
         let(:programme) { create(:programme_activity, parent: fund, roda_identifier_fragment: "BBB") }

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -107,14 +107,14 @@ RSpec.feature "Users can edit an activity" do
       context "when the activity is complete" do
         it "editing and saving a step returns the user to the activity page details tab" do
           activity = create(:fund_activity, organisation: user.organisation)
-          identifier = "AB-CDE-1234"
+          description = "Some new text for the description field."
           visit organisation_activity_details_path(activity.organisation, activity)
 
-          within(".identifier") do
+          within(".description") do
             click_on(t("default.link.edit"))
           end
 
-          fill_in "activity[delivery_partner_identifier]", with: identifier
+          fill_in "activity[description]", with: description
           click_button t("form.button.activity.submit")
 
           expect(page).to have_content t("action.fund.update.success")
@@ -149,20 +149,20 @@ RSpec.feature "Users can edit an activity" do
 
         it "tracks activity updates with public_activity" do
           activity = create(:fund_activity, organisation: user.organisation)
-          identifier = "AB-CDE-1234"
+          description = "Some new text for the description field."
           PublicActivity.with_tracking do
             visit organisation_activity_details_path(activity.organisation, activity)
 
-            within(".identifier") do
+            within(".description") do
               click_on(t("default.link.edit"))
             end
 
-            fill_in "activity[delivery_partner_identifier]", with: identifier
+            fill_in "activity[description]", with: description
             click_button t("form.button.activity.submit")
 
             # grab the most recently created auditable_event
             auditable_events = PublicActivity::Activity.where(trackable_id: activity.id).order("created_at ASC")
-            expect(auditable_events.first.key).to eq "activity.update.identifier"
+            expect(auditable_events.first.key).to eq "activity.update.purpose"
             expect(auditable_events.first.owner_id).to eq user.id
             expect(auditable_events.first.trackable_id).to eq activity.id
           end
@@ -189,14 +189,13 @@ RSpec.feature "Users can edit an activity" do
         end
 
         context "when the activity only has an identifier" do
-          it "shows edit link on the identifier, and add link on only the next step" do
+          it "only shows the add link on the next step" do
             activity = create(:fund_activity, :at_purpose_step, organisation: user.organisation)
 
             visit organisation_activity_details_path(activity.organisation, activity)
 
-            # Click the first edit link that opens the form on step 1
             within(".identifier") do
-              expect(page).to have_content(t("default.link.edit"))
+              expect(page).not_to have_content(t("default.link.edit"))
             end
 
             within(".title") do
@@ -204,7 +203,7 @@ RSpec.feature "Users can edit an activity" do
             end
 
             within(".sector") do
-              expect(page).to_not have_content(t("default.link.add"))
+              expect(page).not_to have_content(t("default.link.add"))
             end
           end
         end
@@ -300,7 +299,7 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to_not have_content(t("summary.label.activity.publish_to_iati.label"))
       end
 
-      scenario "the delivery partner identifier can’t be changed" do
+      scenario "the delivery partner identifier cannot be changed" do
         activity = create(:project_activity, organisation: user.organisation)
         _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
@@ -309,6 +308,10 @@ RSpec.feature "Users can edit an activity" do
         within(".identifier") do
           expect(page).not_to have_content(t("default.link.edit"))
         end
+
+        # not even by visiting the URL directly
+        visit activity_step_path(activity, :identifier)
+        expect(page).not_to have_content("Enter your unique identifier")
       end
 
       context "when the project does not have a delivery partner identifier" do
@@ -443,14 +446,20 @@ RSpec.feature "Users can edit an activity" do
 end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)
-  within(".identifier") do
-    click_on t("default.link.edit")
-    expect(page).to have_current_path(
-      activity_step_path(activity, :identifier)
-    )
+  if activity.delivery_partner_identifier.blank?
+    within(".identifier") do
+      click_on t("default.link.edit")
+      expect(page).to have_current_path(
+        activity_step_path(activity, :identifier)
+      )
+    end
+    click_on t("default.link.back")
+    click_on t("tabs.activity.details")
+  else
+    within(".identifier") do
+      expect(page).to_not have_link(t("default.link.edit"))
+    end
   end
-  click_on t("default.link.back")
-  click_on t("tabs.activity.details")
 
   within(".sector") do
     click_on(t("default.link.edit"))


### PR DESCRIPTION
## Changes in this PR

- Users can no longer update the delivery partner identifier

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
