### PR TITLE
Add pry-byebug gem for more powerful debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem "brakeman"
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
+  gem "pry-byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,9 +260,12 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (1.2.3)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_activity (1.6.4)
@@ -499,6 +502,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0.0)
   parser (~> 2.6.3.0)
   pg
+  pry-byebug
   pry-rails
   public_activity (~> 1.5)
   puma (~> 5.3)


### PR DESCRIPTION
This provides handy debugging behaviour on top of pry, e.g.

taken from https://github.com/deivid-rodriguez/pry-byebug

  *break*: Manage breakpoints.

  *step*: Step execution into the next line or method.
          Takes an optional numeric argument to step
          multiple times.

  *next*: Step over to the next line within the same frame.
          Also takes an optional numeric argument to step
          multiple lines.

  *finish*: Execute until current stack frame returns.

  *continue*: Continue program execution and end the Pry session.
