### PR TITLE
(1948) Feature: split activity report by new and updated activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -744,6 +744,7 @@
 
 - New activities know which was their 'originating' report, and reports can list 'new' activities originating from their financial period
 - Newly updated activities are shown in a report.
+- Newly added activities are shown in a report.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...HEAD
 [release-62]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...release-62

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -743,6 +743,7 @@
 ## [unreleased]
 
 - New activities know which was their 'originating' report, and reports can list 'new' activities originating from their financial period
+- Newly updated activities are shown in a report.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...HEAD
 [release-62]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...release-62

--- a/app/controllers/staff/report_activities_controller.rb
+++ b/app/controllers/staff/report_activities_controller.rb
@@ -8,9 +8,7 @@ class Staff::ReportActivitiesController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-
-    @activities = Activity::ProjectsForReportFinder.new(report: @report).call.order(:title, :roda_identifier_fragment)
-
+    @updated_activities = @report.activities_updated
     render "staff/reports/activities"
   end
 end

--- a/app/controllers/staff/report_activities_controller.rb
+++ b/app/controllers/staff/report_activities_controller.rb
@@ -9,6 +9,8 @@ class Staff::ReportActivitiesController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
     @updated_activities = @report.activities_updated
+    @new_activities = @report.new_activities
+
     render "staff/reports/activities"
   end
 end

--- a/app/views/staff/activity_uploads/_activities_table.html.haml
+++ b/app/views/staff/activity_uploads/_activities_table.html.haml
@@ -1,11 +1,12 @@
-%table.govuk-table
-  %caption.govuk-table__caption= "List of activities #{action}"
+%table{ class: "govuk-table govuk-!-margin-bottom-9" }
+  %caption.govuk-table__caption.govuk-table__caption--m
+    = table_caption
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header{scope: "col"} RODA Identifier
       %th.govuk-table__header{scope: "col"} Title
-      %th.govuk-table__header{scope: "col"} State
-      %th.govuk-table__header{scope: "col"} Link
+      %th.govuk-table__header{scope: "col"} Status
+      %th.govuk-table__header{scope: "col"} Action
   %tbody.govuk-table__body
     - activities.each do |activity|
       - activity_presenter = ActivityPresenter.new(activity)
@@ -14,5 +15,5 @@
         %td.govuk-table__cell= activity_presenter.title
         %td.govuk-table__cell= activity_presenter.programme_status
         %td.govuk-table__cell
-          = link_to "View", organisation_activity_path(activity.organisation, activity)
+          = link_to "View activity", organisation_activity_path(activity.organisation, activity)
 

--- a/app/views/staff/activity_uploads/update.html.haml
+++ b/app/views/staff/activity_uploads/update.html.haml
@@ -13,9 +13,9 @@
 
   - if @success
     - if @activities[:created].any?
-      = render partial: "activities_table", locals: { action: "created", activities: @activities[:created] }
+      = render partial: "activities_table", locals: { action: "created", activities: @activities[:created], table_caption: t("table.caption.activity.new_activities") }
     - if @activities[:updated].any?
-      = render partial: "activities_table", locals: { action: "updated", activities: @activities[:updated] }
+      = render partial: "activities_table", locals: { action: "updated", activities: @activities[:updated], table_caption: t("table.caption.activity.updated_activities") }
   - else
     = render partial: "upload_form"
 

--- a/app/views/staff/reports/activities.html.haml
+++ b/app/views/staff/reports/activities.html.haml
@@ -28,4 +28,6 @@
             %p.govuk-body
               = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
 
+          = render partial: "staff/activity_uploads/activities_table", locals: { table_caption: t("table.caption.activity.new_activities_report"), activities: @new_activities }
+
           = render partial: "staff/activity_uploads/activities_table", locals: { table_caption: t("table.caption.activity.updated_activities_report"), activities: @updated_activities }

--- a/app/views/staff/reports/activities.html.haml
+++ b/app/views/staff/reports/activities.html.haml
@@ -16,18 +16,16 @@
           %h2.govuk-heading-l
             = t("tabs.report.activities")
 
-          %p.govuk-body
-            All activities that are reportable for this report are shown below.
-
-          %p.govuk-body
-            For guidance on adding or updating activities, see the
-            = link_to_new_tab "guidance in the help centre", "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data"
-
           - if policy(@report_presenter).upload?
+            %h3.govuk-heading-m
+              Upload new or changed activity data
             %p.govuk-body
               Large numbers of activities can be added or updated via the activities upload.
 
             %p.govuk-body
-              = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-link"
+              For guidance on adding or updating activities, see the
+              = link_to_new_tab "guidance in the help centre", "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data"
+            %p.govuk-body
+              = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
 
-          = render partial: "staff/activity_uploads/activities_table", locals: { action: "related to this report", activities: @activities }
+          = render partial: "staff/activity_uploads/activities_table", locals: { table_caption: t("table.caption.activity.updated_activities_report"), activities: @updated_activities }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -293,6 +293,12 @@ en:
         transparency_identifier: "Transparency identifier"
         uk_dp_named_contact: UK delivery partner named contact for this activity
   table:
+    caption:
+      activity:
+        new_activities: New activities
+        updated_activities: Updated activities
+        new_activities_report: New activities added in this report
+        updated_activities_report: Activities updated in this report
     header:
       activity:
         identifier: RODA Identifier

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "users can upload activities" do
 
     expect(Activity.count - old_count).to eq(2)
     expect(page).to have_text(t("action.activity.upload.success"))
-    expect(page).to have_text("List of activities created")
+    expect(page).to have_table(t("table.caption.activity.new_activities"))
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[2]", text: "Programme - Award (round 5)")
@@ -175,7 +175,7 @@ RSpec.feature "users can upload activities" do
     CSV
 
     expect(page).to have_text(t("action.activity.upload.success"))
-    expect(page).to have_text("List of activities updated")
+    expect(page).to have_table(t("table.caption.activity.updated_activities"))
 
     expect_change_to_be_recorded_as_historical_event(
       field: "title",

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -78,10 +78,17 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content report.organisation.name
     end
 
-    scenario "the report inclides a list of updated activities" do
-      activity = create(:third_party_project_activity)
-      report = create(:report, :active, organisation: build(:delivery_partner_organisation))
-      history_event = create(:historical_event, activity: activity, report: report)
+    scenario "the report includes a list of newly created and updated activities" do
+      delivery_partner_organisation = create(:delivery_partner_organisation)
+      fund = create(:fund_activity)
+      programme = create(:programme_activity, parent: fund)
+      project = create(:project_activity, parent: programme)
+      report = create(:report, :active, fund: fund, organisation: delivery_partner_organisation, financial_quarter: 1, financial_year: 2021)
+
+      new_activity = create(:third_party_project_activity, organisation: delivery_partner_organisation, parent: project, originating_report: report)
+      updated_activity = create(:third_party_project_activity, organisation: delivery_partner_organisation, parent: project)
+
+      _history_event = create(:historical_event, activity: updated_activity, report: report)
 
       visit reports_path
 
@@ -93,7 +100,8 @@ RSpec.feature "Users can view reports" do
         click_on "Activities"
       end
 
-      expect(page).to have_content activity.title
+      expect(page).to have_content new_activity.title
+      expect(page).to have_content updated_activity.title
     end
 
     context "when there is no report descripiton" do

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -78,6 +78,24 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content report.organisation.name
     end
 
+    scenario "the report inclides a list of updated activities" do
+      activity = create(:third_party_project_activity)
+      report = create(:report, :active, organisation: build(:delivery_partner_organisation))
+      history_event = create(:historical_event, activity: activity, report: report)
+
+      visit reports_path
+
+      within "##{report.id}" do
+        click_on t("default.link.show")
+      end
+
+      within ".govuk-tabs" do
+        click_on "Activities"
+      end
+
+      expect(page).to have_content activity.title
+    end
+
     context "when there is no report descripiton" do
       scenario "the summary does not include the empty value" do
         report = create(:report, :active, organisation: build(:delivery_partner_organisation), description: nil)


### PR DESCRIPTION
## Changes in this PR
The goal of the report > activities tab is to show all users a clear list of the activites which have either been:

- newly added to the report
- had the activity attributes changed in the report

Now we have the `new_activties` association and the `activites_updated` method on Report, this is straight forward to achieve.

## Screenshots of UI changes

### Before
![Screenshot 2021-07-14 at 14-03-25 FQ1 2021-2022 Q1 Report - FY 21 22 activities - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/125627208-8fe8095c-21c2-4fa0-aab1-b27d96203f7d.png)

### After
![Screenshot 2021-07-14 at 14-03-12 FQ1 2021-2022 Q1 Report - FY 21 22 activities - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/125627195-2564f7a7-7d69-4856-a789-d179c18b0cb6.png)


