### PR TITLE
Fix (1995) Don't record changes in the Wizard's "Form state"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,6 +733,7 @@
 
 - Optimise `projects_and_third_party_projects_for_report` scope
 - Group Activity's Change history by "reference" and show newest first
+- Ignore internal "changes" to Activity made by form "wizard"
 
 ## [unreleased]
 - fix guard against orphan HistoricalEvents

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -1,10 +1,15 @@
 class HistoryRecorder
+  INTERNAL_VALUES = ["form_state"].freeze
+
   def initialize(user:)
     @user = user
   end
 
   def call(changes:, reference:, activity:, report: nil)
-    changes.each do |value_changed, (previous_value, new_value)|
+    changes
+      .each do |value_changed, (previous_value, new_value)|
+      next if INTERNAL_VALUES.include?(value_changed)
+
       HistoricalEvent.create(
         user: user,
         activity: activity,

--- a/db/data/20210712154227_remove_historical_events_for_wizard_form_state_changes.rb
+++ b/db/data/20210712154227_remove_historical_events_for_wizard_form_state_changes.rb
@@ -1,0 +1,3 @@
+# Run me with `rails runner db/data/20210712154227_remove_historical_events_for_wizard_form_state_changes.rb`
+
+HistoricalEvent.where(value_changed: "form_state").destroy_all

--- a/spec/services/history_recorder_spec.rb
+++ b/spec/services/history_recorder_spec.rb
@@ -50,5 +50,38 @@ RSpec.describe HistoryRecorder do
         new_value: "Updated description"
       )
     end
+
+    context "when the the changes include the internal Wizard 'form_state' property" do
+      let(:changes) do
+        {
+          "objectives" => ["Original objective", "New objective"],
+          "form_state" => ["purpose", "objectives"],
+        }
+      end
+
+      it "does NOT create a HistoricalEvent for that particular property" do
+        recorder.call(changes: changes, activity: activity, reference: reference, report: report)
+
+        expect(HistoricalEvent).not_to have_received(:create).with(
+          hash_including(
+            value_changed: "form_state"
+          )
+        )
+      end
+
+      it "does create a HistoricalEvent for other properties in the batch" do
+        recorder.call(changes: changes, activity: activity, reference: reference, report: report)
+
+        expect(HistoricalEvent).to have_received(:create).with(
+          user: user,
+          activity: activity,
+          report: report,
+          reference: reference,
+          value_changed: "objectives",
+          previous_value: "Original objective",
+          new_value: "New objective"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello
https://trello.com/c/Yr4Kxj3X/1995-change-history-includes-the-formstate-changes

## Changes in this PR

We no longer record HistoricalEvents for changes which are to `Activity#form_state`. This is an internal property of the Wizard system we are using for multi-step forms.

We also include a simple data migration to remove existing events of this type. It should be run after deployment with:

```
rails runner db/data/20210712154227_remove_historical_events_for_wizard_form_state_changes.rb
```

## Screenshots of UI changes

### Before

<img width="1131" alt="wizard_form_state" src="https://user-images.githubusercontent.com/20245/125319540-c5b86c80-e332-11eb-81b1-4a9db6f0711f.png">

### After

<img width="1030" alt="no_more_Internal_form_state" src="https://user-images.githubusercontent.com/20245/125319886-14fe9d00-e333-11eb-9079-f3ad25206840.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
- [ x] Run 'data migration' after deployment 
