### PR TITLE
Send a notification on successful deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,3 +77,14 @@ jobs:
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/master'
+  check_and_notify:
+    needs: deploy
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Notifying the team of a successful deploy
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: script/deployment-notification

--- a/script/deploy-notification
+++ b/script/deploy-notification
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+printf "Waiting for deploy."
+current_sha=$(git rev-parse HEAD)
+
+while :
+do
+  printf "."
+  deployed_sha=$(curl -s https://www.report-official-development-assistance.service.gov.uk/health_check | jq -r '.git_sha')
+  if [ "$deployed_sha" = "$current_sha" ]; then
+    break
+  fi
+  sleep 10
+done
+
+echo "Sending Slack notification!"
+
+curl -s -X POST --data-urlencode "payload={\"text\": \"@here :badgerbadger: The latest release of RODA has been deployed to production :badgerbadger:\"}" "$SLACK_WEBHOOK_URL"
+


### PR DESCRIPTION
This adds a new job in the deploy Github Action to poll the Health Check URL and check the SHA returned matches the current SHA of the code we’ve deployed.

Once it does it sends a message to our Slack channel to inform the team that the code has been deployed.

This only runs on production deploys and times out after 30 minutes (in case something has gone wrong and we end up waiting forever for something that is never going to happen)

Here's a sample of how the Slack message will look

![image](https://user-images.githubusercontent.com/109774/126128357-3548b695-8621-4d89-ac8f-29088d60ff00.png)
