### PR TITLE
(1530) Improvements to the reporting actual spend journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -716,6 +716,8 @@
 
 ## [unreleased]
 
+- Show actuals grouped by activity against a specific report
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59
 [release-58]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-57...release-58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,6 +717,7 @@
 ## [unreleased]
 
 - Show actuals grouped by activity against a specific report
+- Show uploaded transactions after an upload
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/staff/report_transactions_controller.rb
+++ b/app/controllers/staff/report_transactions_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Staff::ReportTransactionsController < Staff::BaseController
+  include Secured
+
+  def show
+    @report = Report.find(params["report_id"])
+    authorize @report
+
+    @report_presenter = ReportPresenter.new(@report)
+    @report_activities = @report.reportable_activities
+    @total_transaction = TotalPresenter.new(transactions.sum(&:value)).value
+    @grouped_transactions = transactions
+      .includes([:parent_activity])
+      .map { |forecast| TransactionPresenter.new(forecast) }
+      .group_by { |forecast| ActivityPresenter.new(forecast.parent_activity) }
+
+    render "staff/reports/transactions"
+  end
+
+  private
+
+  def transactions
+    @transactions ||= @report.transactions
+  end
+end

--- a/app/controllers/staff/transaction_uploads_controller.rb
+++ b/app/controllers/staff/transaction_uploads_controller.rb
@@ -38,6 +38,13 @@ class Staff::TransactionUploadsController < Staff::BaseController
       @errors = importer.errors
 
       if @errors.empty?
+        imported_transactions = importer.imported_transactions.compact
+
+        @total_transaction = TotalPresenter.new(imported_transactions.sum(&:value)).value
+        @grouped_transactions = imported_transactions
+          .map { |forecast| TransactionPresenter.new(forecast) }
+          .group_by { |forecast| ActivityPresenter.new(forecast.parent_activity) }
+
         @success = true
         flash.now[:notice] = t("action.transaction.upload.success")
       end

--- a/app/views/shared/transactions/_transactions_by_activity.html.haml
+++ b/app/views/shared/transactions/_transactions_by_activity.html.haml
@@ -1,0 +1,25 @@
+%table.govuk-table
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} RODA Identifier
+      %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-third", scope: "col"} Amount
+  %tbody.govuk-table__body
+
+    - @grouped_transactions.each do |activity, transactions|
+
+      %tr.govuk-table__row{ id: "activity_#{activity.id}" }
+        %td.govuk-table__cell= activity.title
+        %td.govuk-table__cell= activity.roda_identifier
+        %td.govuk-table__cell
+          %table.govuk-table.transactions
+            - transactions.each do |transaction|
+              %tr.govuk-table__row
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
+                  = transaction.value
+
+    %tr.govuk-table__row.totals
+      %td.govuk-table__cell Total
+      %td.govuk-table__cell
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @total_transaction

--- a/app/views/staff/reports/_actions.html.haml
+++ b/app/views/staff/reports/_actions.html.haml
@@ -1,8 +1,5 @@
 .govuk-grid-row
   .govuk-grid-column-full.page-actions
-    - if policy(@report_presenter).upload?
-      = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
-
     - if policy(@report_presenter).activate?
       = link_to t("action.report.activate.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 

--- a/app/views/staff/reports/_tab.html.haml
+++ b/app/views/staff/reports/_tab.html.haml
@@ -1,0 +1,4 @@
+%li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == name }"}
+  = link_to t("tabs.report.#{name}"),
+    path,
+    { class: "govuk-tabs__tab", aria: { current: (active_tab == name ? "page" : nil) } }

--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -1,21 +1,6 @@
-%ul.govuk-tabs__list
-  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "activities" }"}
-    = link_to t("tabs.report.activities"),
-      report_activities_path(@report),
-      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
-  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "forecasts" }"}
-    = link_to t("tabs.report.forecasts"),
-      report_forecasts_path(@report),
-      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
-  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "actuals" }"}
-    = link_to t("tabs.report.transactions"),
-      report_actuals_path(@report),
-      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
-  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "variance" }"}
-    = link_to t("tabs.report.variance"),
-      report_variance_path(@report),
-      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
-  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "budgets" }"}
-    = link_to t("tabs.report.budgets"),
-      report_budgets_path(@report),
-      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "details", selected: true } }
+%ul.govuk-tabs__list{ role: "navigation", aria: { label: "Report subnavigation" } }
+  = render partial: "staff/reports/tab", locals: { name: "activities", path: report_activities_path(@report), active_tab: active_tab }
+  = render partial: "staff/reports/tab", locals: { name: "forecasts", path: report_forecasts_path(@report), active_tab: active_tab }
+  = render partial: "staff/reports/tab", locals: { name: "transactions", path: report_actuals_path(@report), active_tab: active_tab }
+  = render partial: "staff/reports/tab", locals: { name: "variance", path: report_variance_path(@report), active_tab: active_tab }
+  = render partial: "staff/reports/tab", locals: { name: "budgets", path: report_budgets_path(@report), active_tab: active_tab }

--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -7,6 +7,10 @@
     = link_to t("tabs.report.forecasts"),
       report_forecasts_path(@report),
       { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
+  %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "actuals" }"}
+    = link_to t("tabs.report.transactions"),
+      report_actuals_path(@report),
+      { class: "govuk-tabs__tab", role: "tab", aria: { controls: "financials", selected: false } }
   %li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == "variance" }"}
     = link_to t("tabs.report.variance"),
       report_variance_path(@report),

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -19,7 +19,7 @@
           = t("page_content.tab_content.forecasts.guidance_html")
 
           - if policy(@report_presenter).upload?
-            = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary govuk-!-margin-left-4"
+            = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
 
           %h3.govuk-heading-m
             = t("page_content.tab_content.forecasts.per_activity_heading")

--- a/app/views/staff/reports/transactions.html.haml
+++ b/app/views/staff/reports/transactions.html.haml
@@ -10,7 +10,7 @@
         %h2.govuk-tabs__title
           Contents
 
-        = render partial: "staff/reports/tab_list", locals: { active_tab: "actuals" }
+        = render partial: "staff/reports/tab_list", locals: { active_tab: "transactions" }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/reports/transactions.html.haml
+++ b/app/views/staff/reports/transactions.html.haml
@@ -1,0 +1,29 @@
+=content_for :page_title_prefix, t("page_title.report.transactions",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+
+  = render "staff/reports/meta"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        = render partial: "staff/reports/tab_list", locals: { active_tab: "actuals" }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_content.tab_content.transactions.heading")
+
+          = t("page_content.tab_content.transactions.guidance_html")
+
+          - if policy(@report_presenter).upload?
+            = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
+
+          %h3.govuk-heading-m
+            = t("page_content.tab_content.transactions.per_activity_heading")
+
+          = render partial: "shared/transactions/transactions_by_activity"
+
+

--- a/app/views/staff/transaction_uploads/update.html.haml
+++ b/app/views/staff/transaction_uploads/update.html.haml
@@ -2,14 +2,20 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %h1.govuk-heading-xl
-        = t("page_title.transaction.upload")
+    - if @success == false
+      .govuk-grid-column-two-thirds
+        %h1.govuk-heading-xl
+          = t("page_title.transaction.upload")
 
-  - unless @errors.empty?
-    .govuk-grid-row
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "error_table"
+
+          = render partial: "upload_form"
+    - else
       .govuk-grid-column-full
-        = render partial: "error_table"
+        %h1.govuk-heading-xl
+          = t("page_title.transaction.upload_success")
 
-  - unless @success
-    = render partial: "upload_form"
+        = render partial: "shared/transactions/transactions_by_activity"
+        = link_to t("importer.success.transaction.back_link"), report_actuals_path(@report_presenter), class: "govuk-button govuk-button"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -32,6 +32,7 @@ en:
     report:
       activities: Activities
       forecasts: Forecasts
+      transactions: Actuals
       variance: Variance
       budgets: Budgets
 
@@ -49,6 +50,17 @@ en:
           <p class="govuk-body">
             For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+activities">uploading new activities</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
           </p>
+      transactions:
+        heading: Actuals in this report
+        per_activity_heading: Actual spend per activity
+        guidance_html:
+          <p class="govuk-body">
+            This page shows all the actual spend you have reported in RODA since the last reporting quarter.
+          </p>
+          <p class="govuk-body">
+            For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+actuals">uploading new actuals</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
+          </p>
+
     report:
       activate:
         confirm: By activating this report, you will allow Delivery Partner users to add new data, and amend existing data. These changes will associate to this report only.
@@ -118,6 +130,7 @@ en:
         complete: This report is approved
       variance: "%{report_financial_quarter} %{report_description} variance"
       forecasts: "%{report_financial_quarter} %{report_description} forecasts"
+      transactions: "%{report_financial_quarter} %{report_description} actuals"
       budgets: "%{report_financial_quarter} %{report_description} budgets"
       activities: "%{report_financial_quarter} %{report_description} activities"
   mailer:

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -68,6 +68,7 @@ en:
       edit: Edit transaction
       new: Add a transaction
       upload: Upload bulk transactions data
+      upload_success: Successful uploads
   activerecord:
     errors:
       models:
@@ -104,3 +105,6 @@ en:
         unauthorised: You are not authorised to report against this activity
         unknown_identifier: Identifier is not recognised
         invalid_characters: This cell contains invalid characters
+    success:
+      transaction:
+        back_link: Back to report

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
       resource :transaction_upload, only: [:new, :show, :update]
       get "variance" => "report_variance#show"
       get "forecasts" => "report_forecasts#show"
+      get "actuals" => "report_transactions#show"
       get "budgets" => "report_budgets#show"
       get "activities" => "report_activities#show"
     end

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "users can upload transactions" do
 
   before do
     authenticate!(user: user)
-    visit report_path(report)
+    visit report_actuals_path(report)
     click_link t("action.transaction.upload.link")
   end
 

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -19,6 +19,18 @@ RSpec.feature "users can upload transactions" do
     click_link t("action.transaction.upload.link")
   end
 
+  def expect_to_see_successful_upload_summary_with(count:, total:)
+    expect(page).to have_text(t("page_title.transaction.upload_success"))
+    expect(page).to have_css(".transactions tr", count: count)
+    expect(page).to have_link(
+      t("importer.success.transaction.back_link"),
+      href: report_actuals_path(report)
+    )
+    within ".totals" do
+      expect(page).to have_content(total)
+    end
+  end
+
   scenario "downloading a CSV template with activities for the current report" do
     click_link t("action.transaction.download.button")
 
@@ -68,7 +80,9 @@ RSpec.feature "users can upload transactions" do
 
     expect(Transaction.count).to eq(2)
     expect(page).to have_text(t("action.transaction.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+    expect(page).not_to have_css("table.govuk-table.errors")
+
+    expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
 
   scenario "uploading a valid set of transactions with no organisation data" do
@@ -82,7 +96,8 @@ RSpec.feature "users can upload transactions" do
 
     expect(Transaction.count).to eq(2)
     expect(page).to have_text(t("action.transaction.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+
+    expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
 
   scenario "uploading a valid set of transactions including zero values" do
@@ -96,7 +111,8 @@ RSpec.feature "users can upload transactions" do
 
     expect(Transaction.count).to eq(1)
     expect(page).to have_text(t("action.transaction.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+
+    expect_to_see_successful_upload_summary_with(count: 1, total: 30)
   end
 
   scenario "uploading an invalid set of transactions" do
@@ -161,7 +177,8 @@ RSpec.feature "users can upload transactions" do
 
     expect(Transaction.count).to eq(2)
     expect(page).to have_text(t("action.transaction.upload.success"))
-    expect(page).not_to have_xpath("//tbody/tr")
+
+    expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
 
   def upload_csv(content)

--- a/spec/features/staff/users_can_view_actuals_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_within_report_spec.rb
@@ -1,0 +1,91 @@
+RSpec.feature "Users can view actuals in tab within a report" do
+  context "as a Delivery Partner user" do
+    let(:organisation) { create(:delivery_partner_organisation) }
+    let(:user) { create(:delivery_partner_user, organisation: organisation) }
+
+    before do
+      authenticate!(user: user)
+    end
+
+    def expect_to_see_a_table_of_transactions_grouped_by_activity(activities)
+      expect(page).to have_content(
+        t("page_content.tab_content.transactions.per_activity_heading")
+      )
+
+      fail "We expect some activities to be present" if activities.none?
+
+      activities.each do |activity|
+        within "#activity_#{activity.id}" do
+          expect(page).to have_content(activity.title)
+          expect(page).to have_content(activity.roda_identifier)
+
+          fail "We expect some transactions to be present" if activity.transactions.none?
+
+          within ".transactions" do
+            activity.transactions.each do |transaction|
+              expect(page).to have_content(transaction.value)
+            end
+          end
+        end
+      end
+    end
+
+    def expect_to_see_total_of_actual_amounts(activities)
+      transaction_total = activities.map(&:transactions).flatten.sum(&:value)
+
+      within ".totals" do
+        expect(page).to have_content(
+          ActionController::Base.helpers.number_to_currency(transaction_total, unit: "£")
+        )
+      end
+    end
+
+    scenario "the report contains an _actuals_ tab" do
+      report = create(:report, state: :active, organisation: organisation, description: nil)
+
+      programme = create(:programme_activity)
+      project = create(:project_activity, organisation: organisation, parent: programme)
+
+      activities = [
+        create(:third_party_project_activity,
+          organisation: organisation,
+          parent: project).tap do |activity|
+          create(:transaction, report: report, parent_activity: activity)
+        end,
+        create(:third_party_project_activity,
+          organisation: organisation,
+          parent: project).tap do |activity|
+          create_list(:transaction, 3, report: report, parent_activity: activity)
+        end,
+      ]
+
+      visit report_path(report.id)
+
+      click_link t("tabs.report.transactions")
+
+      expect(page).to have_content(t("page_content.tab_content.transactions.heading"))
+      expect(page).to have_link(t("action.transaction.upload.link"))
+
+      # guidance with 2 links
+      expect(page).to have_content("This page shows all the actual spend you have reported in RODA since the last reporting quarter")
+      expect(page).to have_link("uploading new actuals")
+      expect(page).to have_link("uploading updates to activities")
+
+      expect_to_see_a_table_of_transactions_grouped_by_activity(activities)
+
+      expect_to_see_total_of_actual_amounts(activities)
+    end
+
+    context "report is in a state where upload is not permissable" do
+      scenario "the upload facility is not present" do
+        report = create(:report, state: :approved, organisation: organisation, description: nil)
+
+        visit report_path(report.id)
+
+        click_link "Actuals"
+
+        expect(page).not_to have_link(t("action.transaction.upload.link"))
+      end
+    end
+  end
+end

--- a/spec/services/import_transactions_spec.rb
+++ b/spec/services/import_transactions_spec.rb
@@ -373,7 +373,8 @@ RSpec.describe ImportTransactions do
 
     it "imports all transactions successfully" do
       expect(importer.errors).to eq([])
-      expect(Transaction.count).to eq(3)
+      expect(importer.imported_transactions.count).to eq(3)
+      expect(importer.imported_transactions).to match_array(report.transactions)
     end
 
     it "assigns each transaction to the correct report" do
@@ -401,6 +402,7 @@ RSpec.describe ImportTransactions do
 
       it "does not import any transactions" do
         expect(Transaction.count).to eq(0)
+        expect(importer.imported_transactions).to eq([])
       end
 
       it "returns an error" do


### PR DESCRIPTION
This builds on some of the work in #1189 to:

* Add a new "Actuals" tab to the reports section to show transactions that have been reported during a reporting cycle, together with totals
* Move the "Upload Actuals" button to the "Actuals" page
* Present uploaded transactions back to the user when they have been successfully uploaded, together with a button to navigate back to the Report

## Screenshots

![image](https://user-images.githubusercontent.com/109774/123829201-25a62080-d8fa-11eb-940a-3202d86e85e5.png)

![image](https://user-images.githubusercontent.com/109774/123829654-8d5c6b80-d8fa-11eb-8106-82c45dd3659c.png)

