### PR TITLE
(1835) Transfers store historic BEIS identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -691,9 +691,11 @@
 ## [release-56] - 2021-06-15
 
 - Infer the value of `channel_of_delivery_code` from `collaboration_type`
-- Reports have an Activities tab
 
 ## [unreleased]
+
+- Reports have an Activities tab
+- Incoming and outgoing transfers can store the historic BEIS identifier (tracker row ID)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-56...HEAD
 [release-56]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-55...release-56

--- a/app/controllers/staff/incoming_transfers_controller.rb
+++ b/app/controllers/staff/incoming_transfers_controller.rb
@@ -33,6 +33,7 @@ class Staff::IncomingTransfersController < Staff::BaseController
         :value,
         :destination_id,
         :source_roda_identifier,
+        :beis_identifier,
       )
   end
 

--- a/app/controllers/staff/outgoing_transfers_controller.rb
+++ b/app/controllers/staff/outgoing_transfers_controller.rb
@@ -33,6 +33,7 @@ class Staff::OutgoingTransfersController < Staff::BaseController
         :value,
         :source_id,
         :destination_roda_identifier,
+        :beis_identifier,
       )
   end
 

--- a/app/views/staff/incoming_transfers/confirm.html.haml
+++ b/app/views/staff/incoming_transfers/confirm.html.haml
@@ -20,6 +20,11 @@
               = @transfer_presenter.source.organisation.name
           %tr.govuk-table__row
             %th.govuk-table__header{scope: "row"}
+              = t("fields.outgoing_transfer.beis_identifier")
+            %td.govuk-table__cell
+              = @transfer_presenter.beis_identifier
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "row"}
               = t("fields.incoming_transfer.financial_quarter_and_year")
             %td.govuk-table__cell
               = @transfer_presenter.financial_quarter_and_year
@@ -33,6 +38,7 @@
         = f.hidden_field :confirm, value: 1
         = f.hidden_field :destination_id
         = f.hidden_field :source_roda_identifier, value: @transfer.source_roda_identifier
+        = f.hidden_field :beis_identifier
         = f.hidden_field :financial_quarter
         = f.hidden_field :financial_year
         = f.hidden_field :value

--- a/app/views/staff/outgoing_transfers/confirm.html.haml
+++ b/app/views/staff/outgoing_transfers/confirm.html.haml
@@ -20,6 +20,11 @@
               = @transfer_presenter.destination.organisation.name
           %tr.govuk-table__row
             %th.govuk-table__header{scope: "row"}
+              = t("fields.outgoing_transfer.beis_identifier")
+            %td.govuk-table__cell
+              = @transfer_presenter.beis_identifier
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "row"}
               = t("fields.outgoing_transfer.financial_quarter_and_year")
             %td.govuk-table__cell
               = @transfer_presenter.financial_quarter_and_year
@@ -33,10 +38,10 @@
         = f.hidden_field :confirm, value: 1
         = f.hidden_field :source_id
         = f.hidden_field :destination_roda_identifier, value: @transfer.destination_roda_identifier
+        = f.hidden_field :beis_identifier
         = f.hidden_field :financial_quarter
         = f.hidden_field :financial_year
         = f.hidden_field :value
 
         = f.govuk_submit "Yes"
         = f.govuk_submit "No", secondary: true
-

--- a/app/views/staff/shared/transfers/_form.html.haml
+++ b/app/views/staff/shared/transfers/_form.html.haml
@@ -1,3 +1,7 @@
+= f.govuk_text_field :beis_identifier,
+  label: { size: 'm' },
+  hint: { text: t("form.hint.outgoing_transfer.beis_identifier") }
+
 = f.govuk_fieldset legend: { text: t("form.label.outgoing_transfer.financial_quarter") }, described_by: ["quarter-hint"] do
   %p.govuk-body
     %span.govuk-hint#quarter-hint
@@ -17,5 +21,3 @@
         :name,
         label: { text: t("form.label.outgoing_transfer.financial_year"), tag: :p, size: 's' }
   = f.govuk_text_field :value, label: { size: 'm' }
-
-

--- a/app/views/staff/shared/transfers/_index.html.haml
+++ b/app/views/staff/shared/transfers/_index.html.haml
@@ -28,6 +28,8 @@
             %th.govuk-table__header{scope: "col"}
               =t("fields.#{transfer_type}.transfer_amount")
             %th.govuk-table__header{scope: "col"}
+              =t("fields.#{transfer_type}.beis_identifier")
+            %th.govuk-table__header{scope: "col"}
         %tbody.govuk-table__body
           - transfers.each do |transfer|
             %tr.govuk-table__row
@@ -39,6 +41,7 @@
                 %td.govuk-table__cell= transfer.source.organisation.name
                 %td.govuk-table__cell= transfer.source.roda_identifier
               %td.govuk-table__cell= transfer.value
+              %td.govuk-table__cell= transfer.beis_identifier
               %td.govuk-table__cell
                 - if policy(transfer).update?
                   = link_to "Edit", send("edit_activity_#{transfer_type}_path", @activity.id, transfer.id)

--- a/config/locales/models/incoming_transfer.en.yml
+++ b/config/locales/models/incoming_transfer.en.yml
@@ -20,6 +20,7 @@ en:
       source_organisation: Source organisation
       financial_quarter_and_year: Financial quarter and year
       transfer_amount: Transfer amount
+      beis_identifier: BEIS identifier
   form:
     label:
       incoming_transfer:
@@ -27,10 +28,12 @@ en:
         financial_quarter: Financial Quarter
         financial_year: Financial Year
         value: Transfer amount
+        beis_identifier: BEIS identifier (optional)
     hint:
       incoming_transfer:
         source_roda_identifier: For example, GCRF-BLOB-424434434
         financial_quarter_and_year: The financial quarter in which the transfer was made
+        beis_identifier: The tracker row ID for historic data
     button:
       incoming_transfer:
         submit: Create transfer record

--- a/config/locales/models/outgoing_transfer.en.yml
+++ b/config/locales/models/outgoing_transfer.en.yml
@@ -20,6 +20,7 @@ en:
       receiving_organisation: Receiving organisation
       financial_quarter_and_year: Financial quarter and year
       transfer_amount: Transfer amount
+      beis_identifier: BEIS identifier
   form:
     label:
       outgoing_transfer:
@@ -27,10 +28,12 @@ en:
         financial_quarter: Financial Quarter
         financial_year: Financial Year
         value: Transfer amount
+        beis_identifier: BEIS identifier (optional)
     hint:
       outgoing_transfer:
         destination_roda_identifier: For example, GCRF-BLOB-424434434
         financial_quarter_and_year: The financial quarter in which the transfer was made
+        beis_identifier: The tracker row ID for historic data
     button:
       outgoing_transfer:
         submit: Create transfer record

--- a/db/migrate/20210614155407_add_beis_identifier_to_transfers.rb
+++ b/db/migrate/20210614155407_add_beis_identifier_to_transfers.rb
@@ -1,0 +1,6 @@
+class AddBeisIdentifierToTransfers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :incoming_transfers, :beis_identifier, :string
+    add_column :outgoing_transfers, :beis_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_152129) do
+ActiveRecord::Schema.define(version: 2021_06_14_155407) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -192,6 +193,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_152129) do
     t.integer "financial_quarter"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "beis_identifier"
     t.index ["destination_id"], name: "index_incoming_transfers_on_destination_id"
     t.index ["report_id"], name: "index_incoming_transfers_on_report_id"
     t.index ["source_id"], name: "index_incoming_transfers_on_source_id"
@@ -234,6 +236,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_152129) do
     t.integer "financial_year"
     t.integer "financial_quarter"
     t.uuid "report_id"
+    t.string "beis_identifier"
     t.index ["destination_id"], name: "index_outgoing_transfers_on_destination_id"
     t.index ["report_id"], name: "index_outgoing_transfers_on_report_id"
     t.index ["source_id"], name: "index_outgoing_transfers_on_source_id"

--- a/spec/features/staff/users_can_create_an_incoming_transfer_spec.rb
+++ b/spec/features/staff/users_can_create_an_incoming_transfer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "BEIS users can create an incoming transfer" do
+RSpec.feature "Delivery partner users can create an incoming transfer" do
   let(:user) { create(:delivery_partner_user) }
   before { authenticate!(user: user) }
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -481,7 +481,7 @@ module FormHelpers
     I18n.l(Date.parse("#{year}-#{month}-#{day}"))
   end
 
-  def fill_in_transfer_form(type:, destination: create(:project_activity), source: create(:project_activity), financial_quarter: FinancialQuarter.for_date(Date.today).to_i, financial_year: FinancialYear.for_date(Date.today).to_i, value: 1234)
+  def fill_in_transfer_form(type:, destination: create(:project_activity), source: create(:project_activity), financial_quarter: FinancialQuarter.for_date(Date.today).to_i, financial_year: FinancialYear.for_date(Date.today).to_i, value: 1234, beis_identifier: nil)
     transfer = build(
       type,
       destination: destination,
@@ -497,6 +497,7 @@ module FormHelpers
       fill_in "incoming_transfer[source_roda_identifier]", with: transfer.source.roda_identifier
     end
 
+    fill_in "#{type}[beis_identifier]", with: beis_identifier if beis_identifier
     choose transfer.financial_quarter.to_s, name: "#{type}[financial_quarter]"
     select transfer.financial_year, from: "#{type}[financial_year]"
     fill_in "#{type}[value]", with: transfer.value

--- a/spec/support/shared_examples/creating_a_transfer.rb
+++ b/spec/support/shared_examples/creating_a_transfer.rb
@@ -67,6 +67,19 @@ RSpec.shared_examples "creating a transfer" do
     end
   end
 
+  scenario "records the BEIS identifier if provided" do
+    fill_in_transfer_form(type: transfer_type, value: "1234", beis_identifier: "historic-tracker-id")
+    click_on t("form.button.#{transfer_type}.submit")
+    expect(page).to have_content("historic-tracker-id")
+
+    click_on "Yes"
+    expect(created_transfer.beis_identifier).to eq("historic-tracker-id")
+
+    within "##{transfer_type.pluralize}" do
+      expect(page).to have_content("historic-tracker-id")
+    end
+  end
+
   scenario "allows a transfer to be changed before creating" do
     transfer = fill_in_transfer_form(type: transfer_type, value: "1234")
 


### PR DESCRIPTION
## Changes in this PR
- Incoming and outgoing transfers can store the historic BEIS identifier (tracker row ID)

## Screenshots of UI changes

### Before

### After
![Screenshot 2021-06-14 at 17 28 01](https://user-images.githubusercontent.com/579522/121931360-6cf9b200-cd3b-11eb-85b9-fbe4ba211ee3.png)
![Screenshot 2021-06-14 at 18 08 07](https://user-images.githubusercontent.com/579522/121931433-83077280-cd3b-11eb-81b1-25eb4917653a.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
