### PR TITLE
(2027) Ensure table headers have discernible text

### DIFF
--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -25,6 +25,8 @@
                 %th.govuk-table__header
                   =t("table.header.organisation.beis_organisation_reference")
                 %th.govuk-table__header
+                  %span.govuk-visually-hidden
+                    = t("table.header.default.actions")
 
             %tbody.govuk-table__body
               - organisations.each do |organisation|

--- a/app/views/staff/shared/activities/tree_view/_table.html.haml
+++ b/app/views/staff/shared/activities/tree_view/_table.html.haml
@@ -18,6 +18,8 @@
                 %th{scope: "col", class: "govuk-table__header"}
                   = t("table.header.activity.programme_status")
                 %th{scope: "col", class: "govuk-table__header"}
+                  %span.govuk-visually-hidden
+                    = t("table.header.default.actions")
 
             %tbody{class: "govuk-table__body"}
               - programmes.each do |programme, projects|

--- a/app/views/staff/shared/reports/_table_header.html.haml
+++ b/app/views/staff/shared/reports/_table_header.html.haml
@@ -17,3 +17,5 @@
       %th.govuk-table__header
         =t("table.header.report.deadline")
     %th.govuk-table__header
+      %span.govuk-visually-hidden
+        = t("table.header.default.actions")

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -13,6 +13,8 @@
         %th.govuk-table__header
           = t("table.header.activity.comment")
         %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
   %tbody.govuk-table__body
     - activities.each do |activity|

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -22,4 +22,4 @@
         %td.govuk-table__cell= t("form.user.active.#{user.active}")
         %td.govuk-table__cell
           = a11y_action_link(t("default.link.show"), user_path(user), user.name)
-          = a11y_action_link(t("default.link.edit"), edit_user_path(user), user.name)
+          = a11y_action_link(t("default.link.edit"), edit_user_path(user), user.name, ["govuk-!-margin-left-3"])

--- a/app/views/staff/shared/users/_table.html.haml
+++ b/app/views/staff/shared/users/_table.html.haml
@@ -10,6 +10,8 @@
       %th.govuk-table__header
         = t("table.header.user.active")
       %th.govuk-table__header
+        %span.govuk-visually-hidden
+          = t("table.header.default.actions")
 
   %tbody.govuk-table__body
     - users.each do |user|


### PR DESCRIPTION
This came up in a recent accessibility review. I've wrapped the text in a `govuk-visually-hidden` span, because adding "Actions" everywhere adds a bit too much visual noise.