### PR TITLE
(1997) Allow budgets to be destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -762,8 +762,8 @@
 - Content and layout improvements to the actual spend tab on Report
 - Content and layout improvements to the actual spend upload page
 - Rework the way reports are shown to Delivery Partners and Service Owners
-
 - Fix: 'spending breakdown' download is no longer empty
+- Allow budgets to be deleted
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...HEAD
 [release-63]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-62...release-63

--- a/app/controllers/staff/budgets_controller.rb
+++ b/app/controllers/staff/budgets_controller.rb
@@ -48,6 +48,18 @@ class Staff::BudgetsController < Staff::BaseController
     end
   end
 
+  def destroy
+    @activity = Activity.find(activity_id)
+    @budget = Budget.find(id)
+
+    authorize @budget
+
+    @budget.destroy
+
+    flash[:notice] = t("action.budget.destroy.success")
+    redirect_to organisation_activity_path(@activity.organisation, @activity)
+  end
+
   private
 
   def id

--- a/app/policies/budget_policy.rb
+++ b/app/policies/budget_policy.rb
@@ -33,7 +33,7 @@ class BudgetPolicy < ApplicationPolicy
   end
 
   def destroy?
-    false
+    update?
   end
 
   private def editable_report_for_organisation_and_fund

--- a/app/views/staff/budgets/_form.html.haml
+++ b/app/views/staff/budgets/_form.html.haml
@@ -27,4 +27,6 @@
 
 = f.govuk_text_field :value, class: "govuk-input govuk-input--width-10"
 
+- if action_name == "edit"
+  = link_to t("default.button.delete"), activity_budget_path(@activity, @budget), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this budget?" }
 = f.govuk_submit t("default.button.submit")

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -6,6 +6,8 @@ en:
         success: Budget successfully created
       update:
         success: Budget successfully updated
+      destroy:
+        success: Budget successfully deleted
   form:
     label:
       budget:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     end
 
     concern :budgetable do
-      resources :budgets, only: [:new, :create, :show, :edit, :update]
+      resources :budgets
     end
 
     concern :forecastable do

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -3,16 +3,17 @@ RSpec.describe "Users can edit a budget" do
 
   context "when signed in beis user" do
     let(:user) { create(:beis_user) }
+    let!(:activity) { create(:programme_activity, organisation: user.organisation) }
+    let!(:budget) { create(:budget, parent_activity: activity, value: "10") }
 
-    scenario "a budget can be successfully edited" do
-      activity = create(:programme_activity, organisation: user.organisation)
-      budget = create(:budget, parent_activity: activity, value: "10")
-
+    before do
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
         click_on t("default.link.edit")
       end
+    end
 
+    scenario "a budget can be successfully edited" do
       fill_in "budget[value]", with: "20"
       click_on t("default.button.submit")
 
@@ -21,22 +22,33 @@ RSpec.describe "Users can edit a budget" do
       within("##{budget.id}") do
         expect(page).to have_content("20.00")
       end
+    end
+
+    scenario "a budget can be successfully deleted" do
+      click_on t("default.button.delete")
+
+      expect(page).to have_content(t("action.budget.destroy.success"))
+      expect(page).to_not have_content("10.00")
+
+      expect { budget.reload }.to raise_error { ActiveRecord::RecordNotFound }
     end
   end
 
   context "when signed in as delivery partner user" do
     let(:user) { create(:delivery_partner_user) }
+    let(:activity) { create(:project_activity, organisation: user.organisation) }
+    let(:report) { create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund) }
 
-    scenario "a budget can be successfully edited" do
-      activity = create(:project_activity, organisation: user.organisation)
-      report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
-      budget = create(:budget, parent_activity: activity, value: "10", report: report)
+    let!(:budget) { create(:budget, parent_activity: activity, value: "10", report: report) }
 
+    before do
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
         click_on t("default.link.edit")
       end
+    end
 
+    scenario "a budget can be successfully edited" do
       fill_in "budget[value]", with: "20"
       click_on t("default.button.submit")
 
@@ -46,16 +58,16 @@ RSpec.describe "Users can edit a budget" do
       end
     end
 
+    scenario "a budget can be successfully deleted" do
+      click_on t("default.button.delete")
+
+      expect(page).to have_content(t("action.budget.destroy.success"))
+      expect(page).to_not have_content("10.00")
+
+      expect { budget.reload }.to raise_error { ActiveRecord::RecordNotFound }
+    end
+
     scenario "validation errors work as expected" do
-      activity = create(:project_activity, organisation: user.organisation)
-      report = create(:report, state: :active, organisation: user.organisation, fund: activity.associated_fund)
-      budget = create(:budget, parent_activity: activity, value: "10", report: report)
-
-      visit organisation_activity_path(user.organisation, activity)
-      within("##{budget.id}") do
-        click_on t("default.link.edit")
-      end
-
       fill_in "budget[value]", with: ""
 
       click_on t("default.button.submit")

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe BudgetPolicy do
       it { is_expected.to permit_action(:create) }
       it { is_expected.to permit_action(:edit) }
       it { is_expected.to permit_action(:update) }
-
-      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to permit_action(:destroy) }
     end
 
     context "when the activity is a programme" do
@@ -26,8 +25,7 @@ RSpec.describe BudgetPolicy do
       it { is_expected.to permit_action(:create) }
       it { is_expected.to permit_action(:edit) }
       it { is_expected.to permit_action(:update) }
-
-      it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to permit_action(:destroy) }
     end
 
     context "when the activity is a project" do
@@ -151,8 +149,7 @@ RSpec.describe BudgetPolicy do
               it { is_expected.to permit_action(:create) }
               it { is_expected.to permit_action(:edit) }
               it { is_expected.to permit_action(:update) }
-
-              it { is_expected.to forbid_action(:destroy) }
+              it { is_expected.to permit_action(:destroy) }
             end
           end
         end


### PR DESCRIPTION
We want to make sure if there is an editable report, then budgets created erroneously can be deleted.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/126808140-8e263301-0492-408e-8db0-d4394edc7708.png)

![image](https://user-images.githubusercontent.com/109774/126808163-bd22fcc3-8908-4b67-bc42-d320405a0180.png)
