### PR TITLE
(2062) Breadcrumb trail for BEIS users includes the delivery partner organisation activities index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -788,6 +788,7 @@
 ## [unreleased]
 
 - Allow a refund to be posted against an active report
+- Activity breadcrumb trail for BEIS users includes the delivery partner organisation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...HEAD
 [release-67]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-66...release-67

--- a/app/controllers/concerns/breadcrumbed.rb
+++ b/app/controllers/concerns/breadcrumbed.rb
@@ -2,12 +2,34 @@ module Breadcrumbed
   extend ActiveSupport::Concern
 
   def prepare_default_activity_trail(activity)
-    if activity.historic?
-      add_breadcrumb t("page_content.breadcrumbs.historic_index"), historic_organisation_activities_path(activity.organisation)
-    else
-      add_breadcrumb t("page_content.breadcrumbs.current_index"), organisation_activities_path(activity.organisation)
+    return if (activity.fund? || activity.programme?) && !current_user.service_owner?
+
+    if activity.fund?
+      add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
+      return
+    elsif activity.programme?
+      add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
+      add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
+      return
     end
 
+    # index crumb section
+    index_crumb_title = if activity.historic? && current_user.service_owner?
+      t("page_content.breadcrumbs.organisation_historic_index", org_name: activity.organisation.name)
+    elsif activity.historic?
+      t("page_content.breadcrumbs.historic_index")
+    elsif current_user.service_owner?
+      t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name)
+    else
+      t("page_content.breadcrumbs.current_index")
+    end
+    if activity.historic?
+      add_breadcrumb index_crumb_title, historic_organisation_activities_path(activity.organisation)
+    else
+      add_breadcrumb index_crumb_title, organisation_activities_path(activity.organisation)
+    end
+
+    # activity parent tree section
     if activity.third_party_project?
       add_breadcrumb activity.parent.parent.title, organisation_activity_financials_path(activity.parent.parent.organisation, activity.parent.parent)
       add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
@@ -15,6 +37,7 @@ module Breadcrumbed
       add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
     end
 
+    # "leaf" activity section
     add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
   end
 end

--- a/app/controllers/concerns/breadcrumbed.rb
+++ b/app/controllers/concerns/breadcrumbed.rb
@@ -14,19 +14,10 @@ module Breadcrumbed
     end
 
     # index crumb section
-    index_crumb_title = if activity.historic? && current_user.service_owner?
-      t("page_content.breadcrumbs.organisation_historic_index", org_name: activity.organisation.name)
-    elsif activity.historic?
-      t("page_content.breadcrumbs.historic_index")
-    elsif current_user.service_owner?
-      t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name)
-    else
-      t("page_content.breadcrumbs.current_index")
-    end
     if activity.historic?
-      add_breadcrumb index_crumb_title, historic_organisation_activities_path(activity.organisation)
+      add_breadcrumb index_crumb_title(activity), historic_organisation_activities_path(activity.organisation)
     else
-      add_breadcrumb index_crumb_title, organisation_activities_path(activity.organisation)
+      add_breadcrumb index_crumb_title(activity), organisation_activities_path(activity.organisation)
     end
 
     # activity parent tree section
@@ -39,5 +30,17 @@ module Breadcrumbed
 
     # "leaf" activity section
     add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
+  end
+
+  def index_crumb_title(activity)
+    if activity.historic? && current_user.service_owner?
+      t("page_content.breadcrumbs.organisation_historic_index", org_name: activity.organisation.name)
+    elsif activity.historic?
+      t("page_content.breadcrumbs.historic_index")
+    elsif current_user.service_owner?
+      t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name)
+    else
+      t("page_content.breadcrumbs.current_index")
+    end
   end
 end

--- a/app/controllers/staff/activities_controller.rb
+++ b/app/controllers/staff/activities_controller.rb
@@ -17,7 +17,12 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :current
       ).call
-      add_breadcrumb t("page_content.breadcrumbs.current_index"), organisation_activities_path(@organisation)
+
+      if current_user.service_owner?
+        add_breadcrumb t("page_content.breadcrumbs.organisation_current_index", org_name: @organisation.name), organisation_activities_path(@organisation)
+      else
+        add_breadcrumb t("page_content.breadcrumbs.current_index"), organisation_activities_path(@organisation)
+      end
     end
   end
 
@@ -54,7 +59,12 @@ class Staff::ActivitiesController < Staff::BaseController
         organisation: @organisation,
         scope: :historic
       ).call
-      add_breadcrumb t("page_content.breadcrumbs.historic_index"), historic_organisation_activities_path(@organisation)
+
+      if current_user.service_owner?
+        add_breadcrumb t("page_content.breadcrumbs.organisation_historic_index", org_name: @organisation.name), historic_organisation_activities_path(@organisation)
+      else
+        add_breadcrumb t("page_content.breadcrumbs.historic_index"), historic_organisation_activities_path(@organisation)
+      end
     end
   end
 

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -365,6 +365,8 @@ en:
     breadcrumbs:
       current_index: Current activities
       historic_index: Historic activities
+      organisation_current_index: "%{org_name} current activities"
+      organisation_historic_index: "%{org_name} historic activities"
   tabs:
     activity:
       title: Contents

--- a/spec/controllers/concerns/breadcrumbed_spec.rb
+++ b/spec/controllers/concerns/breadcrumbed_spec.rb
@@ -10,46 +10,98 @@ class StubController < Staff::BaseController
 end
 
 RSpec.describe StubController, type: :controller do
+  let(:user) { create(:delivery_partner_user) }
+  let(:beis_user) { create(:beis_user) }
+
   before do
     allow(subject).to receive(:historic_organisation_activities_path).and_return("historic_index_path")
     allow(subject).to receive(:organisation_activities_path).and_return("current_index_path")
     allow(subject).to receive(:organisation_activity_financials_path).and_return("activity_path")
   end
 
-  context "for a historic project activity" do
-    let(:activity) { build(:project_activity, programme_status: "completed") }
+  context "for a delivery partner user" do
+    before do
+      allow(subject).to receive(:current_user).and_return(user)
+    end
 
-    it "adds the historic index path to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.historic_index"), "historic_index_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+    context "for a historic project activity" do
+      let(:activity) { build(:project_activity, programme_status: "completed") }
 
-      subject.prepare_default_activity_trail(activity)
+      it "adds the historic index path to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.historic_index"), "historic_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a current project activity" do
+      let(:activity) { build(:project_activity) }
+
+      it "adds the current index path to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a third-party project" do
+      let(:activity) { build(:third_party_project_activity) }
+
+      it "adds the parent project and programme activities to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
     end
   end
 
-  context "for a current project activity" do
-    let(:activity) { build(:project_activity) }
-
-    it "adds the current index path to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
-
-      subject.prepare_default_activity_trail(activity)
+  context "for a BEIS user" do
+    before do
+      allow(subject).to receive(:current_user).and_return(beis_user)
     end
-  end
 
-  context "for a third-party project" do
-    let(:activity) { build(:third_party_project_activity) }
+    context "for a historic project activity" do
+      let(:activity) { build(:project_activity, programme_status: "completed") }
 
-    it "adds the parent project and programme activities to the breadcrumb stack" do
-      expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
-      expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+      it "adds the historic index path to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.organisation_historic_index", org_name: activity.organisation.name), "historic_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
 
-      subject.prepare_default_activity_trail(activity)
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a current project activity" do
+      let(:activity) { build(:project_activity) }
+
+      it "adds the current index path to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name), "current_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a third-party project" do
+      let(:activity) { build(:third_party_project_activity) }
+
+      it "adds the parent project and programme activities to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name), "current_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_view_fund_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_fund_level_activities_spec.rb
@@ -9,7 +9,9 @@ RSpec.feature "Users can view fund level activities" do
 
       visit organisation_activity_path(programme.extending_organisation, programme)
       click_on "Details"
-      click_on fund_activity.title
+      within(".activity-details") do
+        click_on fund_activity.title
+      end
 
       page_displays_an_activity(activity_presenter: ActivityPresenter.new(fund_activity))
     end


### PR DESCRIPTION
## Changes in this PR
- The default breadcrumb trail for BEIS users includes the DP organisation to whom the activity belongs

## Screenshots of UI changes

### After
![Screenshot 2021-08-11 at 17 52 06](https://user-images.githubusercontent.com/579522/129187528-87ebde7b-2928-4109-853c-a88c37a90b2d.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
