### PR TITLE
(2059) Show default activity breadcrumb scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,6 +775,7 @@
 ## [unreleased]
 
 - Make sure users are active even after login
+- Add breadcrumb trail for activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-65...HEAD
 [release-65]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-64...release-65

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "webpacker"
 gem "wicked"
 gem "strip_attributes"
 
+gem "breadcrumbs_on_rails"
+
 # Authentication
 gem "omniauth-auth0", "~> 3.0"
 gem "omniauth-rails_csrf_protection", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     bootsnap (1.7.7)
       msgpack (~> 1.0)
     brakeman (5.1.1)
+    breadcrumbs_on_rails (4.1.0)
+      railties (>= 5.0)
     builder (3.2.4)
     bullet (6.1.4)
       activesupport (>= 3.0.0)
@@ -470,6 +472,7 @@ DEPENDENCIES
   better_errors
   bootsnap (>= 1.1.0)
   brakeman
+  breadcrumbs_on_rails
   bullet
   byebug
   capybara (>= 2.15)

--- a/app/assets/stylesheets/partials/_breadcrumbs.css.scss
+++ b/app/assets/stylesheets/partials/_breadcrumbs.css.scss
@@ -1,0 +1,7 @@
+.govuk-breadcrumbs .govuk-breadcrumbs__list li {
+  @extend .govuk-breadcrumbs__list-item;
+}
+
+.govuk-breadcrumbs .govuk-breadcrumbs__list li a {
+  @extend .govuk-breadcrumbs__link;
+}

--- a/app/controllers/concerns/breadcrumbed.rb
+++ b/app/controllers/concerns/breadcrumbed.rb
@@ -3,9 +3,9 @@ module Breadcrumbed
 
   def prepare_default_activity_trail(activity)
     if activity.historic?
-      add_breadcrumb "Historic activities", historic_organisation_activities_path(activity.organisation)
+      add_breadcrumb t("page_content.breadcrumbs.historic_index"), historic_organisation_activities_path(activity.organisation)
     else
-      add_breadcrumb "Current activities", organisation_activities_path(activity.organisation)
+      add_breadcrumb t("page_content.breadcrumbs.current_index"), organisation_activities_path(activity.organisation)
     end
 
     if activity.third_party_project?

--- a/app/controllers/concerns/breadcrumbed.rb
+++ b/app/controllers/concerns/breadcrumbed.rb
@@ -1,0 +1,20 @@
+module Breadcrumbed
+  extend ActiveSupport::Concern
+
+  def prepare_default_activity_trail(activity)
+    if activity.historic?
+      add_breadcrumb "Historic activities", historic_organisation_activities_path(activity.organisation)
+    else
+      add_breadcrumb "Current activities", organisation_activities_path(activity.organisation)
+    end
+
+    if activity.third_party_project?
+      add_breadcrumb activity.parent.parent.title, organisation_activity_financials_path(activity.parent.parent.organisation, activity.parent.parent)
+      add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
+    elsif activity.project?
+      add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
+    end
+
+    add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
+  end
+end

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -17,7 +17,7 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :current
       ).call
-      add_breadcrumb "Current activities", organisation_activities_path(@organisation)
+      add_breadcrumb t("page_content.breadcrumbs.current_index"), organisation_activities_path(@organisation)
     end
   end
 
@@ -54,7 +54,7 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :historic
       ).call
-      add_breadcrumb "Historic activities", historic_organisation_activities_path(@organisation)
+      add_breadcrumb t("page_content.breadcrumbs.historic_index"), historic_organisation_activities_path(@organisation)
     end
   end
 

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -17,6 +17,7 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :current
       ).call
+      add_breadcrumb "Current activities", organisation_activities_path(@organisation)
     end
   end
 
@@ -53,6 +54,7 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :historic
       ).call
+      add_breadcrumb "Historic activities", historic_organisation_activities_path(@organisation)
     end
   end
 

--- a/app/controllers/staff/activity_children_controller.rb
+++ b/app/controllers/staff/activity_children_controller.rb
@@ -2,10 +2,13 @@
 
 class Staff::ActivityChildrenController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     @activity = Activity.find(params[:activity_id])
     authorize @activity
+
+    prepare_default_activity_trail(@activity)
 
     @activities = @activity.child_activities.includes([:organisation, :parent]).order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
   end

--- a/app/controllers/staff/activity_comments_controller.rb
+++ b/app/controllers/staff/activity_comments_controller.rb
@@ -1,9 +1,12 @@
 class Staff::ActivityCommentsController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     @activity = Activity.find(activity_id)
     authorize @activity
+
+    prepare_default_activity_trail(@activity)
 
     @comments = Comment.where(activity_id: activity_id).includes(:report)
   end

--- a/app/controllers/staff/activity_details_controller.rb
+++ b/app/controllers/staff/activity_details_controller.rb
@@ -2,10 +2,13 @@
 
 class Staff::ActivityDetailsController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     @activity = Activity.find(params[:activity_id])
     authorize @activity
+
+    prepare_default_activity_trail(@activity)
 
     @activities = @activity.child_activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
     @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -2,10 +2,13 @@
 
 class Staff::ActivityFinancialsController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     activity = Activity.find(params[:activity_id])
     authorize activity
+
+    prepare_default_activity_trail(activity)
 
     @transactions = policy_scope(Transaction).where(parent_activity: activity).order("date DESC")
     @budgets = policy_scope(Budget).where(parent_activity: activity).order("financial_year DESC")

--- a/app/controllers/staff/activity_historical_events_controller.rb
+++ b/app/controllers/staff/activity_historical_events_controller.rb
@@ -2,10 +2,14 @@
 
 class Staff::ActivityHistoricalEventsController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     activity = Activity.find(params[:activity_id])
     authorize activity
+
+    prepare_default_activity_trail(activity)
+
     @activity = ActivityPresenter.new(activity)
     @historical_events = Activity::HistoricalEventsGrouper.new(activity: activity).call
   end

--- a/app/controllers/staff/activity_other_funding_controller.rb
+++ b/app/controllers/staff/activity_other_funding_controller.rb
@@ -2,10 +2,13 @@
 
 class Staff::ActivityOtherFundingController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     @activity = Activity.find(params[:activity_id])
     authorize @activity
+
+    prepare_default_activity_trail(@activity)
 
     @matched_efforts = @activity.matched_efforts.map { |e| MatchedEffortPresenter.new(e) }
     @external_incomes = @activity.external_incomes.map { |e| ExternalIncomePresenter.new(e) }

--- a/app/controllers/staff/activity_transfers_controller.rb
+++ b/app/controllers/staff/activity_transfers_controller.rb
@@ -2,10 +2,13 @@
 
 class Staff::ActivityTransfersController < Staff::BaseController
   include Secured
+  include Breadcrumbed
 
   def show
     activity = Activity.find(params[:activity_id])
     authorize activity
+
+    prepare_default_activity_trail(activity)
 
     @activity = ActivityPresenter.new(activity)
     @outgoing_transfers = policy_scope(OutgoingTransfer.where(source: activity)).map { |transfer| TransferPresenter.new(transfer) }

--- a/app/controllers/staff/base_controller.rb
+++ b/app/controllers/staff/base_controller.rb
@@ -6,4 +6,6 @@ class Staff::BaseController < ApplicationController
   # Ensure that Pundit 'authorize' and scopes are used
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
+
+  add_breadcrumb "Home", :root_path
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,12 @@ module ApplicationHelper
   def support_email_link
     mail_to(SUPPORT_EMAIL_ADDRESS, nil, class: "govuk-link")
   end
+
+  def breadcrumb_tags
+    content_tag :div, class: "govuk-breadcrumbs" do
+      content_tag :ol, class: "govuk-breadcrumbs__list" do
+        render_breadcrumbs tag: :li, separator: ""
+      end
+    end
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -483,6 +483,10 @@ class Activity < ApplicationRecord
     iati_status_from_programme_status(programme_status)
   end
 
+  def historic?
+    programme_status.in?(["completed", "stopped", "cancelled"])
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.index", delivery_partner_name: @organisation.name)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activities/index.html.haml
+++ b/app/views/staff/activities/index.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.index", delivery_partner_name: @organisation.name)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_children/show.html.haml
+++ b/app/views/staff/activity_children/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.children", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_comments/show.html.haml
+++ b/app/views/staff/activity_comments/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.comments", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_details/show.html.haml
+++ b/app/views/staff/activity_details/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.details", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_financials/show.html.haml
+++ b/app/views/staff/activity_financials/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.financials", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_historical_events/show.html.haml
+++ b/app/views/staff/activity_historical_events/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.historical_events", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_other_funding/show.html.haml
+++ b/app/views/staff/activity_other_funding/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.other_funding", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/staff/activity_transfers/show.html.haml
+++ b/app/views/staff/activity_transfers/show.html.haml
@@ -1,5 +1,7 @@
 = content_for :page_title_prefix, t("document_title.activity.transfers", name: @activity.title)
 
+= breadcrumb_tags
+
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -361,6 +361,9 @@ en:
     tab_content:
       change_history:
         guidance: Changes made to this activity
+    breadcrumbs:
+      current_index: Current activities
+      historic_index: Historic activities
   tabs:
     activity:
       title: Contents

--- a/spec/controllers/concerns/breadcrumbed_spec.rb
+++ b/spec/controllers/concerns/breadcrumbed_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe StubController, type: :controller do
     let(:activity) { build(:project_activity, programme_status: "completed") }
 
     it "adds the historic index path to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with("Historic activities", "historic_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.historic_index"), "historic_index_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
 
@@ -32,7 +32,7 @@ RSpec.describe StubController, type: :controller do
     let(:activity) { build(:project_activity) }
 
     it "adds the current index path to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with("Current activities", "current_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
 
@@ -44,7 +44,7 @@ RSpec.describe StubController, type: :controller do
     let(:activity) { build(:third_party_project_activity) }
 
     it "adds the parent project and programme activities to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with("Current activities", "current_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
       expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")

--- a/spec/controllers/concerns/breadcrumbed_spec.rb
+++ b/spec/controllers/concerns/breadcrumbed_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+class StubController < Staff::BaseController
+  include Breadcrumbed
+
+  def show
+    activity = Activity.find(params[:id])
+    prepare_default_activity_trail(activity)
+  end
+end
+
+RSpec.describe StubController, type: :controller do
+  before do
+    allow(subject).to receive(:historic_organisation_activities_path).and_return("historic_index_path")
+    allow(subject).to receive(:organisation_activities_path).and_return("current_index_path")
+    allow(subject).to receive(:organisation_activity_financials_path).and_return("activity_path")
+  end
+
+  context "for a historic project activity" do
+    let(:activity) { build(:project_activity, programme_status: "completed") }
+
+    it "adds the historic index path to the breadcrumb stack" do
+      expect(subject).to receive(:add_breadcrumb).with("Historic activities", "historic_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+      subject.prepare_default_activity_trail(activity)
+    end
+  end
+
+  context "for a current project activity" do
+    let(:activity) { build(:project_activity) }
+
+    it "adds the current index path to the breadcrumb stack" do
+      expect(subject).to receive(:add_breadcrumb).with("Current activities", "current_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+      subject.prepare_default_activity_trail(activity)
+    end
+  end
+
+  context "for a third-party project" do
+    let(:activity) { build(:third_party_project_activity) }
+
+    it "adds the parent project and programme activities to the breadcrumb stack" do
+      expect(subject).to receive(:add_breadcrumb).with("Current activities", "current_index_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+      subject.prepare_default_activity_trail(activity)
+    end
+  end
+end

--- a/spec/controllers/staff/activity_historical_events_controller_spec.rb
+++ b/spec/controllers/staff/activity_historical_events_controller_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Staff::ActivityHistoricalEventsController do
   before do
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+    allow(controller).to receive(:prepare_default_activity_trail)
   end
 
   describe "#show" do
-    let(:activity) { build_stubbed(:project_activity) }
+    let(:activity) { build_stubbed(:project_activity, organisation: organisation) }
     let(:grouper) { instance_double(Activity::HistoricalEventsGrouper, call: double) }
 
     before do
@@ -21,7 +22,7 @@ RSpec.describe Staff::ActivityHistoricalEventsController do
     end
 
     it "asks the HistoricalEventsGrouper to prepare the 'Change history'" do
-      get :show, params: {activity_id: "abc123", organisation_id: "asd321"}
+      get :show, params: {activity_id: "abc123", organisation_id: organisation.id}
 
       expect(Activity::HistoricalEventsGrouper)
         .to have_received(:new)

--- a/spec/features/staff/users_can_view_an_activitys_children_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_children_spec.rb
@@ -13,7 +13,9 @@ RSpec.feature "Users can an activitys children" do
       visit organisation_activity_path(user.organisation.id, project)
 
       click_on t("tabs.activity.details")
-      click_on programme.title
+      within(".activity-details") do
+        click_on programme.title
+      end
       click_on t("tabs.activity.children")
 
       expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
@@ -29,7 +31,9 @@ RSpec.feature "Users can an activitys children" do
 
       visit organisation_activity_details_path(activity.organisation, activity)
 
-      click_on(programme.title)
+      within(".activity-details") do
+        click_on(programme.title)
+      end
       click_on t("tabs.activity.children")
       click_on activity.title
       click_on t("tabs.activity.details")

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -94,7 +94,9 @@ RSpec.feature "Users can view budgets on an activity page" do
           click_link t("table.body.activity.view_activity")
         end
         click_link t("tabs.activity.details")
-        click_link programme_activity.title
+        within(".activity-details") do
+          click_link programme_activity.title
+        end
 
         budget_information_is_shown_on_page(budget_presenter)
       end

--- a/spec/features/staff/users_can_view_programme_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_programme_level_activities_spec.rb
@@ -29,7 +29,10 @@ RSpec.feature "Users can view programme level activities" do
       project = create(:project_activity, parent: programme_activity, organisation: user.organisation)
 
       visit organisation_activity_details_path(user.organisation, project)
-      click_on programme_activity.title
+
+      within(".activity-details") do
+        click_on programme_activity.title
+      end
 
       page_displays_an_activity(activity_presenter: ActivityPresenter.new(programme_activity))
     end


### PR DESCRIPTION
## Changes in this PR
- Show breadcrumb trail for activities, based on activity index and depth level (project, third-party project)
 
## Screenshots of UI changes

### After
![Screenshot 2021-07-30 at 18 52 15](https://user-images.githubusercontent.com/579522/128055136-e3fb7e92-a406-4bb5-9e30-ff2dc08cd1b5.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
