### PR TITLE
(2061) Fix programme breadcrumb for DP users

### DIFF
--- a/app/controllers/concerns/breadcrumbed.rb
+++ b/app/controllers/concerns/breadcrumbed.rb
@@ -2,12 +2,12 @@ module Breadcrumbed
   extend ActiveSupport::Concern
 
   def prepare_default_activity_trail(activity)
-    return if (activity.fund? || activity.programme?) && !current_user.service_owner?
+    return if activity.fund? && !current_user.service_owner?
 
     if activity.fund?
       add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
       return
-    elsif activity.programme?
+    elsif activity.programme? && current_user.service_owner?
       add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent)
       add_breadcrumb activity.title, organisation_activity_financials_path(activity.organisation, activity)
       return

--- a/spec/controllers/concerns/breadcrumbed_spec.rb
+++ b/spec/controllers/concerns/breadcrumbed_spec.rb
@@ -60,6 +60,27 @@ RSpec.describe StubController, type: :controller do
         subject.prepare_default_activity_trail(activity)
       end
     end
+
+    context "for a programme" do
+      let(:activity) { build(:programme_activity) }
+
+      it "adds the current index path to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.current_index"), "current_index_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a fund" do
+      let(:activity) { build(:fund_activity) }
+
+      it "does not add anything to the breadcrumb stack" do
+        expect(subject).to_not receive(:add_breadcrumb)
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
   end
 
   context "for a BEIS user" do
@@ -98,6 +119,27 @@ RSpec.describe StubController, type: :controller do
         expect(subject).to receive(:add_breadcrumb).with(t("page_content.breadcrumbs.organisation_current_index", org_name: activity.organisation.name), "current_index_path")
         expect(subject).to receive(:add_breadcrumb).with(activity.parent.parent.title, "activity_path")
         expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a programme" do
+      let(:activity) { build(:programme_activity) }
+
+      it "adds the fund and programme paths to the breadcrumb stack" do
+        expect(subject).to receive(:add_breadcrumb).with(activity.parent.title, "activity_path")
+        expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
+
+        subject.prepare_default_activity_trail(activity)
+      end
+    end
+
+    context "for a fund" do
+      let(:activity) { build(:fund_activity) }
+
+      it "adds the fund path to the breadcrumb stack" do
         expect(subject).to receive(:add_breadcrumb).with(activity.title, "activity_path")
 
         subject.prepare_default_activity_trail(activity)


### PR DESCRIPTION
## Changes in this PR
- Fix programme breadcrumb for DP users

## Screenshots of UI changes

### After

#### BEIS user

Looking at a fund:
![Screenshot 2021-08-13 at 15 25 23](https://user-images.githubusercontent.com/579522/129372457-3581ab73-5109-4c39-84ba-f62acf77b9c1.png)

Looking at a programme:
![Screenshot 2021-08-13 at 15 25 33](https://user-images.githubusercontent.com/579522/129372571-0691c7c0-218c-4e07-8fb6-431d6d919f81.png)

Looking at a third-party project:
![Screenshot 2021-08-13 at 15 25 56](https://user-images.githubusercontent.com/579522/129372614-73aeac3b-50a2-4e70-ab3e-c2d3fa5fa817.png)

#### Delivery partner user

Looking at a programme:
![Screenshot 2021-08-13 at 15 26 58](https://user-images.githubusercontent.com/579522/129372690-bfcdcc12-0e61-4555-874a-58a3b32d0036.png)

Looking at a third-party project:
![Screenshot 2021-08-13 at 15 27 13](https://user-images.githubusercontent.com/579522/129372709-4f868741-67d1-466a-90a5-0870304a8532.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
