### PR TITLE
(1907) BEIS should be in the activities organisation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -710,7 +710,7 @@
 
 - Add a Forecasts tab to the Report view, listing forecasts grouped by activity. Move 'Upload forecast' to this tab.
 - Add a list of uploaded forecasts (grouped by activity) to the upload success page
-
+- Fix: include BEIS in the organisation filter on the activities page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...HEAD
 [release-58]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-57...release-58

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -22,6 +22,10 @@ module FormHelper
     @list_of_delivery_partners ||= Organisation.delivery_partners
   end
 
+  def list_of_reporting_organisations
+    @list_of_reporting_organisations ||= Organisation.reporters
+  end
+
   def list_of_financial_quarters
     @list_of_financial_quarters ||= FinancialQuarter::QUARTERS.map { |id| OpenStruct.new(id: id, name: "Q#{id}") }
   end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -19,7 +19,7 @@ module FormHelper
   end
 
   def list_of_delivery_partners
-    @list_of_delivery_partners ||= Organisation.delivery_partners.order(:name)
+    @list_of_delivery_partners ||= Organisation.delivery_partners
   end
 
   def list_of_financial_quarters

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -33,6 +33,7 @@ class Organisation < ApplicationRecord
   scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
   scope :matched_effort_providers, -> { sorted_by_name.where(role: "matched_effort_provider") }
   scope :external_income_providers, -> { sorted_by_name.where(role: "external_income_provider") }
+  scope :reporters, -> { sorted_by_name.where(role: ["delivery_partner", "service_owner"]) }
   scope :active, -> { where(active: true) }
 
   before_validation :ensure_beis_organisation_reference_is_uppercase

--- a/app/views/staff/shared/activities/_filter.html.haml
+++ b/app/views/staff/shared/activities/_filter.html.haml
@@ -6,6 +6,6 @@
       .govuk-form-group
         %label{ class: "govuk-label", for: :organistaion_id }
           = t("filters.activity.organisation")
-        = select_tag :organisation_id, options_from_collection_for_select(list_of_delivery_partners, :id, :name, organisation_id), { class: "govuk-select" }
+        = select_tag :organisation_id, options_from_collection_for_select(list_of_reporting_organisations, :id, :name, organisation_id), { class: "govuk-select" }
       .govuk-form-group
         = submit_tag t("filters.activity.submit"), { class: "govuk-button", data: { module: "govuk-button" } }

--- a/spec/features/staff/users_can_filter_activities_spec.rb
+++ b/spec/features/staff/users_can_filter_activities_spec.rb
@@ -13,6 +13,22 @@ RSpec.feature "Users can filter activities" do
       expect(page).to have_select "organisation_id"
     end
 
+    scenario "the BEIS organisation is the default selection on the activities index" do
+      visit activities_path
+
+      expect(page).to have_select "organisation_id", selected: "Department for Business, Energy and Industrial Strategy"
+    end
+
+    scenario "the organisations are in alphabetical order" do
+      create(:delivery_partner_organisation, name: "Zorg")
+      create(:delivery_partner_organisation, name: "Aardvark")
+
+      visit activities_path
+
+      expect(page.all("#organisation_id option").first).to have_text("Aardvark")
+      expect(page.all("#organisation_id option").last).to have_text("Zorg")
+    end
+
     scenario "they can filter the activities to an organisation" do
       delivery_partner_organisation = create(:delivery_partner_organisation)
       programme = create(:programme_activity, extending_organisation: delivery_partner_organisation)

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe FormHelper, type: :helper do
   end
 
   describe "#list_of_delivery_partners" do
-    it "asks for a list of organisations that are not `service_owner`" do
+    it "asks for a list of organisations that are delivery partners" do
+      _beis = create(:beis_organisation)
       delivery_partner_1 = create(:delivery_partner_organisation, name: "aaaaa")
       delivery_partner_2 = create(:delivery_partner_organisation, name: "zzzzz")
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -23,4 +23,21 @@ RSpec.describe FormHelper, type: :helper do
       ])
     end
   end
+
+  describe "#list_of_reporting_organisations" do
+    it "asks for a list of organisations that are delivery partners or the `service_owner`" do
+      beis = create(:beis_organisation)
+      delivery_partner_1 = create(:delivery_partner_organisation, name: "aaaaa")
+      delivery_partner_2 = create(:delivery_partner_organisation, name: "zzzzz")
+
+      _matched_effort_provider = create(:matched_effort_provider)
+      _external_income_provider = create(:external_income_provider)
+
+      expect(helper.list_of_reporting_organisations).to match_array([
+        delivery_partner_1,
+        beis,
+        delivery_partner_2,
+      ])
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
+  describe ".reporters" do
+    it "should only contain delivery partners and service owners" do
+      beis_organisation = create(:beis_organisation)
+      delivery_partner_organisation = create(:delivery_partner_organisation)
+      matched_effort_provider = create(:matched_effort_provider)
+      external_income_provider = create(:external_income_provider)
+      reporters = Organisation.reporters
+
+      expect(reporters).to include(delivery_partner_organisation)
+      expect(reporters).to include(beis_organisation)
+      expect(reporters).not_to include(matched_effort_provider)
+      expect(reporters).not_to include(external_income_provider)
+    end
+  end
+
   describe ".matched_effort_providers" do
     it "should contain only organisations that are matched effort providers" do
       create_list(:delivery_partner_organisation, 3)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -135,13 +135,17 @@ RSpec.describe Organisation, type: :model do
   end
 
   describe ".delivery_partners" do
-    it "should contain only organisations that are not BEIS" do
+    it "should only contain organisations that are delivery partners" do
       beis_organisation = create(:beis_organisation)
       delivery_partner_organisation = create(:delivery_partner_organisation)
+      matched_effort_provider = create(:matched_effort_provider)
+      external_income_provider = create(:external_income_provider)
       delivery_partners = Organisation.delivery_partners
 
       expect(delivery_partners).to include(delivery_partner_organisation)
       expect(delivery_partners).not_to include(beis_organisation)
+      expect(delivery_partners).not_to include(matched_effort_provider)
+      expect(delivery_partners).not_to include(external_income_provider)
     end
   end
 


### PR DESCRIPTION
## Changes in this PR
- Fix: include BEIS in the organisation filter on the activities page

## Screenshots of UI changes

### Before
![Screenshot 2021-06-24 at 14 36 11](https://user-images.githubusercontent.com/579522/123272390-9b288000-d4f9-11eb-81e8-dcc10be14200.png)

### After
![Screenshot 2021-06-24 at 14 35 57](https://user-images.githubusercontent.com/579522/123272428-a24f8e00-d4f9-11eb-91bf-5e78d66a0d40.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
