### PR TITLE
Fix automatic rebase

### DIFF
--- a/.github/workflows/trigger_rebase.yml
+++ b/.github/workflows/trigger_rebase.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.ref }}
       - name: Automatic Rebase
-        uses: dxw/rebase@master
+        uses: cirrus-actions/rebase@1.5
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
           PR_NUMBER: ${{ matrix.pr_number }}

--- a/.github/workflows/trigger_rebase.yml
+++ b/.github/workflows/trigger_rebase.yml
@@ -7,7 +7,7 @@ on:
 env:
   AUTO_REBASE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
 jobs:
-  fetch_all_prs_awaiting_automerge:
+  fetch_oldest_pr_awaiting_automerge:
     runs-on: ubuntu-latest
     outputs:
       pr_numbers: ${{ steps.get-all-awaiting-pr-numbers.outputs.pr_numbers }}
@@ -15,21 +15,20 @@ jobs:
       - name: Get all awaiting PR numbers
         id: get-all-awaiting-pr-numbers
         run: |
-          PR_NUMBERS=$(curl https://api.github.com/repos/UKGovernmentBEIS/beis-report-official-development-assistance/pulls\?state\=open | jq -c '.[] | select(.auto_merge!=null) | .number | [.]')
-          echo "::set-output name=pr_numbers::$PR_NUMBERS"
+          PR_NUMBER=$(curl https://api.github.com/repos/UKGovernmentBEIS/beis-report-official-development-assistance/pulls\?state\=open | jq -c '.[] | select(.auto_merge!=null) | .number | [.] | first')
+          echo "::set-output name=pr_number::$PR_NUMBER"
   trigger_rebase_action:
-    if: ${{ needs.fetch_all_prs_awaiting_automerge.outputs.pr_numbers != '' }}
-    strategy:
-      matrix:
-        pr_number: ${{ fromJson(needs.fetch_all_prs_awaiting_automerge.outputs.pr_numbers) }}
-    needs: fetch_all_prs_awaiting_automerge
+    if: ${{ needs.fetch_oldest_pr_awaiting_automerge.outputs.pr_number != '' }}
+    env:
+      PR_NUMBER: ${{ needs.fetch_oldest_pr_awaiting_automerge.outputs.pr_number }}
+    needs: fetch_oldest_pr_awaiting_automerge
     runs-on: ubuntu-latest
     steps:
-      - name: Get the latest ref for ${{ matrix.pr_number }}
+      - name: Get the latest ref for ${{ env.PR_NUMBER }}
         run: |
-          PR_DATA=$(curl https://api.github.com/repos/UKGovernmentBEIS/beis-report-official-development-assistance/pulls/${{ matrix.pr_number }})
+          PR_DATA=$(curl https://api.github.com/repos/UKGovernmentBEIS/beis-report-official-development-assistance/pulls/$PR_NUMBER)
           printf 'ref=%q\n' "$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_ENV"
-      - name: Checkout the latest code for ${{ matrix.pr_number }}
+      - name: Checkout the latest code for ${{ env.PR_NUMBER }}
         uses: actions/checkout@v2
         with:
           token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
@@ -39,4 +38,3 @@ jobs:
         uses: cirrus-actions/rebase@1.5
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
-          PR_NUMBER: ${{ matrix.pr_number }}


### PR DESCRIPTION
We have an action that _should_ automatically rebase any PRs that are set to automerge against the develop branch. However, this has not been working, because of a [bug in the rebase action](https://github.com/cirrus-actions/rebase/issues/58) we use (example run here https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/runs/3398039357?check_suite_focus=true)

I've also tweaked the action to only trigger against the oldest PR set to automerge rather than needlessly rebasing all the PRs set to automerge (which will then go out of date). Once that one is merged, it will trigger a rebase on the second oldest one and cascade down, saving us time and resources.

