### PR TITLE
Feature (1927) Record changes made to Activities via Wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -712,6 +712,7 @@
 - Add a list of uploaded forecasts (grouped by activity) to the upload success page
 - Fix: include BEIS in the organisation filter on the activities page
 - Change GCRF Strategic Area codes to Alphanumeric
+- Record edits to Activities made via Wizard form, using new HistoricalEvent entity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...HEAD
 [release-58]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-57...release-58

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -72,6 +72,7 @@ class Staff::ActivityFormsController < Staff::BaseController
     end
 
     update_form_state
+    record_history
     record_auditable_activity
 
     # `render_wizard` calls save on the object passed to it.
@@ -105,6 +106,16 @@ class Staff::ActivityFormsController < Staff::BaseController
     else
       @activity.form_state = step
     end
+  end
+
+  def record_history
+    HistoryRecorder
+      .new(user: current_user)
+      .call(
+        changes: @activity.changes,
+        reference: "Update to Activity #{step}",
+        activity: @activity
+      )
   end
 
   def record_auditable_activity

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -152,6 +152,7 @@ class Activity < ApplicationRecord
   has_many :comments
   has_many :matched_efforts
   has_many :external_incomes
+  has_many :historical_events
 
   enum level: {
     fund: "fund",

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,4 +1,7 @@
 class HistoricalEvent < ApplicationRecord
   belongs_to :user
   belongs_to :activity
+
+  serialize :new_value
+  serialize :previous_value
 end

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,0 +1,5 @@
+class HistoricalEvent
+  def self.create(attrs)
+    # coming soon
+  end
+end

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,2 +1,4 @@
 class HistoricalEvent < ApplicationRecord
+  belongs_to :user
+  belongs_to :activity
 end

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,5 +1,2 @@
-class HistoricalEvent
-  def self.create(attrs)
-    # coming soon
-  end
+class HistoricalEvent < ApplicationRecord
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   include PublicActivity::Common
 
   belongs_to :organisation
+  has_many :historical_events
   validates_presence_of :name, :email
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :email, with: :email_cannot_be_changed_after_create, on: :update

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -4,6 +4,19 @@ class HistoryRecorder
   end
 
   def call(changes:, reference:, activity:)
-    # coming soon
+    changes.each do |value_changed, (previous_value, new_value)|
+      HistoricalEvent.create(
+        user: user,
+        activity: activity,
+        reference: reference,
+        value_changed: value_changed,
+        previous_value: previous_value,
+        new_value: new_value,
+      )
+    end
   end
+
+  private
+
+  attr_reader :user
 end

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -1,0 +1,9 @@
+class HistoryRecorder
+  def initialize(user:)
+    @user = user
+  end
+
+  def call(changes:, reference:, activity:)
+    # coming soon
+  end
+end

--- a/db/migrate/20210624093716_create_historical_events.rb
+++ b/db/migrate/20210624093716_create_historical_events.rb
@@ -1,0 +1,14 @@
+class CreateHistoricalEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :historical_events, id: :uuid do |t|
+      t.references :user, type: :uuid
+      t.references :activity, type: :uuid
+      t.text :value_changed
+      t.text :new_value
+      t.text :previous_value
+      t.text :reference
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,6 +174,19 @@ ActiveRecord::Schema.define(version: 2021_06_24_123510) do
     t.index ["report_id"], name: "index_forecasts_on_report_id"
   end
 
+  create_table "historical_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.uuid "activity_id"
+    t.text "value_changed"
+    t.text "new_value"
+    t.text "previous_value"
+    t.text "reference"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_historical_events_on_activity_id"
+    t.index ["user_id"], name: "index_historical_events_on_user_id"
+  end
+
   create_table "implementing_organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "reference"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -830,6 +830,7 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:destination_transfers) }
     it { should have_many(:matched_efforts) }
     it { should have_many(:external_incomes) }
+    it { should have_many(:historical_events) }
   end
 
   describe "#parent_activities" do

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -5,4 +5,74 @@ RSpec.describe HistoricalEvent, type: :model do
     it { should belong_to(:activity) }
     it { should belong_to(:user) }
   end
+
+  describe "flexible 'value' fields which handle a range of data types" do
+    let(:event) { HistoricalEvent.new }
+
+    context "when value is a String" do
+      let(:persisted_event) do
+        set_value_fields_to("String")
+      end
+
+      it "should read back a String" do
+        expect(persisted_event.new_value).to eq("String")
+        expect(persisted_event.previous_value).to eq("String")
+      end
+    end
+
+    context "when value is an Integer" do
+      let(:persisted_event) do
+        set_value_fields_to(101)
+      end
+
+      it "should read back an Integer" do
+        expect(persisted_event.new_value).to eq(101)
+        expect(persisted_event.previous_value).to eq(101)
+      end
+    end
+
+    context "when value is a boolean" do
+      let(:persisted_event) do
+        set_value_fields_to(true)
+      end
+
+      it "should read back an boolean" do
+        expect(persisted_event.new_value).to be true
+        expect(persisted_event.previous_value).to be true
+      end
+    end
+
+    context "when value is a datetime" do
+      let(:datetime) { Time.current }
+
+      let(:persisted_event) do
+        set_value_fields_to(datetime)
+      end
+
+      it "should read back a datetime" do
+        expect(persisted_event.new_value).to eq(datetime)
+        expect(persisted_event.previous_value).to eq(datetime)
+      end
+    end
+
+    context "when value is a date" do
+      let(:date) { Date.parse("01-Jan-2020") }
+
+      let(:persisted_event) do
+        set_value_fields_to(date)
+      end
+
+      it "should read back a date" do
+        expect(persisted_event.new_value).to eq(date)
+        expect(persisted_event.previous_value).to eq(date)
+      end
+    end
+
+    def set_value_fields_to(value)
+      event.tap do |e|
+        e.new_value = value
+        e.previous_value = value
+      end
+    end
+  end
 end

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe HistoricalEvent, type: :model do
+  describe "associations" do
+    it { should belong_to(:activity) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe HistoricalEvent, type: :model do
       end
     end
 
+    context "when value is a BigDecimal" do
+      let(:bigdecimal) { BigDecimal("101.10") }
+
+      let(:persisted_event) do
+        set_value_fields_to(bigdecimal)
+      end
+
+      it "should read back a bigdecimal" do
+        expect(persisted_event.new_value).to eq(bigdecimal)
+        expect(persisted_event.previous_value).to eq(bigdecimal)
+      end
+    end
+
     def set_value_fields_to(value)
       event.tap do |e|
         e.new_value = value

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe User, type: :model do
   describe "associations" do
     # This also validates that the relationship is present
     it { is_expected.to belong_to(:organisation) }
+    it { is_expected.to have_many(:historical_events) }
   end
 
   describe "delegations" do

--- a/spec/services/history_recorder_spec.rb
+++ b/spec/services/history_recorder_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require "app/services/history_recorder"
+
+RSpec.describe HistoryRecorder do
+  describe "on instantiation" do
+    it "requires a user" do
+      expect { HistoryRecorder.new }.to raise_error(ArgumentError, "missing keyword: :user")
+    end
+  end
+
+  describe "#call(activity:, reference:, changes:)" do
+    before { allow(HistoricalEvent).to receive(:create).and_return(true) }
+
+    subject(:recorder) do
+      HistoryRecorder.new(user: user)
+    end
+
+    let(:changes) do
+      {
+        "title" => ["Original title", "Updated title"],
+        "description" => ["Original description", "Updated description"],
+      }
+    end
+
+    let(:user) { double("user") }
+    let(:reference) { double("reference") }
+    let(:activity) { double("activity") }
+
+    it "creates a HistoricalEvent for each change provided" do
+      recorder.call(changes: changes, activity: activity, reference: reference)
+
+      expect(HistoricalEvent).to have_received(:create).with(
+        user: user,
+        activity: activity,
+        reference: reference,
+        value_changed: "title",
+        previous_value: "Original title",
+        new_value: "Updated title",
+      )
+
+      expect(HistoricalEvent).to have_received(:create).with(
+        user: user,
+        activity: activity,
+        reference: reference,
+        value_changed: "description",
+        previous_value: "Original description",
+        new_value: "Updated description",
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,10 @@ RSpec.configure do |config|
   # Prevent --bisect from locking up
   config.bisect_runner = :shell
 
+  # Add the root of the project to the load path so that we can
+  # explicitly load dependent files in isolated specs
+  $LOAD_PATH << File.expand_path("..", __dir__)
+
   # Don't generate coverage for partial test runs
   SimpleCov.start if config.files_to_run.map { |file| file.split("spec/").last.split("/").first }.uniq.size > 3
 end


### PR DESCRIPTION
## Trello

https://trello.com/c/tt3mt1wQ/1927-record-activity-changes-made-via-wizard

## Changes in this PR

### 1) `HistoryRecorder` decomposes 'changes' into historical events

`Staff::ActivityFormsController` uses new `HistoryRecorder` service to record changes made via wizard:

e.g.

```ruby
HistoryRecorder
  .new(user: current_user)
  .call(
    changes: @activity.changes,
    reference: "Update to Activity purpose",
    activity: @activity
  )
```

### 2) `HistoryRecord` represents 'before' and 'after' state
For each change in the list of `changes` given to `HistoryRecorder`, the recorder creates a `HistoricalEvent` record.

**HistoricalEvent**:

- `activity_id`: uuid
- `value_changed`: the attribute, e.g. "title",
- `new_value`: stored as YAML to handle various data types 
- `previous_value`: stored as YAML to handle various data types 
- `user_id`: UUID (but maybe should be email address or name?),
- `reference`: e.g 'Update to Activity purpose' or 'Upload of file123.csv',
- `created_at`: datetime timestamp


## Screenshots of UI changes

No UI yet

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
- [x] Migration needs to run as part of deployment to create new `historical_events` table 
