### PR TITLE
(1889) Create a script to prepare the dev environment for a data import

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,4 @@ spec/examples.txt
 # SQL files
 **/*.sql
 
-bin/db-restore
+script/db-restore

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -75,7 +75,7 @@ if [ "$delete_data" == "y" ]; then
     psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
 
     echo "==> Restoring the data from the backup..."
-    pg_restore -d roda-development --no-owner --clean "$filename"
+    pg_restore -d roda-development --no-owner --clean "$filename" || true
 
     echo "==> Removing extraneous Postgres extensions..."
     psql -d roda-development -c 'DROP extension citext; DROP extension postgis; DROP extension "uuid-ossp";'

--- a/doc/database-backup-and-restore.md
+++ b/doc/database-backup-and-restore.md
@@ -81,7 +81,7 @@ live environment, and seed the database with the local users, you can
 run this command:
 
 ```bash
-bin/db-restore ENVIRONMENT
+script/db-restore ENVIRONMENT
 ```
 
 (Where `ENVIRONMENT` is one of `pentest`, `prod` or `staging` - default is

--- a/script/db-restore
+++ b/script/db-restore
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# bin/db-restore: Restore the local database from staging/production.
+# script/db-restore: Restore the local database from staging/production.
 
 set -e
 

--- a/script/prepare_for_import.rb
+++ b/script/prepare_for_import.rb
@@ -1,0 +1,37 @@
+require "optparse"
+require_relative "../config/environment"
+
+parser = OptionParser.new { |args|
+  args.on "-f", "--fund FUND"
+  args.on "-o", "--organisation ORGANISATION"
+  args.on "-u", "--user EMAIL"
+}
+
+options = {}
+parser.parse!(into: options)
+
+user_email = options.fetch(:user, "roda+dp@dxw.com")
+
+fund = Activity.fund.by_roda_identifier(options.fetch(:fund))
+organisation = Organisation.find_by(name: options.fetch(:organisation))
+user = User.find_by(email: user_email)
+
+unless fund
+  warn "Could not find fund with RODA identifier '#{options.fetch(:fund)}'"
+  exit 1
+end
+
+unless organisation
+  warn "Could not find organisation with name '#{options.fetch(:organisation)}'"
+  exit 1
+end
+
+unless user
+  warn "Could not find organisation with email '#{user_email}'"
+  exit 1
+end
+
+user.organisation = organisation
+user.save
+
+Report.create(fund: fund, organisation: organisation, state: "active")


### PR DESCRIPTION
As part of the import process for newly onboarded DPs, we need to test the data in development. 

As part of this process, to make sure our local  environment mirrors that of  the production environment, we need to take  a cut of the production data  and import it to our local environment. 

As well as this, we need to make sure  that we have a user for the DP we are  testing with, as well as an active  report. As we have to do this a number of  times for each DP, this needs to be done a lot, so I've added a script that  allows us to automate this, to make the testing process less painful.