### PR TITLE
Fix duplicate shared example warning

### DIFF
--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can create a refund" do
   let(:organisation) { create(:delivery_partner_organisation) }
 
-  RSpec.shared_examples "refunds" do
+  RSpec.shared_examples "create refunds" do
     before { authenticate!(user: user) }
 
     scenario "they can create a refund for an activity" do
@@ -31,14 +31,14 @@ RSpec.feature "Users can create a refund" do
   end
 
   context "when logged in as a BEIS user" do
-    include_examples "refunds" do
+    include_examples "create refunds" do
       let(:user) { create(:beis_user) }
       let(:activity) { create(:programme_activity, :with_report) }
     end
   end
 
   context "when logged in as a delivery partner" do
-    include_examples "refunds" do
+    include_examples "create refunds" do
       let(:user) { create(:delivery_partner_user, organisation: organisation) }
       let(:activity) { create(:project_activity, :with_report, organisation: organisation) }
     end

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Users can edit a refund" do
   let(:organisation) { create(:delivery_partner_organisation) }
 
-  RSpec.shared_examples "refunds" do
+  RSpec.shared_examples "edit refunds" do
     let!(:refund) { create(:refund, parent_activity: activity, report: report) }
 
     before do
@@ -43,7 +43,7 @@ RSpec.feature "Users can edit a refund" do
   end
 
   context "when logged in as a BEIS user" do
-    include_examples "refunds" do
+    include_examples "edit refunds" do
       let(:user) { create(:beis_user) }
       let(:activity) { create(:programme_activity) }
       let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
@@ -51,7 +51,7 @@ RSpec.feature "Users can edit a refund" do
   end
 
   context "when logged in as a delivery partner" do
-    include_examples "refunds" do
+    include_examples "edit refunds" do
       let(:user) { create(:delivery_partner_user, organisation: organisation) }
       let(:activity) { create(:project_activity, organisation: organisation) }
       let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }


### PR DESCRIPTION
After adding refunds, we got the error:

```
Shared example group 'refunds' has been previously defined at:
  /Users/stuartharrison/Documents/beis-report-official-development-assistance/spec/features/staff/users_can_create_a_refund_spec.rb:4
...and you are now defining it at:
  /Users/stuartharrison/Documents/beis-report-official-development-assistance/spec/features/staff/users_can_edit_a_refund_spec.rb:4
The new definition will overwrite the original one.
```

To get round this, I've given the two shared examples different (and more descriptive) names