### PR TITLE
(1937) Budget type should be required and default to the direct type of the current activity fund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -722,6 +722,7 @@
 - Associate Report with HistoricalEvent when editing Activity via Wizard
 - BEIS users have a home page that lets them view activities by delivery partner
   organisation
+- Make sure a Budget has a Budget Type
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -5,6 +5,7 @@ class Staff::BudgetsController < Staff::BaseController
     @activity = Activity.find(activity_id)
     @budget = Budget.new
     @budget.parent_activity = @activity
+    @budget.budget_type = "direct"
 
     authorize @budget
   end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -18,7 +18,8 @@ class Budget < ApplicationRecord
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
   validates_presence_of :value,
     :currency,
-    :financial_year
+    :financial_year,
+    :budget_type
   validates :value, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
 
   with_options if: -> { direct? } do |direct_budget|

--- a/app/presenters/budget_presenter.rb
+++ b/app/presenters/budget_presenter.rb
@@ -1,5 +1,6 @@
 class BudgetPresenter < SimpleDelegator
   def budget_type
+    return if super.blank?
     I18n.t("form.label.budget.budget_type.#{super}")
   end
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -191,7 +191,9 @@ RSpec.describe "Users can create a budget" do
   end
 
   def fill_in_and_submit_budget_form
-    choose(t("form.label.budget.budget_type.direct"))
+    # set the `have_checked_field` argument to  `visible: false`
+    # because Capybara doesn’t pick up the  radio button when using the JavaScript driver
+    expect(page).to have_checked_field("budget[budget_type]", with: "direct", visible: false)
     select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
     fill_in "budget[value]", with: "1000.00"
     click_button t("default.button.submit")

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Budget do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:currency) }
     it { should validate_presence_of(:financial_year) }
+    it { should validate_presence_of(:budget_type) }
 
     describe "providing organisation" do
       let(:another_org) { create(:delivery_partner_organisation) }

--- a/spec/presenters/budget_presenter_spec.rb
+++ b/spec/presenters/budget_presenter_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe BudgetPresenter do
     it "returns the name of the budget type" do
       expect(described_class.new(budget).budget_type).to eq("Direct")
     end
+
+    it "returns nothing when the budget type is not present" do
+      budget.budget_type = nil
+      expect(described_class.new(budget).budget_type).to eq(nil)
+    end
   end
 
   describe "#iati_type" do


### PR DESCRIPTION
When tweaking the allowed budget types, we stopped defaulting to a particular type, and this highlighted the fact that we didn't actually validate the `budget_type` was present. This PR adds a validation to make sure a Budget Type is selected, as well as setting the default `budget_type` to `direct`.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/123965719-a3c2ff80-d9ac-11eb-9bc6-62915215eb1b.png)

### After

![image](https://user-images.githubusercontent.com/109774/123966196-1633df80-d9ad-11eb-84c4-020a761a9809.png)

![image](https://user-images.githubusercontent.com/109774/123966155-0a481d80-d9ad-11eb-99ac-0c27cb989e3e.png)



 