### PR TITLE
Optimise projects_and_third_party_projects_for_report scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,9 +727,11 @@
   own activities
 - Associate Report with HistoricalEvent when uploading a bulk CSV
 - Add a report summary tab
-- List an Activity's historical events in a new "Change history" tab 
+- List an Activity's historical events in a new "Change history" tab
 
 ## [unreleased]
+
+- Optimise `projects_and_third_party_projects_for_report` scope
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-60...HEAD
 [release-60]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...release-60

--- a/app/controllers/staff/report_activities_controller.rb
+++ b/app/controllers/staff/report_activities_controller.rb
@@ -9,7 +9,7 @@ class Staff::ReportActivitiesController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
 
-    @activities = Activity.projects_and_third_party_projects_for_report(@report).order(:title, :roda_identifier_fragment)
+    @activities = Activity::ProjectsForReportFinder.new(report: @report).call.order(:title, :roda_identifier_fragment)
 
     render "staff/reports/activities"
   end

--- a/app/controllers/staff/report_variance_controller.rb
+++ b/app/controllers/staff/report_variance_controller.rb
@@ -16,6 +16,9 @@ class Staff::ReportVarianceController < Staff::BaseController
   private
 
   def hierarchically_grouped_projects
-    Activity.includes(:organisation).projects_and_third_party_projects_for_report(@report).hierarchically_grouped_projects
+    Activity::ProjectsForReportFinder.new(
+      scope: Activity.includes(:organisation),
+      report: @report
+    ).call.hierarchically_grouped_projects
   end
 end

--- a/app/controllers/staff/spending_breakdowns_controller.rb
+++ b/app/controllers/staff/spending_breakdowns_controller.rb
@@ -7,7 +7,7 @@ class Staff::SpendingBreakdownsController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = Activity.projects_and_third_party_projects_for_report(@report)
+    @report_activities = Activity::ProjectsForReportFinder.new(report: @report)
 
     respond_to do |format|
       format.csv { send_csv }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -211,13 +211,11 @@ class Activity < ApplicationRecord
   scope :with_roda_identifier, -> { where.not(roda_identifier_compound: nil) }
 
   scope :projects_and_third_party_projects_for_report, ->(report) {
-    programmes = where(level: :programme, parent_id: report.fund_id)
-    projects = where(level: :project, parent_id: programmes.pluck(:id))
-    third_party_projects = where(level: :third_party_project, parent_id: projects.pluck(:id))
-
-    for_organisation = where(organisation_id: report.organisation_id)
-
-    for_organisation.merge(projects.or(third_party_projects))
+    where(
+      level: [:project, :third_party_project],
+      organisation_id: report.organisation_id,
+      source_fund_code: report.fund.source_fund_code
+    )
   }
 
   scope :current, -> {

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -210,14 +210,6 @@ class Activity < ApplicationRecord
   scope :publishable_to_iati, -> { where(form_state: :complete, publish_to_iati: true) }
   scope :with_roda_identifier, -> { where.not(roda_identifier_compound: nil) }
 
-  scope :projects_and_third_party_projects_for_report, ->(report) {
-    where(
-      level: [:project, :third_party_project],
-      organisation_id: report.organisation_id,
-      source_fund_code: report.fund.source_fund_code
-    )
-  }
-
   scope :current, -> {
                     where.not(programme_status: NON_CURRENT_PROGRAMME_STATUSES).or(where(programme_status: nil))
                   }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -80,7 +80,7 @@ class Report < ApplicationRecord
   end
 
   def reportable_activities
-    Activity.reportable.projects_and_third_party_projects_for_report(self).with_roda_identifier
+    Activity::ProjectsForReportFinder.new(report: self, scope: Activity.reportable).call.with_roda_identifier
   end
 
   def activities_created

--- a/app/services/activity/projects_for_report_finder.rb
+++ b/app/services/activity/projects_for_report_finder.rb
@@ -1,0 +1,20 @@
+class Activity
+  class ProjectsForReportFinder
+    def initialize(report:, scope: Activity.all)
+      @report = report
+      @scope = scope
+    end
+
+    def call
+      scope.where(
+        level: [:project, :third_party_project],
+        organisation_id: report.organisation_id,
+        source_fund_code: report.fund.source_fund_code
+      )
+    end
+
+    private
+
+    attr_reader :report, :scope
+  end
+end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -83,12 +83,16 @@ FactoryBot.define do
 
       trait :newton_funded do
         source_fund_code { Fund::MAPPINGS["NF"] }
-        parent factory: [:fund_activity, :newton]
+        parent do
+          Activity.fund.find_by(source_fund_code: Fund::MAPPINGS["NF"]) || create(:fund_activity, :newton)
+        end
       end
 
       trait :gcrf_funded do
         source_fund_code { Fund::MAPPINGS["GCRF"] }
-        parent factory: [:fund_activity, :gcrf]
+        parent do
+          Activity.fund.find_by(source_fund_code: Fund::MAPPINGS["GCRF"]) || create(:fund_activity, :gcrf)
+        end
       end
     end
 

--- a/spec/features/staff/users_can_upload_forecasts_spec.rb
+++ b/spec/features/staff/users_can_upload_forecasts_spec.rb
@@ -2,9 +2,9 @@ RSpec.feature "users can upload forecasts" do
   let(:organisation) { create(:delivery_partner_organisation) }
   let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
-  let!(:project) { create(:project_activity, organisation: organisation) }
-  let!(:sibling_project) { create(:project_activity, organisation: organisation, parent: project.parent) }
-  let!(:cousin_project) { create(:project_activity, organisation: organisation) }
+  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation) }
+  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
+  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation) }
 
   let! :report do
     create(:report,

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -2,9 +2,9 @@ RSpec.feature "users can upload transactions" do
   let(:organisation) { create(:delivery_partner_organisation) }
   let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
-  let!(:project) { create(:project_activity, organisation: organisation) }
-  let!(:sibling_project) { create(:project_activity, organisation: organisation, parent: project.parent) }
-  let!(:cousin_project) { create(:project_activity, organisation: organisation) }
+  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation) }
+  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
+  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation) }
 
   let! :report do
     create(:report,

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -88,35 +88,6 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    describe ".projects_and_third_party_projects_for_report" do
-      it "only returns projects and third party projects that are for the reports organisation and fund" do
-        organisation = create(:delivery_partner_organisation)
-        newton_fund = create(:fund_activity, :newton)
-        report = create(:report, organisation: organisation, fund: newton_fund)
-
-        programme = create(:programme_activity, :newton_funded, parent: newton_fund)
-        project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
-        third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
-
-        gcrf_fund = create(:fund_activity, :gcrf)
-        another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
-        another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
-        another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
-
-        result = Activity.projects_and_third_party_projects_for_report(report)
-
-        expect(result).to include third_party_project
-        expect(result).to include project
-
-        expect(result).not_to include newton_fund
-        expect(result).not_to include programme
-        expect(result).not_to include gcrf_fund
-        expect(result).not_to include another_programme
-        expect(result).not_to include another_project
-        expect(result).not_to include another_third_party_project
-      end
-    end
-
     describe ".reportable" do
       it "does not return any unreportable activities" do
         completed_project = create(:project_activity, programme_status: "completed")

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -91,25 +91,26 @@ RSpec.describe Activity, type: :model do
     describe ".projects_and_third_party_projects_for_report" do
       it "only returns projects and third party projects that are for the reports organisation and fund" do
         organisation = create(:delivery_partner_organisation)
-        fund = create(:fund_activity)
-        programme = create(:programme_activity, parent: fund)
-        project = create(:project_activity, parent: programme, organisation: organisation)
-        third_party_project = create(:third_party_project_activity, parent: project, organisation: organisation)
-        report = create(:report, organisation: third_party_project.organisation, fund: fund)
+        newton_fund = create(:fund_activity, :newton)
+        report = create(:report, organisation: organisation, fund: newton_fund)
 
-        another_fund = create(:fund_activity)
-        another_programme = create(:programme_activity, parent: another_fund)
-        another_project = create(:project_activity, parent: another_programme, organisation: organisation)
-        another_third_party_project = create(:third_party_project_activity, parent: another_project, organisation: organisation)
+        programme = create(:programme_activity, :newton_funded, parent: newton_fund)
+        project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
+        third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
+
+        gcrf_fund = create(:fund_activity, :gcrf)
+        another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
+        another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
+        another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
 
         result = Activity.projects_and_third_party_projects_for_report(report)
 
         expect(result).to include third_party_project
         expect(result).to include project
 
-        expect(result).not_to include fund
+        expect(result).not_to include newton_fund
         expect(result).not_to include programme
-        expect(result).not_to include another_fund
+        expect(result).not_to include gcrf_fund
         expect(result).not_to include another_programme
         expect(result).not_to include another_project
         expect(result).not_to include another_third_party_project

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -157,16 +157,18 @@ RSpec.describe Report, type: :model do
   end
 
   describe "#reportable_activities" do
-    let!(:report) { create(:report, organisation: build(:delivery_partner_organisation)) }
-    let!(:programme) { create(:programme_activity, parent: report.fund) }
-    let!(:project_a) { create(:project_activity, parent: programme, organisation: report.organisation) }
-    let!(:project_b) { create(:project_activity, parent: programme, organisation: report.organisation) }
-    let!(:third_party_project) { create(:third_party_project_activity, parent: project_b, organisation: report.organisation) }
-    let!(:cancelled_project) { create(:project_activity, parent: programme, organisation: report.organisation, programme_status: "cancelled") }
-    let!(:paused_project) { create(:project_activity, parent: programme, organisation: report.organisation, programme_status: "paused") }
-    let!(:ineligible_project) { create(:project_activity, parent: programme, organisation: report.organisation, oda_eligibility: "never_eligible") }
+    let(:fund) { create(:fund_activity, :newton) }
 
-    let!(:project_in_another_fund) { create(:project_activity, organisation: report.organisation) }
+    let!(:report) { create(:report, organisation: build(:delivery_partner_organisation), fund: fund) }
+    let!(:programme) { create(:programme_activity, :newton_funded, parent: fund) }
+    let!(:project_a) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation) }
+    let!(:project_b) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation) }
+    let!(:third_party_project) { create(:third_party_project_activity, :newton_funded, parent: project_b, organisation: report.organisation) }
+    let!(:cancelled_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, programme_status: "cancelled") }
+    let!(:paused_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, programme_status: "paused") }
+    let!(:ineligible_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, oda_eligibility: "never_eligible") }
+
+    let!(:project_in_another_fund) { create(:project_activity, :gcrf_funded, organisation: report.organisation) }
 
     it "returns the level C and D activities belonging to the report's fund and organisation" do
       expect(report.reportable_activities).to include(project_a)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -157,88 +157,92 @@ RSpec.describe Report, type: :model do
   end
 
   describe "#reportable_activities" do
-    let(:fund) { create(:fund_activity, :newton) }
+    let(:report) { build(:report, financial_quarter: 1, financial_year: 2020) }
+    let(:active_relation) { double("active_relation") }
+    let(:query) { double("query", with_roda_identifier: active_relation) }
+    let(:finder) { instance_double(Activity::ProjectsForReportFinder, call: query) }
 
-    let!(:report) { create(:report, organisation: build(:delivery_partner_organisation), fund: fund) }
-    let!(:programme) { create(:programme_activity, :newton_funded, parent: fund) }
-    let!(:project_a) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation) }
-    let!(:project_b) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation) }
-    let!(:third_party_project) { create(:third_party_project_activity, :newton_funded, parent: project_b, organisation: report.organisation) }
-    let!(:cancelled_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, programme_status: "cancelled") }
-    let!(:paused_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, programme_status: "paused") }
-    let!(:ineligible_project) { create(:project_activity, :newton_funded, parent: programme, organisation: report.organisation, oda_eligibility: "never_eligible") }
+    before do
+      allow(Activity::ProjectsForReportFinder).to receive(:new).and_return(finder)
+    end
 
-    let!(:project_in_another_fund) { create(:project_activity, :gcrf_funded, organisation: report.organisation) }
+    it "appends the `with_roda_identifier` scope" do
+      report.reportable_activities
 
-    it "returns the level C and D activities belonging to the report's fund and organisation" do
-      expect(report.reportable_activities).to include(project_a)
-      expect(report.reportable_activities).to include(project_b)
-      expect(report.reportable_activities).to include(third_party_project)
+      expect(query).to have_received(:with_roda_identifier)
+    end
 
-      expect(report.reportable_activities).not_to include(report.fund)
-      expect(report.reportable_activities).not_to include(programme)
-      expect(report.reportable_activities).not_to include(project_in_another_fund)
-      expect(report.reportable_activities).not_to include(cancelled_project)
-      expect(report.reportable_activities).not_to include(paused_project)
-      expect(report.reportable_activities).not_to include(ineligible_project)
+    it "returns the active_relation" do
+      expect(report.reportable_activities).to eq(active_relation)
     end
   end
 
   describe "#activities_created" do
-    it "only returns activities created in the given reporting period" do
-      fund = create(:fund_activity)
-      programme = create(:programme_activity, parent: fund)
+    let(:report) { build(:report, financial_quarter: 1, financial_year: 2020) }
+    let(:active_relation) { double("active_relation") }
+    let(:query) { double("query", where: active_relation) }
 
-      travel_to(Date.parse("2020-04-26")) do
-        @report = create(:report, organisation: build(:delivery_partner_organisation), fund: fund)
-        @project_in_reporting_period = create(:project_activity, parent: programme, organisation: @report.organisation)
-        @third_party_project_in_reporting_period = create(:third_party_project_activity, parent: @project_in_reporting_period, organisation: @report.organisation)
-      end
+    before do
+      allow(report).to receive(:reportable_activities).and_return(query)
+      allow(query).to receive(:activities_created).and_return(active_relation)
+    end
 
-      _project_outside_reporting_period = create(:project_activity, parent: programme, organisation: @report.organisation)
-      _third_party_project_outside_reporting_period = create(:third_party_project_activity, parent: @project_in_reporting_period, organisation: @report.organisation)
+    it "filters the #reportable_activities using the financial period" do
+      report.activities_created
 
-      expect(@report.activities_created).to match_array([
-        @project_in_reporting_period,
-        @third_party_project_in_reporting_period,
-      ])
+      expect(query).to have_received(:where)
+        .with(created_at: (Date.parse("01-Apr-2020")..Date.parse("30-Jun-2020")))
+    end
+
+    it "returns the active_relation" do
+      expect(report.activities_created).to eq(active_relation)
     end
   end
 
-  describe "forecasts" do
-    let(:report) { create(:report, financial_quarter: 1, financial_year: 2021) }
-    let(:programme) { create(:programme_activity, parent: report.fund) }
+  describe "#forecasts_for_reportable_activities" do
+    let(:report) { build(:report) }
+    let(:reportable_activities) { build_stubbed_list(:project_activity, 5) }
+    let(:active_relation) { double("active_relation") }
+    let(:latest_values) { double("latest_values", where: active_relation) }
+    let(:overview) { instance_double(ForecastOverview, latest_values: latest_values) }
 
-    let!(:activities) do
-      2.times.map {
-        create(
-          :project_activity,
-          organisation: report.organisation,
-          parent: programme
-        ).tap do |activity|
-          ForecastHistory.new(
-            activity,
-            report: report,
-            financial_quarter: 2,
-            financial_year: 2021,
-            user: create(:delivery_partner_user)
-          ).set_value(50_000)
-        end
+    before do
+      allow(report).to receive(:reportable_activities).and_return(reportable_activities)
+      allow(ForecastOverview).to receive(:new).and_return(overview)
+    end
+
+    it "passes the correct reportable activities to the forecast overview" do
+      report.forecasts_for_reportable_activities
+
+      expect(ForecastOverview).to have_received(:new).with(reportable_activities.map(&:id))
+    end
+
+    it "passes the report to the latest_values relation" do
+      report.forecasts_for_reportable_activities
+
+      expect(latest_values).to have_received(:where).with(report: report)
+    end
+
+    it "returns an active relation" do
+      expect(report.forecasts_for_reportable_activities).to eq(active_relation)
+    end
+  end
+
+  describe "#summed_forecasts" do
+    let(:report) { build(:report) }
+
+    before do
+      expect(report).to receive(:forecasts_for_reportable_activities) {
+        [
+          double("forecast", value: 50_000),
+          double("forecast", value: 25_000),
+          double("forecast", value: 25_000),
+        ]
       }
     end
 
-    describe "#forecasts_for_reportable_activities" do
-      it "returns forecasts that have been made for reportable activities" do
-        expect(report.forecasts_for_reportable_activities).to match_array(
-          activities.map(&:latest_forecasts).flatten
-        )
-      end
-    end
-
-    describe "#summed_forecasts" do
-      it "sums the forecasts" do
-        expect(report.summed_forecasts_for_reportable_activities.to_i).to eq(100_000)
-      end
+    it "sums the forecasts" do
+      expect(report.summed_forecasts_for_reportable_activities.to_i).to eq(100_000)
     end
   end
 

--- a/spec/services/activity/projects_for_report_finder_spec.rb
+++ b/spec/services/activity/projects_for_report_finder_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Activity::ProjectsForReportFinder do
+  it "only returns projects and third party projects that are for the report's organisation and fund" do
+    organisation = create(:delivery_partner_organisation)
+    newton_fund = create(:fund_activity, :newton)
+    report = create(:report, organisation: organisation, fund: newton_fund)
+
+    programme = create(:programme_activity, :newton_funded, parent: newton_fund)
+    project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
+    third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
+
+    gcrf_fund = create(:fund_activity, :gcrf)
+    another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
+    another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
+    another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
+
+    result = Activity::ProjectsForReportFinder.new(report: report).call
+
+    expect(result).to include third_party_project
+    expect(result).to include project
+
+    expect(result).not_to include newton_fund
+    expect(result).not_to include programme
+    expect(result).not_to include gcrf_fund
+    expect(result).not_to include another_programme
+    expect(result).not_to include another_project
+    expect(result).not_to include another_third_party_project
+  end
+end


### PR DESCRIPTION
The `projects_and_third_party_projects_for_report` scope is currently quite slow because we walk the entire tree to
get the activities. Now we have the `source_fund_code` attribute, we can get all these in one query.

I also had to make some tweaks to the Activity factory to get the parent fund by fetching or creating a parent fund.