### PR TITLE
(2088) Show error message if search query is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,6 +795,8 @@
 
 ## [unreleased]
 
+- Show an error message if the search query is empty
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-68...HEAD
 [release-68]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...release-68
 [release-67]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-66...release-67

--- a/app/views/staff/searches/show.html.haml
+++ b/app/views/staff/searches/show.html.haml
@@ -6,7 +6,10 @@
       %h1.govuk-heading-xl
         = t("page_content.activity_search.heading", query: @activity_search.query)
 
-      - if @activity_search.results.any?
+      - if @activity_search.query.blank?
+        %p.govuk-body.govuk-error-summary.govuk-error-summary--alert
+          = t("page_content.activity_search.empty_query")
+      - elsif @activity_search.results.any?
         %table.govuk-table
           %thead.govuk-table__head
             %tr.govuk-table__row

--- a/config/locales/views/activity_search.en.yml
+++ b/config/locales/views/activity_search.en.yml
@@ -11,6 +11,7 @@ en:
         roda_identifier: RODA Identifier
         delivery_partner_identifier: Delivery Partner Identifier
       no_results: No results.
+      empty_query: The search query must contain at least 1 character!
   form:
     activity_search:
       query: Enter your search query

--- a/spec/features/staff/users_can_search_for_activities_spec.rb
+++ b/spec/features/staff/users_can_search_for_activities_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe "Users can search for activities" do
     end
   end
 
+  scenario "searching for an empty string shows an error message" do
+    fill_in :query, with: ""
+    click_button t("form.activity_search.submit")
+
+    expect(page).to have_content(t("page_content.activity_search.empty_query"))
+  end
+
   scenario "user sees breadcrumb context when accessing an activity from search results" do
     click_on project.title
 


### PR DESCRIPTION
## Changes in this PR
- Show an error message if the search query is empty

## Screenshots of UI changes

### Before

### After
<img width="1147" alt="Screenshot 2021-08-18 at 17 38 18" src="https://user-images.githubusercontent.com/579522/129944451-6dadfb5f-fe88-4fe6-80bd-789cf44984f4.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
