### PR TITLE
(1808) Change GCRF Strategic Area codes to Alphanumeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,6 +711,7 @@
 - Add a Forecasts tab to the Report view, listing forecasts grouped by activity. Move 'Upload forecast' to this tab.
 - Add a list of uploaded forecasts (grouped by activity) to the upload success page
 - Fix: include BEIS in the organisation filter on the activities page
+- Change GCRF Strategic Area codes to Alphanumeric
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...HEAD
 [release-58]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-57...release-58

--- a/db/data/20210624142643_change_gcrf_strategic_area_to_alphanumeric.rb
+++ b/db/data/20210624142643_change_gcrf_strategic_area_to_alphanumeric.rb
@@ -1,0 +1,9 @@
+# Run me with `rails runner db/data/20210624142643_change_gcrf_strategic_area_to_alphanumeric.rb`
+
+codelist = Codelist.new(type: "gcrf_strategic_area", source: "beis").list
+
+codelist.each do |item|
+  Activity.where(gcrf_strategic_area: [item["legacy_code"]]).update_all(
+    gcrf_strategic_area: [item["code"]]
+  )
+end

--- a/db/migrate/20210624123510_change_gcrf_strategic_area_to_string.rb
+++ b/db/migrate/20210624123510_change_gcrf_strategic_area_to_string.rb
@@ -1,0 +1,9 @@
+class ChangeGcrfStrategicAreaToString < ActiveRecord::Migration[6.1]
+  def up
+    change_column :activities, :gcrf_strategic_area, :string, using: "CAST(gcrf_strategic_area AS varchar[])", array: true, default: []
+  end
+
+  def down
+    change_column :activities, :gcrf_strategic_area, :integer, using: "CAST(gcrf_strategic_area AS integer[])", array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_155407) do
+ActiveRecord::Schema.define(version: 2021_06_24_123510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_155407) do
     t.integer "programme_status"
     t.string "channel_of_delivery_code"
     t.integer "source_fund_code"
-    t.integer "gcrf_strategic_area", default: [], array: true
+    t.string "gcrf_strategic_area", default: [], array: true
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     aid_type { "D01" }
     level { :fund }
     publish_to_iati { true }
-    gcrf_strategic_area { ["1", "2"] }
+    gcrf_strategic_area { ["17A", "RF"] }
     gcrf_challenge_area { 0 }
     oda_eligibility_lead { Faker::Name.name }
     uk_dp_named_contact { Faker::Name.name }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe Activity, type: :model do
 
     context "when gcrf_strategic_area has too many values" do
       let(:source_fund_code) { Fund::MAPPINGS["NF"] }
-      let(:strategic_areas) { %w[1 2 3] }
+      let(:strategic_areas) { %w[RF Clm IP] }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_strategic_area: strategic_areas) }
 
       context "with a GCRF funded activity" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe ActivityPresenter do
 
   describe "#gcrf_strategic_area" do
     it "returns the code list description values for the stored integers" do
-      activity = build(:project_activity, gcrf_strategic_area: %w[1 3])
+      activity = build(:project_activity, gcrf_strategic_area: %w[17A RF])
       result = described_class.new(activity)
 
       expect(result.gcrf_strategic_area).to eql "UKRI Collective Fund (2017 allocation) and Academies Collective Fund: Resilient Futures"

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
       expect(existing_activity.gdi).to eq("1")
-      expect(existing_activity.gcrf_strategic_area).to eq([1, 3])
+      expect(existing_activity.gcrf_strategic_area).to eq(["1", "3"])
       expect(existing_activity.gcrf_challenge_area).to eq(4)
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.fund_pillar).to eq(existing_activity_attributes["Newton Fund Pillar"].to_i)

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Activities::ImportFromCsv do
       "Intended Beneficiaries" => "KH|KP|ID",
       "Delivery partner identifier" => "1234567890",
       "GDI" => "1",
-      "GCRF Strategic Area" => "1|3",
+      "GCRF Strategic Area" => "17A|RF",
       "GCRF Challenge Area" => "4",
       "SDG 1" => "1",
       "SDG 2" => "2",
@@ -160,7 +160,7 @@ RSpec.describe Activities::ImportFromCsv do
       expect(existing_activity.recipient_country).to eq(existing_activity_attributes["Recipient Country"])
       expect(existing_activity.intended_beneficiaries).to eq(["KH", "KP", "ID"])
       expect(existing_activity.gdi).to eq("1")
-      expect(existing_activity.gcrf_strategic_area).to eq(["1", "3"])
+      expect(existing_activity.gcrf_strategic_area).to eq(["17A", "RF"])
       expect(existing_activity.gcrf_challenge_area).to eq(4)
       expect(existing_activity.delivery_partner_identifier).to eq(existing_activity_attributes["Delivery partner identifier"])
       expect(existing_activity.fund_pillar).to eq(existing_activity_attributes["Newton Fund Pillar"].to_i)

--- a/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
+++ b/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
@@ -1,15 +1,15 @@
 data:
-  - code: 0
+  - code: "0"
     description: Core
-  - code: 1
+  - code: "1"
     description: UKRI Collective Fund (2017 allocation)
-  - code: 3
+  - code: "3"
     description: "Academies Collective Fund: Resilient Futures"
-  - code: 4
+  - code: "4"
     description: Coherence and Impact
-  - code: 5
+  - code: "5"
     description: International Partnerships
-  - code: 6
+  - code: "6"
     description: Innovation and Commercialisation
-  - code: 7
+  - code: "7"
     description: Agile response in emergencies

--- a/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
+++ b/vendor/data/codelists/BEIS/gcrf_strategic_area.yml
@@ -1,15 +1,22 @@
 data:
-  - code: "0"
+  - code: "C"
+    legacy_code: "0"
     description: Core
-  - code: "1"
+  - code: "17A"
+    legacy_code: "1"
     description: UKRI Collective Fund (2017 allocation)
-  - code: "3"
+  - code: "RF"
+    legacy_code: "3"
     description: "Academies Collective Fund: Resilient Futures"
-  - code: "4"
+  - code: "Clm"
+    legacy_code: "4"
     description: Coherence and Impact
-  - code: "5"
+  - code: "IP"
+    legacy_code: "5"
     description: International Partnerships
-  - code: "6"
+  - code: "InC"
+    legacy_code: "6"
     description: Innovation and Commercialisation
-  - code: "7"
+  - code: "ARE"
+    legacy_code: "7"
     description: Agile response in emergencies


### PR DESCRIPTION
This changes the GCRF Strategic Area codes from numeric to Alphanumeric, so we can use them when we start to automate the RODA identifiers. I've also added a data migration that will need running to change the existing codes that we do have. 