### PR TITLE
(2089) Breadcrumbs should be truncated if over a certain length number of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -789,6 +789,7 @@
 
 - Allow a refund to be posted against an active report
 - Activity breadcrumb trail for BEIS users includes the delivery partner organisation
+- Truncate breadcrumbs that are over a certain length
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...HEAD
 [release-67]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-66...release-67

--- a/app/assets/stylesheets/partials/_breadcrumbs.css.scss
+++ b/app/assets/stylesheets/partials/_breadcrumbs.css.scss
@@ -1,5 +1,10 @@
 .govuk-breadcrumbs .govuk-breadcrumbs__list li {
   @extend .govuk-breadcrumbs__list-item;
+  display: inline-block;
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .govuk-breadcrumbs .govuk-breadcrumbs__list li a {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,4 +28,8 @@ class ApplicationController < ActionController::Base
     super
     payload[:remote_ip] = request_ip
   end
+
+  def add_breadcrumb(name, path, options = {})
+    super name, path, options.merge(title: name)
+  end
 end


### PR DESCRIPTION
This truncates breadcrumbs with an elipsis (`...`) if they are over a certain width, and adds a title to all the links, so hovering over a link shows the full name of the item.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/129343479-79027d86-a0e8-45f8-956e-1351337f06b0.png)

## After

![image](https://user-images.githubusercontent.com/109774/129343596-dee22a06-f3d7-42ac-94c1-87c4026b7931.png)


