### PR TITLE
(1977) Improve the report variance tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,7 @@
 - Move IATI XML exports to the exports section
 - Collect all benefitting countries in one step
 - Benefitting countries can be imported via CSV upload
+- Tidy up Report Variance tab to only show activities that have a varaince
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-64...HEAD
 [release-64]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...release-64

--- a/app/controllers/staff/report_variance_controller.rb
+++ b/app/controllers/staff/report_variance_controller.rb
@@ -9,16 +9,10 @@ class Staff::ReportVarianceController < Staff::BaseController
 
     @report_presenter = ReportPresenter.new(@report)
 
-    @activities = hierarchically_grouped_projects.map { |activity| ActivityPresenter.new(activity) }
+    @variance = Activity::VarianceFetcher.new(@report)
+
+    @activities = @variance.activities
+    @total = @variance.total
     render "staff/reports/variance"
-  end
-
-  private
-
-  def hierarchically_grouped_projects
-    Activity::ProjectsForReportFinder.new(
-      scope: Activity.includes(:organisation),
-      report: @report
-    ).call.hierarchically_grouped_projects
   end
 end

--- a/app/services/activity/variance_fetcher.rb
+++ b/app/services/activity/variance_fetcher.rb
@@ -1,0 +1,34 @@
+class Activity
+  class VarianceFetcher
+    attr_reader :report
+
+    def initialize(report)
+      @report = report
+    end
+
+    def activities
+      activities_with_variance.map { |activity| ActivityPresenter.new(activity) }
+    end
+
+    def total
+      activities_with_variance.sum { |a| a.variance_for_report_financial_quarter(report: report) }
+    end
+
+    private
+
+    def activities_with_variance
+      @activities_with_variance ||= begin
+        all_activities_for_report.reject { |activity|
+          activity.variance_for_report_financial_quarter(report: report).zero?
+        }
+      end
+    end
+
+    def all_activities_for_report
+      Activity::ProjectsForReportFinder.new(
+        scope: Activity.includes(:organisation),
+        report: report
+      ).call
+    end
+  end
+end

--- a/app/views/staff/reports/variance.html.haml
+++ b/app/views/staff/reports/variance.html.haml
@@ -16,4 +16,7 @@
           %h2.govuk-heading-l
             = t("tabs.report.variance")
 
+          %p.govuk-body
+            This tab shows the variance between forecasted and actual spend in this reporting cycle.
+
           = render partial: "staff/shared/reports/table_variance", locals: { activities: @activities, readonly: false }

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -4,11 +4,11 @@
       %th.govuk-table__header
         = t("table.header.activity.identifier")
       %th.govuk-table__header
-        = t("table.header.activity.forecasted_spend_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+        = t("table.header.activity.forecasted_spend")
       %th.govuk-table__header
-        = t("table.header.activity.actual_spend_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+        = t("table.header.activity.actual_spend")
       %th.govuk-table__header
-        = t("table.header.activity.variance_for_quarter", financial_quarter_and_year: @report_presenter.financial_quarter_and_year)
+        = t("table.header.activity.variance")
       - unless readonly
         %th.govuk-table__header
           = t("table.header.activity.comment")
@@ -19,14 +19,10 @@
   %tbody.govuk-table__body
     - activities.each do |activity|
       %tr.govuk-table__row{id: activity.id}
-        - if activity.project?
-          %td.govuk-table__cell= activity.roda_identifier
-        - else
-          %td.govuk-table__cell.level-d= activity.roda_identifier
-
-        %td.govuk-table__cell= activity.forecasted_total_for_report_financial_quarter(report: @report)
-        %td.govuk-table__cell= activity.actual_total_for_report_financial_quarter(report: @report)
-        %td.govuk-table__cell= activity.variance_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell= activity.roda_identifier
+        %td.govuk-table__cell= number_to_currency activity.forecasted_total_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell= number_to_currency activity.actual_total_for_report_financial_quarter(report: @report)
+        %td.govuk-table__cell= number_to_currency activity.variance_for_report_financial_quarter(report: @report)
         - unless readonly
           %td.govuk-table__cell
             -if activity.comment_for_report(report_id: @report.id) && policy(activity.comment_for_report(report_id: @report.id)).update?
@@ -36,3 +32,8 @@
           %td.govuk-table__cell
             = a11y_action_link(t('default.link.view'), organisation_activity_path(activity.organisation, activity), activity.roda_identifier)
 
+  %tfoot.govuk-table_footer
+    %tr.govuk-table__row
+      %th.govuk-table__header{"scope" => "row", "colspan" => "3"}
+        = t("table.header.activity.total_variance")
+      %td.govuk-table__cell{"colspan" => "3"}= number_to_currency @total

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -6,6 +6,10 @@ en:
     formats:
       default: "%-d %b %Y"
       iati: "%Y-%m-%d"
+  number:
+    currency:
+      format:
+        unit: "&pound;"
   time:
     formats:
       default: "%Y-%m-%d"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -305,11 +305,12 @@ en:
         identifier: RODA Identifier
         title: Name
         level: Level
-        actual_spend_for_quarter: "%{financial_quarter_and_year} actual spend"
-        forecasted_spend_for_quarter: "%{financial_quarter_and_year} forecasted spend"
-        variance_for_quarter: "%{financial_quarter_and_year} variance"
+        actual_spend: Actual spend
+        forecasted_spend: Forecasted spend
+        variance: Variance
         comment: Comment
         programme_status: Status
+        total_variance: Total variance
     body:
       activity:
         level:

--- a/spec/features/staff/users_can_create_a_comment_spec.rb
+++ b/spec/features/staff/users_can_create_a_comment_spec.rb
@@ -4,66 +4,75 @@ RSpec.describe "Users can create a comment" do
 
   let(:activity) { create(:project_activity, organisation: delivery_partner_user.organisation) }
   let(:transaction) { create(:transaction, report: report, activity: activity) }
-  let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
+  let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: delivery_partner_user.organisation, financial_year: 2020, financial_quarter: 1) }
 
-  context "when the user is a BEIS user" do
-    before { authenticate!(user: beis_user) }
+  context "when the activity has variance" do
+    before do
+      variance_stub = instance_double(Activity::VarianceFetcher, activities: [activity], total: 0)
 
-    context "when the report is editable" do
-      scenario "the user cannot add a comment" do
-        visit report_path(report)
-        click_on t("tabs.report.variance")
-        expect(page).not_to have_content t("table.body.report.add_comment")
+      allow(Activity::VarianceFetcher).to receive(:new).and_return(variance_stub)
+      allow(activity).to receive(:variance_for_report_financial_quarter).with(report: report).and_return(100)
+    end
+
+    context "when the user is a BEIS user" do
+      before { authenticate!(user: beis_user) }
+
+      context "when the report is editable" do
+        scenario "the user cannot add a comment" do
+          visit report_path(report)
+          click_on t("tabs.report.variance")
+          expect(page).not_to have_content t("table.body.report.add_comment")
+        end
+      end
+
+      context "when the report is not editable" do
+        let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
+        scenario "the user cannot add a comment" do
+          visit report_path(report)
+          click_on t("tabs.report.variance")
+          expect(page).not_to have_content t("table.body.report.add_comment")
+        end
       end
     end
 
-    context "when the report is not editable" do
-      let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
-      scenario "the user cannot add a comment" do
-        visit report_path(report)
-        click_on t("tabs.report.variance")
-        expect(page).not_to have_content t("table.body.report.add_comment")
+    context "when the user is a Delivery Partner user" do
+      before { authenticate!(user: delivery_partner_user) }
+
+      context "when the report is editable" do
+        scenario "the user sees 'Add comment' in the view" do
+          visit report_path(report)
+          click_on t("tabs.report.variance")
+          expect(page).to have_content t("table.body.report.add_comment")
+          expect(page).to_not have_content t("table.body.report.edit_comment")
+        end
+
+        scenario "the user can add a comment" do
+          visit report_path(report)
+          click_on t("tabs.report.variance")
+          click_on t("table.body.report.add_comment")
+          fill_in "comment[comment]", with: "This activity underspent"
+          click_button t("default.button.submit")
+          expect(Comment.all.count).to eq(1)
+          expect(page).to have_content "This activity underspent"
+          expect(page).to have_content t("action.comment.create.success")
+        end
       end
-    end
-  end
 
-  context "when the user is a Delivery Partner user" do
-    before { authenticate!(user: delivery_partner_user) }
-
-    context "when the report is editable" do
-      scenario "the user sees 'Add comment' in the view" do
-        visit report_path(report)
-        click_on t("tabs.report.variance")
-        expect(page).to have_content t("table.body.report.add_comment")
-        expect(page).to_not have_content t("table.body.report.edit_comment")
+      context "when the report is not editable" do
+        let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
+        scenario "the user cannot add a comment" do
+          visit report_path(report)
+          click_on t("tabs.report.variance")
+          expect(page).not_to have_content t("table.body.report.add_comment")
+        end
       end
 
-      scenario "the user can add a comment" do
-        visit report_path(report)
-        click_on t("tabs.report.variance")
-        click_on t("table.body.report.add_comment")
-        fill_in "comment[comment]", with: "This activity underspent"
-        click_button t("default.button.submit")
-        expect(Comment.all.count).to eq(1)
-        expect(page).to have_content "This activity underspent"
-        expect(page).to have_content t("action.comment.create.success")
-      end
-    end
-
-    context "when the report is not editable" do
-      let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
-      scenario "the user cannot add a comment" do
-        visit report_path(report)
-        click_on t("tabs.report.variance")
-        expect(page).not_to have_content t("table.body.report.add_comment")
-      end
-    end
-
-    context "when the report is editable but does not belong to this user's organisation" do
-      let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
-      scenario "the user cannot add a comment" do
-        visit report_path(report)
-        expect(page).to have_content t("not_authorised.default")
+      context "when the report is editable but does not belong to this user's organisation" do
+        let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
+        scenario "the user cannot add a comment" do
+          visit report_path(report)
+          expect(page).to have_content t("not_authorised.default")
+        end
       end
     end
   end

--- a/spec/features/staff/users_can_edit_a_comment_spec.rb
+++ b/spec/features/staff/users_can_edit_a_comment_spec.rb
@@ -8,63 +8,72 @@ RSpec.describe "Users can edit a comment" do
   let!(:comment) { create(:comment, activity_id: activity.id, report_id: report.id, owner: delivery_partner_user) }
 
   context "editing a comment from the report view" do
-    context "when the user is a BEIS user" do
-      before { authenticate!(user: beis_user) }
+    context "when the activity has variance" do
+      before do
+        variance_stub = instance_double(Activity::VarianceFetcher, activities: [activity], total: 0)
 
-      context "when the report is editable" do
-        scenario "the user cannot edit a comment" do
-          visit report_path(report)
-          click_on t("tabs.report.variance")
-          expect(page).not_to have_content t("table.body.report.edit_comment")
+        allow(Activity::VarianceFetcher).to receive(:new).and_return(variance_stub)
+        allow(activity).to receive(:variance_for_report_financial_quarter).with(report: report).and_return(100)
+      end
+
+      context "when the user is a BEIS user" do
+        before { authenticate!(user: beis_user) }
+
+        context "when the report is editable" do
+          scenario "the user cannot edit a comment" do
+            visit report_path(report)
+            click_on t("tabs.report.variance")
+            expect(page).not_to have_content t("table.body.report.edit_comment")
+          end
+        end
+
+        context "when the report is not editable" do
+          let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
+          scenario "the user cannot edit a comment" do
+            visit report_path(report)
+            click_on t("tabs.report.variance")
+            expect(page).not_to have_content t("table.body.report.edit_comment")
+          end
         end
       end
 
-      context "when the report is not editable" do
-        let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
-        scenario "the user cannot edit a comment" do
-          visit report_path(report)
-          click_on t("tabs.report.variance")
-          expect(page).not_to have_content t("table.body.report.edit_comment")
+      context "when the user is a Delivery Partner user" do
+        before { authenticate!(user: delivery_partner_user) }
+
+        context "when the report is editable" do
+          scenario "the user sees 'Edit comment' in the view" do
+            visit report_path(report)
+            click_on t("tabs.report.variance")
+            expect(page).to have_content t("table.body.report.edit_comment")
+            expect(page).to_not have_content t("table.body.report.add_comment")
+          end
+
+          scenario "the user can edit a comment" do
+            visit report_path(report)
+            click_on t("tabs.report.variance")
+            click_on t("table.body.report.edit_comment")
+            fill_in "comment[comment]", with: "Amendments have been made"
+            click_button t("default.button.submit")
+            expect(page).to have_content "Amendments have been made"
+            expect(page).to have_content t("action.comment.update.success")
+          end
         end
-      end
-    end
 
-    context "when the user is a Delivery Partner user" do
-      before { authenticate!(user: delivery_partner_user) }
-
-      context "when the report is editable" do
-        scenario "the user sees 'Edit comment' in the view" do
-          visit report_path(report)
-          click_on t("tabs.report.variance")
-          expect(page).to have_content t("table.body.report.edit_comment")
-          expect(page).to_not have_content t("table.body.report.add_comment")
+        context "when the report is not editable" do
+          let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
+          scenario "the user cannot edit a comment" do
+            visit report_path(report)
+            click_on t("tabs.report.variance")
+            expect(page).not_to have_content t("table.body.report.edit_comment")
+          end
         end
 
-        scenario "the user can edit a comment" do
-          visit report_path(report)
-          click_on t("tabs.report.variance")
-          click_on t("table.body.report.edit_comment")
-          fill_in "comment[comment]", with: "Amendments have been made"
-          click_button t("default.button.submit")
-          expect(page).to have_content "Amendments have been made"
-          expect(page).to have_content t("action.comment.update.success")
-        end
-      end
-
-      context "when the report is not editable" do
-        let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
-        scenario "the user cannot edit a comment" do
-          visit report_path(report)
-          click_on t("tabs.report.variance")
-          expect(page).not_to have_content t("table.body.report.edit_comment")
-        end
-      end
-
-      context "when the report is editable but does not belong to this user's organisation" do
-        let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
-        scenario "the user cannot edit a comment" do
-          visit report_path(report)
-          expect(page).to have_content t("not_authorised.default")
+        context "when the report is editable but does not belong to this user's organisation" do
+          let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
+          scenario "the user cannot edit a comment" do
+            visit report_path(report)
+            expect(page).to have_content t("not_authorised.default")
+          end
         end
       end
     end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -391,7 +391,6 @@ RSpec.feature "Users can view reports" do
 
         reporting_cycle.tick
         report = Report.for_activity(activity).in_historical_order.first
-        report_presenter = ReportPresenter.new(report)
 
         report_quarter = report.own_financial_quarter
         _actual_value = create(:transaction, parent_activity: activity, report: report, value: 1100, **report_quarter)
@@ -405,12 +404,16 @@ RSpec.feature "Users can view reports" do
           click_on t("tabs.report.variance")
 
           expect(page).to have_content t("table.header.activity.identifier")
-          expect(page).to have_content t("table.header.activity.forecasted_spend_for_quarter", financial_quarter_and_year: report_presenter.financial_quarter_and_year)
+          expect(page).to have_content t("table.header.activity.forecasted_spend")
           within "##{activity.id}" do
-            expect(page).to have_content "1000.00"
-            expect(page).to have_content "1100.00"
-            expect(page).to have_content "100.00"
+            expect(page).to have_content "£1,000.00"
+            expect(page).to have_content "£1,100.00"
+            expect(page).to have_content "£100.00"
             expect(page).to have_link t("default.link.view"), href: organisation_activity_path(activity.organisation, activity)
+          end
+
+          within "tfoot tr:first-child td" do
+            expect(page).to have_content "£100.00"
           end
         end
       end

--- a/spec/services/activity/variance_fetcher_spec.rb
+++ b/spec/services/activity/variance_fetcher_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Activity::VarianceFetcher do
+  let(:report) { build(:report) }
+  let(:projects_finder) { double("ProjectsForReportFinder", call: activities) }
+  let(:fetcher) { described_class.new(report) }
+
+  before do
+    allow(Activity::ProjectsForReportFinder).to receive(:new).and_return(projects_finder)
+  end
+
+  describe "#activities" do
+    subject { fetcher.activities }
+
+    let(:activity_with_variance) { build(:project_activity) }
+    let(:activity_without_variance) { build(:project_activity) }
+
+    let(:activities) { [activity_with_variance, activity_without_variance] }
+
+    before do
+      allow(activity_with_variance).to receive(:variance_for_report_financial_quarter).and_return(100)
+      allow(activity_without_variance).to receive(:variance_for_report_financial_quarter).and_return(0)
+    end
+
+    it "calls variance_for_report_financial_quarter with the correct report" do
+      subject
+      expect(activity_with_variance).to have_received(:variance_for_report_financial_quarter).with(report: report)
+      expect(activity_without_variance).to have_received(:variance_for_report_financial_quarter).with(report: report)
+    end
+
+    it "only returns activities that have a variance" do
+      expect(subject).to eq([activity_with_variance])
+    end
+  end
+
+  describe "#total" do
+    subject { fetcher.total }
+
+    let(:activity_1) { build(:project_activity) }
+    let(:activity_2) { build(:project_activity) }
+    let(:activity_3) { build(:project_activity) }
+
+    let(:activities) { [activity_1, activity_2, activity_3] }
+
+    before do
+      allow(activity_1).to receive(:variance_for_report_financial_quarter).and_return(100)
+      allow(activity_2).to receive(:variance_for_report_financial_quarter).and_return(200)
+      allow(activity_3).to receive(:variance_for_report_financial_quarter).and_return(0)
+    end
+
+    it "sums all the variances" do
+      expect(subject).to eq(300)
+    end
+  end
+end


### PR DESCRIPTION
This improves the report variance tab to only show activities that actually have variance, as well as showing the total. I've also made a bunch of changes to the view to (hopefully) make the tab a bit more approachable.

![image](https://user-images.githubusercontent.com/109774/127476942-2561f918-2401-42a5-864a-b6dcc9314ce3.png)
