### PR TITLE
Speed up activity presenter spec

### DIFF
--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ActivityPresenter do
     let(:field) { field }
     let(:args) { args.reverse_merge(source: "iati") }
     let(:field_type) { field_type }
+    let(:activity) { build(:project_activity) }
 
     def cast_code_to_field(code)
       return code if field_type.nil?
@@ -16,7 +17,6 @@ RSpec.describe ActivityPresenter do
 
     it "has translations for all of the codes" do
       Codelist.new(**args).each do |code|
-        activity = build(:project_activity)
         code = cast_code_to_field(code["code"])
         activity.write_attribute(field, code)
 


### PR DESCRIPTION
Rather than building one activity for every code in the code list, we build one activity and update it for each item in the code list. This speeds up these tests considerably, going from ~12 seconds to ~0.5 seconds