### PR TITLE
(1894) Feature: new BEIS user home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -720,6 +720,8 @@
 - Show uploaded transactions after an upload
 - Record edits to Activities made in bulk via CSV imports, using the new Historical Event entity
 - Associate Report with HistoricalEvent when editing Activity via Wizard
+- BEIS users have a home page that lets them view activities by delivery partner
+  organisation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -13,7 +13,7 @@ class Auth0Controller < ApplicationController
 
     # Redirect to the URL you want after successful auth
     if current_user.active && current_user.organisation
-      redirect_path = session[:redirect_path] || organisation_path(current_user.organisation)
+      redirect_path = session[:redirect_path] || home_path
       redirect_to redirect_path
     else
       render "pages/errors/not_authorised",

--- a/app/controllers/staff/dashboards_controller.rb
+++ b/app/controllers/staff/dashboards_controller.rb
@@ -1,7 +1,0 @@
-class Staff::DashboardsController < Staff::BaseController
-  def show
-    skip_policy_scope # We're not performing any queries here
-
-    authorize :dashboard, :show?
-  end
-end

--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -1,10 +1,12 @@
 class Staff::HomeController < Staff::BaseController
   def show
     authorize :home, :show?
-    redirect_if_delivery_partner
-  end
 
-  private def redirect_if_delivery_partner
-    redirect_to organisation_path(current_user.organisation) unless current_user.service_owner?
+    if current_user.service_owner?
+      @delivery_partner_organisations = Organisation.delivery_partners
+      authorize @delivery_partner_organisations
+    else
+      redirect_to organisation_path(current_user.organisation)
+    end
   end
 end

--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -1,0 +1,10 @@
+class Staff::HomeController < Staff::BaseController
+  def show
+    authorize :home, :show?
+    redirect_if_delivery_partner
+  end
+
+  private def redirect_if_delivery_partner
+    redirect_to organisation_path(current_user.organisation) unless current_user.service_owner?
+  end
+end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -1,5 +1,0 @@
-class DashboardPolicy < ApplicationPolicy
-  def show?
-    true
-  end
-end

--- a/app/policies/home_policy.rb
+++ b/app/policies/home_policy.rb
@@ -1,0 +1,6 @@
+class HomePolicy < ApplicationPolicy
+  def show?
+    return true if beis_user? || delivery_partner_user?
+    false
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -36,7 +36,7 @@
 
         - if authenticated?
           .govuk-header__content
-            %a.govuk-header__link.govuk-header__link--service-name{ href: organisation_path(current_user.organisation) }
+            %a.govuk-header__link.govuk-header__link--service-name{ href: home_path }
               = t('app.title')
 
             %button{type:'button', class:'govuk-header__menu-button govuk-js-header-toggle', aria: {label: 'Show or hide Top Level Navigation', controls: 'navigation'}}

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -2,8 +2,8 @@
   %ul{id: 'navigation', class: 'govuk-header__navigation', aria: { label: "Top Level Navigation"}}
     -if current_user.present? && current_user.active?
 
-      %li{ class: navigation_item_class(organisation_path(current_user.organisation)) }
-        %a{ href: organisation_path(current_user.organisation), class: 'govuk-header__link' }
+      %li{ class: navigation_item_class(home_path)}
+        %a{ href: home_path, class: 'govuk-header__link' }
           = t("page_title.home")
 
       %li{ class: navigation_item_class(reports_path) }

--- a/app/views/staff/home/_delivery_partner_organisations_table.html.haml
+++ b/app/views/staff/home/_delivery_partner_organisations_table.html.haml
@@ -1,0 +1,16 @@
+%table.govuk-table#delivery_partner_organisations
+  %caption.govuk-table__caption.govuk-table__caption--m
+    Delivery partner organisations
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"}
+        = t("table.header.organisation.name")
+      %th.govuk-table__header{scope: "col"}
+        = t("table.header.default.action")
+  %tbody.govuk-table__body
+    - @delivery_partner_organisations.each do |delivery_partner_organisation|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = delivery_partner_organisation.name
+        %td.govuk-table__cell
+          = a11y_action_link "View details and activities", organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link", "govuk-link--no-visited-state"]

--- a/app/views/staff/home/show.html.haml
+++ b/app/views/staff/home/show.html.haml
@@ -1,7 +1,7 @@
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full
-      %h1.govuk-heading-l
-        Home
 
       = render partial: "staff/searches/form"
+
+      = render partial: "delivery_partner_organisations_table", locals: @delivery_partner_organisaitons

--- a/app/views/staff/home/show.html.haml
+++ b/app/views/staff/home/show.html.haml
@@ -1,0 +1,5 @@
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-l
+        Home

--- a/app/views/staff/home/show.html.haml
+++ b/app/views/staff/home/show.html.haml
@@ -3,3 +3,5 @@
     .govuk-grid-column-full
       %h1.govuk-heading-l
         Home
+
+      = render partial: "staff/searches/form"

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -25,6 +25,10 @@ en:
     error:
       unknown: Unknown error
     warning: Warning
+  table:
+    header:
+      default:
+        action: Action
   activerecord:
     errors:
       format: "%{attribute} %{message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 
   scope module: "staff" do
-    resource :dashboard, only: :show
+    get "home", to: "home#show"
     resources :users
     resources :activities, only: [:index] do
       collection do

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(page).to have_content(t("header.link.sign_in"))
     click_on t("header.link.sign_in")
 
-    expect(page).to have_content(user.organisation.name)
     expect(page).to have_content(t("header.link.sign_out"))
   end
 
@@ -29,7 +28,6 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(page).to have_content(t("header.link.sign_in"))
     click_on t("header.link.sign_in")
 
-    expect(page).to have_content(user.organisation.name)
     expect(page).to have_content(t("header.link.sign_out"))
   end
 
@@ -47,8 +45,8 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(current_path).to eq(reports_path)
   end
 
-  scenario "any user lands on their organisation page" do
-    user = create(:administrator)
+  scenario "a BEIS user lands on their home  page" do
+    user = create(:beis_user)
 
     mock_successful_authentication(
       uid: user.identifier, name: user.name, email: user.email
@@ -60,9 +58,24 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(page).to have_content(t("header.link.sign_in"))
     click_on t("header.link.sign_in")
 
-    expect(page).to have_content(user.organisation.name)
+    expect(page.current_path).to eql("/home")
   end
 
+  scenario "a delivery partenr user lands on their home  page" do
+    user = create(:delivery_partner_user)
+
+    mock_successful_authentication(
+      uid: user.identifier, name: user.name, email: user.email
+    )
+
+    visit root_path
+    expect(page).to have_content(t("start_page.title"))
+
+    expect(page).to have_content(t("header.link.sign_in"))
+    click_on t("header.link.sign_in")
+
+    expect(page.current_path).to eql(organisation_path(user.organisation))
+  end
   scenario "protected pages cannot be visited unless signed in" do
     visit root_path
 

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -1,0 +1,37 @@
+RSpec.feature "users can view a home page" do
+  context "when not signed in" do
+    scenario "they cannot reach the home page and are redirected to the sign in" do
+      visit home_path
+
+      expect(page).to have_button("Sign in")
+    end
+  end
+
+  context "when a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+
+    before do
+      authenticate! user: beis_user
+    end
+
+    scenario "they see the home page" do
+      visit home_path
+
+      expect(page).to have_content("Home")
+    end
+  end
+
+  context "when a delivery partner  user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+
+    before do
+      authenticate! user: delivery_partner_user
+    end
+
+    scenario "they are redirected to their organisation show page" do
+      visit home_path
+
+      expect(page).to have_content(delivery_partner_user.organisation.name)
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).to have_link t("page_title.home"), href: home_path
       expect(page).to have_link t("page_title.report.index"), href: reports_path
       expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path
       expect(page).not_to have_link t("page_title.users.index"), href: users_path
@@ -33,7 +33,7 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link t("page_title.home"), href: organisation_path(user.organisation)
+      expect(page).to have_link t("page_title.home"), href: home_path
       expect(page).to have_link t("page_title.report.index"), href: reports_path
       expect(page).to have_link t("page_title.organisation.index"), href: organisations_path
       expect(page).to have_link t("page_title.users.index"), href: users_path


### PR DESCRIPTION
## Changes in this PR

We have been using the organisation show page as the user 'home' page for some time, which never felt right.

This work introduces a distinct home page for BEIS users that lets them focus on common tasks and as a 'launching off point' for the applicaiton, this is the design in our last round of user testing.

Future work will do something similar for delivery partner users, but for now we redirect and keep the experience the same fo them.

## Screenshots of UI changes

### Before

![Screenshot 2021-06-30 at 09-23-48 Organisation Department for Business, Energy and Industrial Strategy - Report your Offici](https://user-images.githubusercontent.com/480578/123957818-28f5e680-d9a4-11eb-9262-868e2e6f27a9.png)

### After

![Screenshot 2021-06-30 at 09-23-42 - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/123957824-2d220400-d9a4-11eb-8f56-e0da7564fe49.png)



