### PR TITLE
(1934) Feature: create new delivery partner home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -723,6 +723,8 @@
 - BEIS users have a home page that lets them view activities by delivery partner
   organisation
 - Make sure a Budget has a Budget Type
+- Delivery partner users have a home page that lets them view and search their
+  own activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/public/visitors_controller.rb
+++ b/app/controllers/public/visitors_controller.rb
@@ -1,5 +1,5 @@
 class Public::VisitorsController < Public::BaseController
   def index
-    redirect_to organisation_path(current_user.organisation) if current_user&.active?
+    redirect_to home_path if current_user&.active?
   end
 end

--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -7,7 +7,22 @@ class Staff::HomeController < Staff::BaseController
       authorize @delivery_partner_organisations
       render :service_owner
     else
+      @grouped_programmes = fetch_grouped_programmes_for(current_user.organisation, :current)
       render :delivery_partner
     end
+  end
+
+  private def fetch_grouped_programmes_for(organisation, scope)
+    activities = policy_scope(
+      Activity.includes(
+        :organisation,
+        parent: [:parent, :organisation],
+        child_activities: [:child_activities, :organisation, :parent]
+      ).programme
+       .send(scope)
+    )
+    activities = activities.where(extending_organisation: organisation)
+    activities.order(:roda_identifier_compound)
+      .group_by(&:parent)
   end
 end

--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -5,8 +5,9 @@ class Staff::HomeController < Staff::BaseController
     if current_user.service_owner?
       @delivery_partner_organisations = Organisation.delivery_partners
       authorize @delivery_partner_organisations
+      render :service_owner
     else
-      redirect_to organisation_path(current_user.organisation)
+      render :delivery_partner
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,7 +16,6 @@
 // const imagePath = (name) => images(name, true)
 
 import accessibleAutocomplete from "accessible-autocomplete"
-import GOVUKFrontend from "govuk-frontend"
 import Rails from "@rails/ujs"
 
 import cookieConsent from "../src/cookie-consent"
@@ -27,6 +26,8 @@ Rails.start()
 window.accessibleAutocomplete = accessibleAutocomplete
 
 document.addEventListener("DOMContentLoaded", () => {
+  const GOVUKFrontend = require('govuk-frontend')
   GOVUKFrontend.initAll()
+
   initTableTreeView()
 })

--- a/app/views/staff/home/delivery_partner.html.haml
+++ b/app/views/staff/home/delivery_partner.html.haml
@@ -6,3 +6,4 @@
 
       = render partial: "staff/searches/form"
 
+      = render partial: "staff/shared/activities/tree_view/table", locals: { grouped_programmes: @grouped_programmes }

--- a/app/views/staff/home/delivery_partner.html.haml
+++ b/app/views/staff/home/delivery_partner.html.haml
@@ -6,4 +6,4 @@
 
       = render partial: "staff/searches/form"
 
-      = render partial: "staff/shared/activities/tree_view/table", locals: { grouped_programmes: @grouped_programmes }
+      = render partial: "staff/shared/activities/tree_view/table_tabbed", locals: { grouped_programmes: @grouped_programmes }

--- a/app/views/staff/home/delivery_partner.html.haml
+++ b/app/views/staff/home/delivery_partner.html.haml
@@ -1,0 +1,8 @@
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-l
+        Activities
+
+      = render partial: "staff/searches/form"
+

--- a/app/views/staff/home/service_owner.html.haml
+++ b/app/views/staff/home/service_owner.html.haml
@@ -1,7 +1,6 @@
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full
-
       = render partial: "staff/searches/form"
 
       = render partial: "delivery_partner_organisations_table", locals: @delivery_partner_organisaitons

--- a/app/views/staff/shared/activities/tree_view/_row.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_row.html.haml
@@ -6,7 +6,7 @@
   %td{class: "govuk-table__cell"}
     = activity_presenter.roda_identifier
   %td{class: "govuk-table__cell"}
-    = activity_presenter.level
+    = activity_presenter.programme_status
   %td{class: "govuk-table__cell"}
     = a11y_action_link t("table.body.activity.view_activity"),
                        organisation_activity_path(activity_presenter.organisation_id, activity_presenter),

--- a/app/views/staff/shared/activities/tree_view/_table.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_table.html.haml
@@ -16,7 +16,7 @@
                 %th{scope: "col", class: "govuk-table__header"}
                   = t("table.header.activity.identifier")
                 %th{scope: "col", class: "govuk-table__header"}
-                  = t("table.header.activity.level")
+                  = t("table.header.activity.programme_status")
                 %th{scope: "col", class: "govuk-table__header"}
 
             %tbody{class: "govuk-table__body"}

--- a/app/views/staff/shared/activities/tree_view/_table_tabbed.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_table_tabbed.html.haml
@@ -1,0 +1,35 @@
+- if grouped_programmes.any?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs{ data: { module: "govuk-tabs" } }
+        %h2.govuk-tabs__title
+          Current activities
+        %ul.govuk-tabs__list
+          - grouped_programmes.each do |fund, programmes|
+            %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+              = link_to fund.title, home_path(anchor: fund.title.parameterize), class: "govuk-tabs__tab"
+        - grouped_programmes.each do |fund, programmes|
+          - if programmes.any?
+            .govuk-tabs__panel{ id: fund.title.parameterize }
+              %table{id: fund.id, class: "govuk-table", data: {module: "table-tree-view"}}
+                %caption{class: "govuk-table__caption govuk-table__caption--m govuk-!-margin-top-4"}
+                  = fund.title
+                %thead{class: "govuk-table__head"}
+                  %tr{class: "govuk-table__row"}
+                    %th{scope: "col", class: "govuk-table__header govuk-!-width-one-half"}
+                      = t("table.header.activity.title")
+                    %th{scope: "col", class: "govuk-table__header"}
+                      = t("table.header.activity.identifier")
+                    %th{scope: "col", class: "govuk-table__header"}
+                      = t("table.header.activity.programme_status")
+                    %th{scope: "col", class: "govuk-table__header"}
+
+                %tbody{class: "govuk-table__body"}
+                  - programmes.each do |programme|
+                    = render partial: "staff/shared/activities/tree_view/row", locals: { activity: programme, parent: fund, is_parent: programme.child_activities.any? }
+                    - programme.child_activities.sort_by{|activity| activity.created_at }.each do |project|
+                      = render partial: "staff/shared/activities/tree_view/row", locals: { activity: project, parent: programme, is_parent: project.child_activities.any? }
+                      - project.child_activities.sort_by{|activity| activity.created_at }.each do |third_party_project|
+                        = render partial: "staff/shared/activities/tree_view/row", locals: { activity: third_party_project, parent: project, is_parent: false }
+
+              = link_to "View all activities", activities_path(organisation_id: current_user.organisation.id), class: "govuk-body govuk-link"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -301,6 +301,7 @@ en:
         forecasted_spend_for_quarter: "%{financial_quarter_and_year} forecasted spend"
         variance_for_quarter: "%{financial_quarter_and_year} variance"
         comment: Comment
+        programme_status: Status
     body:
       activity:
         level:

--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Home page" do
 
     scenario "they are redirected to their organisation show page" do
       visit root_path
-      expect(page.current_path).to eq organisation_path(user.organisation)
+      expect(page.current_path).to eq home_path
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.feature "Home page" do
 
     scenario "they are redirected to their organisation show page" do
       visit root_path
-      expect(page.current_path).to eq organisation_path(user.organisation)
+      expect(page.current_path).to eq home_path
     end
   end
 

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(page).to have_content(t("header.link.sign_in"))
     click_on t("header.link.sign_in")
 
-    expect(page.current_path).to eql("/home")
+    expect(page.current_path).to eql home_path
   end
 
   scenario "a delivery partenr user lands on their home  page" do
@@ -74,7 +74,7 @@ RSpec.feature "Users can sign in with Auth0" do
     expect(page).to have_content(t("header.link.sign_in"))
     click_on t("header.link.sign_in")
 
-    expect(page.current_path).to eql(organisation_path(user.organisation))
+    expect(page.current_path).to eql home_path
   end
   scenario "protected pages cannot be visited unless signed in" do
     visit root_path

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -9,29 +9,36 @@ RSpec.feature "users can view a home page" do
 
   context "when a BEIS user" do
     let(:beis_user) { create(:beis_user) }
+    let!(:delivery_partner_organisation) { create(:delivery_partner_organisation) }
 
     before do
       authenticate! user: beis_user
     end
 
-    scenario "they see the home page" do
+    scenario "they see the home page and the right content" do
       visit home_path
 
       expect(page.current_path).to eql home_path
+      expect(page).to have_button("Search")
+      expect(page).to have_table("Delivery partner organisations")
+      expect(page).to have_content(delivery_partner_organisation.name)
     end
   end
 
-  context "when a delivery partner  user" do
+  context "when a delivery partner user" do
     let(:delivery_partner_user) { create(:delivery_partner_user) }
+    let!(:programme) { create(:programme_activity, extending_organisation: delivery_partner_user.organisation) }
 
     before do
       authenticate! user: delivery_partner_user
     end
 
-    scenario "they are redirected to their home page" do
+    scenario "they see their home page and the right content" do
       visit home_path
 
       expect(page.current_path).to eql home_path
+      expect(page).to have_button("Search")
+      expect(page).to have_content(programme.title)
     end
   end
 end

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "users can view a home page" do
     scenario "they see the home page" do
       visit home_path
 
-      expect(page).to have_content("Home")
+      expect(page.current_path).to eql home_path
     end
   end
 
@@ -28,10 +28,10 @@ RSpec.feature "users can view a home page" do
       authenticate! user: delivery_partner_user
     end
 
-    scenario "they are redirected to their organisation show page" do
+    scenario "they are redirected to their home page" do
       visit home_path
 
-      expect(page).to have_content(delivery_partner_user.organisation.name)
+      expect(page.current_path).to eql home_path
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Following #1210 this work intoduces the delivery partner home page.

Delivery partners see the search widget and the hierarchical activity view on their home page, allowing them to locate their most common activities right from the home page.

The activity views are split by fund and progressively enchanced into tabs, this allows the users to view both funds activities without using a great deal of vertical space, for users with large numbers of activities this stops them potentially having to scroll a long way to locate activities.

The last commit 346384d contains a change to the JS pack as it seems the GOVUK JS was never being initialised correctly that makes the GOVUK JS tabs work.

## Screenshots of UI changes

### Before
![Screenshot 2021-07-01 at 16-22-23 Organisation Academy of Medical Sciences - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/124149518-8feccb80-da88-11eb-8112-515f1445806f.png)

### After
![Screenshot 2021-07-01 at 16-52-27 - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/124153853-ce848500-da8c-11eb-8833-37b45ad38e94.png)



