### PR TITLE
(1949) Feature: track changes to financial info (Transactions aka Actuals initially)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,6 +753,7 @@
 - Improvements to navigation and to url scheme for activities
 - Add new programme (level B) activities buttons are now on the delivery partner
   activities pages
+- Track changes to 'Actual' financials in activity's 'Change history'
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...HEAD
 [release-62]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...release-62

--- a/app/controllers/staff/activity_forms_controller.rb
+++ b/app/controllers/staff/activity_forms_controller.rb
@@ -115,6 +115,7 @@ class Staff::ActivityFormsController < Staff::BaseController
         changes: @activity.changes,
         reference: "Update to Activity #{step}",
         activity: @activity,
+        trackable: @activity,
         report: Report.editable_for_activity(@activity)
       )
   end

--- a/app/controllers/staff/transactions_controller.rb
+++ b/app/controllers/staff/transactions_controller.rb
@@ -44,8 +44,11 @@ class Staff::TransactionsController < Staff::BaseController
     authorize @transaction
 
     @activity = activity
-    result = UpdateTransaction.new(transaction: @transaction)
-      .call(attributes: transaction_params)
+    result = UpdateTransaction.new(
+      transaction: @transaction,
+      user: current_user,
+      report: Report.editable_for_activity(@activity)
+    ).call(attributes: transaction_params)
 
     if result.success?
       @transaction.create_activity key: "transaction.update", owner: current_user

--- a/app/models/historical_event.rb
+++ b/app/models/historical_event.rb
@@ -1,5 +1,6 @@
 class HistoricalEvent < ApplicationRecord
   belongs_to :user
+  belongs_to :trackable, polymorphic: true
   belongs_to :activity
   belongs_to :report, optional: true
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -9,6 +9,7 @@ class Transaction < ApplicationRecord
 
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
+  has_many :historical_events, dependent: :destroy, as: :trackable
 
   validates_with TransactionOrganisationValidator
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -151,6 +151,7 @@ module Activities
             changes: changes,
             reference: "Import from CSV",
             activity: @activity,
+            trackable: @activity,
             report: report
           )
       end

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -13,6 +13,7 @@ class HistoryRecorder
       HistoricalEvent.create(
         user: user,
         activity: activity,
+        trackable: trackable,
         report: report,
         reference: reference,
         value_changed: value_changed,

--- a/app/services/history_recorder.rb
+++ b/app/services/history_recorder.rb
@@ -5,7 +5,7 @@ class HistoryRecorder
     @user = user
   end
 
-  def call(changes:, reference:, activity:, report: nil)
+  def call(changes:, reference:, activity:, trackable:, report: nil)
     changes
       .each do |value_changed, (previous_value, new_value)|
       next if INTERNAL_VALUES.include?(value_changed)

--- a/app/services/update_transaction.rb
+++ b/app/services/update_transaction.rb
@@ -1,8 +1,10 @@
 class UpdateTransaction
   attr_accessor :transaction
 
-  def initialize(transaction:)
-    self.transaction = transaction
+  def initialize(transaction:, user:, report:)
+    @transaction = transaction
+    @user = user
+    @report = report
   end
 
   def call(attributes: {})
@@ -20,6 +22,8 @@ class UpdateTransaction
   end
 
   private
+
+  attr_reader :transaction, :user, :report
 
   def convert_and_assign_value(transaction, value)
     transaction.value = ConvertFinancialValue.new.convert(value.to_s)

--- a/app/services/update_transaction.rb
+++ b/app/services/update_transaction.rb
@@ -9,23 +9,23 @@ class UpdateTransaction
     transaction.assign_attributes(attributes)
 
     convert_and_assign_value(transaction, attributes[:value])
+    changes = transaction.changes
+    success = transaction.save
 
-    result = if transaction.valid?
+    if success
       HistoryRecorder
         .new(user: user)
         .call(
-          changes: transaction.changes,
+          changes: changes,
           reference: "Update to Transaction",
           activity: transaction.parent_activity,
           trackable: transaction,
           report: report
         )
-      Result.new(transaction.save, transaction)
+      Result.new(true, transaction)
     else
       Result.new(false, transaction)
     end
-
-    result
   end
 
   private

--- a/app/services/update_transaction.rb
+++ b/app/services/update_transaction.rb
@@ -1,6 +1,4 @@
 class UpdateTransaction
-  attr_accessor :transaction
-
   def initialize(transaction:, user:, report:)
     @transaction = transaction
     @user = user
@@ -13,6 +11,15 @@ class UpdateTransaction
     convert_and_assign_value(transaction, attributes[:value])
 
     result = if transaction.valid?
+      HistoryRecorder
+        .new(user: user)
+        .call(
+          changes: transaction.changes,
+          reference: "Update to Transaction",
+          activity: transaction.parent_activity,
+          trackable: transaction,
+          report: report
+        )
       Result.new(transaction.save, transaction)
     else
       Result.new(false, transaction)

--- a/app/views/staff/activity_historical_events/show.html.haml
+++ b/app/views/staff/activity_historical_events/show.html.haml
@@ -49,7 +49,7 @@
                   %tbody.govuk-table__body
                     - events.each do |event|
 
-                      %tr.govuk-body-s.govuk-table__row[event]
+                      %tr.govuk-body-s.govuk-table__row[event]{class: event.trackable_type.downcase}
                         %td.govuk-table__cell.property= event.value_changed
                         %td.govuk-table__cell.previous-value= event.previous_value
                         %td.govuk-table__cell.new-value= event.new_value

--- a/db/migrate/20210719082105_make_historical_event_polymorphic.rb
+++ b/db/migrate/20210719082105_make_historical_event_polymorphic.rb
@@ -1,0 +1,13 @@
+class MakeHistoricalEventPolymorphic < ActiveRecord::Migration[6.1]
+  def change
+    change_table :historical_events do |t|
+      t.string :trackable_id
+      t.string :trackable_type
+    end
+    add_index :historical_events, [:trackable_type, :trackable_id]
+
+    HistoricalEvent.all.each do |event|
+      event.update_columns(trackable_id: event.activity_id, trackable_type: "Activity")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_112144) do
+ActiveRecord::Schema.define(version: 2021_07_19_082105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -186,8 +186,11 @@ ActiveRecord::Schema.define(version: 2021_07_08_112144) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "report_id"
+    t.string "trackable_id"
+    t.string "trackable_type"
     t.index ["activity_id"], name: "index_historical_events_on_activity_id"
     t.index ["report_id"], name: "index_historical_events_on_report_id"
+    t.index ["trackable_type", "trackable_id"], name: "index_historical_events_on_trackable_type_and_trackable_id"
     t.index ["user_id"], name: "index_historical_events_on_user_id"
   end
 

--- a/spec/controllers/staff/activity_forms_controller_spec.rb
+++ b/spec/controllers/staff/activity_forms_controller_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Staff::ActivityFormsController do
           changes: expected_changes,
           reference: "Update to Activity purpose",
           activity: activity,
+          trackable: activity,
           report: report
         )
       end

--- a/spec/controllers/staff/transactions_controller_spec.rb
+++ b/spec/controllers/staff/transactions_controller_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe Staff::TransactionsController do
 
       put :update, params: params
 
-      expect(UpdateTransaction).to have_received(:new).with(transaction: transaction)
+      expect(UpdateTransaction).to have_received(:new).with(
+        user: user,
+        transaction: transaction,
+        report: report
+      )
       expect(updater).to have_received(:call).with(
         attributes: {"value" => "200.02", "financial_quarter" => "2"}
       )

--- a/spec/controllers/staff/transactions_controller_spec.rb
+++ b/spec/controllers/staff/transactions_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Staff::TransactionsController do
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+  let(:activity) { build_stubbed(:project_activity) }
+  let(:report) { double("report") }
+  let(:result) { Result.new(false) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+    allow(Activity).to receive(:find).and_return(activity)
+  end
+
+  describe "#update" do
+    let(:transaction) { build_stubbed(:transaction) }
+    let(:updater) { instance_double(UpdateTransaction, call: result) }
+
+    before do
+      allow(Transaction).to receive(:find).and_return(transaction)
+      policy = instance_double(TransactionPolicy, update?: true)
+      allow(TransactionPolicy).to receive(:new).and_return(policy)
+      allow(UpdateTransaction).to receive(:new).and_return(updater)
+      allow(Report).to receive(:editable_for_activity).and_return(report)
+    end
+
+    it "asks the UpdateTransaction service to persist the changes" do
+      params = {
+        transaction: {value: "200.02", financial_quarter: "2"},
+        activity_id: "abc123",
+        id: "xyz321",
+      }
+
+      put :update, params: params
+
+      expect(UpdateTransaction).to have_received(:new).with(transaction: transaction)
+      expect(updater).to have_received(:call).with(
+        attributes: {"value" => "200.02", "financial_quarter" => "2"}
+      )
+    end
+  end
+end

--- a/spec/factories/historical_event.rb
+++ b/spec/factories/historical_event.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :historical_event do
     user { create(:delivery_partner_user) }
     activity { create(:project_activity) }
+    trackable { activity }
     report { create(:report) }
     value_changed { "name" }
     new_value { Faker::Lorem.sentence }

--- a/spec/features/staff/users_can_edit_a_transaction_spec.rb
+++ b/spec/features/staff/users_can_edit_a_transaction_spec.rb
@@ -68,10 +68,24 @@ RSpec.feature "Users can edit a transaction" do
         report.update(state: :active)
       end
 
-      scenario "shows the edit link" do
+      scenario "can be edited, with 'change history'" do
         visit organisation_activity_path(activity.organisation, activity)
 
         expect(page).to have_link t("default.link.edit"), href: edit_activity_transaction_path(activity, transaction)
+
+        within ".transactions" do
+          expect(page).to have_content("£110.01")
+          click_link("Edit")
+        end
+
+        fill_in "transaction[value]", with: 221.12
+
+        click_on(t("default.button.submit"))
+
+        within ".transactions" do
+          expect(page).to have_content("£221.12")
+        end
+        expect_to_see_change_recorded_in_activitys_change_history("110.01", "221.12")
       end
     end
 
@@ -83,6 +97,19 @@ RSpec.feature "Users can edit a transaction" do
 
         expect(page).not_to have_link t("default.link.edit"), href: edit_activity_transaction_path(activity, transaction)
       end
+    end
+  end
+
+  def expect_to_see_change_recorded_in_activitys_change_history(previous_value, new_value)
+    click_link("Change history")
+    within(".historical-events .transaction") do
+      expect(page).to have_css(".property", text: "value")
+      expect(page).to have_css(".previous-value", text: previous_value)
+      expect(page).to have_css(".new-value", text: new_value)
+      expect(page).to have_css(
+        ".report a[href='#{report_path(report)}']",
+        text: report.financial_quarter_and_year
+      )
     end
   end
 end

--- a/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
@@ -27,7 +27,13 @@ RSpec.feature "Users can view an activity's 'Change History' within a tab" do
     def setup_historical_events(report:)
       HistoryRecorder
         .new(user: user)
-        .call(changes: changes, activity: activity, reference: reference, report: report)
+        .call(
+          changes: changes,
+          activity: activity,
+          trackable: activity,
+          reference: reference,
+          report: report
+        )
     end
 
     def expect_to_see_change_history_with_reference(reference:, events:)

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -3,8 +3,33 @@ require "rails_helper"
 RSpec.describe HistoricalEvent, type: :model do
   describe "associations" do
     it { should belong_to(:activity) }
+    it { should belong_to(:trackable) }
     it { should belong_to(:user) }
     it { should belong_to(:report).optional }
+  end
+
+  describe "polymorphic 'trackable' association" do
+    context "when the change being tracked is on an Activity" do
+      let(:trackable) { create(:project_activity) }
+      let(:event) { HistoricalEvent.new(trackable: trackable) }
+
+      it "associates with the expected Activity object" do
+        expect(event.trackable_id).to eq(trackable.id)
+        expect(event.trackable_type).to eq("Activity")
+        expect(event.trackable).to eq(trackable)
+      end
+    end
+
+    context "when the change being tracked is on a Transaction" do
+      let(:trackable) { create(:transaction) }
+      let(:event) { HistoricalEvent.new(trackable: trackable) }
+
+      it "associates with the expected Transaction object" do
+        expect(event.trackable_id).to eq(trackable.id)
+        expect(event.trackable_type).to eq("Transaction")
+        expect(event.trackable).to eq(trackable)
+      end
+    end
   end
 
   describe "flexible 'value' fields which handle a range of data types" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Transaction, type: :model do
   let(:activity) { build(:project_activity) }
 
+  it { should have_many(:historical_events) }
+
   describe "validations" do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:financial_year) }

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -974,6 +974,7 @@ RSpec.describe Activities::ImportFromCsv do
           reference: "Import from CSV",
           changes: expected_changes,
           activity: existing_activity,
+          trackable: existing_activity,
           report: report
         )
       end

--- a/spec/services/activity/historical_events_grouper_spec.rb
+++ b/spec/services/activity/historical_events_grouper_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
   let!(:event1) do
     HistoricalEvent.create(
       activity: activity,
+      trackable: activity,
       reference: "Update to Activity programme_status",
       user: user1,
       created_at: Time.zone.parse("02-Jul-2021 12:08:00")
@@ -16,6 +17,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
   let!(:event2) do
     HistoricalEvent.create(
       activity: activity,
+      trackable: activity,
       reference: "Update to Activity programme_status",
       user: user1,
       created_at: Time.zone.parse("02-Jul-2021 12:08:10")
@@ -25,6 +27,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
   let!(:event3) do
     HistoricalEvent.create(
       activity: activity,
+      trackable: activity,
       reference: "Import from CSV",
       user: user2,
       created_at: Time.zone.parse("07-Jul-2021 10:45:20")
@@ -33,6 +36,7 @@ RSpec.describe Activity::HistoricalEventsGrouper do
   let!(:event4) do
     HistoricalEvent.create(
       activity: activity,
+      trackable: activity,
       reference: "Import from CSV",
       user: user2,
       created_at: Time.zone.parse("07-Jul-2021 10:45:30")

--- a/spec/services/history_recorder_spec.rb
+++ b/spec/services/history_recorder_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe HistoryRecorder do
     let(:user) { double("user") }
     let(:reference) { double("reference") }
     let(:activity) { double("activity") }
+    let(:trackable) { double("trackable") }
     let(:report) { double("report") }
 
     it "creates a HistoricalEvent for each change provided" do
       recorder.call(
         changes: changes,
         activity: activity,
-        trackable: activity,
+        trackable: trackable,
         reference: reference,
         report: report
       )
@@ -39,6 +40,7 @@ RSpec.describe HistoryRecorder do
       expect(HistoricalEvent).to have_received(:create).with(
         user: user,
         activity: activity,
+        trackable: trackable,
         report: report,
         reference: reference,
         value_changed: "title",
@@ -49,6 +51,7 @@ RSpec.describe HistoryRecorder do
       expect(HistoricalEvent).to have_received(:create).with(
         user: user,
         activity: activity,
+        trackable: trackable,
         report: report,
         reference: reference,
         value_changed: "description",
@@ -69,7 +72,7 @@ RSpec.describe HistoryRecorder do
         recorder.call(
           changes: changes,
           activity: activity,
-          trackable: activity,
+          trackable: trackable,
           reference: reference,
           report: report
         )
@@ -85,7 +88,7 @@ RSpec.describe HistoryRecorder do
         recorder.call(
           changes: changes,
           activity: activity,
-          trackable: activity,
+          trackable: trackable,
           reference: reference,
           report: report
         )
@@ -93,6 +96,7 @@ RSpec.describe HistoryRecorder do
         expect(HistoricalEvent).to have_received(:create).with(
           user: user,
           activity: activity,
+          trackable: trackable,
           report: report,
           reference: reference,
           value_changed: "objectives",

--- a/spec/services/history_recorder_spec.rb
+++ b/spec/services/history_recorder_spec.rb
@@ -28,7 +28,13 @@ RSpec.describe HistoryRecorder do
     let(:report) { double("report") }
 
     it "creates a HistoricalEvent for each change provided" do
-      recorder.call(changes: changes, activity: activity, reference: reference, report: report)
+      recorder.call(
+        changes: changes,
+        activity: activity,
+        trackable: activity,
+        reference: reference,
+        report: report
+      )
 
       expect(HistoricalEvent).to have_received(:create).with(
         user: user,
@@ -60,7 +66,13 @@ RSpec.describe HistoryRecorder do
       end
 
       it "does NOT create a HistoricalEvent for that particular property" do
-        recorder.call(changes: changes, activity: activity, reference: reference, report: report)
+        recorder.call(
+          changes: changes,
+          activity: activity,
+          trackable: activity,
+          reference: reference,
+          report: report
+        )
 
         expect(HistoricalEvent).not_to have_received(:create).with(
           hash_including(
@@ -70,7 +82,13 @@ RSpec.describe HistoryRecorder do
       end
 
       it "does create a HistoricalEvent for other properties in the batch" do
-        recorder.call(changes: changes, activity: activity, reference: reference, report: report)
+        recorder.call(
+          changes: changes,
+          activity: activity,
+          trackable: activity,
+          reference: reference,
+          report: report
+        )
 
         expect(HistoricalEvent).to have_received(:create).with(
           user: user,

--- a/spec/services/update_transaction_spec.rb
+++ b/spec/services/update_transaction_spec.rb
@@ -2,6 +2,12 @@ require "rails_helper"
 
 RSpec.describe UpdateTransaction do
   let(:transaction) { create(:transaction) }
+  let(:user) { double("user") }
+  let(:report) { double("report") }
+
+  let(:updater) do
+    described_class.new(transaction: transaction, user: user, report: report)
+  end
 
   describe "#call" do
     context "when the transaction is valid" do
@@ -11,7 +17,7 @@ RSpec.describe UpdateTransaction do
       end
 
       it "returns a successful result" do
-        result = described_class.new(transaction: transaction).call(attributes: {})
+        result = updater.call(attributes: {})
 
         expect(result.success?).to be true
       end
@@ -29,7 +35,7 @@ RSpec.describe UpdateTransaction do
       it "returns a failed result" do
         allow(transaction).to receive(:valid?).and_return(false)
 
-        result = described_class.new(transaction: transaction).call(attributes: {})
+        result = updater.call(attributes: {})
 
         expect(result.success?).to be false
       end
@@ -39,12 +45,12 @@ RSpec.describe UpdateTransaction do
       it "sets the attributes passed in as transaction attributes" do
         attributes = ActionController::Parameters.new(description: "foo").permit!
 
-        result = described_class.new(transaction: transaction).call(attributes: attributes)
+        result = updater.call(attributes: attributes)
 
         expect(result.object.description).to eq("foo")
       end
 
-      subject { described_class.new(transaction: transaction) }
+      subject { updater }
       it_behaves_like "sanitises monetary field"
     end
 
@@ -52,7 +58,7 @@ RSpec.describe UpdateTransaction do
       it "raises an error" do
         attributes = ActionController::Parameters.new(foo: "bar").permit!
 
-        expect { described_class.new(transaction: transaction).call(attributes: attributes) }
+        expect { updater.call(attributes: attributes) }
           .to raise_error(ActiveModel::UnknownAttributeError)
       end
     end

--- a/spec/services/update_transaction_spec.rb
+++ b/spec/services/update_transaction_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UpdateTransaction do
-  let(:transaction) { create(:transaction) }
+  let(:transaction) { create(:transaction, value: BigDecimal("101.01"), financial_quarter: 1) }
   let(:user) { double("user") }
   let(:report) { double("report") }
 
@@ -9,7 +9,15 @@ RSpec.describe UpdateTransaction do
     described_class.new(transaction: transaction, user: user, report: report)
   end
 
+  let(:history_recorder) do
+    instance_double(HistoryRecorder, call: double)
+  end
+
   describe "#call" do
+    before do
+      allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
+    end
+
     context "when the transaction is valid" do
       before do
         allow(transaction).to receive(:valid?).and_return(true)
@@ -23,7 +31,25 @@ RSpec.describe UpdateTransaction do
       end
 
       context "when the change is persisted successfully" do
-        it "asks the HistoryRecorder to handle the changes"
+        let(:expected_changes) do
+          {
+            "value" => [BigDecimal("101.01"), BigDecimal("202.02")],
+            "financial_quarter" => [1, 2],
+          }
+        end
+
+        it "asks the HistoryRecorder to handle the changes" do
+          updater.call(attributes: {value: "202.02", financial_quarter: "2"})
+
+          expect(HistoryRecorder).to have_received(:new).with(user: user)
+          expect(history_recorder).to have_received(:call).with(
+            changes: expected_changes,
+            reference: "Update to Transaction",
+            activity: transaction.parent_activity,
+            trackable: transaction,
+            report: report
+          )
+        end
       end
 
       context "when the change is NOT persisted successfully" do

--- a/spec/services/update_transaction_spec.rb
+++ b/spec/services/update_transaction_spec.rb
@@ -18,10 +18,29 @@ RSpec.describe UpdateTransaction do
       allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
     end
 
-    context "when the transaction is valid" do
+    context "when the change is persisted successfully" do
       before do
-        allow(transaction).to receive(:valid?).and_return(true)
         allow(transaction).to receive(:save).and_return(true)
+      end
+
+      let(:expected_changes) do
+        {
+          "value" => [BigDecimal("101.01"), BigDecimal("202.02")],
+          "financial_quarter" => [1, 2],
+        }
+      end
+
+      it "asks the HistoryRecorder to handle the changes" do
+        updater.call(attributes: {value: "202.02", financial_quarter: "2"})
+
+        expect(HistoryRecorder).to have_received(:new).with(user: user)
+        expect(history_recorder).to have_received(:call).with(
+          changes: expected_changes,
+          reference: "Update to Transaction",
+          activity: transaction.parent_activity,
+          trackable: transaction,
+          report: report
+        )
       end
 
       it "returns a successful result" do
@@ -29,38 +48,20 @@ RSpec.describe UpdateTransaction do
 
         expect(result.success?).to be true
       end
-
-      context "when the change is persisted successfully" do
-        let(:expected_changes) do
-          {
-            "value" => [BigDecimal("101.01"), BigDecimal("202.02")],
-            "financial_quarter" => [1, 2],
-          }
-        end
-
-        it "asks the HistoryRecorder to handle the changes" do
-          updater.call(attributes: {value: "202.02", financial_quarter: "2"})
-
-          expect(HistoryRecorder).to have_received(:new).with(user: user)
-          expect(history_recorder).to have_received(:call).with(
-            changes: expected_changes,
-            reference: "Update to Transaction",
-            activity: transaction.parent_activity,
-            trackable: transaction,
-            report: report
-          )
-        end
-      end
-
-      context "when the change is NOT persisted successfully" do
-        it "does NOT ask the HistoryRecorder to handle the changes"
-      end
     end
 
-    context "when the transaction isn't valid" do
-      it "returns a failed result" do
-        allow(transaction).to receive(:valid?).and_return(false)
+    context "when the change is NOT persisted successfully" do
+      before do
+        allow(transaction).to receive(:save).and_return(false)
+      end
 
+      it "does NOT ask the HistoryRecorder to handle the changes" do
+        updater.call(attributes: {value: "202.02", financial_quarter: "2"})
+
+        expect(HistoryRecorder).not_to have_received(:new).with(user: user)
+      end
+
+      it "returns a failed result" do
         result = updater.call(attributes: {})
 
         expect(result.success?).to be false

--- a/spec/services/update_transaction_spec.rb
+++ b/spec/services/update_transaction_spec.rb
@@ -4,13 +4,25 @@ RSpec.describe UpdateTransaction do
   let(:transaction) { create(:transaction) }
 
   describe "#call" do
-    it "returns a successful result" do
-      allow(transaction).to receive(:valid?).and_return(true)
-      allow(transaction).to receive(:save).and_return(true)
+    context "when the transaction is valid" do
+      before do
+        allow(transaction).to receive(:valid?).and_return(true)
+        allow(transaction).to receive(:save).and_return(true)
+      end
 
-      result = described_class.new(transaction: transaction).call(attributes: {})
+      it "returns a successful result" do
+        result = described_class.new(transaction: transaction).call(attributes: {})
 
-      expect(result.success?).to be true
+        expect(result.success?).to be true
+      end
+
+      context "when the change is persisted successfully" do
+        it "asks the HistoryRecorder to handle the changes"
+      end
+
+      context "when the change is NOT persisted successfully" do
+        it "does NOT ask the HistoryRecorder to handle the changes"
+      end
     end
 
     context "when the transaction isn't valid" do


### PR DESCRIPTION
## Changes in this PR

Every historical event is associated with an activity. It is through the lens of an activity (the 'Activity page') that we wish to study changes.

Some historical events concern the associated activity directly, but others concern a related item, such as a Transaction, Budget or Forecast. 

In this PR we

- require users of `HistoryRecorder` to supply a "trackable" entity in addition to an associated Activity
- adapt the `UpdateTransaction` service to record changes using the `HistoryRecorder`
- add a 'polymorphic' `trackable` association on `HistoricalEvent` to identify the entity (Transaction or Activity and soon Budget and Forecast) which has changed

## Screenshots of UI changes

Details of changes to transactions (aka "actuals") now shown in an Activity's "Change history"
 tab:

<img width="1141" alt="transaction_changes" src="https://user-images.githubusercontent.com/20245/126198779-6ecc83b7-baca-4bc2-9016-63e9a64ef41c.png">

## Trello

https://trello.com/c/hU4kHla4/1949-track-changes-to-financial-info

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
