### PR TITLE
(2038) *Critical* ARIA attributes must conform to valid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -790,6 +790,7 @@
 - Allow a refund to be posted against an active report
 - Activity breadcrumb trail for BEIS users includes the delivery partner organisation
 - Truncate breadcrumbs that are over a certain length
+- Fix `aria-controls` element in the tree view
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...HEAD
 [release-67]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-66...release-67

--- a/app/javascript/src/table-tree-view.js
+++ b/app/javascript/src/table-tree-view.js
@@ -77,7 +77,14 @@ TableTreeView.prototype.initHeaderAttributes = function ($parent, index) {
     var $button = document.createElement('button')
     $button.setAttribute('type', 'button')
     $button.setAttribute('id', parentId + '-heading-' + (index + 1))
-    $button.setAttribute('aria-controls', parentId + '-content-' + (index + 1))
+
+    var children = this.$module.querySelectorAll('[data-child-of="'+$parent.getAttribute('id')+'"]');
+    var childIds = []
+    for (var i = 0; i < children.length; i++) {
+        childIds.push(children[i].id)
+    }
+
+    $button.setAttribute('aria-controls', childIds.join(" "))
 
     // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
     for (var i = 0; i < $span.attributes.length; i++) {


### PR DESCRIPTION
Previously, the `aria-controls` attribute of the button was set to a value that didn't exist on the page. The purpose of `aria-controls` is to show assistive technology what element(s) are controlled by a given element (https://www.w3.org/TR/wai-aria-1.1/#aria-controls).

In our case, this is the child activities that are shown when clicking on the "expand" button. With this in mind, I'm grabbing all the child activity elements, and adding a space seperated list of the child IDs (`aria-controls` accepts a list of IDs, as well as a single ID). This tells assistive technology that clicking this button will show/hide those elements.