### PR TITLE
(1961) Exports page has accessibility links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,7 @@
 - New activities know which was their 'originating' report, and reports can list 'new' activities originating from their financial period
 - Newly updated activities are shown in a report.
 - Newly added activities are shown in a report.
+- Exports page layout is more accessible
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...HEAD
 [release-62]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...release-62

--- a/app/views/staff/exports/index.html.haml
+++ b/app/views/staff/exports/index.html.haml
@@ -11,9 +11,15 @@
       %table.govuk-table
         %thead.govuk-table__head
           %tr.govuk-table__row
-            %th.govuk-table__header{scope: "col"} Delivery partner
+            %th.govuk-table__header{scope: "col"}
+              = t("table.header.organisation.name")
+            %th.govuk-table__header{scope: "col"}
+              = t("table.header.default.action")
+
         %tbody.govuk-table__body
           - @organisations.each do |organisation|
             %tr.govuk-table__row
               %td.govuk-table__cell
-                = link_to organisation.name, exports_organisation_path(organisation), class: "govuk-link"
+                = organisation.name
+              %td.govuk-table__cell
+                = a11y_action_link("View exports", exports_organisation_path(organisation), "for #{organisation.name}")


### PR DESCRIPTION
## Changes in this PR
- Exports page uses the two columns pattern, and has accessibility links to each delivery partner’s exports page.

## Screenshots of UI changes

### Before
![Screenshot 2021-07-20 at 17 07 18](https://user-images.githubusercontent.com/579522/126358059-d3db5f1a-bb1c-496f-95aa-39ca86286d19.png)

### After
![Screenshot 2021-07-20 at 17 07 00](https://user-images.githubusercontent.com/579522/126358083-36e63fd6-0edc-4857-91b3-8d860e931ec8.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
