### PR TITLE
(1895) Hide non-DP orgs on the Activities dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -696,6 +696,7 @@
 
 - Reports have an Activities tab
 - Incoming and outgoing transfers can store the historic BEIS identifier (tracker row ID)
+- Hide non-DP orgs on the Activities dropdown
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-56...HEAD
 [release-56]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-55...release-56

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -19,7 +19,7 @@ module FormHelper
   end
 
   def list_of_delivery_partners
-    @list_of_delivery_partners ||= Organisation.delivery_partners
+    @list_of_delivery_partners ||= Organisation.delivery_partners.order(:name)
   end
 
   def list_of_financial_quarters

--- a/app/views/staff/shared/activities/_filter.html.haml
+++ b/app/views/staff/shared/activities/_filter.html.haml
@@ -6,6 +6,6 @@
       .govuk-form-group
         %label{ class: "govuk-label", for: :organistaion_id }
           = t("filters.activity.organisation")
-        = select_tag :organisation_id, options_from_collection_for_select(Organisation.all, :id, :name, organisation_id), { class: "govuk-select" }
+        = select_tag :organisation_id, options_from_collection_for_select(list_of_delivery_partners, :id, :name, organisation_id), { class: "govuk-select" }
       .govuk-form-group
         = submit_tag t("filters.activity.submit"), { class: "govuk-button", data: { module: "govuk-button" } }

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -35,6 +35,23 @@ RSpec.feature "Users can view activities" do
       expect(page).to have_content activity.roda_identifier
     end
 
+    scenario "only delivery partners are listed" do
+      delivery_partners = create_list(:delivery_partner_organisation, 3)
+      matched_effort_provider = create(:matched_effort_provider)
+      external_income_provider = create(:external_income_provider)
+
+      visit activities_path(organisation_id: user.organisation)
+
+      within "select#organisation_id" do
+        delivery_partners.each do |delivery_partner|
+          expect(page).to have_content(delivery_partner.name)
+        end
+
+        expect(page).to_not have_content(matched_effort_provider.name)
+        expect(page).to_not have_content(external_income_provider.name)
+      end
+    end
+
     context "when an organisation id query parameter is not supplied" do
       scenario "it defaults to showing the current users organisation activities" do
         activity = create(:programme_activity, organisation: user.organisation)

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -10,11 +10,16 @@ RSpec.describe FormHelper, type: :helper do
 
   describe "#list_of_delivery_partners" do
     it "asks for a list of organisations that are not `service_owner`" do
-      delivery_partner = build_stubbed(:delivery_partner_organisation)
-      allow(Organisation).to receive(:delivery_partners).and_return([delivery_partner])
+      delivery_partner_1 = create(:delivery_partner_organisation, name: "aaaaa")
+      delivery_partner_2 = create(:delivery_partner_organisation, name: "zzzzz")
 
-      expect(Organisation).to receive(:delivery_partners)
-      helper.list_of_delivery_partners
+      _matched_effort_provider = create(:matched_effort_provider)
+      _external_income_provider = create(:external_income_provider)
+
+      expect(helper.list_of_delivery_partners).to match_array([
+        delivery_partner_1,
+        delivery_partner_2,
+      ])
     end
   end
 end


### PR DESCRIPTION
As only Delivery Partners have activities assoiciated with them, we don't want to see any non-Delivery Partners to be able to be selected when filtering Activites by organisation.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/122243750-444cf600-cebc-11eb-94c8-a90efc1ff822.png)

### After

![image](https://user-images.githubusercontent.com/109774/122243896-5fb80100-cebc-11eb-9d1b-55fbbdfd852d.png)
