### PR TITLE
(1964) improve the budget report tab

### DIFF
--- a/app/views/staff/reports/budgets.html.haml
+++ b/app/views/staff/reports/budgets.html.haml
@@ -16,4 +16,7 @@
           %h2.govuk-heading-l
             = t("tabs.report.budgets")
 
+          %p.govuk-body
+            This page shows all the budgets you have added during this reporting cycle.
+
           = render partial: "staff/shared/reports/table_budgets", locals: { budgets: @budgets }

--- a/app/views/staff/shared/reports/_table_budgets.html.haml
+++ b/app/views/staff/shared/reports/_table_budgets.html.haml
@@ -1,4 +1,6 @@
-- unless budgets.empty?
+- if budgets.empty?
+  %p.govuk-body= t("page_content.budgets.no_budgets")
+- else
   %table.govuk-table.budgets
     %thead.govuk-table__head
       %tr.govuk-table__row

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -47,6 +47,7 @@ en:
     budgets:
       button:
         create: Add budget
+      no_budgets: There are no budgets created during this reporting cycle.
   page_title:
     budget:
       edit: Edit budget


### PR DESCRIPTION
This is just some small text tweaks to the budget tab within reports

![image](https://user-images.githubusercontent.com/109774/127183732-b7396020-5168-4bb0-a980-df6c0a8243e7.png)
