### PR TITLE
Feature/1529 improvements to the reporting forecast journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,6 +708,10 @@
 
 ## [unreleased]
 
+- Add a Forecasts tab to the Report view, listing forecasts grouped by activity. Move 'Upload forecast' to this tab.
+- Add a list of uploaded forecasts (grouped by activity) to the upload success page
+
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...HEAD
 [release-58]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-57...release-58
 [release-57]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-56...release-57

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -1,3 +1,9 @@
 .level-d {
   padding-left: 2em;
 }
+
+table .totals td {
+  font-weight: bold;
+  padding-top: 1.5em;
+  padding-bottom: 1.5em;
+}

--- a/app/controllers/staff/forecast_uploads_controller.rb
+++ b/app/controllers/staff/forecast_uploads_controller.rb
@@ -43,8 +43,7 @@ class Staff::ForecastUploadsController < Staff::BaseController
         @grouped_forecasts = imported_forecasts
           .map { |forecast| ForecastPresenter.new(forecast) }
           .group_by { |forecast| ActivityPresenter.new(forecast.parent_activity) }
-        @total_forecast = ActionController::Base.helpers
-          .number_to_currency(imported_forecasts.sum(&:value), unit: "£")
+        @total_forecast = TotalPresenter.new(imported_forecasts.sum(&:value)).value
         @success = true
         flash.now[:notice] = t("action.forecast.upload.success")
       end

--- a/app/controllers/staff/forecast_uploads_controller.rb
+++ b/app/controllers/staff/forecast_uploads_controller.rb
@@ -39,6 +39,12 @@ class Staff::ForecastUploadsController < Staff::BaseController
       @errors = importer.errors
 
       if @errors.empty?
+        imported_forecasts = importer.imported_forecasts.compact
+        @grouped_forecasts = imported_forecasts
+          .map { |forecast| ForecastPresenter.new(forecast) }
+          .group_by { |forecast| ActivityPresenter.new(forecast.parent_activity) }
+        @total_forecast = ActionController::Base.helpers
+          .number_to_currency(imported_forecasts.sum(&:value), unit: "£")
         @success = true
         flash.now[:notice] = t("action.forecast.upload.success")
       end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -9,11 +9,23 @@ class Staff::ReportForecastsController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
     @report_activities = @report.reportable_activities
-    @grouped_forecasts = ForecastOverview
-      .new(@report_activities.map(&:id))
-      .latest_values
+    @total_forecast = formatted(forecasts.sum(&:value))
+    @grouped_forecasts = forecasts
+      .map { |forecast| ForecastPresenter.new(forecast) }
       .group_by { |forecast| forecast.parent_activity_id }
 
     render "staff/reports/forecasts"
+  end
+
+  private
+
+  def forecasts
+    ForecastOverview
+      .new(@report_activities.map(&:id))
+      .latest_values
+  end
+
+  def formatted(bigdecimal)
+    ActionController::Base.helpers.number_to_currency(bigdecimal, unit: "£")
   end
 end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Staff::ReportForecastsController < Staff::BaseController
+  include Secured
+
+  def show
+    @report = Report.find(params["report_id"])
+    authorize @report
+
+    @report_presenter = ReportPresenter.new(@report)
+
+    render "staff/reports/forecasts"
+  end
+end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -11,8 +11,9 @@ class Staff::ReportForecastsController < Staff::BaseController
     @report_activities = @report.reportable_activities
     @total_forecast = formatted(forecasts.sum(&:value))
     @grouped_forecasts = forecasts
+      .includes([:parent_activity])
       .map { |forecast| ForecastPresenter.new(forecast) }
-      .group_by { |forecast| forecast.parent_activity_id }
+      .group_by { |forecast| ActivityPresenter.new(forecast.parent_activity) }
 
     render "staff/reports/forecasts"
   end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -9,7 +9,7 @@ class Staff::ReportForecastsController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
     @report_activities = @report.reportable_activities
-    @total_forecast = formatted(forecasts.sum(&:value))
+    @total_forecast = TotalPresenter.new(forecasts.sum(&:value)).value
     @grouped_forecasts = forecasts
       .includes([:parent_activity])
       .map { |forecast| ForecastPresenter.new(forecast) }
@@ -24,9 +24,5 @@ class Staff::ReportForecastsController < Staff::BaseController
     ForecastOverview
       .new(@report_activities.map(&:id))
       .latest_values
-  end
-
-  def formatted(bigdecimal)
-    ActionController::Base.helpers.number_to_currency(bigdecimal, unit: "£")
   end
 end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -9,6 +9,10 @@ class Staff::ReportForecastsController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
     @report_activities = @report.reportable_activities
+    @grouped_forecasts = ForecastOverview
+      .new(@report_activities.map(&:id))
+      .latest_values
+      .group_by { |forecast| forecast.parent_activity_id }
 
     render "staff/reports/forecasts"
   end

--- a/app/controllers/staff/report_forecasts_controller.rb
+++ b/app/controllers/staff/report_forecasts_controller.rb
@@ -8,6 +8,7 @@ class Staff::ReportForecastsController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
+    @report_activities = @report.reportable_activities
 
     render "staff/reports/forecasts"
   end

--- a/app/presenters/total_presenter.rb
+++ b/app/presenters/total_presenter.rb
@@ -1,0 +1,7 @@
+class TotalPresenter
+  def initialize(bigdecimal)
+    @value = ActionController::Base.helpers.number_to_currency(bigdecimal, unit: "£")
+  end
+
+  attr_reader :value
+end

--- a/app/services/forecast_history.rb
+++ b/app/services/forecast_history.rb
@@ -101,6 +101,7 @@ class ForecastHistory
 
     entry = Forecast.unscoped.create!(attributes)
     entry.create_activity(key: "forecast.create", owner: @user)
+    entry
   end
 
   def revise_entry(entry, value, report = nil)
@@ -112,6 +113,7 @@ class ForecastHistory
       report: report
     )
     new_entry.create_activity(key: "forecast.create", owner: @user)
+    new_entry
   end
 
   def update_entry(entry, value)
@@ -121,6 +123,7 @@ class ForecastHistory
       entry.update!(value: value)
       entry.create_activity(key: "forecast.update", owner: @user)
     end
+    entry
   end
 
   def series_attributes

--- a/app/services/import_forecasts.rb
+++ b/app/services/import_forecasts.rb
@@ -45,7 +45,7 @@ class ImportForecasts
     end
   end
 
-  attr_reader :errors
+  attr_reader :errors, :imported_forecasts
 
   def initialize(uploader: nil, report: nil)
     if uploader && report
@@ -56,6 +56,7 @@ class ImportForecasts
     @report = report
     @errors = []
     @warned_columns = Set.new
+    @imported_forecasts = []
   end
 
   def import(forecasts)
@@ -95,7 +96,7 @@ class ImportForecasts
       if match
         year = match[1].to_i
         quarter = match[2].to_i
-        import_forecast(activity, FinancialQuarter.new(year, quarter), value, header: key)
+        imported_forecasts << import_forecast(activity, FinancialQuarter.new(year, quarter), value, header: key)
       elsif !COLUMN_HEADINGS.include?(key) && @warned_columns.add?(key)
         @errors << Error.new(-1, key, "", I18n.t("importer.errors.forecast.unrecognised_column"))
       end

--- a/app/views/shared/forecasts/_forecasts_by_activity.html.haml
+++ b/app/views/shared/forecasts/_forecasts_by_activity.html.haml
@@ -1,0 +1,29 @@
+%table.govuk-table
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Activity
+      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} RODA Identifier
+      %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Financial Quarter
+      %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Amount
+  %tbody.govuk-table__body
+
+    - @grouped_forecasts.each do |activity, forecasts|
+
+      %tr.govuk-table__row{ id: "activity_#{activity.id}" }
+        %td.govuk-table__cell= activity.title
+        %td.govuk-table__cell= activity.roda_identifier
+        %td.govuk-table__cell{ colspan: 2 }
+          %table.govuk-table.forecasts
+            - forecasts.each do |forecast|
+              %tr.govuk-table__row
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
+                  = forecast.financial_quarter_and_year
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
+                  = forecast.value
+
+    %tr.govuk-table__row.totals
+      %td.govuk-table__cell Total
+      %td.govuk-table__cell
+      %td.govuk-table__cell
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @total_forecast

--- a/app/views/staff/forecast_uploads/update.html.haml
+++ b/app/views/staff/forecast_uploads/update.html.haml
@@ -2,14 +2,20 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %h1.govuk-heading-xl
-        = t("page_title.forecast.upload")
+    - if @success
+      .govuk-grid-column-full
+        %h1.govuk-heading-xl
+          = t("importer.success.heading")
+        = render partial: "shared/forecasts/forecasts_by_activity"
+        = link_to t("importer.success.back_link"), report_forecasts_path(@report_presenter), class: "govuk-button govuk-button"
 
-  - unless @errors.empty?
-    .govuk-grid-row
+    - else
+      .govuk-grid-column-two-thirds
+        %h1.govuk-heading-xl
+          = t("page_title.forecast.upload")
+        = render partial: "upload_form"
+
+    - if @errors.any?
       .govuk-grid-column-full
         = render partial: "error_table"
 
-  - unless @success
-    = render partial: "upload_form"

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -1,7 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full.page-actions
     - if policy(@report_presenter).upload?
-      = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
       = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
     - if policy(@report_presenter).activate?

--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -3,6 +3,10 @@
     = link_to t("tabs.report.activities"),
       report_activities_path(@report),
       { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
+  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "forecasts" }"}
+    = link_to t("tabs.report.forecasts"),
+      report_forecasts_path(@report),
+      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
   %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "variance" }"}
     = link_to t("tabs.report.variance"),
       report_variance_path(@report),

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -16,6 +16,8 @@
           %h2.govuk-heading-l
             = t("page_content.tab_content.forecasts.heading")
 
+          = t("page_content.tab_content.forecasts.guidance_html")
+
           - if policy(@report_presenter).upload?
             = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -24,36 +24,6 @@
           %h3.govuk-heading-m
             = t("page_content.tab_content.forecasts.per_activity_heading")
 
-          %table.govuk-table
-            %thead.govuk-table__head
-              %tr.govuk-table__row
-                %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Activity
-                %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} RODA Identifier
-                %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Financial Quarter
-                %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Amount
-            %tbody.govuk-table__body
-
-              - @grouped_forecasts.each do |activity_id, forecasts|
-                - activity = @report_activities.find { |r| r.id == activity_id }
-                - activity_presenter = ActivityPresenter.new(activity)
-
-                %tr.govuk-table__row[activity]
-                  %td.govuk-table__cell= activity_presenter.title
-                  %td.govuk-table__cell= activity_presenter.roda_identifier
-                  %td.govuk-table__cell{ colspan: 2 }
-                    %table.govuk-table.forecasts
-                      - forecasts.each do |forecast|
-                        %tr.govuk-table__row
-                          %td.govuk-table__cell--numeric
-                            = forecast.financial_quarter_and_year
-                          %td.govuk-table__cell--numeric
-                            = forecast.value
-
-              %tr.govuk-table__row.totals
-                %td.govuk-table__cell{class: "govuk-!-width-one-third", scope: "col"} Total
-                %td.govuk-table__cell{class: "govuk-!-width-one-quarter", scope: "col"}
-                %td.govuk-table__cell
-                %td.govuk-table__cell.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
-                  = @total_forecast
+          = render partial: "shared/forecasts/forecasts_by_activity"
 
 

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -1,0 +1,18 @@
+=content_for :page_title_prefix, t("page_title.report.forecasts",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+
+  = render "staff/reports/meta"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        = render partial: "staff/reports/tab_list", locals: { active_tab: "forecasts" }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_content.tab_content.forecasts.heading")
+

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -42,11 +42,18 @@
                   %td.govuk-table__cell= activity_presenter.roda_identifier
                   %td.govuk-table__cell{ colspan: 2 }
                     %table.govuk-table.forecasts
-                      - forecasts.map {|f| ForecastPresenter.new(f) }.each do |forecast|
+                      - forecasts.each do |forecast|
                         %tr.govuk-table__row
                           %td.govuk-table__cell--numeric
                             = forecast.financial_quarter_and_year
                           %td.govuk-table__cell--numeric
                             = forecast.value
+
+              %tr.govuk-table__row.totals
+                %td.govuk-table__cell{class: "govuk-!-width-one-third", scope: "col"} Total
+                %td.govuk-table__cell{class: "govuk-!-width-one-quarter", scope: "col"}
+                %td.govuk-table__cell
+                %td.govuk-table__cell.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
+                  = @total_forecast
 
 

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -21,3 +21,22 @@
           - if policy(@report_presenter).upload?
             = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
 
+          %h3.govuk-heading-m
+            = t("page_content.tab_content.forecasts.per_activity_heading")
+
+          %table.govuk-table
+            %thead.govuk-table__head
+              %tr.govuk-table__row
+                %th.govuk-table__header{scope: "col"} Activity
+                %th.govuk-table__header{scope: "col"} RODA Identifier
+                %th.govuk-table__header{scope: "col"} Financial Quarter
+                %th.govuk-table__header{scope: "col"} Amount
+            %tbody.govuk-table__body
+              - @report_activities.each do |activity|
+                - activity_presenter = ActivityPresenter.new(activity)
+                %tr.govuk-table__row[activity]
+                  %td.govuk-table__cell= activity_presenter.title
+                  %td.govuk-table__cell= activity_presenter.roda_identifier
+                  %td.govuk-table__cell
+                  %td.govuk-table__cell
+

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -32,11 +32,21 @@
                 %th.govuk-table__header{scope: "col"} Financial Quarter
                 %th.govuk-table__header{scope: "col"} Amount
             %tbody.govuk-table__body
-              - @report_activities.each do |activity|
+
+              - @grouped_forecasts.each do |activity_id, forecasts|
+                - activity = @report_activities.find { |r| r.id == activity_id }
                 - activity_presenter = ActivityPresenter.new(activity)
+
                 %tr.govuk-table__row[activity]
                   %td.govuk-table__cell= activity_presenter.title
                   %td.govuk-table__cell= activity_presenter.roda_identifier
-                  %td.govuk-table__cell
-                  %td.govuk-table__cell
+                  %td.govuk-table__cell{ colspan: 2 }
+                    %table.govuk-table.forecasts
+                      - forecasts.map {|f| ForecastPresenter.new(f) }.each do |forecast|
+                        %tr.govuk-table__row
+                          %td
+                            = forecast.financial_quarter_and_year
+                          %td
+                            = forecast.value
+
 

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -16,3 +16,6 @@
           %h2.govuk-heading-l
             = t("page_content.tab_content.forecasts.heading")
 
+          - if policy(@report_presenter).upload?
+            = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -27,10 +27,10 @@
           %table.govuk-table
             %thead.govuk-table__head
               %tr.govuk-table__row
-                %th.govuk-table__header{scope: "col"} Activity
-                %th.govuk-table__header{scope: "col"} RODA Identifier
-                %th.govuk-table__header{scope: "col"} Financial Quarter
-                %th.govuk-table__header{scope: "col"} Amount
+                %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Activity
+                %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} RODA Identifier
+                %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Financial Quarter
+                %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-quarter", scope: "col"} Amount
             %tbody.govuk-table__body
 
               - @grouped_forecasts.each do |activity_id, forecasts|
@@ -44,9 +44,9 @@
                     %table.govuk-table.forecasts
                       - forecasts.map {|f| ForecastPresenter.new(f) }.each do |forecast|
                         %tr.govuk-table__row
-                          %td
+                          %td.govuk-table__cell--numeric
                             = forecast.financial_quarter_and_year
-                          %td
+                          %td.govuk-table__cell--numeric
                             = forecast.value
 
 

--- a/config/locales/models/forecast.en.yml
+++ b/config/locales/models/forecast.en.yml
@@ -61,6 +61,9 @@ en:
             financial_quarter:
               in_the_past: The forecast must be for a future financial quarter
   importer:
+    success:
+      heading: Successful uploads
+      back_link: Back to report
     errors:
       forecast:
         non_numeric_value: The value must be numeric

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -41,6 +41,7 @@ en:
     tab_content:
       forecasts:
         heading: Forecasts in this report
+        per_activity_heading: Forecast spend per activity
         guidance_html:
           <p class="govuk-body">
             This page shows all the new or updated forecasts you have reported in RODA since the last reporting quarter.

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -41,6 +41,13 @@ en:
     tab_content:
       forecasts:
         heading: Forecasts in this report
+        guidance_html:
+          <p class="govuk-body">
+            This page shows all the new or updated forecasts you have reported in RODA since the last reporting quarter.
+          </p>
+          <p class="govuk-body">
+            For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+activities">uploading new activities</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
+          </p>
     report:
       activate:
         confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will associate to this report only.

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -31,11 +31,16 @@ en:
   tabs:
     report:
       activities: Activities
+      forecasts: Forecasts
       variance: Variance
       budgets: Budgets
+
   page_content:
     reports:
       title: Reports
+    tab_content:
+      forecasts:
+        heading: Forecasts in this report
     report:
       activate:
         confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will associate to this report only.
@@ -104,6 +109,7 @@ en:
         confirm: Confirm approval of %{report_organisation} %{report_financial_quarter} report
         complete: This report is approved
       variance: "%{report_financial_quarter} %{report_description} variance"
+      forecasts: "%{report_financial_quarter} %{report_description} forecasts"
       budgets: "%{report_financial_quarter} %{report_description} budgets"
       activities: "%{report_financial_quarter} %{report_description} activities"
   mailer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       resource :forecast_upload, only: [:new, :show, :update]
       resource :transaction_upload, only: [:new, :show, :update]
       get "variance" => "report_variance#show"
+      get "forecasts" => "report_forecasts#show"
       get "budgets" => "report_budgets#show"
       get "activities" => "report_activities#show"
     end

--- a/spec/features/staff/users_can_upload_forecasts_spec.rb
+++ b/spec/features/staff/users_can_upload_forecasts_spec.rb
@@ -21,6 +21,18 @@ RSpec.feature "users can upload forecasts" do
     click_link t("action.forecast.upload.link")
   end
 
+  def expect_to_see_successful_upload_summary_with(count:, total:)
+    expect(page).to have_text(t("importer.success.heading"))
+    expect(page).to have_css(".forecasts tr", count: count)
+    expect(page).to have_link(
+      t("importer.success.back_link"),
+      href: report_forecasts_path(report)
+    )
+    within ".totals" do
+      expect(page).to have_content(total)
+    end
+  end
+
   describe "downloading a CSV template with activities for the current report" do
     before do
       click_link t("action.forecast.download.button")
@@ -110,7 +122,7 @@ RSpec.feature "users can upload forecasts" do
 
     expect(Forecast.unscoped.count).to eq(6)
     expect(page).to have_text(t("action.forecast.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+    expect_to_see_successful_upload_summary_with(count: 6, total: "£110.00")
   end
 
   scenario "uploading an invalid set of forecasts" do
@@ -124,6 +136,10 @@ RSpec.feature "users can upload forecasts" do
 
     expect(Forecast.unscoped.count).to eq(0)
     expect(page).not_to have_text(t("action.forecast.upload.success"))
+
+    # upload info not present
+    expect(page).not_to have_text(t("importer.success.heading"))
+    expect(page).not_to have_link(t("importer.success.back_link"))
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[1]", text: "FC 2021/22 FY Q3")
@@ -144,7 +160,7 @@ RSpec.feature "users can upload forecasts" do
 
     expect(Forecast.unscoped.count).to eq(3)
     expect(page).to have_text(t("action.forecast.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+    expect_to_see_successful_upload_summary_with(count: 3, total: "£110.00")
   end
 
   scenario "uploading a set of forecasts with encoding errors" do
@@ -181,7 +197,7 @@ RSpec.feature "users can upload forecasts" do
 
     expect(Forecast.unscoped.count).to eq(6)
     expect(page).to have_text(t("action.forecast.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+    expect_to_see_successful_upload_summary_with(count: 6, total: "£210.00")
   end
 
   def upload_csv(content)

--- a/spec/features/staff/users_can_upload_forecasts_spec.rb
+++ b/spec/features/staff/users_can_upload_forecasts_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "users can upload forecasts" do
 
   before do
     authenticate!(user: user)
-    visit report_path(report)
+    visit report_forecasts_path(report)
     click_link t("action.forecast.upload.link")
   end
 

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -16,10 +16,14 @@ RSpec.feature "Users can view forecasts in tab within a report" do
         .latest_values
         .map { |f| ForecastPresenter.new(f) }
 
+      fail "We expect some activities to be present" if activities.none?
+
       activities.each do |activity|
         within "#activity_#{activity.id}" do
           expect(page).to have_content(activity.title)
           expect(page).to have_content(activity.roda_identifier)
+
+          fail "We expect some forecasts to be present" if forecasts.none?
 
           within ".forecasts" do
             forecasts.each do |forecast|

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -1,0 +1,20 @@
+RSpec.feature "Users can view forecasts in tab within a report" do
+  context "as a Delivery Partner user" do
+    let(:organisation) { create(:delivery_partner_organisation) }
+    let(:user) { create(:delivery_partner_user, organisation: organisation) }
+
+    before do
+      authenticate!(user: user)
+    end
+
+    scenario "the report contains a _forecasts_ tab" do
+      report = create(:report, :active, organisation: organisation, description: nil)
+
+      visit report_path(report.id)
+
+      click_link "Forecasts"
+
+      expect(page).to have_content(t("page_content.tab_content.forecasts.heading"))
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -35,6 +35,16 @@ RSpec.feature "Users can view forecasts in tab within a report" do
       end
     end
 
+    def expect_to_see_total_of_forecasted_amounts(activities)
+      forecasts = ForecastOverview.new(activities.map(&:id)).latest_values
+
+      within ".totals" do
+        expect(page).to have_content(
+          ActionController::Base.helpers.number_to_currency(forecasts.sum(&:value), unit: "£")
+        )
+      end
+    end
+
     scenario "the report contains a _forecasts_ tab" do
       programme = create(:programme_activity)
 
@@ -85,6 +95,8 @@ RSpec.feature "Users can view forecasts in tab within a report" do
 
       # forecasts per activity
       expect_to_see_a_table_of_forecasts_grouped_by_activity(activities)
+
+      expect_to_see_total_of_forecasted_amounts(activities)
     end
 
     context "report is in a state where upload is not permissable" do

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -16,7 +16,12 @@ RSpec.feature "Users can view forecasts in tab within a report" do
 
       expect(page).to have_content(t("page_content.tab_content.forecasts.heading"))
       expect(page).to have_link(t("action.forecast.upload.link"))
+
       # guidance with 2 links
+      expect(page).to have_content("This page shows all the new or updated forecasts")
+      expect(page).to have_link("uploading new activities")
+      expect(page).to have_link("uploading updates to activities")
+
       # forecasts per activity
     end
 

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -7,8 +7,27 @@ RSpec.feature "Users can view forecasts in tab within a report" do
       authenticate!(user: user)
     end
 
+    def expect_to_see_a_table_of_forecasts_grouped_by_activity(activities)
+      expect(page).to have_content(
+        t("page_content.tab_content.forecasts.per_activity_heading")
+      )
+      activities.each do |activity|
+        within "#activity_#{activity.id}" do
+          expect(page).to have_content(activity.title)
+          expect(page).to have_content(activity.roda_identifier)
+        end
+      end
+    end
+
     scenario "the report contains a _forecasts_ tab" do
-      report = create(:report, :active, organisation: organisation, description: nil)
+      programme = create(:programme_activity)
+
+      report = create(:report, :active, organisation: organisation, fund: programme.parent)
+      project = create(:project_activity, organisation: organisation, parent: programme)
+
+      activities = 2.times.map {
+        create(:third_party_project_activity, organisation: organisation, parent: project)
+      }
 
       visit report_path(report.id)
 
@@ -23,6 +42,7 @@ RSpec.feature "Users can view forecasts in tab within a report" do
       expect(page).to have_link("uploading updates to activities")
 
       # forecasts per activity
+      expect_to_see_a_table_of_forecasts_grouped_by_activity(activities)
     end
 
     context "report is in a state where upload is not permissable" do

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -15,6 +15,21 @@ RSpec.feature "Users can view forecasts in tab within a report" do
       click_link "Forecasts"
 
       expect(page).to have_content(t("page_content.tab_content.forecasts.heading"))
+      expect(page).to have_link(t("action.forecast.upload.link"))
+      # guidance with 2 links
+      # forecasts per activity
+    end
+
+    context "report is in a state where upload is not permissable" do
+      scenario "the upload facility is not present" do
+        report = create(:report, state: :approved, organisation: organisation, description: nil)
+
+        visit report_path(report.id)
+
+        click_link "Forecasts"
+
+        expect(page).not_to have_link(t("action.forecast.upload.link"))
+      end
     end
   end
 end

--- a/spec/presenters/total_presenter_spec.rb
+++ b/spec/presenters/total_presenter_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe TotalPresenter do
+  describe "#value" do
+    it "returns a currency formatted string" do
+      expect(TotalPresenter.new(BigDecimal("4321.1")).value).to eq("£4,321.10")
+    end
+  end
+end

--- a/spec/services/forecast_history_spec.rb
+++ b/spec/services/forecast_history_spec.rb
@@ -158,6 +158,10 @@ RSpec.describe ForecastHistory do
       ])
     end
 
+    it "returns a _Forecast_" do
+      expect(history.set_value(10)).to be_a(Forecast)
+    end
+
     it "does not create an original entry with a zero value" do
       history.set_value(0)
       expect(history_entries).to eq([])

--- a/spec/services/import_forecasts_spec.rb
+++ b/spec/services/import_forecasts_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe ImportForecasts do
     end
   end
 
+  describe "#imported_forecasts" do
+    let(:forecast) { double("forecast") }
+
+    let :forecast_row do
+      {
+        "Activity RODA Identifier" => project.roda_identifier,
+        "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+        "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+      }
+    end
+
+    before do
+      forecast_history = instance_double(ForecastHistory, set_value: forecast)
+      allow(ForecastHistory).to receive(:new).and_return(forecast_history)
+    end
+
+    it "returns a list of forecasts" do
+      importer.import([forecast_row])
+
+      expect(importer.imported_forecasts).to eq([forecast, forecast])
+    end
+  end
+
   describe "importing a row of forecasts" do
     let :forecast_row do
       {


### PR DESCRIPTION
## Trello
https://trello.com/c/4Km0NgOB/1529-improvements-to-the-reporting-forecast-journey

## Changes in this PR

This PR adds a new 'Forecasts' tab to the 'Report' view. On the new tab:

- the "Upload forecasts" button is on the new tab rather than in the 'actions' partial which is common to all the tabs
- we show a table of forecasts associated with the report, grouped by activity

This also adds to the forecast upload journey, so that the "upload success" page:

- uses the same table of forecasts to list the successfully uploaded forecasts. 
- includes the total amount forecast
- includes a button linking back to the new "report forecasts" path

## Screenshots of UI changes

### Before


<img width="1124" alt="before_heading_no_tab" src="https://user-images.githubusercontent.com/20245/122458539-d54ccb80-cfa7-11eb-8de9-9ae62003dcab.png">




### After

<img width="1145" alt="after_heading_with_tab" src="https://user-images.githubusercontent.com/20245/122458456-ba7a5700-cfa7-11eb-8ee4-09907e1e9d3e.png">


<img width="1121" alt="test_fixtures" src="https://user-images.githubusercontent.com/20245/122457592-b69a0500-cfa6-11eb-9293-909a298b5fa4.png">

Upload success page now uses the same table of forecasts grouped by activity:

![successfull_uploads](https://user-images.githubusercontent.com/20245/122799126-45659500-d2b9-11eb-91df-bb56c386bd36.png)

 
## To do / verify

From Trello: 

- ~the total of all forecasts in the table is shown~
- ~successfully uploading forecasts shows a list of the forecasts added in that upload~ 
- ~the success page has a link back to the report~

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
