### PR TITLE
(2004) fix: orphanned historicevents cause activitiesupdated to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,7 @@
 - Group Activity's Change history by "reference" and show newest first
 
 ## [unreleased]
+- fix guard against orphan HistoricalEvents
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...HEAD
 [release-61]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-60...release-61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -736,6 +736,7 @@
 
 ## [unreleased]
 - fix guard against orphan HistoricalEvents
+- delete related HistoricalEvents when their associated activity is deleted
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...HEAD
 [release-61]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-60...release-61

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -152,7 +152,7 @@ class Activity < ApplicationRecord
   has_many :comments
   has_many :matched_efforts
   has_many :external_incomes
-  has_many :historical_events
+  has_many :historical_events, dependent: :destroy
 
   enum level: {
     fund: "fund",

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -88,7 +88,7 @@ class Report < ApplicationRecord
   end
 
   def activities_updated
-    Activity.find(historical_events.pluck(:activity_id))
+    Activity.where(id: historical_events.pluck(:activity_id))
   end
 
   def forecasts_for_reportable_activities

--- a/db/data/20210712154115_remove_orphaned_historical_events.rb
+++ b/db/data/20210712154115_remove_orphaned_historical_events.rb
@@ -1,0 +1,4 @@
+# Run me with `rails runner db/data/20210712154115_remove_orphaned_historical_events.rb`
+#
+orphaned_events = HistoricalEvent.all.select { |event| Activity.find_by(id: event.activity_id).nil? }
+orphaned_events.destroy_all

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -270,6 +270,15 @@ RSpec.describe Report, type: :model do
         third_party_project_updated_in_report,
       ])
     end
+
+    it "handles the case where there are orphaned HistoricalEvents, after an activity has been deleted" do
+      historical_event = create(:historical_event)
+      report = historical_event.report
+
+      historical_event.activity.destroy
+
+      expect(report.activities_updated.count).to eql 0
+    end
   end
 
   describe "#editable?" do


### PR DESCRIPTION
## Changes in this PR

We heard from a BEIS user that they could not view a report. The issue was that we had deleted an `Activity` from the report that had already created some `HistroricalEvents`. This meant the event stored the ID of an activity that no longer exists.

The `Report` method `activities_updated` uses the Activity IDs in the HistoricalEvents to get a list of 'activities which have been modified in this report`. Under the hood, this method called `find` passing in an array of activity IDs from the historical events.

In cases where the activity has been deleted, this causes `find` to raise an error.

To fix this we swap to a `where` as this will always return a enumerable, even if it is empty and so the view can be rendered in an empty state.

This work also adds `dependent: destroy` on `Activity` so that HIstoricalEvents are removed along with their associated activities - see the commit long for further thoughts on this, on balance, I think this is the best approach for now.

Finally there is a data migration to remove any orphened HIstoricalEvents, we have 10 in production at this time.

## Deployment warning!
This PR includes a manual data migration that has to be run in production once the code is deployed.

```
bin/rails runner db/data/20210712154115_remove_orphaned_historical_events.rb
```