### PR TITLE
Allow DPs to search for their own programmes

### DIFF
--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -34,7 +34,7 @@ class ActivitySearch
     @_activities ||= if @user.service_owner?
       Activity.all
     else
-      Activity.where(organisation: @user.organisation)
+      Activity.where(extending_organisation: @user.organisation)
     end
   end
 end


### PR DESCRIPTION
Before, the ActivitySearch only searched for activities where the organisation matched the organisation of
the DP. However, this doesn't quite chime with the experience of how DPs view Activities. When they log in they see Programmes, Projects and Third-Party Projects.

Programmes ALWAYS have the `organisation` set to the Service Owner organisation, while the `extending_organisation` is that of the Delivery Partner. Projects and Third-Party Projects have both `organisation` and `extending_organisation` set to that of the Delivery Partner.

With this in mind, to get Programmes to show up in the search, we need to search by `extending_orgaisation`, not `organisation`. I've updated the tests to reflect this too.