### PR TITLE
origin/2026-minor-id-attribute-value-must-be-unique

### DIFF
--- a/app/views/staff/activity_forms/aid_type.html.haml
+++ b/app/views/staff/activity_forms/aid_type.html.haml
@@ -1,3 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :aid_type
   = f.govuk_collection_radio_buttons :aid_type, aid_type_radio_options, :code, :name, :description, legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.aid_type") }, hint: { text: t("form.hint.activity.aid_type").html_safe }


### PR DESCRIPTION
A hidden input exists with a duplicate ID `activity_aid_type`. The ID attribute uniquely identifies elements on a page. It doesn't make sense to duplicate an ID. This may make it more difficult for screen reader users to navigate the page and associate form labels with their relevant input field, even when hidden.

- Remove hidden field

Trello
https://trello.com/c/T6Ek40Uw/2026-minor-id-attribute-value-must-be-unique