### PR TITLE
Feature (1928) Record activity changes made in bulk via CSV upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -718,6 +718,7 @@
 
 - Show actuals grouped by activity against a specific report
 - Show uploaded transactions after an upload
+- Record edits to Activities made in bulk via CSV imports, using the new Historical Event entity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -122,10 +122,10 @@ module Activities
           end
         end
 
-        return set_errors unless @activity.valid?
+        changes = @activity.changes
+        return set_errors unless @activity.save
 
-        record_history
-        @activity.save
+        record_history(changes)
       end
 
       def find_activity_by_roda_id(roda_id)
@@ -137,11 +137,11 @@ module Activities
 
       private
 
-      def record_history
+      def record_history(changes)
         HistoryRecorder
           .new(user: @uploader)
           .call(
-            changes: @activity.changes,
+            changes: changes,
             reference: "Import from CSV",
             activity: @activity
           )

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -122,11 +122,10 @@ module Activities
           end
         end
 
-        return if @activity.save
+        return set_errors unless @activity.valid?
 
-        @activity.errors.each do |error|
-          @errors[error.attribute] ||= [@converter.raw(error.attribute), error.message]
-        end
+        record_history
+        @activity.save
       end
 
       def find_activity_by_roda_id(roda_id)
@@ -134,6 +133,24 @@ module Activities
         @errors[:roda_id] ||= [roda_id, I18n.t("importer.errors.activity.not_found")] if activity.nil?
 
         activity
+      end
+
+      private
+
+      def record_history
+        HistoryRecorder
+          .new(user: @uploader)
+          .call(
+            changes: @activity.changes,
+            reference: "Import from CSV",
+            activity: @activity
+          )
+      end
+
+      def set_errors
+        @activity.errors.each do |error|
+          @errors[error.attribute] ||= [@converter.raw(error.attribute), error.message]
+        end
       end
     end
 

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -177,6 +177,25 @@ RSpec.feature "users can upload activities" do
     expect(page).to have_text(t("action.activity.upload.success"))
     expect(page).to have_text("List of activities updated")
 
+    expect_change_to_be_recorded_as_historical_event(
+      field: "title",
+      previous_value: activity_to_update.title,
+      new_value: "New Title",
+      activity: activity_to_update
+    )
+    expect_change_to_be_recorded_as_historical_event(
+      field: "recipient_country",
+      previous_value: activity_to_update.recipient_country,
+      new_value: "BR",
+      activity: activity_to_update
+    )
+    expect_change_to_be_recorded_as_historical_event(
+      field: "geography",
+      previous_value: activity_to_update.geography,
+      new_value: "recipient_country",
+      activity: activity_to_update
+    )
+
     expect(activity_to_update.reload.title).to eq("New Title")
 
     within "//tbody/tr[1]" do
@@ -204,6 +223,19 @@ RSpec.feature "users can upload activities" do
       expect(page).to have_xpath("td[2]", text: "2")
       expect(page).to have_xpath("td[3]", text: "new-id-oh-no")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.activity.cannot_update.delivery_partner_identifier_present"))
+    end
+  end
+
+  def expect_change_to_be_recorded_as_historical_event(field:, previous_value:, new_value:, activity:)
+    historical_event = HistoricalEvent.find_by!(value_changed: field)
+
+    aggregate_failures do
+      expect(historical_event.value_changed).to eq(field)
+      expect(historical_event.previous_value).to eq(previous_value)
+      expect(historical_event.new_value).to eq(new_value)
+      expect(historical_event.reference).to eq("Import from CSV")
+      expect(historical_event.user).to eq(user)
+      expect(historical_event.activity).to eq(activity)
     end
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -966,6 +966,20 @@ RSpec.describe Activities::ImportFromCsv do
           activity: existing_activity
         )
       end
+
+      context "when the activity fails to update" do
+        before do
+          allow(existing_activity).to receive(:save).and_return(false)
+        end
+
+        it "doesn't record any History" do
+          rows = [existing_activity_attributes, new_activity_attributes]
+
+          subject.import(rows)
+
+          expect(history_recorder).not_to have_received(:call)
+        end
+      end
     end
 
     it "creates and imports implementing organisations" do

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -924,9 +924,11 @@ RSpec.describe Activities::ImportFromCsv do
 
   context "when updating and importing" do
     let(:activity_policy_double) { instance_double("ActivityPolicy", create_child?: true, update?: true) }
+    let(:history_recorder) { instance_double(HistoryRecorder, call: true) }
 
     before do
       allow(ActivityPolicy).to receive(:new).and_return(activity_policy_double)
+      allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
     end
 
     it "creates and imports activities" do
@@ -937,6 +939,33 @@ RSpec.describe Activities::ImportFromCsv do
       expect(subject.updated.count).to eq(1)
 
       expect(subject.errors.count).to eq(0)
+    end
+
+    describe "recording changes" do
+      let(:expected_changes) do
+        {
+          "attr_1" => ["old attr_1 value", "new attr_1 value"],
+          "attr_2" => ["old attr_2 value", "new attr_2 value"],
+        }
+      end
+
+      before do
+        allow(existing_activity).to receive(:changes).and_return(expected_changes)
+        allow(Activity).to receive(:by_roda_identifier).and_return(existing_activity)
+      end
+
+      it "records the changes made using the HistoryRecorder" do
+        rows = [existing_activity_attributes, new_activity_attributes]
+
+        subject.import(rows)
+
+        expect(HistoryRecorder).to have_received(:new).with(user: uploader)
+        expect(history_recorder).to have_received(:call).with(
+          reference: "Import from CSV",
+          changes: expected_changes,
+          activity: existing_activity
+        )
+      end
     end
 
     it "creates and imports implementing organisations" do


### PR DESCRIPTION
## Trello card
https://trello.com/c/BDdnYxcb/1928-record-activity-changes-made-in-bulk

## Changes in this PR
When processing bulk imports of activities in CSV form we now record any updates to existing activities using the new `HistoryRecorder` service, which creates a `HistoricalEntry` record for each attribute being updated. 

Those updated attributes are obtained using `Activity#changes` before the activity in question is saved.


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
