### PR TITLE
(2009) Auto deploy to pentest environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,38 @@ jobs:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Staging
         run: script/deploy-terraform
+  deploy_to_training:
+    needs: build_and_push_to_dockerhub
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    env:
+      TF_VAR_docker_image: ${{ needs.build_and_push_to_dockerhub.outputs.docker_tag }}
+      TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
+      TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      TF_VAR_environment: "pentest"
+      TF_VAR_secret_key_base: ${{ secrets.TRAINING_SECRET_KEY_BASE }}
+      TF_VAR_auth0_client_id: ${{ secrets.TRAINING_AUTH0_CLIENT_ID }}
+      TF_VAR_auth0_client_secret: ${{ secrets.TRAINING_AUTH0_CLIENT_SECRET }}
+      TF_VAR_auth0_domain: ${{ secrets.TRAINING_AUTH0_DOMAIN }}
+      TF_VAR_notify_key: ${{ secrets.TRAINING_NOTIFY_KEY }}
+      TF_VAR_notify_welcome_email_template: ${{ secrets.TRAINING_NOTIFY_WELCOME_EMAIL_TEMPLATE }}
+      TF_VAR_notify_view_template: "b541df04-add8-458e-a7d3-2e156386e150"
+      TF_VAR_rollbar_access_token: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+      TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
+      TF_VAR_skylight_env: "pentest"
+      TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
+      TF_VAR_additional_hostnames: ${{ secrets.TRAINING_ADDITIONAL_HOSTNAMES }}
+      TF_VAR_papertrail_destination: ${{ secrets.TRAINING_PAPERTRAIL_DESTINATION }}
+      TF_VAR_google_tag_manager_container_id: ${{ secrets.TRAINING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
+      TF_VAR_google_tag_manager_environment_auth: ${{ secrets.TRAINING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
+      TF_VAR_google_tag_manager_environment_preview: ${{ secrets.TRAINING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
+      TF_VAR_custom_domain: ${{ secrets.TRAINING_CUSTOM_DOMAIN }}
+      TF_VAR_custom_hostname: ${{ secrets.TRAINING_CUSTOM_HOSTNAME }}
+      TF_VAR_robot_noindex: "true"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy latest code to the Training environment
+        run: script/deploy-terraform
   check_and_notify:
     needs: deploy_to_production
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,70 +15,85 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
-  deploy:
+  build_and_push_to_dockerhub:
     runs-on: ubuntu-latest
+    outputs:
+      docker_tag: ${{ steps.set_output.outputs.docker_tag }}
     steps:
       - uses: actions/checkout@v2
       - name: Set Docker tag environment variable
         run: echo "DOCKER_TAG=${GITHUB_RUN_ID}-${GITHUB_SHA}" >> $GITHUB_ENV
       - name: Tag and Push Docker Container
         run: script/docker-push
-      - name: Deploy terraform to staging
-        env:
-          TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
-          TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
-          TF_VAR_environment: "staging"
-          TF_VAR_secret_key_base: ${{ secrets.STAGING_SECRET_KEY_BASE }}
-          TF_VAR_auth0_client_id: ${{ secrets.STAGING_AUTH0_CLIENT_ID }}
-          TF_VAR_auth0_client_secret: ${{ secrets.STAGING_AUTH0_CLIENT_SECRET }}
-          TF_VAR_auth0_domain: ${{ secrets.STAGING_AUTH0_DOMAIN }}
-          TF_VAR_notify_key: ${{ secrets.STAGING_NOTIFY_KEY }}
-          TF_VAR_notify_welcome_email_template: ${{ secrets.STAGING_NOTIFY_WELCOME_EMAIL_TEMPLATE }}
-          TF_VAR_notify_view_template: "b541df04-add8-458e-a7d3-2e156386e150"
-          TF_VAR_rollbar_access_token: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
-          TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
-          TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
-          TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
-          TF_VAR_additional_hostnames: ${{ secrets.STAGING_ADDITIONAL_HOSTNAMES }}
-          TF_VAR_papertrail_destination: ${{ secrets.STAGING_PAPERTRAIL_DESTINATION }}
-          TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
-          TF_VAR_google_tag_manager_environment_auth: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
-          TF_VAR_google_tag_manager_environment_preview: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
-          TF_VAR_custom_domain: ${{ secrets.STAGING_CUSTOM_DOMAIN }}
-          TF_VAR_custom_hostname: ${{ secrets.STAGING_CUSTOM_HOSTNAME }}
-          TF_VAR_robot_noindex: "true"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/develop'
-      - name: Deploy terraform to production
-        env:
-          TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
-          TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
-          TF_VAR_environment: "prod"
-          TF_VAR_secret_key_base: ${{ secrets.PROD_SECRET_KEY_BASE }}
-          TF_VAR_auth0_client_id: ${{ secrets.PROD_AUTH0_CLIENT_ID }}
-          TF_VAR_auth0_client_secret: ${{ secrets.PROD_AUTH0_CLIENT_SECRET }}
-          TF_VAR_auth0_domain: ${{ secrets.PROD_AUTH0_DOMAIN }}
-          TF_VAR_notify_key: ${{ secrets.PROD_NOTIFY_KEY }}
-          TF_VAR_notify_welcome_email_template: ${{ secrets.PROD_NOTIFY_WELCOME_EMAIL_TEMPLATE }}
-          TF_VAR_notify_view_template: "b541df04-add8-458e-a7d3-2e156386e150"
-          TF_VAR_rollbar_access_token: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
-          TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
-          TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
-          TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
-          TF_VAR_additional_hostnames: ${{ secrets.PROD_ADDITIONAL_HOSTNAMES }}
-          TF_VAR_papertrail_destination: ${{ secrets.PROD_PAPERTRAIL_DESTINATION }}
-          TF_VAR_google_tag_manager_container_id: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
-          TF_VAR_google_tag_manager_environment_auth: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
-          TF_VAR_google_tag_manager_environment_preview: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
-          TF_VAR_custom_domain: ${{ secrets.PROD_CUSTOM_DOMAIN }}
-          TF_VAR_custom_hostname: ${{ secrets.PROD_CUSTOM_HOSTNAME }}
-          TF_VAR_robot_noindex: "false"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/master'
+      - name: Set Docker tag as an output
+        id: set_output
+        run: echo "::set-output name=docker_tag::${{ env.DOCKER_TAG }}"
+  deploy_to_production:
+    needs: build_and_push_to_dockerhub
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    env:
+      TF_VAR_docker_image: ${{ needs.build_and_push_to_dockerhub.outputs.docker_tag }}
+      TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
+      TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      TF_VAR_environment: "prod"
+      TF_VAR_secret_key_base: ${{ secrets.PROD_SECRET_KEY_BASE }}
+      TF_VAR_auth0_client_id: ${{ secrets.PROD_AUTH0_CLIENT_ID }}
+      TF_VAR_auth0_client_secret: ${{ secrets.PROD_AUTH0_CLIENT_SECRET }}
+      TF_VAR_auth0_domain: ${{ secrets.PROD_AUTH0_DOMAIN }}
+      TF_VAR_notify_key: ${{ secrets.PROD_NOTIFY_KEY }}
+      TF_VAR_notify_welcome_email_template: ${{ secrets.PROD_NOTIFY_WELCOME_EMAIL_TEMPLATE }}
+      TF_VAR_notify_view_template: "b541df04-add8-458e-a7d3-2e156386e150"
+      TF_VAR_rollbar_access_token: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+      TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
+      TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
+      TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
+      TF_VAR_additional_hostnames: ${{ secrets.PROD_ADDITIONAL_HOSTNAMES }}
+      TF_VAR_papertrail_destination: ${{ secrets.PROD_PAPERTRAIL_DESTINATION }}
+      TF_VAR_google_tag_manager_container_id: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
+      TF_VAR_google_tag_manager_environment_auth: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
+      TF_VAR_google_tag_manager_environment_preview: ${{ secrets.PROD_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
+      TF_VAR_custom_domain: ${{ secrets.PROD_CUSTOM_DOMAIN }}
+      TF_VAR_custom_hostname: ${{ secrets.PROD_CUSTOM_HOSTNAME }}
+      TF_VAR_robot_noindex: "false"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy latest code to Production
+        run: script/deploy-terraform
+  deploy_to_staging:
+    needs: build_and_push_to_dockerhub
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    env:
+      TF_VAR_docker_image: ${{ needs.build_and_push_to_dockerhub.outputs.docker_tag }}
+      TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}
+      TF_VAR_docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      TF_VAR_environment: "staging"
+      TF_VAR_secret_key_base: ${{ secrets.STAGING_SECRET_KEY_BASE }}
+      TF_VAR_auth0_client_id: ${{ secrets.STAGING_AUTH0_CLIENT_ID }}
+      TF_VAR_auth0_client_secret: ${{ secrets.STAGING_AUTH0_CLIENT_SECRET }}
+      TF_VAR_auth0_domain: ${{ secrets.STAGING_AUTH0_DOMAIN }}
+      TF_VAR_notify_key: ${{ secrets.STAGING_NOTIFY_KEY }}
+      TF_VAR_notify_welcome_email_template: ${{ secrets.STAGING_NOTIFY_WELCOME_EMAIL_TEMPLATE }}
+      TF_VAR_notify_view_template: "b541df04-add8-458e-a7d3-2e156386e150"
+      TF_VAR_rollbar_access_token: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+      TF_VAR_skylight_access_token: ${{ secrets.SKYLIGHT_ACCESS_TOKEN }}
+      TF_VAR_skylight_env: ${{ secrets.SKYLIGHT_ENV }}
+      TF_VAR_skylight_enable_sidekiq: ${{ secrets.SKYLIGHT_ENABLE_SIDEKIQ }}
+      TF_VAR_additional_hostnames: ${{ secrets.STAGING_ADDITIONAL_HOSTNAMES }}
+      TF_VAR_papertrail_destination: ${{ secrets.STAGING_PAPERTRAIL_DESTINATION }}
+      TF_VAR_google_tag_manager_container_id: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_CONTAINER_ID }}
+      TF_VAR_google_tag_manager_environment_auth: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_AUTH }}
+      TF_VAR_google_tag_manager_environment_preview: ${{ secrets.STAGING_GOOGLE_TAG_MANAGER_ENVIRONMENT_PREVIEW }}
+      TF_VAR_custom_domain: ${{ secrets.STAGING_CUSTOM_DOMAIN }}
+      TF_VAR_custom_hostname: ${{ secrets.STAGING_CUSTOM_HOSTNAME }}
+      TF_VAR_robot_noindex: "true"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy latest code to Staging
+        run: script/deploy-terraform
   check_and_notify:
-    needs: deploy
+    needs: deploy_to_production
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ The `develop` branch is deployed to staging after a successful build via GitHub 
 
 The app has a training and or penetration testing environment: [http://training.report-official-development-assistance.service.gov.uk](https://training.report-official-development-assistance.service.gov.uk)
 
-The environment must be manually deployed, see [the
-documentation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/terraform/README.md) for more
-information.
+The `master` branch is deployed to the training/pentest environment after a
+successful build via GitHub Actions.
 
 ### Production
 
@@ -103,7 +102,6 @@ The app is currently hosted on GPaaS: [https://www.report-official-development-a
 The `master` branch is deployed to production after a successful build via GitHub Actions.
 
 ## DNS
-
 
 The DNS for the service is hosted and managed by [dxw](https://dxw.com) the
 source for which is maintained in this private repo:

--- a/script/deploy-terraform
+++ b/script/deploy-terraform
@@ -3,8 +3,6 @@
 # exit on error or if a variable is unbound
 set -eu
 
-export TF_VAR_docker_image=$DOCKER_TAG
-
 # Disable the shellcheck check for unassigned variables. We export this var
 # in Github Actions, but Shellcheck complains because there are lowercase
 # characters in it


### PR DESCRIPTION
This updates the deploy script to deploy to the pentest (training) environment at the same time as we deploy to production to ensure parity of feature set across the two environments.

~I haven't yet added the environment variables to Github, so this needs to be done first. Will update the PR when I'm done.~

I've tweaked the steps to run as seperate jobs for a couple of reasons:

- I (think?) it's more readable
- It allows us to run the prod and training deploys in parallel, so the deploy shouldn't be much slower than what we have already.

Totally happy to have a chat about how this all fits together - I am aware that I am the Github Actions "expert" here, so keen to pass on more knowlege if I can!