### PR TITLE
Make sure users are active even after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -774,6 +774,8 @@
 
 ## [unreleased]
 
+- Make sure users are active even after login
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-65...HEAD
 [release-65]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-64...release-65
 [release-64]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-63...release-64

--- a/app/controllers/concerns/auth.rb
+++ b/app/controllers/concerns/auth.rb
@@ -19,7 +19,7 @@ module Auth
 
   def current_user
     @current_user ||= if session.dig(:userinfo)
-      User.includes(:organisation).find_by!(identifier: signed_in_user_identifier) do |user|
+      User.active.includes(:organisation).find_by!(identifier: signed_in_user_identifier) do |user|
         user.name = session.dig(:userinfo, "info", "name")
         user.email = session.dig(:userinfo, "info", "email")
       end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -76,6 +76,7 @@ RSpec.feature "Users can sign in with Auth0" do
 
     expect(page.current_path).to eql home_path
   end
+
   scenario "protected pages cannot be visited unless signed in" do
     visit root_path
 
@@ -145,6 +146,27 @@ RSpec.feature "Users can sign in with Auth0" do
 
       expect(page).to have_content(t("header.link.sign_in"))
       click_on t("header.link.sign_in")
+
+      expect(page).to have_content(t("page_title.errors.not_authorised"))
+      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+    end
+
+    scenario "a user who is logged in and then deactivated sees an error message" do
+      user = create(:delivery_partner_user)
+
+      mock_successful_authentication(
+        uid: user.identifier, name: user.name, email: user.email
+      )
+
+      visit root_path
+      click_on t("header.link.sign_in")
+
+      expect(page.current_path).to eql home_path
+
+      user.active = false
+      user.save
+
+      visit home_path
 
       expect(page).to have_content(t("page_title.errors.not_authorised"))
       expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))


### PR DESCRIPTION
Currently, users that are made inactive, but still logged in can access parts of the site while their session remains valid (i.e. they don't logout, or their session doesn't time out). To get around this edge case, when fetching the `current_user`, we limit our query to only current users. If an active user is not found, we invalidate the session and return an error message