### PR TITLE
(1956) Improve the query that populates the activity tree view

### DIFF
--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -7,22 +7,12 @@ class Staff::HomeController < Staff::BaseController
       authorize @delivery_partner_organisations
       render :service_owner
     else
-      @grouped_programmes = fetch_grouped_programmes_for(current_user.organisation, :current)
+      @grouped_activities = Activity::GroupedActivitiesFetcher.new(
+        user: current_user,
+        organisation: current_user.organisation,
+        scope: :current
+      ).call
       render :delivery_partner
     end
-  end
-
-  private def fetch_grouped_programmes_for(organisation, scope)
-    activities = policy_scope(
-      Activity.includes(
-        :organisation,
-        parent: [:parent, :organisation],
-        child_activities: [:child_activities, :organisation, :parent]
-      ).programme
-       .send(scope)
-    )
-    activities = activities.where(extending_organisation: organisation)
-    activities.order(:roda_identifier_compound)
-      .group_by(&:parent)
   end
 end

--- a/app/services/activity/grouped_activities_fetcher.rb
+++ b/app/services/activity/grouped_activities_fetcher.rb
@@ -1,0 +1,41 @@
+class Activity
+  class GroupedActivitiesFetcher
+    def initialize(user:, organisation:, scope: :all)
+      @organisation = organisation
+      @scope = scope
+      @activities = ActivityPolicy::Scope.new(user, Activity).resolve
+    end
+
+    def call
+      grouped_programmes.each_with_object({}) do |(fund, programmes), funds|
+        funds[fund] = programmes.each_with_object({}) { |programme, programmes|
+          programmes[programme] = scoped_child_activities_for(programme).each_with_object({}) { |project, projects|
+            projects[project] = scoped_child_activities_for(project)
+          }
+        }
+      end
+    end
+
+    private
+
+    def grouped_programmes
+      programmes = activities.includes(
+        :organisation,
+        parent: [:parent, :organisation],
+        child_activities: [:child_activities, :organisation, :parent]
+      ).programme.send(scope)
+
+      unless organisation.service_owner?
+        programmes = programmes.where(extending_organisation: organisation)
+      end
+
+      programmes.order(:roda_identifier_compound).group_by(&:parent)
+    end
+
+    def scoped_child_activities_for(activity)
+      activity.child_activities.send(scope).order(:created_at).to_a
+    end
+
+    attr_reader :organisation, :activities, :scope
+  end
+end

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -30,4 +30,4 @@
           %h2.govuk-heading-l
             = t("page_title.activities.historic")
 
-          = render partial: "staff/shared/activities/tree_view/table", locals: { grouped_programmes: @grouped_programmes }
+          = render partial: "staff/shared/activities/tree_view/table", locals: { activities: @grouped_activities }

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -11,4 +11,4 @@
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
-      = render partial: "staff/shared/activities/table", locals: { activities: @grouped_programmes }
+      = render partial: "staff/shared/activities/table", locals: { activities: @grouped_activities }

--- a/app/views/staff/home/delivery_partner.html.haml
+++ b/app/views/staff/home/delivery_partner.html.haml
@@ -6,4 +6,4 @@
 
       = render partial: "staff/searches/form"
 
-      = render partial: "staff/shared/activities/tree_view/table_tabbed", locals: { grouped_programmes: @grouped_programmes }
+      = render partial: "staff/shared/activities/tree_view/table_tabbed", locals: { grouped_activities: @grouped_activities }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -20,4 +20,4 @@
           %h2.govuk-heading-l
             = t("page_title.activities.current")
 
-          = render partial: "staff/shared/activities/tree_view/table", locals: { grouped_programmes: activities }
+          = render partial: "staff/shared/activities/tree_view/table", locals: { activities: activities }

--- a/app/views/staff/shared/activities/tree_view/_table.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_table.html.haml
@@ -1,7 +1,7 @@
-- if grouped_programmes.any?
+- if activities.any?
   .govuk-grid-row
     .govuk-grid-column-full
-      - grouped_programmes.each do |fund, programmes|
+      - activities.each do |fund, programmes|
         - if programmes.any?
           %table{id: fund.id, class: "govuk-table", data: {module: "table-tree-view"}}
             %caption{class: "govuk-table__caption govuk-table__caption--m govuk-!-margin-top-4"}
@@ -20,9 +20,9 @@
                 %th{scope: "col", class: "govuk-table__header"}
 
             %tbody{class: "govuk-table__body"}
-              - programmes.each do |programme|
-                = render partial: "staff/shared/activities/tree_view/row", locals: { activity: programme, parent: fund, is_parent: programme.child_activities.any? }
-                - programme.child_activities.sort_by{|activity| activity.created_at }.each do |project|
-                  = render partial: "staff/shared/activities/tree_view/row", locals: { activity: project, parent: programme, is_parent: project.child_activities.any? }
-                  - project.child_activities.sort_by{|activity| activity.created_at }.each do |third_party_project|
+              - programmes.each do |programme, projects|
+                = render partial: "staff/shared/activities/tree_view/row", locals: { activity: programme, parent: fund, is_parent: projects.any? }
+                - projects.each do |project, third_party_projects|
+                  = render partial: "staff/shared/activities/tree_view/row", locals: { activity: project, parent: programme, is_parent: third_party_projects.any? }
+                  - third_party_projects.each do |third_party_project|
                     = render partial: "staff/shared/activities/tree_view/row", locals: { activity: third_party_project, parent: project, is_parent: false }

--- a/app/views/staff/shared/activities/tree_view/_table_tabbed.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_table_tabbed.html.haml
@@ -1,14 +1,14 @@
-- if grouped_programmes.any?
+- if grouped_activities.any?
   .govuk-grid-row
     .govuk-grid-column-full
       .govuk-tabs{ data: { module: "govuk-tabs" } }
         %h2.govuk-tabs__title
           Current activities
         %ul.govuk-tabs__list
-          - grouped_programmes.each do |fund, programmes|
+          - grouped_activities.each do |fund, _programmes|
             %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
               = link_to fund.title, home_path(anchor: fund.title.parameterize), class: "govuk-tabs__tab"
-        - grouped_programmes.each do |fund, programmes|
+        - grouped_activities.each do |fund, programmes|
           - if programmes.any?
             .govuk-tabs__panel{ id: fund.title.parameterize }
               %table{id: fund.id, class: "govuk-table", data: {module: "table-tree-view"}}
@@ -25,11 +25,11 @@
                     %th{scope: "col", class: "govuk-table__header"}
 
                 %tbody{class: "govuk-table__body"}
-                  - programmes.each do |programme|
-                    = render partial: "staff/shared/activities/tree_view/row", locals: { activity: programme, parent: fund, is_parent: programme.child_activities.any? }
-                    - programme.child_activities.sort_by{|activity| activity.created_at }.each do |project|
-                      = render partial: "staff/shared/activities/tree_view/row", locals: { activity: project, parent: programme, is_parent: project.child_activities.any? }
-                      - project.child_activities.sort_by{|activity| activity.created_at }.each do |third_party_project|
+                  - programmes.each do |programme, projects|
+                    = render partial: "staff/shared/activities/tree_view/row", locals: { activity: programme, parent: fund, is_parent: projects.any? }
+                    - projects.each do |project, third_party_projects|
+                      = render partial: "staff/shared/activities/tree_view/row", locals: { activity: project, parent: programme, is_parent: third_party_projects.any? }
+                      - third_party_projects.each do |third_party_project|
                         = render partial: "staff/shared/activities/tree_view/row", locals: { activity: third_party_project, parent: project, is_parent: false }
 
               = link_to "View all activities", activities_path(organisation_id: current_user.organisation.id), class: "govuk-body govuk-link"

--- a/spec/controllers/staff/activities_controller_spec.rb
+++ b/spec/controllers/staff/activities_controller_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe Staff::ActivitiesController do
+  shared_examples "fetches activities" do |params|
+    let(:scope) { params[:scope] }
+    let(:route) { params[:route] }
+
+    let(:fund) { build_stubbed(:fund_activity) }
+    let(:programme) { build_stubbed(:programme_activity) }
+    let(:project) { build_stubbed(:project_activity) }
+    let(:third_party_projects) { build_stubbed_list(:third_party_project_activity, 2) }
+    let(:activities) do
+      {
+        fund => {
+          programme => {
+            project => third_party_projects,
+          },
+        },
+      }
+    end
+
+    let(:fetcher) { instance_double(Activity::GroupedActivitiesFetcher, call: activities) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+      allow(Activity::GroupedActivitiesFetcher).to receive(:new).and_return(fetcher)
+    end
+
+    context "when signed in as a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "defaults to fetching the BEIS organisation's activities" do
+        get route
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: scope
+        )
+      end
+
+      it "allows fetching of another organisation's activites" do
+        organisation = create(:delivery_partner_organisation)
+
+        get route, params: {organisation_id: organisation.id}
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: organisation,
+          scope: scope
+        )
+      end
+
+      it "assigns the activities correctly" do
+        get route
+
+        expect(assigns(:grouped_activities)).to eq(activities)
+      end
+
+      it "defaults to the BEIS organisation when the organisation parameter is blank" do
+        get route, params: {organisation_id: ""}
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: scope
+        )
+      end
+
+      it "defaults to the BEIS organisation when the organisation parameter is not a known organisation" do
+        get route, params: {organisation_id: "this-is-not-a-know-organisation"}
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: scope
+        )
+      end
+    end
+
+    context "when signed in as a delivery partner" do
+      let(:user) { create(:delivery_partner_user) }
+
+      it "fetches the activities for the user's organisation" do
+        get route
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: scope
+        )
+      end
+
+      it "fetches the activities for the user's organisation when the organisation ID is that of another organisation" do
+        organisation = create(:delivery_partner_organisation)
+
+        get route, params: {organisation_id: organisation.id}
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: scope
+        )
+      end
+    end
+  end
+
+  describe "#index" do
+    include_examples "fetches activities", {route: :index, scope: :current}
+  end
+
+  describe "#historic" do
+    include_examples "fetches activities", {route: :historic, scope: :historic}
+  end
+end

--- a/spec/controllers/staff/home_controller_spec.rb
+++ b/spec/controllers/staff/home_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Staff::HomeController do
+  describe "show" do
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+    end
+
+    context "when signed in as a BEIS user" do
+      let(:user) { create(:beis_user) }
+      let(:delivery_partners) { create_list(:delivery_partner_organisation, 5) }
+
+      it "fetches the delivery partners" do
+        get :show
+
+        expect(assigns(:delivery_partner_organisations)).to match_array(delivery_partners)
+      end
+
+      it "renders the service owner view" do
+        expect(get(:show)).to render_template(:service_owner)
+      end
+    end
+
+    context "when signed in as a delivery partner" do
+      let(:fund) { build_stubbed(:fund_activity) }
+      let(:programme) { build_stubbed(:programme_activity) }
+      let(:project) { build_stubbed(:project_activity) }
+      let(:third_party_projects) { build_stubbed_list(:third_party_project_activity, 2) }
+      let(:activities) do
+        {
+          fund => {
+            programme => {
+              project => third_party_projects,
+            },
+          },
+        }
+      end
+
+      let(:fetcher) { instance_double(Activity::GroupedActivitiesFetcher, call: activities) }
+      let(:user) { create(:delivery_partner_user) }
+
+      before do
+        allow(Activity::GroupedActivitiesFetcher).to receive(:new).and_return(fetcher)
+      end
+
+      it "fetches the activities for the user's organisation" do
+        get :show
+
+        expect(Activity::GroupedActivitiesFetcher).to have_received(:new).with(
+          user: user,
+          organisation: user.organisation,
+          scope: :current
+        )
+      end
+
+      it "assigns the activities correctly" do
+        get :show
+
+        expect(assigns(:grouped_activities)).to eq(activities)
+      end
+
+      it "renders the delivery partner view" do
+        expect(get(:show)).to render_template(:delivery_partner)
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -7,33 +7,76 @@ RSpec.feature "Users can view activities" do
     end
   end
 
-  context "when the user is signed in as a BEIS user" do
-    let(:user) { create(:beis_user) }
-    before { authenticate!(user: user) }
+  shared_examples "shows activities" do |params|
+    let(:user) { create(params[:user_type]) }
+    let(:organisation) { params[:user_type] == :beis_user ? create(:delivery_partner_organisation) : user.organisation }
 
-    scenario "the activities index shows activities associated to the BEIS organisation" do
-      activities = create_list(:programme_activity, 2, organisation: user.organisation)
-      another_activity = create(:project_activity)
+    let!(:fund) { create(:fund_activity, :newton) }
+    let!(:programme) { create(:programme_activity, parent: fund, extending_organisation: organisation) }
+    let!(:project) { create(:project_activity, parent: programme, extending_organisation: organisation) }
+    let!(:third_party_projects) { create_list(:third_party_project_activity, 3, parent: project, extending_organisation: organisation) }
 
-      visit activities_path(organisation_id: user.organisation)
+    let!(:historic_programme) { create(:programme_activity, parent: fund, extending_organisation: organisation, programme_status: "completed") }
+
+    before do
+      authenticate!(user: user)
+    end
+
+    scenario "they can see and navigate current activities", js: true do
+      visit activities_path
+
       expect(page).to have_content t("page_title.activity.index")
 
-      first_activity = activities.first
-      last_activity = activities.last
+      expect(page).to have_css(".govuk-tabs__tab", count: 2)
+      expect(page).to have_css(".govuk-tabs__tab", text: "Current")
+      expect(page).to have_css(".govuk-tabs__tab", text: "Historic")
 
-      expect(page).to have_content first_activity.roda_identifier
-      expect(page).to have_content last_activity.roda_identifier
-      expect(page).to have_content another_activity.roda_identifier
+      expect(page).to have_content(programme.title)
+      expect(page).to have_content(programme.roda_identifier)
+
+      expect(page).to_not have_content(historic_programme.roda_identifier)
+
+      expect(page).not_to have_css("#activity-#{project.id}", visible: true)
+      third_party_projects.each do |third_party_project|
+        expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+      end
+
+      click_on programme.title
+      expect(page).to have_css("#activity-#{project.id}", visible: true)
+
+      third_party_projects.each do |third_party_project|
+        expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+      end
+
+      click_on project.title
+      expect(page).to have_css("#activity-#{project.id}", visible: true)
+
+      third_party_projects.each do |third_party_project|
+        expect(page).to have_css("#activity-#{third_party_project.id}", visible: true)
+      end
+
+      # Users can hide the expanded rows by clicking the parent activity
+      click_on programme.title
+      expect(page).not_to have_css("#activity-#{project.id}", visible: true)
+
+      third_party_projects.each do |third_party_project|
+        expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+      end
     end
 
-    scenario "they can view another organisations activities" do
-      delivery_partner = create(:delivery_partner_organisation)
-      activity = create(:programme_activity, extending_organisation: delivery_partner)
+    scenario "they can see historic activities" do
+      visit historic_activities_path
 
-      visit activities_path(organisation_id: activity.organisation)
+      expect(page).to have_content t("page_title.activity.index")
 
-      expect(page).to have_content activity.roda_identifier
+      expect(page).to have_content(historic_programme.title)
     end
+  end
+
+  context "when the user is signed in as a BEIS user" do
+    include_examples "shows activities", {
+      user_type: :beis_user,
+    }
 
     scenario "only delivery partners are listed" do
       delivery_partners = create_list(:delivery_partner_organisation, 3)
@@ -51,258 +94,118 @@ RSpec.feature "Users can view activities" do
         expect(page).to_not have_content(external_income_provider.name)
       end
     end
-
-    context "when an organisation id query parameter is not supplied" do
-      scenario "it defaults to showing the current users organisation activities" do
-        activity = create(:programme_activity, organisation: user.organisation)
-
-        visit activities_path(organisation_id: "")
-
-        expect(page).to have_content activity.roda_identifier
-      end
-    end
-
-    context "when the organisation id query parameter is not the BEIS organisation id" do
-      scenario "it shows the supplied organisation activities" do
-        delivery_partner = create(:delivery_partner_organisation)
-        activity = create(:programme_activity, extending_organisation: delivery_partner)
-
-        visit activities_path(organisation_id: delivery_partner.id)
-        expect(page).to have_content activity.roda_identifier
-      end
-    end
-
-    context "when the organisation id query parameter is not a know organisation" do
-      scenario "it defaults to showing the current users organisation activities" do
-        activity = create(:programme_activity, extending_organisation: user.organisation)
-
-        visit activities_path(organisation_id: "this-is-no-a-know-organisation")
-
-        expect(page).to have_content activity.roda_identifier
-      end
-    end
   end
 
   context "when the user is signed in as a delivery partner" do
-    let(:user) { create(:delivery_partner_user) }
-    before { authenticate!(user: user) }
-
-    scenario "the page displays two tabs, one for current activities and one for historic ones" do
-      create_list(:programme_activity, 5, extending_organisation: user.organisation)
-      visit activities_path
-
-      expect(page).to have_css(".govuk-tabs__tab", count: 2)
-      expect(page).to have_css(".govuk-tabs__tab", text: "Current")
-      expect(page).to have_css(".govuk-tabs__tab", text: "Historic")
+    context "when viewing the activities index page" do
+      include_examples "shows activities", {
+        user_type: :delivery_partner_user,
+      }
     end
 
-    scenario "they see a list of all current activities" do
-      current_programme = create(:programme_activity, extending_organisation: user.organisation)
-      current_project = create(:project_activity, organisation: user.organisation, parent: current_programme)
-      another_current_project = create(:project_activity, :at_purpose_step, organisation: user.organisation, parent: current_programme)
-      historic_programme = create(:programme_activity, extending_organisation: user.organisation, programme_status: "completed")
-      historic_project = create(:project_activity, organisation: user.organisation, programme_status: "completed", parent: historic_programme)
+    context "when viewing a single activity" do
+      let(:user) { create(:delivery_partner_user) }
 
-      visit activities_path
-
-      expect(page).to have_content(current_programme.title)
-      expect(page).to have_content(current_programme.roda_identifier)
-      expect(page).to have_content(current_project.title)
-      expect(page).to have_content(current_project.roda_identifier)
-      expect(page).to have_content(another_current_project.roda_identifier)
-
-      expect(page).to_not have_content(historic_project.title)
-      expect(page).to_not have_content(historic_project.roda_identifier)
-    end
-
-    scenario "they can choose to see a list of historic activities" do
-      current_programme = create(:programme_activity, extending_organisation: user.organisation)
-      current_project = create(:project_activity, organisation: user.organisation, parent: current_programme)
-      historic_programme = create(:programme_activity, extending_organisation: user.organisation, programme_status: "completed")
-      historic_project = create(:project_activity, organisation: user.organisation, programme_status: "completed", parent: historic_programme)
-      another_historic_project = create(:project_activity, organisation: user.organisation, programme_status: "stopped", parent: historic_programme)
-
-      visit activities_path
-      click_on t("tabs.activities.historic")
-
-      expect(page).to have_content(historic_project.title)
-      expect(page).to have_content(another_historic_project.title)
-      expect(page).to_not have_content(current_project.title)
-    end
-
-    scenario "they see a list of all their projects" do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      project = create(:project_activity, organisation: user.organisation, parent: programme)
-
-      visit activities_path
-
-      within("#activity-#{project.id}") do
-        expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
-        expect(page).to have_content project.roda_identifier
+      before do
+        authenticate!(user: user)
       end
-    end
 
-    scenario "the list of projects is ordered by created_at (oldest first)" do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      project = create(:project_activity, organisation: user.organisation, parent: programme)
-      another_project = create(:project_activity, organisation: user.organisation, created_at: 2.days.ago, parent: programme)
-
-      visit activities_path
-
-      expect(page.find("table tbody tr:nth-child(2)")[:id]).to have_content("activity-#{another_project.id}")
-      expect(page.find("table tbody tr:nth-child(3)")[:id]).to have_content("activity-#{project.id}")
-    end
-
-    scenario "they do not see a Publish to Iati column & status against projects" do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      project = create(:project_activity, organisation: user.organisation, parent: programme)
-
-      visit activities_path
-      click_on project.title
-      click_on t("tabs.activity.details")
-      click_on programme.title
-      click_on t("tabs.activity.children")
-
-      expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
-
-      within("##{project.id}") do
-        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
-      end
-    end
-
-    scenario "the activity financials can be viewed" do
-      activity = create(:project_activity, organisation: user.organisation)
-      transaction = create(:transaction, parent_activity: activity)
-      budget = create(:budget, parent_activity: activity)
-
-      visit organisation_activity_financials_path(activity.organisation, activity)
-      within ".govuk-tabs__list-item--selected" do
-        expect(page).to have_content "Financials"
-      end
-      expect(page).to have_content transaction.value
-      expect(page).to have_content budget.value
-    end
-
-    scenario "the activity details can be viewed" do
-      activity = create(:project_activity, organisation: user.organisation)
-
-      visit organisation_activity_details_path(activity.organisation, activity)
-
-      within ".govuk-tabs__list-item--selected" do
-        expect(page).to have_content "Details"
-      end
-      expect(page).to have_content activity.title
-      expect(page).to have_link t("page_content.activity.implementing_organisation.button.new")
-    end
-
-    scenario "all activities can be viewed" do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      activities = create_list(:project_activity, 5, organisation: user.organisation, parent: programme)
-
-      visit activities_path(organisation_id: user.organisation)
-
-      expect(page).to have_content t("page_title.activity.index")
-
-      first_activity = activities.first
-      last_activity = activities.last
-
-      expect(page).to have_content first_activity.roda_identifier
-
-      expect(page).to have_content last_activity.roda_identifier
-    end
-
-    scenario "an activity can be viewed" do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      activity = create(:project_activity, parent: programme, organisation: user.organisation, sdgs_apply: true, sdg_1: 5)
-
-      visit activities_path
-
-      click_on(programme.title)
-      click_on t("tabs.activity.children")
-      click_on activity.title
-      click_on t("tabs.activity.details")
-
-      activity_presenter = ActivityPresenter.new(activity)
-
-      expect(page).to have_content activity_presenter.roda_identifier
-      expect(page).to have_content activity_presenter.sector
-      expect(page).to have_content activity_presenter.title
-      expect(page).to have_content activity_presenter.description
-      expect(page).to have_content activity_presenter.planned_start_date
-      expect(page).to have_content activity_presenter.planned_end_date
-      expect(page).to have_content activity_presenter.recipient_region
-
-      within ".sustainable_development_goals" do
-        expect(page).to have_content "Gender Equality"
-      end
-    end
-
-    context "when the organisation id query parameter is not the delivery_partners organisation id" do
-      scenario "it defaults to showing the current users organisation activities" do
-        another_delivery_partner = create(:delivery_partner_organisation)
+      scenario "they do not see a Publish to Iati column & status against projects" do
         programme = create(:programme_activity, extending_organisation: user.organisation)
-        activity = create(:project_activity, organisation: user.organisation, parent: programme)
+        project = create(:project_activity, organisation: user.organisation, parent: programme)
 
-        visit activities_path(organisation_id: another_delivery_partner.id)
+        visit organisation_activity_path(user.organisation.id, project)
 
-        expect(page).to have_content activity.roda_identifier
+        click_on t("tabs.activity.details")
+        click_on programme.title
+        click_on t("tabs.activity.children")
+
+        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
+
+        within("##{project.id}") do
+          expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
+        end
       end
-    end
 
-    scenario "activities have human readable date format" do
-      travel_to Time.zone.local(2020, 1, 29) do
-        activity = create(:project_activity, planned_start_date: Date.new(2020, 2, 3),
-                                             planned_end_date: Date.new(2024, 6, 22),
-                                             actual_start_date: Date.new(2020, 1, 2),
-                                             actual_end_date: Date.new(2020, 1, 29),
-                                             organisation: user.organisation)
+      scenario "the activity financials can be viewed" do
+        activity = create(:project_activity, organisation: user.organisation)
+        transaction = create(:transaction, parent_activity: activity)
+        budget = create(:budget, parent_activity: activity)
 
-        visit organisation_activity_path(user.organisation, activity)
+        visit organisation_activity_financials_path(activity.organisation, activity)
+        within ".govuk-tabs__list-item--selected" do
+          expect(page).to have_content "Financials"
+        end
+        expect(page).to have_content transaction.value
+        expect(page).to have_content budget.value
+      end
+
+      scenario "the activity details can be viewed" do
+        activity = create(:project_activity, organisation: user.organisation)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        within ".govuk-tabs__list-item--selected" do
+          expect(page).to have_content "Details"
+        end
+        expect(page).to have_content activity.title
+        expect(page).to have_link t("page_content.activity.implementing_organisation.button.new")
+      end
+
+      scenario "an activity can be viewed" do
+        programme = create(:programme_activity, extending_organisation: user.organisation)
+        activity = create(:project_activity, parent: programme, organisation: user.organisation, sdgs_apply: true, sdg_1: 5)
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+
+        click_on(programme.title)
+        click_on t("tabs.activity.children")
+        click_on activity.title
         click_on t("tabs.activity.details")
 
-        within(".planned_start_date") do
-          expect(page).to have_content("3 Feb 2020")
-        end
+        activity_presenter = ActivityPresenter.new(activity)
 
-        within(".planned_end_date") do
-          expect(page).to have_content("22 Jun 2024")
-        end
+        expect(page).to have_content activity_presenter.roda_identifier
+        expect(page).to have_content activity_presenter.sector
+        expect(page).to have_content activity_presenter.title
+        expect(page).to have_content activity_presenter.description
+        expect(page).to have_content activity_presenter.planned_start_date
+        expect(page).to have_content activity_presenter.planned_end_date
+        expect(page).to have_content activity_presenter.recipient_region
 
-        within(".actual_start_date") do
-          expect(page).to have_content("2 Jan 2020")
-        end
-
-        within(".actual_end_date") do
-          expect(page).to have_content("29 Jan 2020")
+        within ".sustainable_development_goals" do
+          expect(page).to have_content "Gender Equality"
         end
       end
-    end
 
-    scenario "they can expand and collapse the rows to see child activities", js: true do
-      programme = create(:programme_activity, extending_organisation: user.organisation)
-      project = create(:project_activity, organisation: user.organisation, parent: programme)
-      third_party_project = create(:third_party_project_activity, organisation: user.organisation, parent: project)
+      scenario "activities have human readable date format" do
+        travel_to Time.zone.local(2020, 1, 29) do
+          activity = create(:project_activity, planned_start_date: Date.new(2020, 2, 3),
+                                               planned_end_date: Date.new(2024, 6, 22),
+                                               actual_start_date: Date.new(2020, 1, 2),
+                                               actual_end_date: Date.new(2020, 1, 29),
+                                               organisation: user.organisation)
 
-      visit activities_path
+          visit organisation_activity_path(user.organisation, activity)
+          click_on t("tabs.activity.details")
 
-      expect(page).to have_content(programme.title)
-      expect(page).to have_content(programme.roda_identifier)
+          within(".planned_start_date") do
+            expect(page).to have_content("3 Feb 2020")
+          end
 
-      expect(page).not_to have_css("#activity-#{project.id}", visible: true)
-      expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+          within(".planned_end_date") do
+            expect(page).to have_content("22 Jun 2024")
+          end
 
-      click_on programme.title
-      expect(page).to have_css("#activity-#{project.id}", visible: true)
-      expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+          within(".actual_start_date") do
+            expect(page).to have_content("2 Jan 2020")
+          end
 
-      click_on project.title
-      expect(page).to have_css("#activity-#{project.id}", visible: true)
-      expect(page).to have_css("#activity-#{third_party_project.id}", visible: true)
-
-      # Users can hide the expanded rows by clicking the parent activity
-      click_on programme.title
-      expect(page).not_to have_css("#activity-#{project.id}", visible: true)
-      expect(page).not_to have_css("#activity-#{third_party_project.id}", visible: true)
+          within(".actual_end_date") do
+            expect(page).to have_content("29 Jan 2020")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/activity/grouped_actitvities_fetcher_spec.rb
+++ b/spec/services/activity/grouped_actitvities_fetcher_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.describe Activity::GroupedActivitiesFetcher do
+  let(:user) { create(:beis_user) }
+
+  context "when the organisation is a service owner" do
+    let(:organisation) { create(:beis_organisation) }
+
+    it "groups all programmes by parent" do
+      fund = create(:fund_activity)
+      programme = create(:programme_activity, parent: fund)
+      project = create(:project_activity, parent: programme)
+      third_party_project = create(:third_party_project_activity, parent: project)
+
+      activities = described_class.new(user: user, organisation: organisation).call
+
+      expect(activities).to eq({
+        fund => {
+          programme => {
+            project => [
+              third_party_project,
+            ],
+          },
+        },
+      })
+    end
+
+    it "only includes scoped activities if a scope is provided" do
+      fund = create(:fund_activity)
+      non_current_programme = create(:programme_activity, programme_status: "completed", parent: fund)
+      non_current_project_1 = create(:project_activity, programme_status: "completed", parent: non_current_programme)
+
+      programme = create(:programme_activity, parent: fund)
+      project = create(:project_activity, parent: programme)
+      third_party_project = create(:third_party_project_activity, parent: project)
+
+      _non_current_project_2 = create(:project_activity, parent: programme, programme_status: "stopped")
+      _non_current_third_party_project = create(:third_party_project_activity, parent: project, programme_status: "stopped")
+
+      completed_activities = described_class.new(user: user, organisation: organisation, scope: :current).call
+      historic_activities = described_class.new(user: user, organisation: organisation, scope: :historic).call
+
+      expect(completed_activities).to eq({
+        fund => {
+          programme => {
+            project => [
+              third_party_project,
+            ],
+          },
+        },
+      })
+
+      expect(historic_activities).to eq({
+        fund => {
+          non_current_programme => {
+            non_current_project_1 => [],
+          },
+        },
+      })
+    end
+  end
+
+  context "when the organisation is not a service owner" do
+    let(:organisation) { create(:delivery_partner_organisation) }
+
+    it "filters by extending organisation" do
+      fund = create(:fund_activity)
+      programme = create(:programme_activity, extending_organisation: organisation, parent: fund)
+      project = create(:project_activity, parent: programme, extending_organisation: organisation)
+      third_party_project = create(:third_party_project_activity, parent: project, extending_organisation: organisation)
+
+      other_programme = create(:programme_activity, parent: fund)
+      _other_project = create(:project_activity, parent: other_programme)
+
+      activities = described_class.new(user: user, organisation: organisation).call
+
+      expect(activities).to eq({
+        fund => {
+          programme => {
+            project => [
+              third_party_project,
+            ],
+          },
+        },
+      })
+    end
+  end
+
+  it "orders the activities by created date" do
+    organisation = create(:delivery_partner_organisation)
+    fund = create(:fund_activity)
+    old_programme = create(:programme_activity, extending_organisation: organisation, parent: fund, created_at: 1.month.ago)
+    new_programme = create(:programme_activity, extending_organisation: organisation, parent: fund, created_at: 3.days.ago)
+
+    old_project_1 = create(:project_activity, extending_organisation: organisation, parent: old_programme, created_at: 10.days.ago)
+    new_project_1 = create(:project_activity, extending_organisation: organisation, parent: old_programme, created_at: 7.days.ago)
+
+    old_project_2 = create(:project_activity, extending_organisation: organisation, parent: new_programme, created_at: 4.days.ago)
+    new_project_2 = create(:project_activity, extending_organisation: organisation, parent: new_programme, created_at: 2.days.ago)
+
+    old_third_party_project = create(:third_party_project_activity, extending_organisation: organisation, parent: old_project_2, created_at: 1.days.ago)
+    new_third_party_project = create(:third_party_project_activity, extending_organisation: organisation, parent: old_project_2)
+
+    activities = described_class.new(user: create(:beis_user), organisation: organisation).call
+
+    expect(activities).to eq({
+      fund => {
+        old_programme => {
+          old_project_1 => [],
+          new_project_1 => [],
+        },
+        new_programme => {
+          old_project_2 => [
+            old_third_party_project,
+            new_third_party_project,
+          ],
+          new_project_2 => [],
+        },
+      },
+    })
+  end
+end


### PR DESCRIPTION
This PR changes the way we fetch grouped activities by adding a new `Activity::GroupedActivitiesFetcher`, which we can
use in the homepage and activities page. It also improves on what we have by doing all the fetching of child activities in the class itself, rather than while rendering the page. It also fixes a bug where child activities didn't have the same scope as the programmes, so historic projects were showing up under currently running programmes.

I've also taken the opportunity to tweak some of the feature tests to use stubs and mocks, so we're not having to create so many objects in the database, hopefully speeding up the tests a little bit.