### PR TITLE
(2063) Show search breadcrumb scheme when appropriate

### DIFF
--- a/app/controllers/concerns/activities/breadcrumbed.rb
+++ b/app/controllers/concerns/activities/breadcrumbed.rb
@@ -2,6 +2,7 @@ module Activities
   module Breadcrumbed
     extend ActiveSupport::Concern
     include Reports::Breadcrumbed
+    include Searches::Breadcrumbed
 
     def prepare_default_activity_trail(activity)
       return if activity.fund? && !current_user.service_owner?
@@ -9,6 +10,9 @@ module Activities
       if breadcrumb_context.type == :report
         # If we've come here from a report - show the report breadcrumb
         prepare_default_report_trail(breadcrumb_context.model)
+      elsif breadcrumb_context.type == :search
+        # If we've come from a search query - show the search breadcrumb
+        prepare_default_search_trail(breadcrumb_context.model)
       elsif current_user.service_owner? && (activity.fund? || activity.programme?)
         # Show fund/programme breadcrumbs (these don't belong to an organisation)
         add_breadcrumb activity.parent.title, organisation_activity_financials_path(activity.parent.organisation, activity.parent) if activity.parent

--- a/app/controllers/concerns/searches/breadcrumbed.rb
+++ b/app/controllers/concerns/searches/breadcrumbed.rb
@@ -1,0 +1,9 @@
+module Searches
+  module Breadcrumbed
+    extend ActiveSupport::Concern
+
+    def prepare_default_search_trail(search)
+      add_breadcrumb t("page_content.activity_search.heading", query: search.query), search_path(query: search.query)
+    end
+  end
+end

--- a/app/controllers/concerns/searches/breadcrumbed.rb
+++ b/app/controllers/concerns/searches/breadcrumbed.rb
@@ -3,6 +3,7 @@ module Searches
     extend ActiveSupport::Concern
 
     def prepare_default_search_trail(search)
+      BreadcrumbContext.new(session).set(type: :search, model: search)
       add_breadcrumb t("page_content.activity_search.heading", query: search.query), search_path(query: search.query)
     end
   end

--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -1,8 +1,11 @@
 class Staff::SearchesController < Staff::BaseController
   include Secured
+  include Searches::Breadcrumbed
 
   def show
     skip_authorization
+
     @activity_search = ActivitySearch.new(user: current_user, query: params[:query])
+    prepare_default_search_trail(@activity_search)
   end
 end

--- a/spec/features/staff/users_can_search_for_activities_spec.rb
+++ b/spec/features/staff/users_can_search_for_activities_spec.rb
@@ -4,11 +4,20 @@ RSpec.describe "Users can search for activities" do
 
   let!(:project) { create(:programme_activity, roda_identifier: "roda-id", title: "Project A") }
 
-  scenario "searching by RODA identifier" do
+  before do
     visit "/"
     fill_in :query, with: "roda-id"
     click_button t("form.activity_search.submit")
+  end
 
+  scenario "searching by RODA identifier" do
     expect(page).to have_link project.title, href: organisation_activity_path(project.organisation, project)
+
+    within ".govuk-breadcrumbs" do
+      expect(page).to have_content("Home")
+      expect(page).to have_content("Search results for “roda-id”")
+    end
+  end
+
   end
 end

--- a/spec/features/staff/users_can_search_for_activities_spec.rb
+++ b/spec/features/staff/users_can_search_for_activities_spec.rb
@@ -19,5 +19,13 @@ RSpec.describe "Users can search for activities" do
     end
   end
 
+  scenario "user sees breadcrumb context when accessing an activity from search results" do
+    click_on project.title
+
+    within ".govuk-breadcrumbs" do
+      expect(page).to have_content("Home")
+      expect(page).to have_content("Search results for “roda-id”")
+      expect(page).to have_content(project.title)
+    end
   end
 end


### PR DESCRIPTION
This builds on #1293 to add a search results breadcrumb and use the existing work we have done with the breadcrumb context to have a new context that shows a link back to the search results in breadcrumbs.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/129750380-d8201471-d641-4d61-8606-f4b1a9288e72.png)

![image](https://user-images.githubusercontent.com/109774/129750414-aef1cec5-38e1-4f88-a905-76701be5ccf3.png)
