### PR TITLE
(1790) Collaboration type logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -684,6 +684,7 @@
 
 - Users can no longer update the delivery partner identifier
 - Rename `Transfer` to `OutgoingTransfer`
+- Infer the collaboration type when aid type is B02 or B03
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-54...HEAD
 [release-54]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...release-54

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -32,6 +32,7 @@ class Staff::ActivityFormsController < Staff::BaseController
       skip_step unless @activity.requires_additional_benefitting_countries?
     when :collaboration_type
       skip_step if @activity.fund?
+      skip_step if can_infer_collaboration_type?(@activity.aid_type)
       assign_default_collaboration_type_value_if_nil
     when :policy_markers
       skip_step unless @activity.is_project?

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -3,11 +3,6 @@
 module CodelistHelper
   DEVELOPING_COUNTRIES_CODE = "998"
 
-  COLLABORATION_TYPE_FROM_AID_TYPE_CODE = {
-    "B02" => "2",
-    "B03" => "1",
-  }
-
   def default_currency_options
     Codelist.new(type: "default_currency").to_objects
   end
@@ -84,11 +79,12 @@ module CodelistHelper
   end
 
   def collaboration_type_from_aid_type(aid_type_code)
-    COLLABORATION_TYPE_FROM_AID_TYPE_CODE[aid_type_code]
+    item = aid_types.find_item_by_code(aid_type_code) || {}
+    item["collaboration_type"]
   end
 
   def can_infer_collaboration_type?(aid_type_code)
-    COLLABORATION_TYPE_FROM_AID_TYPE_CODE.key?(aid_type_code)
+    collaboration_type_from_aid_type(aid_type_code).present?
   end
 
   def fstc_from_aid_type(aid_type_code)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -3,6 +3,11 @@
 module CodelistHelper
   DEVELOPING_COUNTRIES_CODE = "998"
 
+  COLLABORATION_TYPE_FROM_AID_TYPE_CODE = {
+    "B02" => "2",
+    "B03" => "1",
+  }
+
   def default_currency_options
     Codelist.new(type: "default_currency").to_objects
   end
@@ -76,6 +81,14 @@ module CodelistHelper
     aid_types.to_objects_with_description(
       code_displayed_in_name: true,
     )
+  end
+
+  def collaboration_type_from_aid_type(aid_type_code)
+    COLLABORATION_TYPE_FROM_AID_TYPE_CODE[aid_type_code]
+  end
+
+  def can_infer_collaboration_type?(aid_type_code)
+    COLLABORATION_TYPE_FROM_AID_TYPE_CODE.key?(aid_type_code)
   end
 
   def fstc_from_aid_type(aid_type_code)

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -42,7 +42,8 @@ module CodelistHelper
   end
 
   def collaboration_type_radio_options
-    Codelist.new(type: "collaboration_type").to_objects(with_empty_item: false).sort_by(&:code)
+    codelist = Codelist.new(type: "collaboration_type", source: "beis")
+    codelist.to_objects(with_empty_item: false).sort_by(&:code)
   end
 
   def sector_category_radio_options

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -105,6 +105,9 @@ class Activity
 
     def set_aid_type
       activity.assign_attributes(aid_type: params_for("aid_type"))
+      if can_infer_collaboration_type?(activity.aid_type)
+        activity.collaboration_type = collaboration_type_from_aid_type(activity.aid_type)
+      end
       if can_infer_fstc?(activity.aid_type)
         activity.fstc_applies = fstc_from_aid_type(activity.aid_type)
       end

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -282,7 +282,7 @@
       %dd.govuk-summary-list__value
         = activity_presenter.collaboration_type
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :collaboration_type)
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :collaboration_type) && !can_infer_collaboration_type?(@activity.aid_type)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:collaboration_type)}"), activity_step_path(activity_presenter, :collaboration_type), t("summary.label.activity.collaboration_type"))
 
   - unless activity_presenter.fund?

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     intended_beneficiaries { ["CU", "DM", "DO"] }
     gdi { "4" }
     fstc_applies { true }
-    aid_type { "B02" }
+    aid_type { "D01" }
     level { :fund }
     publish_to_iati { true }
     gcrf_strategic_area { ["1", "2"] }

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -149,6 +149,22 @@ RSpec.feature "Users can create a project" do
         end
       end
 
+      context "when the aid type is one of 'B02', 'B03'" do
+        it "skips the collaboration type step and infers it from the aid type" do
+          programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)
+          create(:report, state: :active, organisation: user.organisation, fund: programme.associated_fund)
+
+          visit organisation_activity_children_path(programme.extending_organisation, programme)
+          click_on t("action.activity.add_child")
+
+          # Test is done in this method:
+          fill_in_activity_form(level: "project", parent: programme, aid_type: "B02")
+
+          expect(page).to have_content t("action.project.create.success")
+          expect(programme.child_activities.last.collaboration_type).to eql "2"
+        end
+      end
+
       context "when the aid type is one of 'D02', 'E01', 'G01'" do
         it "skips the FSTC applies step and infers it from the aid type" do
           programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)

--- a/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
+++ b/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
@@ -31,10 +31,10 @@ RSpec.feature "Users can add a collaboration type for an activity" do
 
       expect(find_field("activity-collaboration-type-2-field")).to be_checked
 
-      choose "Private Sector Outflows"
+      choose "Bilateral, core contributions to NGOs and other private bodies / PPPs"
       click_button t("form.button.activity.submit")
 
-      expect(programme.reload.collaboration_type).to eq("6")
+      expect(programme.reload.collaboration_type).to eq("3")
     end
   end
 end

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe CodelistHelper, type: :helper do
       it "returns the different options for collaboration type sorted by code" do
         options = helper.collaboration_type_radio_options
 
-        expect(options.length).to eq 7
+        expect(options.length).to eq 3
         expect(options.first.code).to eq "1"
         expect(options.first.name).to eq "Bilateral"
-        expect(options.last.code).to eq "8"
-        expect(options.last.name).to eq "Bilateral, triangular co-operation"
+        expect(options.last.code).to eq "3"
+        expect(options.last.name).to eq "Bilateral, core contributions to NGOs and other private bodies / PPPs"
       end
     end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -123,6 +123,40 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
+    describe "#collaboration_type_from_aid_type" do
+      it "returns nil if the aid type is not set" do
+        expect(helper.collaboration_type_from_aid_type(nil)).to be_nil
+      end
+
+      it "returns Multilateral for B02" do
+        expect(helper.collaboration_type_from_aid_type("B02")).to eq("2")
+      end
+
+      it "returns Bilateral for B02" do
+        expect(helper.collaboration_type_from_aid_type("B03")).to eq("1")
+      end
+
+      it "returns nil for any other aid type" do
+        expect(helper.collaboration_type_from_aid_type("C01")).to be_nil
+      end
+    end
+
+    describe "#can_infer_collaboration_type?" do
+      it "returns false if the aid type is not set" do
+        expect(helper.can_infer_collaboration_type?(nil)).to eql false
+      end
+
+      it "returns true for aid types 'B02', B03'" do
+        %w[B02 B03].each do |at|
+          expect(helper.can_infer_collaboration_type?(at)).to eql true
+        end
+      end
+
+      it "returns false for any other aid type" do
+        expect(helper.can_infer_collaboration_type?("C01")).to eql false
+      end
+    end
+
     context "When using aid types to infer Free Standing Technical Cooperation" do
       let(:codelist) { double("Codelist", list: list) }
       let(:list) do

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -209,7 +209,7 @@ module FormHelpers
     choose("activity[aid_type]", option: aid_type)
     click_button t("form.button.activity.submit")
 
-    unless level == "fund"
+    unless level == "fund" || aid_type.in?(["B02", "B03"])
       expect(page).to have_content t("form.label.activity.collaboration_type")
       choose "Bilateral"
       click_button t("form.button.activity.submit")
@@ -327,8 +327,17 @@ module FormHelpers
       expect(page).not_to have_content objectives
     else
       expect(page).to have_content t("activity.programme_status.#{programme_status}")
-      expect(page).to have_content collaboration_type
       expect(page).to have_content objectives
+    end
+
+    within(".govuk-summary-list__row.collaboration_type") do
+      if aid_type == "B02"
+        expect(page).to have_content "Multilateral (inflows)"
+      elsif aid_type == "B03"
+        expect(page).to have_content "Bilateral"
+      else
+        expect(page).to have_content collaboration_type
+      end
     end
 
     # NB: Since the parent might be a fund, `is_newton_fund?` won't work here

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -39,7 +39,7 @@ module FormHelpers
     collaboration_type: "Bilateral",
     sdg_1: 1,
     fund_pillar: "1",
-    aid_type: "B02",
+    aid_type: "D01",
     fstc_applies: true,
     policy_marker_gender: "Not assessed",
     policy_marker_climate_change_adaptation: "Not targeted",

--- a/vendor/data/codelists/BEIS/aid_type.yml
+++ b/vendor/data/codelists/BEIS/aid_type.yml
@@ -15,6 +15,7 @@ data:
       core contributions to which may be reported under B02 (Section I. Multilateral
       institutions).
     ftsc_applies: false
+    collaboration_type: "2"
   - category: B
     code: B03
     name:
@@ -27,6 +28,7 @@ data:
       programmes and funds are recorded here, e.g. “UNICEF girls’ education”, “Education
       For All Fast Track Initiative”, various trust funds, including for reconstruction
       (e.g. Afghanistan Reconstruction Trust Fund).
+    collaboration_type: "1"
   - category: C
     code: C01
     name: Project-type interventions

--- a/vendor/data/codelists/BEIS/collaboration_type.yml
+++ b/vendor/data/codelists/BEIS/collaboration_type.yml
@@ -1,0 +1,7 @@
+data:
+  - code: '1'
+    name: Bilateral
+  - code: '2'
+    name: Multilateral (inflows)
+  - code: '3'
+    name: Bilateral, core contributions to NGOs and other private bodies / PPPs


### PR DESCRIPTION
## Changes in this PR

If `aid_type` is set to `B02` or `B03` then we infer the value of `collaboration_type` and do not let the user change it.

I based this on an earlier pattern that @CristinaRO implemented for inferring the FSTC value, but this has recently been refactored in `CodelistHelper`. I have got this working on top of those recent changes but wonder if I should also refactor what I've done here to match the new pattern done by @pezholio.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
