### PR TITLE
(2101) Delivery partner users see status module on reports current tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -796,6 +796,7 @@
 ## [unreleased]
 
 - Show an error message if the search query is empty
+- Show delivery partner users more information about the current reports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-68...HEAD
 [release-68]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-67...release-68

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -7,7 +7,7 @@ class ReportPolicy < ApplicationPolicy
 
   def show?
     return true if beis_user?
-    return true if record.organisation == user.organisation && record.state != "inactive"
+    return true if record.organisation == user.organisation && record.state.downcase != "inactive"
     false
   end
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -6,6 +6,11 @@ class ReportPresenter < SimpleDelegator
     I18n.t("label.report.state.#{super.downcase}")
   end
 
+  def can_edit_message
+    return if state.blank?
+    I18n.t("label.report.can_edit.#{to_model.state.downcase}")
+  end
+
   def deadline
     return if super.blank?
     I18n.l(super)

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -20,7 +20,7 @@ class Report
 
     private def fetch(relation)
       relation
-        .includes([:fund])
+        .includes([:organisation, :fund])
         .order("financial_year, financial_quarter DESC")
         .map { |report| ReportPresenter.new(report) }
     end

--- a/app/views/staff/shared/reports/_table_header.html.haml
+++ b/app/views/staff/shared/reports/_table_header.html.haml
@@ -7,15 +7,18 @@
         = t("table.header.report.organisation")
     %th{class: "govuk-table__header govuk-!-width-one-quarter"}
       =t("table.header.report.financial_quarter")
-    %th.govuk-table__header
-      =t("table.header.report.description")
-    %th.govuk-table__header
-      =t("table.header.report.fund")
     - if type == "current"
       %th.govuk-table__header
-        =t("table.header.report.state")
-      %th.govuk-table__header
         =t("table.header.report.deadline")
+      %th.govuk-table__header
+        =t("table.header.report.state")
+    %th.govuk-table__header
+      =t("table.header.report.fund")
+    %th.govuk-table__header
+      =t("table.header.report.description")
+    - if type == "current" && current_user.delivery_partner?
+      %th.govuk-table__header
+        =t("table.header.report.can_edit")
     %th.govuk-table__header
       %span.govuk-visually-hidden
         = t("table.header.default.actions")

--- a/app/views/staff/shared/reports/_table_row.html.haml
+++ b/app/views/staff/shared/reports/_table_row.html.haml
@@ -10,4 +10,5 @@
   %td.govuk-table__cell
     - if policy(:report).edit?
       = a11y_action_link(t("default.link.edit"), edit_report_path(report), report.description)
-    = a11y_action_link(t("default.link.view"), report_path(report), report.description)
+    - if policy(report).show?
+      = a11y_action_link(t("default.link.view"), report_path(report), report.description)

--- a/app/views/staff/shared/reports/_table_row.html.haml
+++ b/app/views/staff/shared/reports/_table_row.html.haml
@@ -2,11 +2,13 @@
   - if defined?(index) && index == 0
     %th.govuk-table__cell{rowspan: reports.count, scope: "rowgroup", id: report.organisation.id}= report.organisation.name
   %td.govuk-table__cell= report.financial_quarter_and_year
-  %td.govuk-table__cell= report.description
-  %td.govuk-table__cell= report.fund.title
   - if type == "current"
-    %td.govuk-table__cell= report.state
     %td.govuk-table__cell= report.deadline
+    %td.govuk-table__cell= report.state
+  %td.govuk-table__cell= report.fund.source_fund.short_name
+  %td.govuk-table__cell= report.description
+  - if type == "current" && current_user.delivery_partner?
+    %td.govuk-table__cell= report.can_edit_message
   %td.govuk-table__cell
     - if policy(:report).edit?
       = a11y_action_link(t("default.link.edit"), edit_report_path(report), report.description)

--- a/app/views/staff/shared/reports/_tabs.html.haml
+++ b/app/views/staff/shared/reports/_tabs.html.haml
@@ -1,9 +1,9 @@
 %h2.govuk-tabs__title
   = t("page_title.report.index")
 %ul.govuk-tabs__list{role: "tablist"}
-  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
+  %li.govuk-tabs__list-item{role: "presentation"}
     %a.govuk-tabs__tab{href: "#current", role: "tab"}
       = t("tabs.report.current")
-  %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
+  %li.govuk-tabs__list-item{role: "presentation"}
     %a.govuk-tabs__tab{href: "#historic", role: "tab"}
       = t("tabs.report.historic")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -19,7 +19,8 @@ en:
         organisation: Organisation
         fund: Fund (level A)
         deadline: Deadline
-        state: State
+        state: Status
+        can_edit: Can edit?
     body:
       report:
         action:
@@ -91,7 +92,13 @@ en:
         in_review: In review
         inactive: Inactive
         submitted: Submitted
-
+      can_edit:
+        active: Yes, data can be added/edited
+        awaiting_changes: Yes, data can be revised
+        in_review: No, report is in review with BEIS
+        submitted: No, report has been submitted to BEIS
+        inactive: No, the report needs to be activated by BEIS
+        approved: N/A
   form:
     label:
       report:

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Users can approve reports" do
 
         within "##{new_report.id}" do
           expect(page).to have_content new_report.organisation.name
-          expect(page).to have_content new_report.fund.title
+          expect(page).to have_content new_report.fund.source_fund.short_name
           expect(page).to have_content "Q2 2019-2020"
         end
       end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -11,6 +11,30 @@ RSpec.describe ReportPresenter do
     end
   end
 
+  describe "#can_edit_message" do
+    it "returns the right message corresponding to the report state" do
+      report = build(:report, state: "active")
+      result = described_class.new(report).can_edit_message
+      expect(result).to eql(t("label.report.can_edit.active"))
+
+      report.state = "awaiting_changes"
+      result = described_class.new(report).can_edit_message
+      expect(result).to eql(t("label.report.can_edit.awaiting_changes"))
+
+      report.state = "in_review"
+      result = described_class.new(report).can_edit_message
+      expect(result).to eql(t("label.report.can_edit.in_review"))
+
+      report.state = "submitted"
+      result = described_class.new(report).can_edit_message
+      expect(result).to eql(t("label.report.can_edit.submitted"))
+
+      report.state = "inactive"
+      result = described_class.new(report).can_edit_message
+      expect(result).to eql(t("label.report.can_edit.inactive"))
+    end
+  end
+
   describe "#deadline" do
     it "returns the formatted date for the deadline" do
       report = build(:report, deadline: Date.today)

--- a/spec/services/report/organisation_reports_fetcher_spec.rb
+++ b/spec/services/report/organisation_reports_fetcher_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(Report).to receive(:where).with(organisation: organisation).and_return(approved_relation_double)
       expect(approved_relation_double).to receive(:approved).and_return(approved_relation_double)
 
-      expect(approved_relation_double).to receive(:includes).with([:fund]).and_return(approved_relation_double)
+      expect(approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(approved_relation_double)
       expect(approved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(approved_reports)
 
       expect(subject).to eq(approved_reports)
@@ -34,7 +34,7 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(Report).to receive(:where).with(organisation: organisation).and_return(unapproved_relation_double)
       expect(unapproved_relation_double).to receive(:not_approved).and_return(unapproved_relation_double)
 
-      expect(unapproved_relation_double).to receive(:includes).with([:fund]).and_return(unapproved_relation_double)
+      expect(unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(unapproved_relation_double)
       expect(unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(unapproved_reports)
 
       expect(subject).to eq(unapproved_reports)


### PR DESCRIPTION
## Changes in this PR
- Reordered the columns as indicated in the mockup
- Added a "Can edit?" column to make it clearer to the DP why they can or cannot modify the data in the report

## Screenshots of UI changes

### Before

### After
<img width="1130" alt="Screenshot 2021-08-19 at 15 31 29" src="https://user-images.githubusercontent.com/579522/130096227-7553d3c6-9d67-49d0-b10b-25b682f059fb.png">
<img width="1143" alt="Screenshot 2021-08-19 at 15 32 52" src="https://user-images.githubusercontent.com/579522/130096230-deda2a64-e072-4bb4-a95f-2afca8a7678f.png">
<img width="1125" alt="Screenshot 2021-08-19 at 15 34 30" src="https://user-images.githubusercontent.com/579522/130096231-ce036796-4ada-482a-9b52-2cffbb444d7f.png">
<img width="1142" alt="Screenshot 2021-08-19 at 15 34 54" src="https://user-images.githubusercontent.com/579522/130096233-fe20aed8-0a98-49fb-9818-3de4461f612a.png">
<img width="1141" alt="Screenshot 2021-08-19 at 15 35 17" src="https://user-images.githubusercontent.com/579522/130096235-d21de826-72b4-4d60-9e9f-1ff8e235edfa.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
