### PR TITLE
Add horizontal scroll inside wrapper

### DIFF
--- a/app/assets/stylesheets/partials/_table.scss
+++ b/app/assets/stylesheets/partials/_table.scss
@@ -1,0 +1,10 @@
+table.govuk-table {
+  @include govuk-media-query($until: tablet) {
+    display: block;
+  }
+  overflow-x: scroll;
+}
+
+.govuk-template {
+  overflow-x:hidden;
+}


### PR DESCRIPTION


## Changes in this PR
Table overflows the normal device veiwport, causing the browser to add a horizontal scroll on the website, this is an accessibility issue. I have styled the data tables so that it doesn't break from its container and scrolls within its wrapper div

trello card: https://trello.com/c/fh8On5Hg/2032-moderate-page-reflow-issues-horizontal-scroll

## Screenshots of UI changes
<img width="643" alt="Screenshot 2021-08-09 at 13 36 26" src="https://user-images.githubusercontent.com/10596845/128716127-668f351a-8d94-4a12-ba6e-ae9b5097c8e8.png">


### Before
<img width="579" alt="Screenshot 2021-08-09 at 14 45 18" src="https://user-images.githubusercontent.com/10596845/128716349-90cb3dd5-bbac-4e3d-aa4b-5d7e0043525e.png">