### PR TITLE
(2011) Report actuals tab improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,7 @@
 ## [unreleased]
 - Show the financial quarter of the actuals spend on the Report view
 - Content and layout improvements to the actual spend tab on Report
+- Content and layout improvements to the actual spend upload page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...HEAD
 [release-63]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...release-63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,6 +757,7 @@
 - Create and populate an activity's RODA identifier automatically
 
 ## [unreleased]
+- Show the financial quarter of the actuals spend on the Report view
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...HEAD
 [release-63]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...release-63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -758,6 +758,7 @@
 
 ## [unreleased]
 - Show the financial quarter of the actuals spend on the Report view
+- Content and layout improvements to the actual spend tab on Report
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...HEAD
 [release-63]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...release-63

--- a/app/views/shared/transactions/_transactions_by_activity.html.haml
+++ b/app/views/shared/transactions/_transactions_by_activity.html.haml
@@ -3,19 +3,23 @@
     %tr.govuk-table__row
       %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity
       %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} RODA Identifier
-      %th.govuk-table__header.govuk-table__header--numeric{class: "govuk-!-width-one-third", scope: "col"} Amount
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Actual spend
   %tbody.govuk-table__body
 
     - @grouped_transactions.each do |activity, transactions|
 
       %tr.govuk-table__row{ id: "activity_#{activity.id}" }
-        %td.govuk-table__cell= activity.title
-        %td.govuk-table__cell= activity.roda_identifier
-        %td.govuk-table__cell
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.title
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.roda_identifier
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
           %table.govuk-table.transactions
             - transactions.each do |transaction|
               %tr.govuk-table__row
-                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-quarter", scope: "col"}
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
+                  = transaction.financial_quarter_and_year
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
                   = transaction.value
 
     %tr.govuk-table__row.totals

--- a/app/views/shared/transactions/_transactions_by_activity.html.haml
+++ b/app/views/shared/transactions/_transactions_by_activity.html.haml
@@ -1,4 +1,6 @@
 %table.govuk-table
+  %caption.govuk-table__caption.govuk-table__caption--m
+    = t("table.caption.transaction.actuals_in_report")
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity

--- a/app/views/staff/reports/transactions.html.haml
+++ b/app/views/staff/reports/transactions.html.haml
@@ -14,16 +14,30 @@
 
         .govuk-tabs__panel
           %h2.govuk-heading-l
-            = t("page_content.tab_content.transactions.heading")
+            = t("tabs.transactions.heading")
 
-          = t("page_content.tab_content.transactions.guidance_html")
+          %p.govuk-body
+            = t("tabs.transactions.copy")
 
           - if policy(@report_presenter).upload?
-            = link_to t("action.transaction.upload.link"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
+            %h3.govuk-heading-m
+              = t("tabs.transactions.providing.heading")
 
-          %h3.govuk-heading-m
-            = t("page_content.tab_content.transactions.per_activity_heading")
+            %p.govuk-body
+              = t("tabs.transactions.providing.copy")
+
+            %h3.govuk-heading-s
+              = t("tabs.transactions.upload.heading")
+
+            = t("tabs.transactions.upload.copy_html")
+
+            .govuk-inset-text
+              = t("tabs.transactions.upload.warning")
+
+            .govuk-button-group
+              = link_to t("page_content.transactions.button.download_template"), report_transaction_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+              = link_to t("page_content.transactions.button.upload"), new_report_transaction_upload_path(@report_presenter), class: "govuk-button govuk-button"
+
+            %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
           = render partial: "shared/transactions/transactions_by_activity"
-
-

--- a/app/views/staff/transaction_uploads/new.html.haml
+++ b/app/views/staff/transaction_uploads/new.html.haml
@@ -6,19 +6,10 @@
       %h1.govuk-heading-xl
         = t("page_title.transaction.upload")
 
-      %p.govuk-body
-        This page allows you to
-        %a{href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/360058523436-Uploading-actual-transactions-in-bulk"} upload actual transactions in bulk
-        using the provided template.
+      = t("page_content.transactions.upload.copy_html", report_actuals_template_path: report_transaction_upload_path(@report_presenter, format: :csv))
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %h2.govuk-heading-m
-        = link_to t("action.transaction.download.button"), report_transaction_upload_path(@report_presenter, format: :csv), class: "govuk-link"
-
-      %p.govuk-body
-        = t("action.transaction.download.hint_html")
-
       - if policy(@report_presenter).upload?
         .govuk-body.upload-form
           = form_for @report_presenter, url: report_transaction_upload_path(@report_presenter) do |f|

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -51,16 +51,6 @@ en:
           <p class="govuk-body">
             For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+activities">uploading new activities</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
           </p>
-      transactions:
-        heading: Actuals in this report
-        per_activity_heading: Actual spend per activity
-        guidance_html:
-          <p class="govuk-body">
-            This page shows all the actual spend you have reported in RODA since the last reporting quarter.
-          </p>
-          <p class="govuk-body">
-            For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+actuals">uploading new actuals</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
-          </p>
       summary:
         heading: Summary of the contents of this report
         activities_added: New activities added

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -49,20 +49,39 @@ en:
         receiving_organisation: The organisation receiving the money from this transaction.
         receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
   table:
+    caption:
+      transaction:
+        actuals_in_report: Actuals added to this report
     header:
       transaction:
         financial_quarter: Financial quarter
         value: Transaction amount
         receiving_organisation: Receiver
+  tabs:
+    transactions:
+      heading: Actuals
+      copy: Listed below are the actuals that have been added to this report.
+      providing:
+        heading: Providing actuals data
+        copy: Actuals data can be added by using the application interface or by uploading data.
+      upload:
+        heading: Upload data
+        copy_html:
+          <p class="govuk-body">Large numbers of actuals can be added via the actuals upload.</p>
+          <p class="govuk-body">For guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.</p>
+        warning: Ensure you use the correct template (available below) when uploading actuals data.
   page_content:
     transactions:
       button:
         create: Add a transaction
+        upload: Upload actuals data
+        download_template: Download actuals data template
       edit_noun: transaction
       table:
         headers:
           providing_organisation: Provider
           receiving_organisation: Receiver
+
   page_title:
     transaction:
       edit: Edit transaction

--- a/config/locales/models/transaction.en.yml
+++ b/config/locales/models/transaction.en.yml
@@ -19,7 +19,7 @@ en:
   form:
     label:
       transaction:
-        csv_file: Upload CSV spreadsheet
+        csv_file: Provide actuals data to upload
         csv_file_recover_from_error: Re-upload CSV spreadsheet
         currency: Currency
         description: Describe the transaction
@@ -39,7 +39,7 @@ en:
         receiving_organisation: Receiving organisation (optional)
     hint:
       transaction:
-        csv_file: Upload a spreadsheet containing transaction information in CSV format.
+        csv_file: Select the file that contains the actuals data for this report.
         csv_file_recover_from_error_html: Upload a spreadsheet containing transaction information in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
         date: If you're reporting quarterly data, select the last day of the quarter. For example, 31 12 2020
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
@@ -81,12 +81,22 @@ en:
         headers:
           providing_organisation: Provider
           receiving_organisation: Receiver
-
+      upload:
+        copy_html:
+          <p class="govuk-body">Large numbers of actuals can be added to the report by uploading them here.</p>
+          <p class="govuk-body">The basic steps are:</p>
+          <ol class="govuk-list govuk-list--number">
+            <li>Prepare the acutals data</li>
+            <li>Use the <a class="govuk-button govuk-button--secondary" href="%{report_actuals_template_path}">Download actuals data template</a>} as is or as a guide if required</li>
+            <li>Ensure the file is saved as UTF-8 CSV, <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005515621-Uploading-your-Activity-Actuals-or-Forecasts-data-via-the-Templates-to-RODA">see guidance in the help centre (opens in new tab)</a></li>
+            <li>Upload and verify the data here</li>
+          </ol>
+          <p class="govuk-body">For more detailed guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a></p>
   page_title:
     transaction:
       edit: Edit transaction
       new: Add a transaction
-      upload: Upload bulk transactions data
+      upload: Upload actuals data
       upload_success: Successful uploads
   activerecord:
     errors:

--- a/spec/features/staff/users_can_upload_transactions_spec.rb
+++ b/spec/features/staff/users_can_upload_transactions_spec.rb
@@ -31,8 +31,15 @@ RSpec.feature "users can upload transactions" do
     end
   end
 
+  scenario "they get helpful guidance and a link to actuals upload template on the upload page" do
+    visit new_report_transaction_upload_path(report)
+
+    expect(page.html).to include t("page_content.transactions.upload.copy_html",
+      report_actuals_template_path: report_transaction_upload_path(report, format: :csv))
+  end
+
   scenario "downloading a CSV template with activities for the current report" do
-    click_link t("action.transaction.download.button")
+    visit report_transaction_upload_path(report, format: :csv)
 
     csv_data = page.body.delete_prefix("\uFEFF")
     rows = CSV.parse(csv_data, headers: true).map(&:to_h)

--- a/spec/features/staff/users_can_view_actuals_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_within_report_spec.rb
@@ -8,10 +8,6 @@ RSpec.feature "Users can view actuals in tab within a report" do
     end
 
     def expect_to_see_a_table_of_transactions_grouped_by_activity(activities)
-      expect(page).to have_content(
-        t("page_content.tab_content.transactions.per_activity_heading")
-      )
-
       fail "We expect some activities to be present" if activities.none?
 
       activities.each do |activity|
@@ -64,13 +60,8 @@ RSpec.feature "Users can view actuals in tab within a report" do
 
       click_link t("tabs.report.transactions")
 
-      expect(page).to have_content(t("page_content.tab_content.transactions.heading"))
+      expect(page).to have_content("Actuals")
       expect(page).to have_link(t("action.transaction.upload.link"))
-
-      # guidance with 2 links
-      expect(page).to have_content("This page shows all the actual spend you have reported in RODA since the last reporting quarter")
-      expect(page).to have_link("uploading new actuals")
-      expect(page).to have_link("uploading updates to activities")
 
       expect_to_see_a_table_of_transactions_grouped_by_activity(activities)
 

--- a/spec/features/staff/users_can_view_actuals_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_within_report_spec.rb
@@ -21,9 +21,10 @@ RSpec.feature "Users can view actuals in tab within a report" do
 
           fail "We expect some transactions to be present" if activity.transactions.none?
 
-          within ".transactions" do
-            activity.transactions.each do |transaction|
+          activity.transactions.each do |transaction|
+            within ".transactions" do
               expect(page).to have_content(transaction.value)
+              expect(page).to have_content(transaction.financial_quarter_and_year)
             end
           end
         end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -374,6 +374,18 @@ RSpec.feature "Users can view reports" do
         end
       end
 
+      scenario "they see helpful content about uploading acutals spend data and a link to the template on the actuals tab" do
+        report = create(:report, :active, organisation: delivery_partner_user.organisation)
+
+        visit report_actuals_path(report)
+
+        expect(page.html).to include t("tabs.transactions.upload.copy_html")
+        expect(page).to have_link t("page_content.transactions.button.download_template"),
+          href: report_transaction_upload_path(report, format: :csv)
+        expect(page).to have_link "guidance in the help centre (opens in new tab)",
+          href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload"
+      end
+
       scenario "they can view and edit budgets in a report" do
         activity = create(:project_activity, organisation: delivery_partner_user.organisation)
         report = create(:report, :active, organisation: delivery_partner_user.organisation, fund: activity.associated_fund)


### PR DESCRIPTION
## Changes in this PR
The main motivation here was:

- the old content was using the wrong lanuage and linking to the wrong guidance
- it was clear in Q1 that showing the financial quarter for each actual spend entry would help users in the short term.

As we don't have a content designer, I had a go at improving things on the tab and relating upload page.

## Screenshots of UI changes
Actuals tab with no active report:
![Screenshot 2021-07-20 at 10-27-22 FQ1 2021-2022 Q1 Report - FY 21 22 actuals - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/126297897-dfab0c01-deb7-4db9-bb3a-51be89634b98.png)

Actuals tabs with active report, shows new content and layout:
![Screenshot 2021-07-20 at 10-28-18 FQ1 2021-2022 Q1 Report - FY 21 22 actuals - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/126297902-6686ea66-44b3-4d93-b403-42942cee105c.png)

Actual spend upload, shows new content:
![Screenshot 2021-07-20 at 10-28-31 Upload actuals data - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/126297912-a6d5ccab-b553-4b7e-9471-68e80ced217d.png)

