### PR TITLE
Remove Bullet deprecation warning

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,18 +76,18 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true # raise an error if n+1 query occurs
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "User", association: :organisation
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :organisation
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :child_activities
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :parent
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :extending_organisation
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :implementing_organisations
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Activity", association: :budgets
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Report", association: :fund
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Budget", association: :providing_organisation
-    Bullet.add_whitelist type: :unused_eager_loading, class_name: "HistoricalEvent", association: :report
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :organisation
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :organisation
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :child_activities
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Transaction", association: :provider
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Transaction", association: :receiver
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :parent
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :extending_organisation
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :implementing_organisations
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :budgets
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Report", association: :fund
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Budget", association: :providing_organisation
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "HistoricalEvent", association: :report
   end
 
   config.hosts = [


### PR DESCRIPTION
`add_whitelist` has been replaced with `add_safelist`, so this removes the deprecation warning when running the tests.