### PR TITLE
Group historical events according to reference. And order, newest first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -732,6 +732,7 @@
 ## [unreleased]
 
 - Optimise `projects_and_third_party_projects_for_report` scope
+- Group Activity's Change history by "reference" and show newest first
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-60...HEAD
 [release-60]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-59...release-60

--- a/app/assets/stylesheets/partials/_historical_events.css.scss
+++ b/app/assets/stylesheets/partials/_historical_events.css.scss
@@ -1,0 +1,16 @@
+ul.historical-events {
+  list-style-type: none;
+  padding-left: 0;
+  dl {
+    margin-bottom: 0;
+    .govuk-summary-list__row {
+      dd, dt {
+        padding-top: 0;
+
+      }
+    }
+  }
+  li {
+    margin-bottom: 3em;
+  }
+}

--- a/app/controllers/staff/activity_historical_events_controller.rb
+++ b/app/controllers/staff/activity_historical_events_controller.rb
@@ -7,6 +7,13 @@ class Staff::ActivityHistoricalEventsController < Staff::BaseController
     activity = Activity.find(params[:activity_id])
     authorize activity
     @activity = ActivityPresenter.new(activity)
-    @historical_events = @activity.historical_events.includes([:user, :report])
+    @historical_events = @activity
+      .historical_events
+      .includes([:user, :report])
+      .group_by { |event|
+        {reference: event.reference,
+         user: event.user&.email,
+         timestamp: event.created_at.strftime("%d %b %Y at %R"),}
+      }
   end
 end

--- a/app/controllers/staff/activity_historical_events_controller.rb
+++ b/app/controllers/staff/activity_historical_events_controller.rb
@@ -7,13 +7,6 @@ class Staff::ActivityHistoricalEventsController < Staff::BaseController
     activity = Activity.find(params[:activity_id])
     authorize activity
     @activity = ActivityPresenter.new(activity)
-    @historical_events = @activity
-      .historical_events
-      .includes([:user, :report])
-      .group_by { |event|
-        {reference: event.reference,
-         user: event.user&.email,
-         timestamp: event.created_at.strftime("%d %b %Y at %R"),}
-      }
+    @historical_events = Activity::HistoricalEventsGrouper.new(activity: activity).call
   end
 end

--- a/app/services/activity/historical_events_grouper.rb
+++ b/app/services/activity/historical_events_grouper.rb
@@ -1,0 +1,22 @@
+class Activity
+  class HistoricalEventsGrouper
+    def initialize(activity:)
+      @activity = activity
+    end
+
+    def call
+      activity
+        .historical_events
+        .includes([:user, :report])
+        .group_by { |event|
+          {reference: event.reference,
+           user: event.user&.email,
+           timestamp: event.created_at.strftime("%d %b %Y at %R"),}
+        }
+    end
+
+    private
+
+    attr_reader :activity
+  end
+end

--- a/app/services/activity/historical_events_grouper.rb
+++ b/app/services/activity/historical_events_grouper.rb
@@ -8,6 +8,7 @@ class Activity
       activity
         .historical_events
         .includes([:user, :report])
+        .order(created_at: :desc)
         .group_by { |event|
           {reference: event.reference,
            user: event.user&.email,

--- a/app/views/staff/activity_historical_events/show.html.haml
+++ b/app/views/staff/activity_historical_events/show.html.haml
@@ -18,27 +18,41 @@
           %p.govuk-body
             = t("page_content.tab_content.change_history.guidance")
 
-          %table.govuk-table.historical-events
-            %thead.govuk-table__head
-              %tr.govuk-body-s.govuk-table__row
-                %th.govuk-table__header{scope: "col"} Reference
-                %th.govuk-table__header{scope: "col"} Property
-                %th.govuk-table__header{scope: "col"} Previous value
-                %th.govuk-table__header{scope: "col"} New value
-                %th.govuk-table__header{scope: "col"} Who
-                %th.govuk-table__header{scope: "col"} When
-                %th.govuk-table__header{scope: "col"} Report
+          %ul.historical-events
+            - @historical_events.each do |group, events|
+              %li.historical-event-group.govuk-inset-text
+                %dl.govuk-summary-list.govuk-summary-list--no-border
+                  .govuk-summary-list__row
+                    %dt.govuk-body-s.govuk-summary-list__key
+                      Reference
+                    %dd.govuk-body-s.reference.govuk-summary-list__value
+                      = group[:reference]
+                  .govuk-summary-list__row
+                    %dt.govuk-body-s.govuk-summary-list__key
+                      User
+                    %dd.govuk-body-s.user.govuk-summary-list__value
+                      = group[:user]
+                  .govuk-summary-list__row
+                    %dt.govuk-body-s.govuk-summary-list__key
+                      When
+                    %dd.govuk-body-s.timestamp.govuk-summary-list__value
+                      = group[:timestamp]
 
-            %tbody.govuk-table__body
-              - @historical_events.each do |event|
+                %table.govuk-table
+                  %thead.govuk-table__head
+                    %tr.govuk-body-s.govuk-table__row
+                      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Property
+                      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Previous value
+                      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} New value
+                      %th.govuk-table__header{class: "govuk-!-width-one-quarter", scope: "col"} Report
 
-                %tr.govuk-body-xs.govuk-table__row[event]
-                  %td.govuk-table__cell.reference= event.reference
-                  %td.govuk-table__cell.property= event.value_changed
-                  %td.govuk-table__cell.previous-value= event.previous_value
-                  %td.govuk-table__cell.new-value= event.new_value
-                  %td.govuk-table__cell.user= event.user.email
-                  %td.govuk-table__cell.timestamp= event.created_at.strftime("%d/%m/%C at %R")
-                  %td.govuk-table__cell.report
-                    = link_to(event.report.financial_quarter_and_year, report_path(event.report)) if event.report
+                  %tbody.govuk-table__body
+                    - events.each do |event|
+
+                      %tr.govuk-body-s.govuk-table__row[event]
+                        %td.govuk-table__cell.property= event.value_changed
+                        %td.govuk-table__cell.previous-value= event.previous_value
+                        %td.govuk-table__cell.new-value= event.new_value
+                        %td.govuk-table__cell.report
+                          = link_to(event.report.financial_quarter_and_year, report_path(event.report)) if event.report
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -87,6 +87,7 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :budgets
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Report", association: :fund
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Budget", association: :providing_organisation
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "HistoricalEvent", association: :report
   end
 
   config.hosts = [

--- a/spec/controllers/staff/activity_historical_events_controller_spec.rb
+++ b/spec/controllers/staff/activity_historical_events_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Staff::ActivityHistoricalEventsController do
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
+  describe "#show" do
+    let(:activity) { build_stubbed(:project_activity) }
+    let(:grouper) { instance_double(Activity::HistoricalEventsGrouper, call: double) }
+
+    before do
+      allow(Activity).to receive(:find).and_return(activity)
+      policy = instance_double(ActivityPolicy, show?: true)
+      allow(ActivityPolicy).to receive(:new).and_return(policy)
+      allow(Activity::HistoricalEventsGrouper).to receive(:new).and_return(grouper)
+    end
+
+    it "asks the HistoricalEventsGrouper to prepare the 'Change history'" do
+      get :show, params: {activity_id: "abc123", organisation_id: "asd321"}
+
+      expect(Activity::HistoricalEventsGrouper)
+        .to have_received(:new)
+        .with(activity: activity)
+
+      expect(grouper).to have_received(:call)
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
@@ -33,17 +33,17 @@ RSpec.feature "Users can view an activity's 'Change History' within a tab" do
     def expect_to_see_change_history_with_reference(reference:, events:)
       fail "We expect to see some Historical Events!" if events.empty?
 
-      within ".historical-events" do
+      within ".historical-events .historical-event-group" do
         expect(page).to have_css(".historical_event", count: events.count)
         expect(page).to have_css(".reference", text: reference)
+        expect(page).to have_css(".user", text: events.first.user.email)
+        expect(page).to have_css(".timestamp", text: events.first.created_at.strftime("%d %b %Y at %R"))
 
         events.each do |event|
           within "#historical_event_#{event.id}" do
             expect(page).to have_css(".property", text: event.value_changed)
             expect(page).to have_css(".previous-value", text: event.previous_value)
             expect(page).to have_css(".new-value", text: event.new_value)
-            expect(page).to have_css(".user", text: event.user.email)
-            expect(page).to have_css(".timestamp", text: event.created_at.strftime("%d/%m/%C at %R"))
             if event.report
               expect(page).to have_css(
                 ".report a[href='#{report_path(event.report)}']",

--- a/spec/services/activity/historical_events_grouper_spec.rb
+++ b/spec/services/activity/historical_events_grouper_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Activity::HistoricalEventsGrouper do
+  let(:user1) { create(:delivery_partner_user, email: "john@example.com") }
+  let(:user2) { create(:delivery_partner_user, email: "fred@example.com") }
+  let(:activity) { create(:project_activity) }
+
+  let!(:event1) do
+    HistoricalEvent.create(
+      activity: activity,
+      reference: "Update to Activity programme_status",
+      user: user1,
+      created_at: Time.zone.parse("02-Jul-2021 12:08")
+    )
+  end
+  let!(:event2) do
+    HistoricalEvent.create(
+      activity: activity,
+      reference: "Update to Activity programme_status",
+      user: user1,
+      created_at: Time.zone.parse("02-Jul-2021 12:08")
+    )
+  end
+
+  let!(:event3) do
+    HistoricalEvent.create(
+      activity: activity,
+      reference: "Import from CSV",
+      user: user2,
+      created_at: Time.zone.parse("07-Jul-2021 10:45")
+    )
+  end
+  let!(:event4) do
+    HistoricalEvent.create(
+      activity: activity,
+      reference: "Import from CSV",
+      user: user2,
+      created_at: Time.zone.parse("07-Jul-2021 10:45")
+    )
+  end
+
+  it "groups events using a combination of reference, user.email and time" do
+    expect(Activity::HistoricalEventsGrouper.new(activity: activity).call).to eq(
+      {
+        {
+          reference: "Update to Activity programme_status",
+          user: "john@example.com",
+          timestamp: "02 Jul 2021 at 12:08",
+        } => [event1, event2],
+
+        {
+          reference: "Import from CSV",
+          user: "fred@example.com",
+          timestamp: "07 Jul 2021 at 10:45",
+        } => [event3, event4],
+      }
+    )
+  end
+end

--- a/spec/services/activity/historical_events_grouper_spec.rb
+++ b/spec/services/activity/historical_events_grouper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
       activity: activity,
       reference: "Update to Activity programme_status",
       user: user1,
-      created_at: Time.zone.parse("02-Jul-2021 12:08")
+      created_at: Time.zone.parse("02-Jul-2021 12:08:00")
     )
   end
   let!(:event2) do
@@ -18,7 +18,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
       activity: activity,
       reference: "Update to Activity programme_status",
       user: user1,
-      created_at: Time.zone.parse("02-Jul-2021 12:08")
+      created_at: Time.zone.parse("02-Jul-2021 12:08:10")
     )
   end
 
@@ -27,7 +27,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
       activity: activity,
       reference: "Import from CSV",
       user: user2,
-      created_at: Time.zone.parse("07-Jul-2021 10:45")
+      created_at: Time.zone.parse("07-Jul-2021 10:45:20")
     )
   end
   let!(:event4) do
@@ -35,24 +35,24 @@ RSpec.describe Activity::HistoricalEventsGrouper do
       activity: activity,
       reference: "Import from CSV",
       user: user2,
-      created_at: Time.zone.parse("07-Jul-2021 10:45")
+      created_at: Time.zone.parse("07-Jul-2021 10:45:30")
     )
   end
 
-  it "groups events using a combination of reference, user.email and time" do
+  it "groups events using a combination of reference, user.email and time, newest first" do
     expect(Activity::HistoricalEventsGrouper.new(activity: activity).call).to eq(
       {
-        {
-          reference: "Update to Activity programme_status",
-          user: "john@example.com",
-          timestamp: "02 Jul 2021 at 12:08",
-        } => [event1, event2],
-
         {
           reference: "Import from CSV",
           user: "fred@example.com",
           timestamp: "07 Jul 2021 at 10:45",
-        } => [event3, event4],
+        } => [event4, event3],
+
+        {
+          reference: "Update to Activity programme_status",
+          user: "john@example.com",
+          timestamp: "02 Jul 2021 at 12:08",
+        } => [event2, event1],
       }
     )
   end


### PR DESCRIPTION
## Changes in this PR

- Group historical events by reference (and timestamp)
- Order, newest first

## Screenshots of UI changes

### Before
Ordered by creation time, ungrouped:

<img width="1117" alt="historical_events_ungrouped" src="https://user-images.githubusercontent.com/20245/124576294-12d4a400-de44-11eb-9a16-57aa1ca124ba.png">


### After
Ordered (newest first), and grouped by reference:

![sorted_and_grouped](https://user-images.githubusercontent.com/20245/124890518-05e4bb80-dfd0-11eb-9aa0-d3df7fe99f34.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
