### PR TITLE
2037-critical-certain-aria-roles-must-be-contained-by-particular-parents

### DIFF
--- a/app/views/staff/reports/_tab.html.haml
+++ b/app/views/staff/reports/_tab.html.haml
@@ -1,4 +1,4 @@
-%li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == name }"}
+%li{class: "govuk-tabs__list-item #{ "govuk-tabs__list-item--selected" if active_tab == name }", role: "presentation"}
   = link_to t("tabs.report.#{name}"),
     path,
-    { class: "govuk-tabs__tab", aria: { current: (active_tab == name ? "page" : nil) } }
+    { class: "govuk-tabs__tab", role: "tab", aria: { current: (active_tab == name ? "page" : nil) } }

--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -1,4 +1,4 @@
-%ul.govuk-tabs__list{ aria: { label: "Report subnavigation" } }
+%ul.govuk-tabs__list{role: "tablist", aria: { label: "Report subnavigation" } }
   = render partial: "staff/reports/tab", locals: { name: "summary", path: report_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "activities", path: report_activities_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "forecasts", path: report_forecasts_path(@report), active_tab: active_tab }

--- a/app/views/staff/shared/activities/_tab_nav.html.haml
+++ b/app/views/staff/shared/activities/_tab_nav.html.haml
@@ -1,7 +1,7 @@
 %h2.govuk-tabs__title
   = t("tabs.activity.title")
 
-%ul.govuk-tabs__list
+%ul.govuk-tabs__list{role: "tablist"}
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "financials", path: organisation_activity_financials_path(@activity.organisation, @activity) }
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "other_funding", path: organisation_activity_other_funding_path(@activity.organisation, @activity) }
   = render partial: "staff/shared/activities/tab_nav_item", locals: { tab: "details", path: organisation_activity_details_path(@activity.organisation, @activity) }

--- a/app/views/staff/shared/activities/_tab_nav_item.html.haml
+++ b/app/views/staff/shared/activities/_tab_nav_item.html.haml
@@ -1,4 +1,4 @@
 - selected = controller_name.ends_with?(tab)
-%li{class: ["govuk-tabs__list-item", ("govuk-tabs__list-item--selected" if selected)] }
+%li{role: "presentation", class: ["govuk-tabs__list-item", ("govuk-tabs__list-item--selected" if selected)] }
   = link_to t(tab, scope: "tabs.activity"), path,
     { class: "govuk-tabs__tab", role: "tab", aria: { controls: tab, selected: selected } }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -5,13 +5,13 @@
         %h2.govuk-tabs__title
           Activities
 
-        %ul.govuk-tabs__list
-          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+        %ul.govuk-tabs__list{role: "tablist"}
+          %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
             = link_to t("tabs.activities.current"),
               organisation_activities_path(@organisation),
               { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: true } }
 
-          %li.govuk-tabs__list-item
+          %li.govuk-tabs__list-item{role: "presentation"}
             = link_to t("tabs.activities.historic"),
               historic_organisation_activities_path(@organisation),
               { class: "govuk-tabs__tab", role: "tab", aria: { controls: "historic", selected: false } }

--- a/app/views/staff/shared/reports/_tabs.html.haml
+++ b/app/views/staff/shared/reports/_tabs.html.haml
@@ -1,9 +1,9 @@
 %h2.govuk-tabs__title
   = t("page_title.report.index")
-%ul.govuk-tabs__list
-  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
-    %a.govuk-tabs__tab{ "href": "#current"}
+%ul.govuk-tabs__list{role: "tablist"}
+  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
+    %a.govuk-tabs__tab{href: "#current", role: "tab"}
       = t("tabs.report.current")
-  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
-    %a.govuk-tabs__tab{ "href": "#historic"}
+  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
+    %a.govuk-tabs__tab{href: "#historic", role: "tab"}
       = t("tabs.report.historic")


### PR DESCRIPTION
## Changes in this PR
For Activities and Reports pages ensure the structural syntax of the tablist matches the example set out in the GOV.UK Design System, when applied to a list.
- The list should include role="tablist", 
- The list item should include role="presentation" 
- The anchor link role="tab".

## Trello card
https://trello.com/c/h4CVmQNA/2037-critical-certain-aria-roles-must-be-contained-by-particular-parents