### PR TITLE
(1929) Feature: associate report with HistoricalEvents arising from bulk changes to activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,6 +725,7 @@
 - Make sure a Budget has a Budget Type
 - Delivery partner users have a home page that lets them view and search their
   own activities
+- Associate Report with HistoricalEvent when uploading a bulk CSV
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/staff/activity_uploads_controller.rb
+++ b/app/controllers/staff/activity_uploads_controller.rb
@@ -29,7 +29,11 @@ class Staff::ActivityUploadsController < Staff::BaseController
     @success = false
 
     if upload.valid?
-      importer = Activities::ImportFromCsv.new(uploader: current_user, delivery_partner_organisation: current_user.organisation)
+      importer = Activities::ImportFromCsv.new(
+        uploader: current_user,
+        delivery_partner_organisation: current_user.organisation,
+        report: report
+      )
       importer.import(upload.rows)
       @errors = importer.errors
       @activities = {created: importer.created, updated: importer.updated}

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -20,10 +20,11 @@ module Activities
       ["Parent RODA ID"] + Converter::FIELDS.values
     end
 
-    def initialize(uploader:, delivery_partner_organisation:)
+    def initialize(uploader:, delivery_partner_organisation:, report: nil)
       @uploader = uploader
       @uploader_organisation = uploader.organisation
       @delivery_partner_organisation = delivery_partner_organisation
+      @report = report
       @errors = []
       @created = []
       @updated = []
@@ -71,7 +72,12 @@ module Activities
       elsif row["Delivery Partner Identifier"].present?
         add_error(index, :delivery_partner_identifier, row["Delivery Partner Identifier"], I18n.t("importer.errors.activity.cannot_update.delivery_partner_identifier_present")) && return
       else
-        updater = ActivityUpdater.new(row: row, uploader: @uploader, delivery_partner_organisation: @delivery_partner_organisation)
+        updater = ActivityUpdater.new(
+          row: row,
+          uploader: @uploader,
+          delivery_partner_organisation: @delivery_partner_organisation,
+          report: @report
+        )
         updater.update
         updated << updater.activity unless updater.errors.any?
 
@@ -84,14 +90,15 @@ module Activities
     end
 
     class ActivityUpdater
-      attr_reader :errors, :activity, :row
+      attr_reader :errors, :activity, :row, :report
 
-      def initialize(row:, uploader:, delivery_partner_organisation:)
+      def initialize(row:, uploader:, delivery_partner_organisation:, report: nil)
         @errors = {}
         @activity = find_activity_by_roda_id(row["RODA ID"])
         @uploader = uploader
         @delivery_partner_organisation = delivery_partner_organisation
         @row = row
+        @report = report
         @converter = Converter.new(row, :update)
 
         if @activity && !ActivityPolicy.new(@uploader, @activity).update?
@@ -143,7 +150,8 @@ module Activities
           .call(
             changes: changes,
             reference: "Import from CSV",
-            activity: @activity
+            activity: @activity,
+            report: report
           )
       end
 

--- a/spec/controllers/staff/activity_uploads_controller_spec.rb
+++ b/spec/controllers/staff/activity_uploads_controller_spec.rb
@@ -80,7 +80,8 @@ RSpec.describe Staff::ActivityUploadsController do
 
         expect(Activities::ImportFromCsv).to have_received(:new).with(
           uploader: user,
-          delivery_partner_organisation: organisation
+          delivery_partner_organisation: organisation,
+          report: report
         )
 
         expect(importer).to have_received(:import).with(uploaded_rows)

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -181,19 +181,22 @@ RSpec.feature "users can upload activities" do
       field: "title",
       previous_value: activity_to_update.title,
       new_value: "New Title",
-      activity: activity_to_update
+      activity: activity_to_update,
+      report: report
     )
     expect_change_to_be_recorded_as_historical_event(
       field: "recipient_country",
       previous_value: activity_to_update.recipient_country,
       new_value: "BR",
-      activity: activity_to_update
+      activity: activity_to_update,
+      report: report
     )
     expect_change_to_be_recorded_as_historical_event(
       field: "geography",
       previous_value: activity_to_update.geography,
       new_value: "recipient_country",
-      activity: activity_to_update
+      activity: activity_to_update,
+      report: report
     )
 
     expect(activity_to_update.reload.title).to eq("New Title")
@@ -226,7 +229,13 @@ RSpec.feature "users can upload activities" do
     end
   end
 
-  def expect_change_to_be_recorded_as_historical_event(field:, previous_value:, new_value:, activity:)
+  def expect_change_to_be_recorded_as_historical_event(
+    field:,
+    previous_value:,
+    new_value:,
+    activity:,
+    report:
+  )
     historical_event = HistoricalEvent.find_by!(value_changed: field)
 
     aggregate_failures do
@@ -236,6 +245,7 @@ RSpec.feature "users can upload activities" do
       expect(historical_event.reference).to eq("Import from CSV")
       expect(historical_event.user).to eq(user)
       expect(historical_event.activity).to eq(activity)
+      expect(historical_event.report).to eq(report)
     end
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -942,6 +942,16 @@ RSpec.describe Activities::ImportFromCsv do
     end
 
     describe "recording changes" do
+      subject do
+        described_class.new(
+          uploader: uploader,
+          delivery_partner_organisation: organisation,
+          report: report
+        )
+      end
+
+      let(:report) { double("report") }
+
       let(:expected_changes) do
         {
           "attr_1" => ["old attr_1 value", "new attr_1 value"],
@@ -963,7 +973,8 @@ RSpec.describe Activities::ImportFromCsv do
         expect(history_recorder).to have_received(:call).with(
           reference: "Import from CSV",
           changes: expected_changes,
-          activity: existing_activity
+          activity: existing_activity,
+          report: report
         )
       end
 


### PR DESCRIPTION
This PR adds an optional `report` parameter to `Activities::ImportFromCsv` (and its internal `ActivityUpdater` class) so that when a CSV containing changes to existing activities is uploaded via the `Staff::ActivityUploadsController`, the appropriate report can be passed through to the `HistoryRecorder`.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
