### PR TITLE
(2100) Rename "historic" to "approved" in the context of reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,6 +802,7 @@
 ## [unreleased]
 
 - The Activities upload template no longer includes the "BEIS ID" column
+- Replace the use of "historic" with "approved" in the context of reports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-69...HEAD
 [release-69]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-68...release-69

--- a/app/controllers/concerns/reports/breadcrumbed.rb
+++ b/app/controllers/concerns/reports/breadcrumbed.rb
@@ -6,7 +6,7 @@ module Reports
       BreadcrumbContext.new(session).set(type: :report, model: report)
 
       if report.approved?
-        add_breadcrumb "Historic Reports", reports_path(anchor: "historic")
+        add_breadcrumb "Approved Reports", reports_path(anchor: "approved")
       else
         add_breadcrumb "Current Reports", reports_path
       end
@@ -15,16 +15,16 @@ module Reports
     end
 
     def prepare_default_report_variance_trail(report)
-      add_historic_or_current_report_breadcrumb(report)
+      add_approved_or_current_report_breadcrumb(report)
 
       add_breadcrumb t("page_title.report.show", report_fund: report.fund.source_fund.name, report_financial_quarter: report.financial_quarter_and_year), report_variance_path(report)
     end
 
     private
 
-    def add_historic_or_current_report_breadcrumb(report)
+    def add_approved_or_current_report_breadcrumb(report)
       if report.approved?
-        add_breadcrumb "Historic Reports", reports_path(anchor: "historic")
+        add_breadcrumb "Approved Reports", reports_path(anchor: "approved")
       else
         add_breadcrumb "Current Reports", reports_path
       end

--- a/app/services/report/grouped_reports_fetcher.rb
+++ b/app/services/report/grouped_reports_fetcher.rb
@@ -4,8 +4,8 @@ class Report
       @current ||= fetch(Report.not_approved)
     end
 
-    def historic
-      @historic ||= fetch(Report.approved)
+    def approved
+      @approved ||= fetch(Report.approved)
     end
 
     private def fetch(relation)

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -8,8 +8,8 @@ class Report
       @current ||= fetch(reports.not_approved)
     end
 
-    def historic
-      @historic ||= fetch(reports.approved)
+    def approved
+      @approved ||= fetch(reports.approved)
     end
 
     private

--- a/app/views/staff/organisations/reports/index.html.haml
+++ b/app/views/staff/organisations/reports/index.html.haml
@@ -11,5 +11,5 @@
 
     .govuk-tabs__panel{ id: "current" }
       = render partial: "staff/shared/reports/table", locals: { reports: @reports.current, type: "current" }
-    .govuk-tabs__panel{ id: "historic" }
-      = render partial: "staff/shared/reports/table", locals: { reports: @reports.historic, type: "historic" }
+    .govuk-tabs__panel{ id: "approved" }
+      = render partial: "staff/shared/reports/table", locals: { reports: @reports.historic, type: "approved" }

--- a/app/views/staff/organisations/reports/index.html.haml
+++ b/app/views/staff/organisations/reports/index.html.haml
@@ -12,4 +12,4 @@
     .govuk-tabs__panel{ id: "current" }
       = render partial: "staff/shared/reports/table", locals: { reports: @reports.current, type: "current" }
     .govuk-tabs__panel{ id: "approved" }
-      = render partial: "staff/shared/reports/table", locals: { reports: @reports.historic, type: "approved" }
+      = render partial: "staff/shared/reports/table", locals: { reports: @reports.approved, type: "approved" }

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -15,5 +15,5 @@
     .govuk-tabs__panel{ id: "current" }
       = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.current, type: "current" }
     .govuk-tabs__panel{ id: "approved" }
-      = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.historic, type: "approved" }
+      = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.approved, type: "approved" }
 

--- a/app/views/staff/reports/index.html.haml
+++ b/app/views/staff/reports/index.html.haml
@@ -14,6 +14,6 @@
 
     .govuk-tabs__panel{ id: "current" }
       = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.current, type: "current" }
-    .govuk-tabs__panel{ id: "historic" }
-      = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.historic, type: "historic" }
+    .govuk-tabs__panel{ id: "approved" }
+      = render partial: "staff/shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.historic, type: "approved" }
 

--- a/app/views/staff/shared/reports/_tabs.html.haml
+++ b/app/views/staff/shared/reports/_tabs.html.haml
@@ -5,5 +5,5 @@
     %a.govuk-tabs__tab{href: "#current", role: "tab"}
       = t("tabs.report.current")
   %li.govuk-tabs__list-item{role: "presentation"}
-    %a.govuk-tabs__tab{href: "#historic", role: "tab"}
-      = t("tabs.report.historic")
+    %a.govuk-tabs__tab{href: "#approved", role: "tab"}
+      = t("tabs.report.approved")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -10,7 +10,6 @@ en:
         awaiting_changes: Reports awaiting changes
         approved: Approved reports
         current: Current reports
-        historic: Historic reports
     header:
       report:
         financial_quarter: Financial quarter
@@ -41,8 +40,7 @@ en:
       variance: Variance
       budgets: Budgets
       current: Current
-      historic: Historic
-
+      approved: Approved
   page_content:
     reports:
       title: Reports

--- a/spec/controllers/concerns/reports/breadcrumbed_spec.rb
+++ b/spec/controllers/concerns/reports/breadcrumbed_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe StubController, type: :controller do
     allow(subject).to receive(:report_variance_path).and_return("report_path")
   end
 
-  context "when the report is historic" do
+  context "when the report is approved" do
     let(:report) { build(:report, state: :approved) }
 
     describe "#prepare_default_report_trail" do
-      it "adds the historic reports path to the breadcrumbs" do
-        expect(subject).to receive(:add_breadcrumb).with("Historic Reports", reports_path(anchor: "historic"))
+      it "adds the approved reports path to the breadcrumbs" do
+        expect(subject).to receive(:add_breadcrumb).with("Approved Reports", reports_path(anchor: "approved"))
         expect(subject).to receive(:add_breadcrumb).with(t("page_title.report.show", report_fund: report.fund.source_fund.name, report_financial_quarter: report.financial_quarter_and_year), report_path(report))
 
         subject.prepare_default_report_trail(report)
@@ -41,8 +41,8 @@ RSpec.describe StubController, type: :controller do
     end
 
     describe "#prepare_default_report_variance_trail" do
-      it "adds the historic reports path and the variance to the breadcrumbs" do
-        expect(subject).to receive(:add_breadcrumb).with("Historic Reports", reports_path(anchor: "historic"))
+      it "adds the approved reports path and the variance to the breadcrumbs" do
+        expect(subject).to receive(:add_breadcrumb).with("Approved Reports", reports_path(anchor: "approved"))
         expect(subject).to receive(:add_breadcrumb).with(t("page_title.report.show", report_fund: report.fund.source_fund.name, report_financial_quarter: report.financial_quarter_and_year), report_variance_path(report))
 
         subject.prepare_default_report_trail(report)
@@ -72,7 +72,7 @@ RSpec.describe StubController, type: :controller do
     end
 
     describe "#prepare_default_report_variance_trail" do
-      it "adds the historic reports path and the variance to the breadcrumbs" do
+      it "adds the approved reports path and the variance to the breadcrumbs" do
         expect(subject).to receive(:add_breadcrumb).with("Current Reports", reports_path)
         expect(subject).to receive(:add_breadcrumb).with(t("page_title.report.show", report_fund: report.fund.source_fund.name, report_financial_quarter: report.financial_quarter_and_year), report_variance_path(report))
 

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -61,7 +61,9 @@ RSpec.feature "Users can approve reports" do
 
         visit report_path(report)
 
-        expect(page).not_to have_link t("action.report.approve.button")
+        within("#main-content") do
+          expect(page).not_to have_link t("action.report.approve.button")
+        end
       end
     end
   end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Users can view reports" do
       )
 
       expect_to_see_a_table_of_reports_grouped_by_organisation(
-        selector: "#historic",
+        selector: "#approved",
         reports: approved_reports,
         organisations: organisations
       )
@@ -336,7 +336,7 @@ RSpec.feature "Users can view reports" do
       authenticate!(user: delivery_partner_user)
     end
 
-    scenario "they can see a list of all their active and historic reports" do
+    scenario "they can see a list of all their active and approved reports" do
       reports_awaiting_changes = create_list(:report, 2, organisation: delivery_partner_user.organisation, state: :awaiting_changes)
       approved_reports = create_list(:report, 3, organisation: delivery_partner_user.organisation, state: :approved)
 
@@ -345,7 +345,7 @@ RSpec.feature "Users can view reports" do
       expect(page).to have_content t("page_title.report.index")
 
       expect_to_see_a_table_of_reports(selector: "#current", reports: reports_awaiting_changes)
-      expect_to_see_a_table_of_reports(selector: "#historic", reports: approved_reports)
+      expect_to_see_a_table_of_reports(selector: "#approved", reports: approved_reports)
     end
 
     context "when there is an active report" do

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Users can view reports" do
       end
     end
 
-    scenario "they can see a list of all active and historic reports" do
+    scenario "they can see a list of all active and approved reports" do
       organisations = create_list(:delivery_partner_organisation, 2)
 
       unapproved_reports = [

--- a/spec/services/report/grouped_reports_fetcher_spec.rb
+++ b/spec/services/report/grouped_reports_fetcher_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Report::GroupedReportsFetcher do
   let(:organisation1) { build(:delivery_partner_organisation) }
   let(:organisation2) { build(:delivery_partner_organisation) }
 
-  describe "#historic" do
+  describe "#approved" do
     it "returns approved reports grouped by organisation" do
       organisation1_approved_reports = build_list(:report, 3, organisation: organisation1)
       organisation2_approved_reports = build_list(:report, 2, organisation: organisation2)
@@ -16,7 +16,7 @@ RSpec.describe Report::GroupedReportsFetcher do
       expect(approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(approved_relation_double)
       expect(approved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(approved_reports)
 
-      expect(described_class.new.historic).to eq({
+      expect(described_class.new.approved).to eq({
         organisation1 => organisation1_approved_reports,
         organisation2 => organisation2_approved_reports,
       })

--- a/spec/services/report/organisation_reports_fetcher_spec.rb
+++ b/spec/services/report/organisation_reports_fetcher_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Report::OrganisationReportsFetcher do
 
   let(:fetcher) { described_class.new(organisation: organisation) }
 
-  describe "#historic" do
-    subject { fetcher.historic }
+  describe "#approved" do
+    subject { fetcher.approved }
 
     it "returns approved reports for an organisation" do
       approved_reports = build_list(:report, 3, organisation: organisation)


### PR DESCRIPTION
## Changes in this PR
- Replace the use of "historic" with "approved" in the context of reports

## Screenshots of UI changes

### Before

### After
<img width="777" alt="Screenshot 2021-08-24 at 14 18 23" src="https://user-images.githubusercontent.com/579522/130623473-68dfb382-7463-47b2-9875-62a87c1f4cac.png">
<img width="803" alt="Screenshot 2021-08-24 at 14 18 12" src="https://user-images.githubusercontent.com/579522/130623505-29e069ec-a314-4eca-ad83-8c5bd6ec729c.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
