### PR TITLE
(2066) Post refund against active report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -787,6 +787,8 @@
 
 ## [unreleased]
 
+- Allow a refund to be posted against an active report
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...HEAD
 [release-67]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-66...release-67
 [release-66]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-65...release-66

--- a/app/controllers/staff/activity_financials_controller.rb
+++ b/app/controllers/staff/activity_financials_controller.rb
@@ -13,11 +13,14 @@ class Staff::ActivityFinancialsController < Staff::BaseController
     @transactions = policy_scope(Transaction).where(parent_activity: activity).order("date DESC")
     @budgets = policy_scope(Budget).where(parent_activity: activity).order("financial_year DESC")
     @forecasts = policy_scope(activity.latest_forecasts)
+    @refunds = policy_scope(Refund).where(parent_activity: activity).order("financial_year DESC")
 
     @activity = ActivityPresenter.new(activity)
     @transaction_presenters = @transactions.includes(:parent_activity).map { |transaction| TransactionPresenter.new(transaction) }
     @budget_presenters = @budgets.includes(:parent_activity, :providing_organisation).map { |budget| BudgetPresenter.new(budget) }
     @forecast_presenters = @forecasts.map { |forecast| ForecastPresenter.new(forecast) }
+    @refund_presenters = @refunds.map { |forecast| RefundPresenter.new(forecast) }
+
     @implementing_organisation_presenters = activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
   end
 end

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -51,6 +51,17 @@ class Staff::RefundsController < Staff::ActivitiesController
     end
   end
 
+  def destroy
+    @refund = Refund.find(id)
+    authorize @refund
+
+    @refund.destroy
+
+    flash[:notice] = t("action.refund.destroy.success")
+
+    redirect_to organisation_activity_path(activity.organisation, activity)
+  end
+
   private
 
   def refund_params

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -1,0 +1,53 @@
+class Staff::RefundsController < Staff::ActivitiesController
+  include Secured
+
+  def new
+    @activity = activity
+    @refund = Refund.new
+    @report = Report.editable_for_activity(@activity)
+
+    @refund.parent_activity = @activity
+    @refund.report = @report
+
+    authorize @refund
+  end
+
+  def create
+    @activity = activity
+    authorize @activity
+
+    result = CreateRefund.new(activity: @activity)
+      .call(attributes: refund_params)
+    @refund = result.object
+
+    if result.success?
+      flash[:notice] = t("action.refund.create.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def refund_params
+    params.require(:refund).permit(
+      :value,
+      :financial_quarter,
+      :financial_year,
+      :comment
+    )
+  end
+
+  def activity_id
+    params[:activity_id]
+  end
+
+  def id
+    params[:id]
+  end
+
+  def activity
+    @activity ||= Activity.find(activity_id)
+  end
+end

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -28,6 +28,29 @@ class Staff::RefundsController < Staff::ActivitiesController
     end
   end
 
+  def edit
+    @activity = activity
+    @refund = Refund.find(id)
+
+    authorize @refund
+  end
+
+  def update
+    @refund = Refund.find(id)
+    authorize @refund
+
+    result = UpdateRefund.new(
+      refund: @refund,
+    ).call(attributes: refund_params)
+
+    if result.success?
+      flash[:notice] = t("action.refund.update.success")
+      redirect_to organisation_activity_path(activity.organisation, activity)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def refund_params

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -1,0 +1,10 @@
+class Refund < ApplicationRecord
+  include HasFinancialQuarter
+
+  belongs_to :parent_activity, class_name: "Activity"
+  belongs_to :report
+
+  validates :financial_quarter, presence: true
+  validates :financial_year, presence: true
+  validates :value, presence: true
+end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -31,6 +31,13 @@ class ActivityPolicy < ApplicationPolicy
     end
   end
 
+  def create_refund?
+    Pundit.policy(
+      user,
+      Refund.new(parent_activity: record)
+    ).create?
+  end
+
   def edit?
     update?
   end

--- a/app/policies/refund_policy.rb
+++ b/app/policies/refund_policy.rb
@@ -1,0 +1,43 @@
+class RefundPolicy < ApplicationPolicy
+  def show?
+    return true if beis_user?
+    record.parent_activity.organisation == user.organisation
+  end
+
+  def create?
+    return false if record.parent_activity.level.nil?
+    return true if beis_user? && editable_report_for_organisation_and_fund.present? && parent_activity_is_a_programme?
+    return true if delivery_partner_user? && editable_report_for_organisation_and_fund.present?
+
+    false
+  end
+
+  def update?
+    can_update_or_delete?
+  end
+
+  def destroy?
+    can_update_or_delete?
+  end
+
+  private
+
+  def can_update_or_delete?
+    return false if record.parent_activity.level.nil?
+    return true if beis_user? && parent_activity_is_a_programme?
+
+    if delivery_partner_user? && editable_report_for_organisation_and_fund.present?
+      return true if editable_report_for_organisation_and_fund == record.report
+    end
+
+    false
+  end
+
+  def editable_report_for_organisation_and_fund
+    Report.editable_for_activity(record.parent_activity)
+  end
+
+  def parent_activity_is_a_programme?
+    record.parent_activity.programme?
+  end
+end

--- a/app/presenters/refund_presenter.rb
+++ b/app/presenters/refund_presenter.rb
@@ -1,0 +1,6 @@
+class RefundPresenter < SimpleDelegator
+  def value
+    return if super.blank?
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+end

--- a/app/services/create_refund.rb
+++ b/app/services/create_refund.rb
@@ -1,0 +1,23 @@
+class CreateRefund
+  attr_accessor :activity, :report, :refund
+
+  def initialize(activity:)
+    self.activity = activity
+    self.report = Report.editable_for_activity(activity)
+    self.refund = Refund.new
+  end
+
+  def call(attributes:)
+    refund.parent_activity = activity
+    refund.report = report
+    refund.assign_attributes(attributes)
+
+    result = if refund.valid?
+      Result.new(refund.save, refund)
+    else
+      Result.new(false, refund)
+    end
+
+    result
+  end
+end

--- a/app/services/update_refund.rb
+++ b/app/services/update_refund.rb
@@ -1,0 +1,21 @@
+class UpdateRefund
+  def initialize(refund:)
+    @refund = refund
+  end
+
+  def call(attributes: {})
+    refund.assign_attributes(attributes)
+
+    success = refund.save
+
+    if success
+      Result.new(true, refund)
+    else
+      Result.new(false, refund)
+    end
+  end
+
+  private
+
+  attr_reader :refund
+end

--- a/app/views/staff/activity_financials/show.html.haml
+++ b/app/views/staff/activity_financials/show.html.haml
@@ -55,3 +55,5 @@
               locals: { activity: @activity, forecasts: @forecast_presenters }
             = render partial: "staff/shared/activities/transactions",
               locals: { activity: @activity, transaction_presenters: @transaction_presenters }
+            = render partial: "staff/shared/activities/refunds",
+              locals: { activity: @activity, refund_presenters: @refund_presenters }

--- a/app/views/staff/refunds/_form.html.haml
+++ b/app/views/staff/refunds/_form.html.haml
@@ -1,0 +1,22 @@
+= f.govuk_error_summary
+
+= f.govuk_text_field :value
+
+= f.govuk_fieldset legend: { text: t("form.label.refund.financial_quarter") } do
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = f.govuk_collection_radio_buttons :financial_quarter,
+        list_of_financial_quarters,
+        :id,
+        :name,
+        inline: true,
+        legend: { text: t("form.label.refund.financial_quarter") , tag: :p, size: 's' }
+    .govuk-grid-column-one-third
+      = f.govuk_collection_select :financial_year,
+        list_of_financial_years(FinancialYear.previous_ten),
+        :id,
+        :name,
+        label: { text: t("form.label.refund.financial_year"), tag: :p, size: 's' }
+
+= f.govuk_text_area :comment
+

--- a/app/views/staff/refunds/edit.html.haml
+++ b/app/views/staff/refunds/edit.html.haml
@@ -1,0 +1,15 @@
+=content_for :page_title_prefix, t("page_title.refund.edit")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = @activity.title
+
+      %h2.govuk-heading-l
+        = t("page_title.refund.edit")
+
+      = form_with model: @refund, url: activity_refund_path(@activity, @refund) do |f|
+        = render partial: "form", locals: { f: f, activity: @activity }
+
+        = f.govuk_submit t("default.button.submit")

--- a/app/views/staff/refunds/edit.html.haml
+++ b/app/views/staff/refunds/edit.html.haml
@@ -13,3 +13,5 @@
         = render partial: "form", locals: { f: f, activity: @activity }
 
         = f.govuk_submit t("default.button.submit")
+
+        = link_to t("default.button.delete"), activity_refund_path(@activity, @refund), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this refund?" }

--- a/app/views/staff/refunds/new.html.haml
+++ b/app/views/staff/refunds/new.html.haml
@@ -1,0 +1,16 @@
+=content_for :page_title_prefix, t("page_title.refund.new")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = @activity.title
+
+      %h2.govuk-heading-l
+        = t("page_title.refund.new")
+
+      = form_with model: @refund, url: activity_refunds_path(@activity) do |f|
+        = render partial: "form", locals: { f: f, activity: @activity }
+
+        = f.govuk_submit t("default.button.submit")
+        = link_to t("form.link.activity.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"

--- a/app/views/staff/shared/activities/_refunds.html.haml
+++ b/app/views/staff/shared/activities/_refunds.html.haml
@@ -1,0 +1,8 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.refunds")
+
+    - if policy(activity).create_refund?
+      = link_to(t("page_content.refund.button.create"), new_activity_refund_path(activity), class: "govuk-button")
+    = render partial: '/staff/shared/refunds/table', locals: { refunds: refund_presenters }

--- a/app/views/staff/shared/refunds/_table.html.haml
+++ b/app/views/staff/shared/refunds/_table.html.haml
@@ -1,0 +1,14 @@
+- unless refunds.empty?
+  %table.govuk-table.refunds
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.refund.financial_quarter")
+        %th.govuk-table__header
+          = t("table.header.refund.value")
+
+    %tbody.govuk-table__body
+      - refunds.each do |refund|
+        %tr.govuk-table__row{id: refund.id}
+          %td.govuk-table__cell= refund.financial_quarter_and_year
+          %td.govuk-table__cell= refund.value

--- a/app/views/staff/shared/refunds/_table.html.haml
+++ b/app/views/staff/shared/refunds/_table.html.haml
@@ -6,9 +6,13 @@
           = t("table.header.refund.financial_quarter")
         %th.govuk-table__header
           = t("table.header.refund.value")
+        %th.govuk-table__header
 
     %tbody.govuk-table__body
       - refunds.each do |refund|
         %tr.govuk-table__row{id: refund.id}
           %td.govuk-table__cell= refund.financial_quarter_and_year
           %td.govuk-table__cell= refund.value
+          %td.govuk-table__cell
+            - if policy(refund).edit?
+              = a11y_action_link(t('default.link.edit'), edit_activity_refund_path(refund.parent_activity_id, refund), t("page_content.refund.edit_noun"))

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -358,6 +358,7 @@ en:
         default_selection_value: Select a recipient country
       third_party_projects: Third-party projects (level D)
       transactions: Transactions
+      refunds: Refunds
     tab_content:
       change_history:
         guidance: Changes made to this activity

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -1,0 +1,17 @@
+en:
+  action:
+    refund:
+      create:
+        success: Refund successfully created
+  page_title:
+    refund:
+      new: Add a new refund
+  form:
+    label:
+      refund:
+        value: Transaction amount
+        financial_quarter: Financial Quarter
+        financial_year: Financial Year
+    hint:
+      refund:
+        financial_quarter_and_year: The financial quarter the refund applies to

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -5,6 +5,8 @@ en:
         success: Refund successfully created
       update:
         success: Refund successfully updated
+      destroy:
+        success: Refund successfully deleted
   page_content:
     refund:
       button:

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -3,13 +3,17 @@ en:
     refund:
       create:
         success: Refund successfully created
+      update:
+        success: Refund successfully updated
   page_content:
     refund:
       button:
         create: Add a refund
+      edit_noun: refund
   page_title:
     refund:
       new: Add a new refund
+      edit: Edit refund
   form:
     label:
       refund:

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -3,6 +3,10 @@ en:
     refund:
       create:
         success: Refund successfully created
+  page_content:
+    refund:
+      button:
+        create: Add a refund
   page_title:
     refund:
       new: Add a new refund
@@ -15,3 +19,8 @@ en:
     hint:
       refund:
         financial_quarter_and_year: The financial quarter the refund applies to
+  table:
+    header:
+      refund:
+        financial_quarter: Financial quarter
+        value: Refund amount

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
       resources :comments, only: [:new, :create, :edit, :update]
       resources :outgoing_transfers, except: [:index]
       resources :incoming_transfers, except: [:index]
+      resources :refunds, only: [:new, :create]
     end
 
     resource :search, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
       resources :comments, only: [:new, :create, :edit, :update]
       resources :outgoing_transfers, except: [:index]
       resources :incoming_transfers, except: [:index]
-      resources :refunds, only: [:new, :create, :edit, :update]
+      resources :refunds, except: [:index]
     end
 
     resource :search, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
       resources :comments, only: [:new, :create, :edit, :update]
       resources :outgoing_transfers, except: [:index]
       resources :incoming_transfers, except: [:index]
-      resources :refunds, only: [:new, :create]
+      resources :refunds, only: [:new, :create, :edit, :update]
     end
 
     resource :search, only: [:show]

--- a/db/migrate/20210811093658_create_refunds.rb
+++ b/db/migrate/20210811093658_create_refunds.rb
@@ -1,0 +1,14 @@
+class CreateRefunds < ActiveRecord::Migration[6.1]
+  def change
+    create_table :refunds, id: :uuid do |t|
+      t.references :parent_activity, type: :uuid
+      t.references :report, type: :uuid
+      t.integer :financial_year
+      t.integer :financial_quarter
+      t.decimal :value, precision: 13, scale: 2
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_27_163803) do
+ActiveRecord::Schema.define(version: 2021_08_11_093658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -244,6 +244,18 @@ ActiveRecord::Schema.define(version: 2021_07_27_163803) do
   end
 
   create_table "reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "parent_activity_id"
+    t.uuid "report_id"
+    t.integer "financial_year"
+    t.integer "financial_quarter"
+    t.decimal "value", precision: 13, scale: 2
+    t.text "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["parent_activity_id"], name: "index_refunds_on_parent_activity_id"
+    t.index ["report_id"], name: "index_refunds_on_report_id"
+  end
     t.string "state", default: "inactive", null: false
     t.string "description"
     t.uuid "fund_id"

--- a/spec/factories/refunds.rb
+++ b/spec/factories/refunds.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :refund do
+    association :parent_activity, factory: :project_activity
+    association :report
+
+    financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
+    financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
+    value { BigDecimal("110.01") }
+    comment { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -1,0 +1,35 @@
+RSpec.feature "Users can create a refund" do
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  RSpec.shared_examples "refunds" do
+    before { authenticate!(user: user) }
+
+    scenario "they can create a refund for an activity" do
+      visit new_activity_refund_path(activity_id: activity.id)
+
+      fill_in "refund[value]", with: "100"
+
+      choose "4", name: "refund[financial_quarter]"
+      select "2019-2020", from: "refund[financial_year]"
+      fill_in "refund[comment]", with: "Comment goes here"
+
+      expect { click_on(t("default.button.submit")) }.to change(Refund, :count).by(1)
+
+      expect(page).to have_content(t("action.refund.create.success"))
+    end
+  end
+
+  context "when logged in as a BEIS user" do
+    include_examples "refunds" do
+      let(:user) { create(:beis_user) }
+      let(:activity) { create(:programme_activity, :with_report) }
+    end
+  end
+
+  context "when logged in as a delivery partner" do
+    include_examples "refunds" do
+      let(:user) { create(:delivery_partner_user, organisation: organisation) }
+      let(:activity) { create(:project_activity, :with_report, organisation: organisation) }
+    end
+  end
+end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -5,10 +5,14 @@ RSpec.feature "Users can create a refund" do
     before { authenticate!(user: user) }
 
     scenario "they can create a refund for an activity" do
-      visit new_activity_refund_path(activity_id: activity.id)
+      visit organisation_activity_financials_path(
+        organisation_id: activity.organisation.id,
+        activity_id: activity.id
+      )
+
+      click_on t("page_content.refund.button.create")
 
       fill_in "refund[value]", with: "100"
-
       choose "4", name: "refund[financial_quarter]"
       select "2019-2020", from: "refund[financial_year]"
       fill_in "refund[comment]", with: "Comment goes here"
@@ -16,6 +20,13 @@ RSpec.feature "Users can create a refund" do
       expect { click_on(t("default.button.submit")) }.to change(Refund, :count).by(1)
 
       expect(page).to have_content(t("action.refund.create.success"))
+
+      newly_created_refund = Refund.last
+
+      within "##{newly_created_refund.id}" do
+        expect(page).to have_content("Q4 2019-2020")
+        expect(page).to have_content("£100")
+      end
     end
   end
 

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature "Users can edit a refund" do
   RSpec.shared_examples "refunds" do
     let!(:refund) { create(:refund, parent_activity: activity, report: report) }
 
-    before { authenticate!(user: user) }
+    before do
+      authenticate!(user: user)
 
-    scenario "they can edit a refund for an activity" do
       visit organisation_activity_financials_path(
         organisation_id: activity.organisation.id,
         activity_id: activity.id
@@ -15,7 +15,9 @@ RSpec.feature "Users can edit a refund" do
       within "##{refund.id}" do
         click_on "Edit refund"
       end
+    end
 
+    scenario "they can edit a refund for an activity" do
       fill_in "refund[value]", with: "100"
       choose "4", name: "refund[financial_quarter]"
       select "2019-2020", from: "refund[financial_year]"
@@ -33,6 +35,10 @@ RSpec.feature "Users can edit a refund" do
       })
 
       expect(page).to have_content(t("action.refund.update.success"))
+    end
+
+    scenario "they can delete a refund" do
+      expect { click_on t("default.button.delete") }.to change(Refund, :count).by(-1)
     end
   end
 

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -1,0 +1,54 @@
+RSpec.feature "Users can edit a refund" do
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  RSpec.shared_examples "refunds" do
+    let!(:refund) { create(:refund, parent_activity: activity, report: report) }
+
+    before { authenticate!(user: user) }
+
+    scenario "they can edit a refund for an activity" do
+      visit organisation_activity_financials_path(
+        organisation_id: activity.organisation.id,
+        activity_id: activity.id
+      )
+
+      within "##{refund.id}" do
+        click_on "Edit refund"
+      end
+
+      fill_in "refund[value]", with: "100"
+      choose "4", name: "refund[financial_quarter]"
+      select "2019-2020", from: "refund[financial_year]"
+      fill_in "refund[comment]", with: "Comment goes here"
+
+      expect {
+        click_on(t("default.button.submit"))
+      }.to change {
+        refund.reload.attributes.slice("financial_year", "financial_quarter", "value", "comment")
+      }.to({
+        "financial_year" => 2019,
+        "financial_quarter" => 4,
+        "value" => BigDecimal("100"),
+        "comment" => "Comment goes here",
+      })
+
+      expect(page).to have_content(t("action.refund.update.success"))
+    end
+  end
+
+  context "when logged in as a BEIS user" do
+    include_examples "refunds" do
+      let(:user) { create(:beis_user) }
+      let(:activity) { create(:programme_activity) }
+      let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
+    end
+  end
+
+  context "when logged in as a delivery partner" do
+    include_examples "refunds" do
+      let(:user) { create(:delivery_partner_user, organisation: organisation) }
+      let(:activity) { create(:project_activity, organisation: organisation) }
+      let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
+    end
+  end
+end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Refund, type: :model do
+  let(:refund) { build(:refund) }
+
+  it { should belong_to(:parent_activity) }
+  it { should belong_to(:report) }
+
+  it { should validate_presence_of(:financial_quarter) }
+  it { should validate_presence_of(:financial_year) }
+  it { should validate_presence_of(:value) }
+end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
+      it { is_expected.to forbid_action(:create_refund) }
 
       it { is_expected.to permit_action(:create_child) }
       it { is_expected.to permit_action(:create_transfer) }
@@ -34,9 +35,16 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
+      it { is_expected.to forbid_action(:create_refund) }
 
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to permit_action(:create_transfer) }
+
+      context "and there is an active report" do
+        let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
+
+        it { is_expected.to permit_action(:create_refund) }
+      end
     end
 
     context "when the activity is a project" do
@@ -44,6 +52,7 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:redact_from_iati) }
+      it { is_expected.to forbid_action(:create_refund) }
 
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
@@ -67,6 +76,7 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to forbid_action(:create_transfer) }
+      it { is_expected.to forbid_action(:create_refund) }
     end
   end
 
@@ -85,6 +95,7 @@ RSpec.describe ActivityPolicy do
 
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to forbid_action(:create_transfer) }
+      it { is_expected.to forbid_action(:create_refund) }
     end
 
     context "when the activity is a programme" do
@@ -100,6 +111,7 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
+        it { is_expected.to forbid_action(:create_refund) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -117,6 +129,7 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
+        it { is_expected.to forbid_action(:create_refund) }
 
         context "and there is an editable report for the users organisation" do
           before do
@@ -125,6 +138,7 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to permit_action(:create_child) }
           it { is_expected.to forbid_action(:create_transfer) }
+          it { is_expected.to forbid_action(:create_refund) }
         end
       end
     end
@@ -142,6 +156,7 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
+        it { is_expected.to forbid_action(:create_refund) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -160,6 +175,7 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to forbid_action(:create_child) }
           it { is_expected.to forbid_action(:create_transfer) }
+          it { is_expected.to forbid_action(:create_refund) }
         end
 
         context "and there is an editable report for the users organisation" do
@@ -177,6 +193,7 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to permit_action(:create_child) }
           it { is_expected.to permit_action(:create_transfer) }
+          it { is_expected.to permit_action(:create_refund) }
         end
       end
     end
@@ -194,6 +211,7 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
+        it { is_expected.to forbid_action(:create_refund) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -212,6 +230,7 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to forbid_action(:create_child) }
           it { is_expected.to forbid_action(:create_transfer) }
+          it { is_expected.to forbid_action(:create_refund) }
         end
 
         context "and there is an editable report for the users organisation" do
@@ -229,6 +248,7 @@ RSpec.describe ActivityPolicy do
 
           it { is_expected.to forbid_action(:create_child) }
           it { is_expected.to permit_action(:create_transfer) }
+          it { is_expected.to permit_action(:create_refund) }
         end
       end
     end

--- a/spec/policies/refund_policy_spec.rb
+++ b/spec/policies/refund_policy_spec.rb
@@ -1,0 +1,172 @@
+require "rails_helper"
+
+RSpec.describe RefundPolicy do
+  let(:refund) { create(:refund, parent_activity: activity) }
+
+  subject { described_class.new(user, refund) }
+
+  context "when signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      context "and the activity has an associated report" do
+        let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to permit_action(:create) }
+        it { is_expected.to permit_action(:edit) }
+        it { is_expected.to permit_action(:update) }
+        it { is_expected.to permit_action(:destroy) }
+      end
+
+      context "and the activity does not have an associated report" do
+        let(:activity) { create(:programme_activity, organisation: user.organisation) }
+
+        it { is_expected.to permit_action(:show) }
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to permit_action(:edit) }
+        it { is_expected.to permit_action(:update) }
+        it { is_expected.to permit_action(:destroy) }
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: create(:delivery_partner_organisation)) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a third party project" do
+      let(:activity) { create(:third_party_project_activity, organisation: create(:delivery_partner_organisation)) }
+
+      it { is_expected.to permit_action(:show) }
+
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+  end
+
+  context "when signed in as a Delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity) }
+
+      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity) }
+
+      it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to forbid_action(:edit) }
+      it { is_expected.to forbid_action(:update) }
+      it { is_expected.to forbid_action(:destroy) }
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity) }
+
+      context "and the activity does not belong to the users organisation" do
+        it { is_expected.to forbid_action(:show) }
+        it { is_expected.to forbid_action(:create) }
+        it { is_expected.to forbid_action(:edit) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
+      end
+
+      context "and the activity does belong to the users organisation" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        context "when there is no editable report" do
+          let(:report) { create(:report, state: :inactive) }
+
+          it { is_expected.to permit_action(:show) }
+
+          it { is_expected.to forbid_action(:create) }
+          it { is_expected.to forbid_action(:edit) }
+          it { is_expected.to forbid_action(:update) }
+          it { is_expected.to forbid_action(:destroy) }
+        end
+
+        context "when there is an editable report" do
+          let(:report) { create(:report, state: :active) }
+
+          context "and the report is not for the organisation or fund of the activity" do
+            it { is_expected.to permit_action(:show) }
+
+            it { is_expected.to forbid_action(:create) }
+            it { is_expected.to forbid_action(:edit) }
+            it { is_expected.to forbid_action(:update) }
+            it { is_expected.to forbid_action(:destroy) }
+          end
+
+          context "and the report is for the organisation but not the fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation)
+            end
+
+            it { is_expected.to permit_action(:show) }
+
+            it { is_expected.to forbid_action(:create) }
+            it { is_expected.to forbid_action(:edit) }
+            it { is_expected.to forbid_action(:update) }
+            it { is_expected.to forbid_action(:destroy) }
+          end
+
+          context "and the report is for the organisation and fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation, fund: activity.associated_fund)
+            end
+
+            context "when the report is not the one in which the transaction was created" do
+              it { is_expected.to permit_action(:show) }
+              it { is_expected.to permit_action(:create) }
+
+              it { is_expected.to forbid_action(:edit) }
+              it { is_expected.to forbid_action(:update) }
+              it { is_expected.to forbid_action(:destroy) }
+            end
+
+            context "when the report is the one in which the transaction was created" do
+              before do
+                refund.update(report: report)
+              end
+
+              it { is_expected.to permit_action(:show) }
+              it { is_expected.to permit_action(:create) }
+              it { is_expected.to permit_action(:edit) }
+              it { is_expected.to permit_action(:update) }
+              it { is_expected.to permit_action(:destroy) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe CreateRefund do
+  let(:activity) { create(:project_activity) }
+  let(:report) { create(:report) }
+  let(:creator) { described_class.new(activity: activity) }
+
+  describe "#call" do
+    subject { creator.call(attributes: attributes) }
+    let(:refund) { subject.object }
+
+    context "when there is an editable report for the activity" do
+      before do
+        allow(Report).to receive(:editable_for_activity) { report }
+      end
+
+      context "when the attributes are valid" do
+        let(:attributes) do
+          {
+            value: 100.10,
+            financial_quarter: 1,
+            financial_year: 2020,
+            comment: "Some words",
+          }
+        end
+
+        it "creates a refund" do
+          expect { subject }.to change { Refund.count }.by(1)
+        end
+
+        it "returns a result object" do
+          expect(subject).to be_a(Result)
+          expect(subject.success?).to eq(true)
+          expect(subject.object).to be_a(Refund)
+        end
+
+        it "sets the correct attributes" do
+          expect(refund.parent_activity).to eq(activity)
+          expect(refund.report).to eq(report)
+          expect(refund.value).to eq(100.10)
+          expect(refund.financial_quarter).to eq(1)
+          expect(refund.financial_year).to eq(2020)
+          expect(refund.comment).to eq("Some words")
+        end
+      end
+
+      context "when the atrributes are invalid" do
+        let(:attributes) do
+          {
+            value: 100.10,
+            financial_quarter: nil,
+            financial_year: nil,
+            comment: "Some words",
+          }
+        end
+
+        it "does not create a refund" do
+          expect { subject }.to_not change { Refund.count }
+        end
+      end
+    end
+
+    context "when there is no editable report for the activity" do
+      before do
+        allow(Report).to receive(:editable_for_activity) { nil }
+      end
+
+      let(:attributes) do
+        {
+          value: 100.10,
+          financial_quarter: 1,
+          financial_year: 2020,
+          comment: "Some words",
+        }
+      end
+
+      it "does not create a refund" do
+        expect { subject }.to_not change { Refund.count }
+      end
+    end
+  end
+end

--- a/spec/services/update_refund_spec.rb
+++ b/spec/services/update_refund_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe UpdateRefund do
+  let(:refund) { create(:refund) }
+
+  describe "#call" do
+    it "returns a successful result" do
+      allow(refund).to receive(:valid?).and_return(true)
+      allow(refund).to receive(:save).and_return(true)
+
+      result = described_class.new(refund: refund).call(attributes: {})
+
+      expect(result.success?).to be true
+    end
+
+    context "when the refund isn't valid" do
+      it "returns a failed result" do
+        allow(refund).to receive(:valid?).and_return(false)
+
+        result = described_class.new(refund: refund).call(attributes: {})
+
+        expect(result.success?).to be false
+      end
+    end
+
+    context "when attributes are passed in" do
+      it "sets the attributes passed in as refund attributes" do
+        attributes = ActionController::Parameters.new(comment: "abc").permit!
+
+        result = described_class.new(refund: refund).call(attributes: attributes)
+
+        expect(result.object.comment).to eq("abc")
+      end
+    end
+
+    context "when unknown attributes are passed in" do
+      it "raises an error" do
+        attributes = ActionController::Parameters.new(foo: "bar").permit!
+
+        expect { described_class.new(refund: refund).call(attributes: attributes) }
+          .to raise_error(ActiveModel::UnknownAttributeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows users to post and edit a refund against an active report from the activities page. All added refunds are then listed on the Activity's financials page.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/129056456-58d18b6a-c63c-467d-9712-6ab726d2a8a0.png)

![image](https://user-images.githubusercontent.com/109774/129056498-4e597b60-72eb-4965-927a-66efe00f7c05.png)

![image](https://user-images.githubusercontent.com/109774/129056523-0c6657b9-0452-475a-a517-216a43a894c7.png)

![image](https://user-images.githubusercontent.com/109774/129056560-e0ee58d5-a113-4101-8942-9f336de8d061.png)

![image](https://user-images.githubusercontent.com/109774/129056583-47e2d552-25fc-40ff-8260-95ad9f5259d7.png)

