### PR TITLE
Data migration sets nil policy markers to default

### DIFF
--- a/db/data/20210823135218_set_nil_policy_markers_to_default.rb
+++ b/db/data/20210823135218_set_nil_policy_markers_to_default.rb
@@ -1,0 +1,15 @@
+# Run me with `rails runner db/data/20210823135218_set_nil_policy_markers_to_default.rb`
+
+[
+  "gender",
+  "climate_change_adaptation",
+  "climate_change_mitigation",
+  "biodiversity",
+  "desertification",
+  "disability",
+  "disaster_risk_reduction",
+  "nutrition",
+].each do |policy_marker_category|
+  key = "policy_marker_#{policy_marker_category}"
+  Activity.where("#{key}": nil).update_all("#{key}": "not_assessed")
+end


### PR DESCRIPTION
This adds a data migration that sets any policy markers set to `nil` to the default state, which should be `not_assessed`. This will fix the issue where we see blank policy markers in the XML.