### PR TITLE
(1993) Fund model stores the shortname

### DIFF
--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -2,7 +2,7 @@ class Fund
   class InvalidActivity < StandardError; end
   class InvalidFund < StandardError; end
 
-  attr_reader :id, :name
+  attr_reader :id, :name, :short_name
 
   MAPPINGS = {
     "NF" => 1,
@@ -16,6 +16,7 @@ class Fund
 
     @id = data["code"]
     @name = data["name"]
+    @short_name = data["short_name"]
   end
 
   def gcrf?

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -4,11 +4,6 @@ class Fund
 
   attr_reader :id, :name, :short_name
 
-  MAPPINGS = {
-    "NF" => 1,
-    "GCRF" => 2,
-  }
-
   def initialize(id)
     data = self.class.codelist.find_item_by_code(id.to_i)
 
@@ -20,11 +15,11 @@ class Fund
   end
 
   def gcrf?
-    id == MAPPINGS["GCRF"]
+    short_name == "GCRF"
   end
 
   def newton?
-    id == MAPPINGS["NF"]
+    short_name == "NF"
   end
 
   def activity
@@ -39,9 +34,13 @@ class Fund
     def from_activity(activity)
       raise InvalidActivity unless activity.fund?
 
-      id = MAPPINGS.fetch(activity.roda_identifier_fragment) { raise InvalidFund }
+      by_short_name(activity.roda_identifier_fragment)
+    end
 
-      new(id)
+    def by_short_name(short_name)
+      all.find(-> { raise InvalidFund }) { |fund|
+        fund.short_name == short_name
+      }
     end
 
     def all

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -1,8 +1,8 @@
 class Fund
-  attr_reader :code
-
   class InvalidActivity < StandardError; end
   class InvalidFund < StandardError; end
+
+  attr_reader :id, :name
 
   MAPPINGS = {
     "NF" => 1,
@@ -10,17 +10,12 @@ class Fund
   }
 
   def initialize(id)
-    @code = self.class.codelist.find_item_by_code(id.to_i)
+    data = self.class.codelist.find_item_by_code(id.to_i)
 
-    raise InvalidFund if @code.nil?
-  end
+    raise InvalidFund if data.nil?
 
-  def id
-    code["code"]
-  end
-
-  def name
-    code["name"]
+    @id = data["code"]
+    @name = data["name"]
   end
 
   def gcrf?

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Staff::ActivityFormsController do
         it { is_expected.to skip_to_next_step }
 
         context "when activity is the GCRF fund" do
-          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund.by_short_name("GCRF").id) }
 
           it { is_expected.to render_current_step }
         end
@@ -34,7 +34,7 @@ RSpec.describe Staff::ActivityFormsController do
         it { is_expected.to skip_to_next_step }
 
         context "when activity is the GCRF fund" do
-          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+          let(:activity) { create(:project_activity, organisation: organisation, parent: fund, source_fund_code: Fund.by_short_name("GCRF").id) }
 
           it { is_expected.to render_current_step }
         end
@@ -52,7 +52,7 @@ RSpec.describe Staff::ActivityFormsController do
         it { is_expected.to skip_to_next_step }
 
         context "when activity is associated with the GCRF fund" do
-          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund.by_short_name("GCRF").id) }
 
           it { is_expected.to render_current_step }
         end
@@ -71,7 +71,7 @@ RSpec.describe Staff::ActivityFormsController do
         it { is_expected.to skip_to_next_step }
 
         context "when activity is associated with the GCRF fund" do
-          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+          let(:activity) { create(:project_activity, organisation: organisation, parent: programme, source_fund_code: Fund.by_short_name("GCRF").id) }
 
           it { is_expected.to render_current_step }
         end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     sector_category { "111" }
     sector { "11110" }
-    source_fund_code { Fund::MAPPINGS["NF"] }
+    source_fund_code { Fund.by_short_name("NF").id }
     programme_status { 7 }
     planned_start_date { Date.today }
     planned_end_date { Date.tomorrow }
@@ -53,7 +53,7 @@ FactoryBot.define do
       trait :gcrf do
         roda_identifier_fragment { "GCRF" }
         title { "Global Challenges Research Fund (GCRF)" }
-        source_fund_code { Fund::MAPPINGS["GCRF"] }
+        source_fund_code { Fund.by_short_name("GCRF").id }
 
         initialize_with do
           Activity.find_or_initialize_by(roda_identifier_fragment: "GCRF")
@@ -63,7 +63,7 @@ FactoryBot.define do
       trait :newton do
         roda_identifier_fragment { "NF" }
         title { "Newton Fund" }
-        source_fund_code { Fund::MAPPINGS["NF"] }
+        source_fund_code { Fund.by_short_name("NF").id }
 
         initialize_with do
           Activity.find_or_initialize_by(roda_identifier_fragment: "NF")
@@ -82,16 +82,16 @@ FactoryBot.define do
       association :extending_organisation, factory: :delivery_partner_organisation
 
       trait :newton_funded do
-        source_fund_code { Fund::MAPPINGS["NF"] }
+        source_fund_code { Fund.by_short_name("NF").id }
         parent do
-          Activity.fund.find_by(source_fund_code: Fund::MAPPINGS["NF"]) || create(:fund_activity, :newton)
+          Activity.fund.find_by(source_fund_code: Fund.by_short_name("NF").id) || create(:fund_activity, :newton)
         end
       end
 
       trait :gcrf_funded do
-        source_fund_code { Fund::MAPPINGS["GCRF"] }
+        source_fund_code { Fund.by_short_name("GCRF").id }
         parent do
-          Activity.fund.find_by(source_fund_code: Fund::MAPPINGS["GCRF"]) || create(:fund_activity, :gcrf)
+          Activity.fund.find_by(source_fund_code: Fund.by_short_name("GCRF").id) || create(:fund_activity, :gcrf)
         end
       end
     end
@@ -130,12 +130,12 @@ FactoryBot.define do
       end
 
       trait :newton_funded do
-        source_fund_code { Fund::MAPPINGS["NF"] }
+        source_fund_code { Fund.by_short_name("NF").id }
         parent factory: [:programme_activity, :newton_funded]
       end
 
       trait :gcrf_funded do
-        source_fund_code { Fund::MAPPINGS["GCRF"] }
+        source_fund_code { Fund.by_short_name("GCRF").id }
         parent factory: [:programme_activity, :gcrf_funded]
       end
     end
@@ -163,12 +163,12 @@ FactoryBot.define do
       association :extending_organisation, factory: :delivery_partner_organisation
 
       trait :newton_funded do
-        source_fund_code { Fund::MAPPINGS["NF"] }
+        source_fund_code { Fund.by_short_name("NF").id }
         parent factory: [:project_activity, :newton_funded]
       end
 
       trait :gcrf_funded do
-        source_fund_code { Fund::MAPPINGS["GCRF"] }
+        source_fund_code { Fund.by_short_name("GCRF").id }
         parent factory: [:project_activity, :gcrf_funded]
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1531,7 +1531,8 @@ RSpec.describe Activity, type: :model do
 
       it "returns a GCRF fund" do
         expect(activity.source_fund).to be_a(Fund)
-        expect(activity.source_fund.name).to eq("GCRF")
+        expect(activity.source_fund.name).to eq("Global Challenges Research Fund")
+        expect(activity.source_fund.short_name).to eq("GCRF")
         expect(activity.source_fund.id).to eq(2)
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -591,13 +591,13 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when gcrf_strategic_area is blank" do
-      let(:source_fund_code) { Fund::MAPPINGS["NF"] }
+      let(:source_fund_code) { Fund.by_short_name("NF").id }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_strategic_area: nil) }
 
       it { is_expected.to be_valid(:gcrf_strategic_area_step) }
 
       context "with a GCRF funded activity" do
-        let(:source_fund_code) { Fund::MAPPINGS["GCRF"] }
+        let(:source_fund_code) { Fund.by_short_name("GCRF").id }
 
         it { is_expected.to be_invalid(:gcrf_strategic_area_step) }
       end
@@ -610,26 +610,26 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when gcrf_strategic_area has too many values" do
-      let(:source_fund_code) { Fund::MAPPINGS["NF"] }
+      let(:source_fund_code) { Fund.by_short_name("NF").id }
       let(:strategic_areas) { %w[RF Clm IP] }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_strategic_area: strategic_areas) }
 
       context "with a GCRF funded activity" do
-        let(:source_fund_code) { Fund::MAPPINGS["GCRF"] }
+        let(:source_fund_code) { Fund.by_short_name("GCRF").id }
 
         it { is_expected.to be_invalid(:gcrf_strategic_area_step) }
       end
     end
 
     context "when gcrf_challenge_area is blank" do
-      let(:source_fund_code) { Fund::MAPPINGS["NF"] }
+      let(:source_fund_code) { Fund.by_short_name("NF").id }
       subject { build(:programme_activity, source_fund_code: source_fund_code, gcrf_challenge_area: nil) }
 
       it { is_expected.to be_valid(:gcrf_challenge_area_step) }
       it { is_expected.to be_valid }
 
       context "with a GCRF funded activity" do
-        let(:source_fund_code) { Fund::MAPPINGS["GCRF"] }
+        let(:source_fund_code) { Fund.by_short_name("GCRF").id }
 
         it { is_expected.to be_invalid(:gcrf_challenge_area_step) }
         it { is_expected.to be_invalid }
@@ -1517,7 +1517,7 @@ RSpec.describe Activity, type: :model do
 
   describe "#source_fund" do
     context "for a Newton fund activity" do
-      let(:activity) { build(:project_activity, source_fund_code: Fund::MAPPINGS["NF"]) }
+      let(:activity) { build(:project_activity, source_fund_code: Fund.by_short_name("NF").id) }
 
       it "returns a Newton fund" do
         expect(activity.source_fund).to be_a(Fund)
@@ -1527,7 +1527,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context "for a GCRF activity" do
-      let(:activity) { build(:project_activity, source_fund_code: Fund::MAPPINGS["GCRF"]) }
+      let(:activity) { build(:project_activity, source_fund_code: Fund.by_short_name("GCRF").id) }
 
       it "returns a GCRF fund" do
         expect(activity.source_fund).to be_a(Fund)
@@ -1541,7 +1541,7 @@ RSpec.describe Activity, type: :model do
   describe "#source_fund=" do
     it "sets the source fund code" do
       activity = build(:project_activity)
-      activity.source_fund = Fund.new(Fund::MAPPINGS["GCRF"])
+      activity.source_fund = Fund.new(Fund.by_short_name("GCRF").id)
       activity.save
 
       expect(activity.reload.source_fund_code).to eq(2)

--- a/spec/models/fund_spec.rb
+++ b/spec/models/fund_spec.rb
@@ -43,17 +43,25 @@ RSpec.describe Fund do
       it "should return '1' as the ID" do
         expect(fund.id).to eq(1)
       end
+
+      it "should return 'NF' as the short name" do
+        expect(fund.short_name).to eq("NF")
+      end
     end
 
     context "when the associated fund is GCRF" do
       let(:activity) { build(:fund_activity, :gcrf) }
 
       it "should return 'GCRF' as the name" do
-        expect(fund.name).to eq("GCRF")
+        expect(fund.name).to eq("Global Challenges Research Fund")
       end
 
       it "should return '1' as the ID" do
         expect(fund.id).to eq(2)
+      end
+
+      it "should return 'GCRF' as the short name" do
+        expect(fund.short_name).to eq("GCRF")
       end
     end
 

--- a/spec/models/fund_spec.rb
+++ b/spec/models/fund_spec.rb
@@ -1,32 +1,27 @@
 require "rails_helper"
 
 RSpec.describe Fund do
+  let(:newton_code) { 1 }
+  let(:gcrf_code) { 2 }
+
   describe ".initialize" do
     it "initializes successfully when the code exists" do
-      fund = described_class.new(1)
+      fund = described_class.new(newton_code)
 
       expect(fund.name).to eq("Newton Fund")
-      expect(fund.id).to eq(1)
+      expect(fund.id).to eq(newton_code)
     end
 
     it "initializes successfully when the code was provided as a string" do
-      fund = described_class.new("1")
+      fund = described_class.new(newton_code.to_s)
 
       expect(fund.name).to eq("Newton Fund")
-      expect(fund.id).to eq(1)
+      expect(fund.id).to eq(newton_code)
     end
 
     it "raises and error when the code does not exist" do
       expect { described_class.new(99) }.to raise_error("Fund::InvalidFund")
       expect { described_class.new("99") }.to raise_error("Fund::InvalidFund")
-    end
-  end
-
-  describe ".MAPPINGS" do
-    it "contains a mapping for every entry in the 'fund_types' codelist" do
-      codelist = Codelist.new(type: "fund_types", source: "beis")
-
-      expect(described_class::MAPPINGS.values).to eql(codelist.values_for("code"))
     end
   end
 
@@ -56,7 +51,7 @@ RSpec.describe Fund do
         expect(fund.name).to eq("Global Challenges Research Fund")
       end
 
-      it "should return '1' as the ID" do
+      it "should return '2' as the ID" do
         expect(fund.id).to eq(2)
       end
 
@@ -99,13 +94,13 @@ RSpec.describe Fund do
     subject { fund.gcrf? }
 
     context "when the fund is GCRF" do
-      let(:id) { Fund::MAPPINGS["GCRF"] }
+      let(:id) { gcrf_code }
 
       it { is_expected.to be true }
     end
 
     context "when the fund is not GCRF" do
-      let(:id) { Fund::MAPPINGS["NF"] }
+      let(:id) { newton_code }
 
       it { is_expected.to be false }
     end
@@ -116,13 +111,13 @@ RSpec.describe Fund do
     subject { fund.newton? }
 
     context "when the fund is Newton" do
-      let(:id) { Fund::MAPPINGS["NF"] }
+      let(:id) { newton_code }
 
       it { is_expected.to be true }
     end
 
     context "when the fund is not Newton" do
-      let(:id) { Fund::MAPPINGS["GCRF"] }
+      let(:id) { gcrf_code }
 
       it { is_expected.to be false }
     end
@@ -130,8 +125,8 @@ RSpec.describe Fund do
 
   describe "#==" do
     it "is true when the instances have the same id" do
-      instance_1 = described_class.new(1)
-      instance_2 = described_class.new(1)
+      instance_1 = described_class.new(newton_code)
+      instance_2 = described_class.new(newton_code)
 
       expect(instance_1 == instance_2).to be_truthy
     end
@@ -141,7 +136,7 @@ RSpec.describe Fund do
     let(:fund) { described_class.new(id) }
 
     context "when the fund is GCRF" do
-      let(:id) { Fund::MAPPINGS["GCRF"] }
+      let(:id) { gcrf_code }
 
       it "returns the GCRF fund-level Activity for the current Fund" do
         fund_activity = create(:fund_activity, :gcrf)
@@ -151,7 +146,7 @@ RSpec.describe Fund do
     end
 
     context "when the fund is Newton Fund" do
-      let(:id) { Fund::MAPPINGS["NF"] }
+      let(:id) { newton_code }
 
       it "returns the Newton fund-level Activity for the current Fund" do
         fund_activity = create(:fund_activity, :newton)

--- a/spec/services/export_activity_to_csv_spec.rb
+++ b/spec/services/export_activity_to_csv_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ExportActivityToCsv do
     expect(export_service.headers).to include("Source fund")
 
     column_position = export_service.headers.index("Source fund")
-    expect(export_service.call[column_position]).to eql("GCRF")
+    expect(export_service.call[column_position]).to eql("Global Challenges Research Fund")
   end
 
   it "includes the delivery partner's short_name in the export" do

--- a/vendor/data/codelists/BEIS/fund_types.yml
+++ b/vendor/data/codelists/BEIS/fund_types.yml
@@ -1,5 +1,7 @@
 data:
   - code: 1
     name: Newton Fund
+    short_name: NF
   - code: 2
-    name: GCRF
+    name: Global Challenges Research Fund
+    short_name: GCRF


### PR DESCRIPTION
This allows the `Fund` model to return the short name of a given Fund - taken from the Yaml code file. I've also made a couple of quality of life improvments and also made sure all our knowedge about a fund's codes is taken from the Yaml file, rather than spread across the codebase.