### PR TITLE
(1930) Feature: associate Report with Wizard-orchestrated change to activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,6 +719,7 @@
 - Show actuals grouped by activity against a specific report
 - Show uploaded transactions after an upload
 - Record edits to Activities made in bulk via CSV imports, using the new Historical Event entity
+- Associate Report with HistoricalEvent when editing Activity via Wizard
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -114,7 +114,8 @@ class Staff::ActivityFormsController < Staff::BaseController
       .call(
         changes: @activity.changes,
         reference: "Update to Activity #{step}",
-        activity: @activity
+        activity: @activity,
+        report: Report.editable_for_activity(@activity)
       )
   end
 

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,6 +1,7 @@
 class HistoricalEvent < ApplicationRecord
   belongs_to :user
   belongs_to :activity
+  belongs_to :report, optional: true
 
   serialize :new_value
   serialize :previous_value

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -12,6 +12,7 @@ class Report < ApplicationRecord
   belongs_to :organisation
   has_many :transactions
   has_many :forecasts
+  has_many :historical_events
 
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -3,7 +3,7 @@ class HistoryRecorder
     @user = user
   end
 
-  def call(changes:, reference:, activity:)
+  def call(changes:, reference:, activity:, report: nil)
     changes.each do |value_changed, (previous_value, new_value)|
       HistoricalEvent.create(
         user: user,

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -8,6 +8,7 @@ class HistoryRecorder
       HistoricalEvent.create(
         user: user,
         activity: activity,
+        report: report,
         reference: reference,
         value_changed: value_changed,
         previous_value: previous_value,

--- a/db/migrate/20210630094140_add_report_id_to_historical_event.rb
+++ b/db/migrate/20210630094140_add_report_id_to_historical_event.rb
@@ -1,0 +1,5 @@
+class AddReportIdToHistoricalEvent < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :historical_events, :report, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_123510) do
+ActiveRecord::Schema.define(version: 2021_06_30_094140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -183,7 +183,9 @@ ActiveRecord::Schema.define(version: 2021_06_24_123510) do
     t.text "reference"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "report_id"
     t.index ["activity_id"], name: "index_historical_events_on_activity_id"
+    t.index ["report_id"], name: "index_historical_events_on_report_id"
     t.index ["user_id"], name: "index_historical_events_on_user_id"
   end
 

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -93,10 +93,12 @@ RSpec.describe Staff::ActivityFormsController do
         parent: programme
       )
     end
+    let(:report) { double("report") }
 
     before do
       policy = instance_double(ActivityPolicy, update?: true)
       allow(ActivityPolicy).to receive(:new).and_return(policy)
+      allow(Report).to receive(:editable_for_activity).and_return(report)
       allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
     end
 
@@ -108,6 +110,12 @@ RSpec.describe Staff::ActivityFormsController do
         }
       end
 
+      it "finds the appropriate report to be associated with the changes" do
+        put_step(:purpose, {title: "Updated title", description: "Updated description"})
+
+        expect(Report).to have_received(:editable_for_activity).with(activity)
+      end
+
       it "asks the HistoryRecorder to record the changes" do
         put_step(:purpose, {title: "Updated title", description: "Updated description"})
 
@@ -115,7 +123,8 @@ RSpec.describe Staff::ActivityFormsController do
         expect(history_recorder).to have_received(:call).with(
           changes: expected_changes,
           reference: "Update to Activity purpose",
-          activity: activity
+          activity: activity,
+          report: report
         )
       end
     end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -123,7 +123,9 @@ RSpec.feature "Users can edit an activity" do
           expect_change_to_be_recorded_as_historical_event(
             field: "description",
             previous_value: activity.description,
-            new_value: updated_description
+            new_value: updated_description,
+            activity: activity,
+            report: nil # no report in this scenario. Realistic or failure in setup?
           )
         end
 
@@ -423,7 +425,7 @@ RSpec.feature "Users can edit an activity" do
       it "the policy markers can be added" do
         activity = create(:project_activity, organisation: user.organisation)
         # Report needs to exist so the activity is editable
-        _report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
+        report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
 
         visit organisation_activity_details_path(activity.organisation, activity)
 
@@ -440,7 +442,9 @@ RSpec.feature "Users can edit an activity" do
         expect_change_to_be_recorded_as_historical_event(
           field: "policy_marker_gender",
           previous_value: "not_assessed",
-          new_value: "significant_objective"
+          new_value: "significant_objective",
+          activity: activity,
+          report: report
         )
       end
 
@@ -760,11 +764,19 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   end
 end
 
-def expect_change_to_be_recorded_as_historical_event(field:, previous_value:, new_value:)
+def expect_change_to_be_recorded_as_historical_event(
+  field:,
+  previous_value:,
+  new_value:,
+  activity:,
+  report:
+)
   historical_event = HistoricalEvent.last
   aggregate_failures do
     expect(historical_event.value_changed).to eq(field)
     expect(historical_event.previous_value).to eq(previous_value)
     expect(historical_event.new_value).to eq(new_value)
+    expect(historical_event.activity).to eq(activity)
+    expect(historical_event.report).to eq(report)
   end
 end

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe HistoricalEvent, type: :model do
   describe "associations" do
     it { should belong_to(:activity) }
     it { should belong_to(:user) }
+    it { should belong_to(:report).optional }
   end
 
   describe "flexible 'value' fields which handle a range of data types" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Report, type: :model do
   describe "associations" do
     it { should belong_to(:fund).class_name("Activity") }
     it { should belong_to(:organisation) }
+    it { should have_many(:historical_events) }
   end
 
   describe ".editable_for_activity" do

--- a/spec/services/history_recorder_spec.rb
+++ b/spec/services/history_recorder_spec.rb
@@ -25,26 +25,29 @@ RSpec.describe HistoryRecorder do
     let(:user) { double("user") }
     let(:reference) { double("reference") }
     let(:activity) { double("activity") }
+    let(:report) { double("report") }
 
     it "creates a HistoricalEvent for each change provided" do
-      recorder.call(changes: changes, activity: activity, reference: reference)
+      recorder.call(changes: changes, activity: activity, reference: reference, report: report)
 
       expect(HistoricalEvent).to have_received(:create).with(
         user: user,
         activity: activity,
+        report: report,
         reference: reference,
         value_changed: "title",
         previous_value: "Original title",
-        new_value: "Updated title",
+        new_value: "Updated title"
       )
 
       expect(HistoricalEvent).to have_received(:create).with(
         user: user,
         activity: activity,
+        report: report,
         reference: reference,
         value_changed: "description",
         previous_value: "Original description",
-        new_value: "Updated description",
+        new_value: "Updated description"
       )
     end
   end


### PR DESCRIPTION
## Changes in this PR

When editing an `Activity` via the `ActivityFormController` we now:

- look up the appropriate `Report` 
- pass that report to the `HistoryRecorder`
- see the `HistoryRecorder` associate the given `Report` with each `HistoricalEvent` created

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
