### PR TITLE
Feature/1950 view change history via a tab on activity page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,6 +727,7 @@
   own activities
 - Associate Report with HistoricalEvent when uploading a bulk CSV
 - Add a report summary tab
+- List an Activity's historical events in a new "Change history" tab 
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...HEAD
 [release-59]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-58...release-59

--- a/app/controllers/staff/activity_historical_events_controller.rb
+++ b/app/controllers/staff/activity_historical_events_controller.rb
@@ -7,5 +7,6 @@ class Staff::ActivityHistoricalEventsController < Staff::BaseController
     activity = Activity.find(params[:activity_id])
     authorize activity
     @activity = ActivityPresenter.new(activity)
+    @historical_events = @activity.historical_events.includes([:user, :report])
   end
 end

--- a/app/controllers/staff/activity_historical_events_controller.rb
+++ b/app/controllers/staff/activity_historical_events_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Staff::ActivityHistoricalEventsController < Staff::BaseController
+  include Secured
+
+  def show
+    activity = Activity.find(params[:activity_id])
+    authorize activity
+    @activity = ActivityPresenter.new(activity)
+  end
+end

--- a/app/views/staff/activity_historical_events/show.html.haml
+++ b/app/views/staff/activity_historical_events/show.html.haml
@@ -1,0 +1,19 @@
+= content_for :page_title_prefix, t("document_title.activity.historical_events", name: @activity.title)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        = @activity.title
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        = render "staff/shared/activities/tab_nav"
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_title.activity.change_history")
+
+          %p.govuk-body
+            = t("page_content.tab_content.change_history.guidance")

--- a/app/views/staff/activity_historical_events/show.html.haml
+++ b/app/views/staff/activity_historical_events/show.html.haml
@@ -17,3 +17,28 @@
 
           %p.govuk-body
             = t("page_content.tab_content.change_history.guidance")
+
+          %table.govuk-table.historical-events
+            %thead.govuk-table__head
+              %tr.govuk-body-s.govuk-table__row
+                %th.govuk-table__header{scope: "col"} Reference
+                %th.govuk-table__header{scope: "col"} Property
+                %th.govuk-table__header{scope: "col"} Previous value
+                %th.govuk-table__header{scope: "col"} New value
+                %th.govuk-table__header{scope: "col"} Who
+                %th.govuk-table__header{scope: "col"} When
+                %th.govuk-table__header{scope: "col"} Report
+
+            %tbody.govuk-table__body
+              - @historical_events.each do |event|
+
+                %tr.govuk-body-xs.govuk-table__row[event]
+                  %td.govuk-table__cell.reference= event.reference
+                  %td.govuk-table__cell.property= event.value_changed
+                  %td.govuk-table__cell.previous-value= event.previous_value
+                  %td.govuk-table__cell.new-value= event.new_value
+                  %td.govuk-table__cell.user= event.user.email
+                  %td.govuk-table__cell.timestamp= event.created_at.strftime("%d/%m/%C at %R")
+                  %td.govuk-table__cell.report
+                    = link_to(event.report.financial_quarter_and_year, report_path(event.report)) if event.report
+

--- a/app/views/staff/shared/activities/_tab_nav.html.haml
+++ b/app/views/staff/shared/activities/_tab_nav.html.haml
@@ -8,3 +8,4 @@
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "children", path: organisation_activity_children_path(@activity.organisation, @activity) }
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "comments", path: organisation_activity_comments_path(@activity.organisation, @activity) }
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "transfers", path: organisation_activity_transfers_path(@activity.organisation, @activity) }
+  = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "historical_events", path: organisation_activity_historical_events_path(@activity.organisation, @activity) }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -22,6 +22,7 @@ en:
       children: Activity %{name} - Child activities
       comments: Activity %{name} - Comments
       transfers: Activity %{name} - Transfers
+      historical_events: Activity %{name} - Change history
   form:
     button:
       activity:
@@ -346,6 +347,9 @@ en:
         default_selection_value: Select a recipient country
       third_party_projects: Third-party projects (level D)
       transactions: Transactions
+    tab_content:
+      change_history:
+        guidance: Changes made to this activity
   tabs:
     activity:
       title: Contents
@@ -355,6 +359,7 @@ en:
       children: Child activities
       comments: Comments
       transfers: Transfers
+      historical_events: Change history
     activities:
       current: Current
       historic: Historic
@@ -370,6 +375,7 @@ en:
       upload: Upload bulk activity data
       other_funding: Other funding
       transfers: Transfers
+      change_history: Change history
     activities:
       current: Current activities
       historic: Historic activities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
         get "comments" => "activity_comments#show"
         get "other_funding" => "activity_other_funding#show"
         get "transfers" => "activity_transfers#show"
+        get "historical_events" => "activity_historical_events#show"
       end
     end
 

--- a/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
@@ -1,0 +1,21 @@
+RSpec.feature "Users can view an activity's 'Change History' within a tab" do
+  context "as a Delivery Partner user" do
+    let(:organisation) { create(:delivery_partner_organisation) }
+    let(:user) { create(:delivery_partner_user, organisation: organisation) }
+
+    before do
+      authenticate!(user: user)
+    end
+
+    scenario "the activities page contains a _Change History_ tab" do
+      programme = create(:programme_activity)
+      activity = create(:project_activity, organisation: organisation, parent: programme)
+      visit organisation_activity_path(organisation, activity)
+
+      click_link "Change history"
+
+      expect(page).to have_css("h2", text: t("page_title.activity.change_history"))
+      expect(page).to have_content(t("page_content.tab_content.change_history.guidance"))
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
@@ -1,21 +1,89 @@
 RSpec.feature "Users can view an activity's 'Change History' within a tab" do
   context "as a Delivery Partner user" do
-    let(:organisation) { create(:delivery_partner_organisation) }
-    let(:user) { create(:delivery_partner_user, organisation: organisation) }
+    let(:user) { create(:delivery_partner_user) }
+    let(:programme) { create(:programme_activity) }
+    let(:activity) { create(:project_activity, organisation: user.organisation, parent: programme) }
+    let(:report) do
+      create(
+        :report,
+        :active,
+        organisation: programme.organisation,
+        fund: programme.parent,
+        financial_quarter: 3,
+        financial_year: 2020,
+      )
+    end
+
+    let(:reference) { "Update to Activity purpose" }
+    let(:changes) do
+      {"title" => ["Original title", "Updated title"],
+       "description" => ["Original description", "Updated description"],}
+    end
 
     before do
       authenticate!(user: user)
     end
 
+    def setup_historical_events(report:)
+      HistoryRecorder
+        .new(user: user)
+        .call(changes: changes, activity: activity, reference: reference, report: report)
+    end
+
+    def expect_to_see_change_history_with_reference(reference:, events:)
+      fail "We expect to see some Historical Events!" if events.empty?
+
+      within ".historical-events" do
+        expect(page).to have_css(".historical_event", count: events.count)
+        expect(page).to have_css(".reference", text: reference)
+
+        events.each do |event|
+          within "#historical_event_#{event.id}" do
+            expect(page).to have_css(".property", text: event.value_changed)
+            expect(page).to have_css(".previous-value", text: event.previous_value)
+            expect(page).to have_css(".new-value", text: event.new_value)
+            expect(page).to have_css(".user", text: event.user.email)
+            expect(page).to have_css(".timestamp", text: event.created_at.strftime("%d/%m/%C at %R"))
+            if event.report
+              expect(page).to have_css(
+                ".report a[href='#{report_path(event.report)}']",
+                text: event.report.financial_quarter_and_year
+              )
+            end
+          end
+        end
+      end
+    end
+
     scenario "the activities page contains a _Change History_ tab" do
-      programme = create(:programme_activity)
-      activity = create(:project_activity, organisation: organisation, parent: programme)
-      visit organisation_activity_path(organisation, activity)
+      setup_historical_events(report: report)
+
+      visit organisation_activity_path(activity.organisation, activity)
 
       click_link "Change history"
 
       expect(page).to have_css("h2", text: t("page_title.activity.change_history"))
       expect(page).to have_content(t("page_content.tab_content.change_history.guidance"))
+
+      expect_to_see_change_history_with_reference(
+        events: HistoricalEvent.last(2),
+        reference: reference
+      )
+    end
+
+    context "when the history is not associated with a report" do
+      scenario "the _Change History_ is represented without error" do
+        setup_historical_events(report: nil)
+
+        visit organisation_activity_path(activity.organisation, activity)
+
+        click_link "Change history"
+
+        expect_to_see_change_history_with_reference(
+          events: HistoricalEvent.last(2),
+          reference: reference
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

- Add a "Change history" tab to the Activity view
- Display a table of historical events

## Screenshots of UI changes

![change_history](https://user-images.githubusercontent.com/20245/124163714-c3832200-da97-11eb-9809-5f90a195392d.png)

## To follow in a future PR

### Group by reference. 

This needs a tweak to how `HistoricalEvent#reference` is set (see last commit message). My idea is to present each group as a list item containing:

- a definition list giving the properties common to the *group*:
  + reference
  + user email
  + link to report
  + time of change

- a table showing for each historical element in the group:
  + property 
  + previous value
  + new value
 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)

## Trello

https://trello.com/c/8AxbdARO/1950-view-change-history-via-a-tab-on-activity-page
