### PR TITLE
(1982) Adjust XML exports to use new benefitting countries field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,6 +776,7 @@
 
 - Make sure users are active even after login
 - Add breadcrumb trail for activities
+- Adjust XML exports to use new benefitting countries field
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-65...HEAD
 [release-65]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-64...release-65

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -1,4 +1,6 @@
 module ActivityHelper
+  include CodelistHelper
+
   def step_is_complete_or_next?(activity:, step:)
     steps = Activity::FORM_STEPS
 
@@ -32,5 +34,23 @@ module ActivityHelper
 
   def policy_markers_desertification_iati_codes_to_enum(code)
     Activity::DESERTIFICATION_POLICY_MARKER_CODES.key(code.to_i)
+  end
+
+  def benefitting_countries_with_percentages(benefitting_countries)
+    return [] if benefitting_countries.blank?
+
+    # Get an equal percentage split between all the countries
+    # (together with the remainder if possible)
+    percentage, remainder = 100.divmod(benefitting_countries.count)
+
+    benefitting_countries.map do |country|
+      # If we're at the last item, add the remainder to the percentage
+      # split
+      percentage += remainder if country == benefitting_countries.last
+
+      OpenStruct.new(code: country,
+                     name: country_name_from_code(country),
+                     percentage: percentage.to_f)
+    end
   end
 end

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -39,7 +39,11 @@
     %website= I18n.t("contact_info.website")
     %mailing-address
       %narrative= I18n.t("contact_info.mailing_address")
-  - if activity.recipient_country?
+  - if activity.benefitting_countries.present?
+    - benefitting_countries_with_percentages(activity.benefitting_countries).each do |country|
+      %recipient-country{"code" => country.code, "percentage" => country.percentage}
+        %narrative= country.name
+  - elsif activity.recipient_country?
     %recipient-country{"code" => activity.recipient_country}
       %narrative= country_name_from_code(activity.recipient_country)
   - elsif activity.recipient_region?

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -89,4 +89,45 @@ RSpec.describe ActivityHelper, type: :helper do
       end
     end
   end
+
+  describe "#benefitting_countries_with_percentages" do
+    it "returns an array of structs with country name, code and percentage" do
+      codes = ["AG", "LC"]
+      countries = benefitting_countries_with_percentages(codes)
+
+      expect(countries.count).to eql(2)
+
+      expect(countries.first.code).to eq("AG")
+      expect(countries.first.name).to eq("Antigua and Barbuda")
+      expect(countries.first.percentage).to eq(50.0)
+
+      expect(countries.last.code).to eq("LC")
+      expect(countries.last.name).to eq("Saint Lucia")
+      expect(countries.last.percentage).to eq(50.0)
+    end
+
+    it "appends the remainder to the last item if the country list count is an odd number" do
+      codes = ["AG", "LC", "BZ"]
+      countries = benefitting_countries_with_percentages(codes)
+
+      expect(countries.count).to eql(3)
+
+      expect(countries.first.code).to eq("AG")
+      expect(countries.first.name).to eq("Antigua and Barbuda")
+      expect(countries.first.percentage).to eq(33.0)
+
+      expect(countries.second.code).to eq("LC")
+      expect(countries.second.name).to eq("Saint Lucia")
+      expect(countries.second.percentage).to eq(33.0)
+
+      expect(countries.last.code).to eq("BZ")
+      expect(countries.last.name).to eq("Belize")
+      expect(countries.last.percentage).to eq(34.0)
+    end
+
+    it "returns an empty array if the codes are nil or empty" do
+      expect(benefitting_countries_with_percentages(nil)).to eq([])
+      expect(benefitting_countries_with_percentages([])).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
This adjusts the XML exports to use the new `benefitting_countries` field, rather than the old, legacy `recipient_country` / `recipient_region` fields