### PR TITLE
(1871) Show the user the uploaded activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,7 @@
 - Users can no longer update the delivery partner identifier
 - Rename `Transfer` to `OutgoingTransfer`
 - Infer the collaboration type when aid type is B02 or B03
+- Show the user the activities that they've just uploaded
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-54...HEAD
 [release-54]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-53...release-54

--- a/app/controllers/staff/activity_uploads_controller.rb
+++ b/app/controllers/staff/activity_uploads_controller.rb
@@ -32,6 +32,7 @@ class Staff::ActivityUploadsController < Staff::BaseController
       importer = Activities::ImportFromCsv.new(uploader: current_user, delivery_partner_organisation: current_user.organisation)
       importer.import(upload.rows)
       @errors = importer.errors
+      @activities = {created: importer.created, updated: importer.updated}
 
       if @errors.empty?
         @success = true

--- a/app/views/staff/activity_uploads/_success_table.html.haml
+++ b/app/views/staff/activity_uploads/_success_table.html.haml
@@ -1,0 +1,18 @@
+%table.govuk-table
+  %caption.govuk-table__caption= "List of activities successfully #{action} from your CSV file"
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} RODA Identifier
+      %th.govuk-table__header{scope: "col"} Title
+      %th.govuk-table__header{scope: "col"} State
+      %th.govuk-table__header{scope: "col"} Link
+  %tbody.govuk-table__body
+    - activities.each do |activity|
+      - activity_presenter = ActivityPresenter.new(activity)
+      %tr.govuk-table__row
+        %td.govuk-table__cell= activity_presenter.roda_identifier
+        %td.govuk-table__cell= activity_presenter.title
+        %td.govuk-table__cell= activity_presenter.programme_status
+        %td.govuk-table__cell
+          = link_to "View", organisation_activity_path(activity.organisation, activity)
+

--- a/app/views/staff/activity_uploads/update.html.haml
+++ b/app/views/staff/activity_uploads/update.html.haml
@@ -11,5 +11,10 @@
       .govuk-grid-column-full
         = render partial: "error_table"
 
-  - unless @success
+  - if @success
+    - if @activities[:created].any?
+      = render partial: "success_table", locals: { action: "created", activities: @activities[:created] }
+    - if @activities[:updated].any?
+      = render partial: "success_table", locals: { action: "updated", activities: @activities[:updated] }
+  - else
     = render partial: "upload_form"

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -81,7 +81,15 @@ RSpec.feature "users can upload activities" do
 
     expect(Activity.count - old_count).to eq(2)
     expect(page).to have_text(t("action.activity.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+    expect(page).to have_text("List of activities successfully created")
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[2]", text: "Programme - Award (round 5)")
+    end
+
+    within "//tbody/tr[2]" do
+      expect(page).to have_xpath("td[2]", text: "Isolation and redesign of single-celled examples")
+    end
   end
 
   scenario "uploading a set of activities with a BOM at the start" do
@@ -90,13 +98,12 @@ RSpec.feature "users can upload activities" do
       click_button t("action.activity.upload.button")
 
       expect(page).to have_text(t("action.activity.upload.success"))
-      expect(page).not_to have_xpath("//tbody/tr")
 
-      new_activites = Activity.where(created_at: DateTime.now)
+      new_activities = Activity.where(created_at: DateTime.now)
 
-      expect(new_activites.count).to eq(2)
+      expect(new_activities.count).to eq(2)
 
-      expect(new_activites.pluck(:transparency_identifier)).to match_array(["1234", "1235"])
+      expect(new_activities.pluck(:transparency_identifier)).to match_array(["1234", "1235"])
     end
   end
 
@@ -168,8 +175,13 @@ RSpec.feature "users can upload activities" do
     CSV
 
     expect(page).to have_text(t("action.activity.upload.success"))
+    expect(page).to have_text("List of activities successfully updated")
 
     expect(activity_to_update.reload.title).to eq("New Title")
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[2]", text: "New Title")
+    end
   end
 
   scenario "attempting to change the delivery partner identifier of an existing activity" do


### PR DESCRIPTION
## Changes in this PR

Show the user a table view of the freshly uploaded activities, split by created and updated.

## Screenshots of UI changes

### After
![Screenshot 2021-06-04 at 20 14 00](https://user-images.githubusercontent.com/579522/120852351-ff4aca80-c571-11eb-92cb-2bc161668524.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
