### PR TITLE
(2102) Current reports are listed on DP homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,6 +803,7 @@
 
 - The Activities upload template no longer includes the "BEIS ID" column
 - Replace the use of "historic" with "approved" in the context of reports
+- List the current reports on the delivery partners' homepage
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-69...HEAD
 [release-69]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-68...release-69

--- a/app/controllers/staff/home_controller.rb
+++ b/app/controllers/staff/home_controller.rb
@@ -12,6 +12,7 @@ class Staff::HomeController < Staff::BaseController
         organisation: current_user.organisation,
         scope: :current
       ).call
+      @reports = Report::OrganisationReportsFetcher.new(organisation: current_user.organisation).current
       render :delivery_partner
     end
   end

--- a/app/views/staff/home/delivery_partner.html.haml
+++ b/app/views/staff/home/delivery_partner.html.haml
@@ -1,7 +1,18 @@
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-full
-      %h1.govuk-heading-l
+      %h2.govuk-heading-l
+        = t("page_content.reports.title")
+
+      - unless @reports.blank?
+        = render partial: "staff/shared/reports/table", locals: { reports: @reports, type: "current" }
+
+      .govuk-body
+        = link_to t("page_content.reports.approved_reports_link"), organisation_reports_path(organisation_id: current_user.organisation_id, anchor: "approved"), class: "govuk-link"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h2.govuk-heading-l
         Activities
 
       = render partial: "staff/searches/form"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -44,6 +44,7 @@ en:
   page_content:
     reports:
       title: Reports
+      approved_reports_link: View approved reports
     tab_content:
       forecasts:
         heading: Forecasts in this report

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "users can view a home page" do
       visit home_path
 
       expect(page.current_path).to eql home_path
+      expect(page).to have_content t("page_content.reports.title")
       expect(page).to have_button("Search")
       expect(page).to have_content(programme.title)
     end


### PR DESCRIPTION
## Changes in this PR
- List the current reports on the delivery partners’ homepage, to give them immediate access to one of the most important elements of RODA.

## Screenshots of UI changes

### After
<img width="1227" alt="Screenshot 2021-08-23 at 16 47 34" src="https://user-images.githubusercontent.com/579522/130480009-023bcfc3-993d-4ca5-9931-5e966c00b21b.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
