### PR TITLE
(2033) Remove role=navigation from reports tabs

### DIFF
--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -1,4 +1,4 @@
-%ul.govuk-tabs__list{ role: "navigation", aria: { label: "Report subnavigation" } }
+%ul.govuk-tabs__list{ aria: { label: "Report subnavigation" } }
   = render partial: "staff/reports/tab", locals: { name: "summary", path: report_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "activities", path: report_activities_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "forecasts", path: report_forecasts_path(@report), active_tab: active_tab }


### PR DESCRIPTION
This has the effect of invalidating the HTML code. Screen readers notify users when they come to a list, and tell them how many items are in a list. If you don't mark up a list using proper semantic markup in a hierarchy, list items cannot inform the listener that they are listening to a list when no parent is indicating the presence of a list and the type of list.