### PR TITLE
Fix: Load report activities correctly for spending report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -761,6 +761,8 @@
 - Content and layout improvements to the actual spend tab on Report
 - Content and layout improvements to the actual spend upload page
 
+- Fix: 'spending breakdown' download is no longer empty
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...HEAD
 [release-63]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...release-63
 [release-62]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-61...release-62

--- a/app/controllers/staff/spending_breakdowns_controller.rb
+++ b/app/controllers/staff/spending_breakdowns_controller.rb
@@ -7,7 +7,7 @@ class Staff::SpendingBreakdownsController < Staff::BaseController
     authorize @report
 
     @report_presenter = ReportPresenter.new(@report)
-    @report_activities = Activity::ProjectsForReportFinder.new(report: @report)
+    @report_activities = Activity::ProjectsForReportFinder.new(report: @report).call
 
     respond_to do |format|
       format.csv { send_csv }


### PR DESCRIPTION
Spending reports were throwing a:

NoMethodError (undefined method `each' for #<Activity::ProjectsForReportFinder>):
  /app/controllers/staff/spending_breakdowns_controller.rb:24

error which was causing an empty CSV file to be downloaded.

We now include an Actual "transaction" in our feature test
and verify that the downloaded file is not empty.

Trello: https://trello.com/c/ceicvcWC/2010

![spending_report](https://user-images.githubusercontent.com/20245/126669920-51171811-85fa-417d-bb6c-06bba0be684f.png)
