### PR TITLE
(2049) Feature: Delivery Partner creates an adjustment via a form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -825,6 +825,7 @@
 
 - BEIS users have a link to delivery partners reports on the homepage
 - Show the activity summary on all activity tabs
+- Delivery Partner can post an adjustment to an approved report
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-73...HEAD
 [release-73]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-72...release-73

--- a/app/controllers/staff/adjustments_controller.rb
+++ b/app/controllers/staff/adjustments_controller.rb
@@ -1,0 +1,73 @@
+class Staff::AdjustmentsController < Staff::ActivitiesController
+  include Secured
+
+  def new
+    @activity = activity
+    @adjustment = AdjustmentForm.new
+    @adjustment.parent_activity = @activity
+
+    authorize(@adjustment, policy_class: AdjustmentPolicy)
+  end
+
+  def create
+    @adjustment = AdjustmentForm.new(params[:adjustment_form])
+    @activity = activity
+    @adjustment.parent_activity = @activity
+
+    authorize(@adjustment, policy_class: AdjustmentPolicy)
+    return show_errors unless @adjustment.valid?
+
+    result = create_adjustment
+    @adjustment = result.object
+    if result.success?
+      flash[:notice] = t("action.adjustment.create.success")
+      redirect_to organisation_activity_path(@activity.organisation, @activity)
+    else
+      show_errors
+    end
+  end
+
+  def show
+    @activity = activity
+    @adjustment = AdjustmentPresenter.new(@activity.adjustments.find(params[:id]))
+
+    authorize @adjustment
+  end
+
+  private
+
+  def show_errors
+    render :new
+  end
+
+  def create_adjustment
+    CreateAdjustment
+      .new(activity: @activity)
+      .call(attributes: adjustment_params.merge(
+        user: current_user,
+        report: Report.editable_for_activity(activity)
+      ))
+  end
+
+  def adjustment_params
+    params.require(:adjustment_form).permit(
+      :value,
+      :financial_quarter,
+      :financial_year,
+      :comment,
+      :adjustment_type
+    )
+  end
+
+  def activity_id
+    params[:activity_id]
+  end
+
+  def id
+    params[:id]
+  end
+
+  def activity
+    @activity ||= Activity.find(activity_id)
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -130,6 +130,7 @@ class Activity < ApplicationRecord
   has_many :budgets, foreign_key: "parent_activity_id"
   has_many :actuals, foreign_key: "parent_activity_id"
   has_many :refunds, foreign_key: "parent_activity_id"
+  has_many :adjustments, foreign_key: "parent_activity_id"
 
   has_many :source_transfers, foreign_key: "source_id", class_name: "OutgoingTransfer"
   has_many :destination_transfers, foreign_key: "destination_id", class_name: "OutgoingTransfer"

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -6,5 +6,20 @@ class Adjustment < Transaction
     autosave: true,
     class_name: "FlexibleComment"
 
+  has_one :detail,
+    dependent: :destroy,
+    autosave: true,
+    class_name: "AdjustmentDetail"
+
+  has_one :creator, through: :detail, source: :user
+
   validates_associated :comment
+  validates_associated :detail
+
+  delegate :adjustment_type, to: :detail
+
+  def adjustment_type=(variant)
+    build_detail unless detail
+    detail.adjustment_type = variant
+  end
 end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -1,0 +1,10 @@
+class Adjustment < Transaction
+  has_one :comment,
+    -> { where(commentable_type: "Adjustment") },
+    foreign_key: :commentable_id,
+    dependent: :destroy,
+    autosave: true,
+    class_name: "FlexibleComment"
+
+  validates_associated :comment
+end

--- a/app/models/adjustment_detail.rb
+++ b/app/models/adjustment_detail.rb
@@ -1,0 +1,7 @@
+class AdjustmentDetail < ApplicationRecord
+  belongs_to :user
+  belongs_to :adjustment
+
+  validates :adjustment_type, inclusion: {in: %w[Actual Refund]}
+  validates :user, presence: true
+end

--- a/app/models/adjustment_form.rb
+++ b/app/models/adjustment_form.rb
@@ -1,0 +1,21 @@
+class AdjustmentForm
+  include ActiveModel::Model
+
+  attr_accessor :financial_quarter, :financial_year,
+    :value, :comment, :parent_activity, :adjustment_type
+
+  validates :financial_quarter, presence: true
+  validates :financial_year, presence: true
+  validates :value, presence: true
+  validates :comment, presence: true
+  validates :adjustment_type, presence: true
+
+  def initialize(params = {})
+    @financial_quarter = params[:financial_quarter]
+    @financial_year = params[:financial_year]
+    @value = params[:value]
+    @comment = params[:comment]
+    @parent_activity = params[:parent_activity]
+    @adjustment_type = params[:adjustment_type]
+  end
+end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -38,6 +38,13 @@ class ActivityPolicy < ApplicationPolicy
     ).create?
   end
 
+  def create_adjustment?
+    Pundit.policy(
+      user,
+      Adjustment.new(parent_activity: record)
+    ).create?
+  end
+
   def edit?
     update?
   end

--- a/app/policies/adjustment_policy.rb
+++ b/app/policies/adjustment_policy.rb
@@ -1,0 +1,34 @@
+class AdjustmentPolicy < ApplicationPolicy
+  def new?
+    return false if record.parent_activity.level.nil?
+    return true if delivery_partner_user? && active_report_exists?
+
+    false
+  end
+
+  def create?
+    return false if record.parent_activity.level.nil?
+    return true if delivery_partner_user? && active_report_exists?
+
+    false
+  end
+
+  def show?
+    return true if beis_user?
+    record.parent_activity.organisation == user.organisation
+  end
+
+  private
+
+  def active_report_exists?
+    active_report.any?
+  end
+
+  def active_report
+    Report.for_activity(record.parent_activity).where(state: "active")
+  end
+
+  def activity_is_a_programme?
+    record.parent_activity.programme?
+  end
+end

--- a/app/presenters/adjustment_presenter.rb
+++ b/app/presenters/adjustment_presenter.rb
@@ -1,0 +1,6 @@
+class AdjustmentPresenter < SimpleDelegator
+  def value
+    return if super.blank?
+    ActionController::Base.helpers.number_to_currency(super, unit: "£")
+  end
+end

--- a/app/services/activity/tab.rb
+++ b/app/services/activity/tab.rb
@@ -41,11 +41,13 @@ class Activity
       @budgets = policy_scope(Budget).where(parent_activity: @activity).order("financial_year DESC")
       @forecasts = policy_scope(@activity.latest_forecasts)
       @refunds = policy_scope(Refund).where(parent_activity: @activity).order("financial_year DESC")
+      @adjustments = policy_scope(Adjustment).where(parent_activity: @activity).order("date DESC")
 
       @actual_presenters = @actuals.includes(:parent_activity).map { |actual| TransactionPresenter.new(actual) }
       @budget_presenters = @budgets.includes(:parent_activity, :providing_organisation).map { |budget| BudgetPresenter.new(budget) }
       @forecast_presenters = @forecasts.map { |forecast| ForecastPresenter.new(forecast) }
       @refund_presenters = @refunds.map { |forecast| RefundPresenter.new(forecast) }
+      @adjustment_presenters = @adjustments.map { |adj| AdjustmentPresenter.new(adj) }
 
       @implementing_organisation_presenters = @activity.implementing_organisations.map { |implementing_organisation| ImplementingOrganisationPresenter.new(implementing_organisation) }
     end

--- a/app/services/create_adjustment.rb
+++ b/app/services/create_adjustment.rb
@@ -1,0 +1,68 @@
+class CreateAdjustment
+  class AdjustmentError < RuntimeError; end
+
+  def initialize(activity:)
+    @activity = activity
+  end
+
+  def call(attributes:)
+    @attributes = attributes
+    bail_if_report_not_acceptable
+
+    adjustment = create_adjustment
+    result = if adjustment.errors.any?
+      Result.new(false, adjustment)
+    else
+      Result.new(true, adjustment)
+    end
+
+    result
+  end
+
+  private
+
+  attr_reader :activity, :attributes
+
+  def create_adjustment
+    Adjustment.new(adjustment_attrs).tap do |adjustment|
+      adjustment.build_comment(
+        comment: attributes.fetch(:comment),
+        commentable: adjustment
+      )
+      adjustment.build_detail(
+        user: attributes.fetch(:user),
+        adjustment_type: attributes.fetch(:adjustment_type)
+      )
+      adjustment.save
+    end
+  end
+
+  def adjustment_attrs
+    {
+      parent_activity: activity,
+      report: report,
+      value: attributes.fetch(:value),
+      financial_quarter: attributes.fetch(:financial_quarter),
+      financial_year: attributes.fetch(:financial_year),
+    }
+  end
+
+  def bail_if_report_not_acceptable
+    if report.state != "active"
+      msg = "Report ##{report.id} is not in the active state"
+    end
+    unless valid_reports_for_activity.include?(report)
+      msg = "Report ##{report.id} is not associated with Activity ##{activity.id}"
+    end
+
+    raise AdjustmentError, msg if msg
+  end
+
+  def report
+    attributes.fetch(:report)
+  end
+
+  def valid_reports_for_activity
+    Report.for_activity(activity)
+  end
+end

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -60,3 +60,5 @@
               locals: { activity: @activity, actual_presenters: @actual_presenters }
             = render partial: "staff/shared/activities/refunds",
               locals: { activity: @activity, refund_presenters: @refund_presenters }
+            = render partial: "staff/shared/activities/adjustments",
+              locals: { activity: @activity, adjustment_presenters: @adjustment_presenters }

--- a/app/views/staff/adjustments/_form.html.haml
+++ b/app/views/staff/adjustments/_form.html.haml
@@ -1,0 +1,29 @@
+= f.govuk_error_summary
+
+= f.govuk_text_field :value, label: { text:  t("form.label.adjustment.value")}
+
+= f.govuk_collection_select :adjustment_type,
+  %w[Actual Refund],
+  :to_s,
+  :to_s,
+  label: { text: t("form.label.adjustment.adjustment_type") },
+  options: { include_blank: true }
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = f.govuk_collection_radio_buttons :financial_quarter,
+      list_of_financial_quarters,
+      :id,
+      :name,
+      inline: true,
+      legend: { text: t("form.label.adjustment.financial_quarter") , tag: :p, size: 's' }
+  .govuk-grid-column-one-third
+    = f.govuk_collection_select :financial_year,
+      list_of_financial_years(FinancialYear.previous_ten),
+      :id,
+      :name,
+      label: { text: t("form.label.adjustment.financial_year"), tag: :p, size: 's' },
+      options: { include_blank: true }
+
+= f.govuk_text_area :comment
+

--- a/app/views/staff/adjustments/new.html.haml
+++ b/app/views/staff/adjustments/new.html.haml
@@ -1,0 +1,16 @@
+=content_for :page_title_prefix, t("page_title.adjustment.new")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = @activity.title
+
+      %h2.govuk-heading-l
+        = t("page_title.adjustment.new")
+
+      = form_with model: @adjustment, url: activity_adjustments_path(@activity) do |f|
+        = render partial: "form", locals: { f: f, activity: @activity }
+
+        = f.govuk_submit t("default.button.submit")
+        = link_to t("form.link.activity.back"), organisation_activity_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"

--- a/app/views/staff/adjustments/show.html.haml
+++ b/app/views/staff/adjustments/show.html.haml
@@ -1,0 +1,64 @@
+=content_for :page_title_prefix, t("page_title.adjustment.show")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.adjustment.show")
+
+      %h2.govuk-heading-l
+        = @activity.title
+
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %dl.govuk-summary-list
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.timestamp")
+          %dd.govuk-summary-list__value
+            = @adjustment.created_at.strftime("%d %b %Y at %R")
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.creator")
+          %dd.govuk-summary-list__value
+            = @adjustment.creator.email
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.financial_period")
+          %dd.govuk-summary-list__value
+            = @adjustment.financial_quarter_and_year
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.activity")
+          %dd.govuk-summary-list__value
+            = link_to("View", organisation_activity_financials_path(organisation_id: @activity.organisation.id, activity_id: @activity.id))
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.report")
+          %dd.govuk-summary-list__value
+            = link_to("View", report_path(@adjustment.report))
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.value")
+          %dd.govuk-summary-list__value
+            = @adjustment.value
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.adjustment_type")
+          %dd.govuk-summary-list__value
+            = @adjustment.adjustment_type
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.headings.adjustment.comment")
+          %dd.govuk-summary-list__value
+            = @adjustment.comment.comment
+

--- a/app/views/staff/shared/activities/_adjustments.html.haml
+++ b/app/views/staff/shared/activities/_adjustments.html.haml
@@ -1,0 +1,8 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m
+      = t("page_content.activity.adjustments")
+
+    - if policy(activity).create_adjustment?
+      = link_to(t("page_content.adjustment.button.create"), new_activity_adjustment_path(activity), class: "govuk-button")
+      = render partial: '/staff/shared/adjustments/table', locals: { adjustments: adjustment_presenters }

--- a/app/views/staff/shared/adjustments/_table.html.haml
+++ b/app/views/staff/shared/adjustments/_table.html.haml
@@ -1,0 +1,23 @@
+- unless adjustments.empty?
+  %table.govuk-table.adjustments
+    %thead.govuk-table__head
+      %tr.govuk-table__row
+        %th.govuk-table__header
+          = t("table.header.adjustment.financial_quarter")
+        %th.govuk-table__header
+          = t("table.header.adjustment.value")
+        %th.govuk-table__header
+          = t("table.header.adjustment.adjustment_type")
+        %th.govuk-table__header
+          Report
+        %th.govuk-table__header
+          Actions
+
+    %tbody.govuk-table__body
+      - adjustments.each do |adjustment|
+        %tr.adjustment.govuk-table__row{id: "adjustment_#{adjustment.id}"}
+          %td.financial-period.govuk-table__cell= adjustment.financial_quarter_and_year
+          %td.value.govuk-table__cell= adjustment.value
+          %td.type.govuk-table__cell= adjustment.adjustment_type
+          %td.report.govuk-table__cell= link_to("Report", report_path(adjustment.report))
+          %td.actions.govuk-table__cell= link_to("View", activity_adjustment_path(@activity, adjustment))

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -363,6 +363,7 @@ en:
       third_party_projects: Third-party projects (level D)
       actuals: Actual spend
       refunds: Refunds
+      adjustments: Adjustments
     tab_content:
       change_history:
         guidance: Changes made to this activity

--- a/config/locales/models/adjustment.en.yml
+++ b/config/locales/models/adjustment.en.yml
@@ -1,0 +1,16 @@
+en:
+  activerecord:
+    errors:
+      models:
+        adjustment:
+          attributes:
+            comment:
+              invalid: Enter a comment explaining the adjustment
+            financial_year:
+              blank: Select a financial year
+            financial_quarter:
+              blank: Select a financial quarter
+            value:
+              blank: Enter a adjustment amount
+              inclusion: Refund amount must be between 0.01 and 99,999,999,999.00
+              not_a_number: "Refund amount must be a valid number"

--- a/config/locales/models/adjustment.en.yml
+++ b/config/locales/models/adjustment.en.yml
@@ -1,4 +1,50 @@
 en:
+  action:
+    adjustment:
+      create:
+        success: Adjustment successfully created
+
+  page_content:
+    adjustment:
+      button:
+        create: Add an adjustment
+
+  page_title:
+    adjustment:
+      new: Add a new adjustment
+      show: Adjustment
+  form:
+    label:
+      adjustment:
+        report: Report
+        value: Adjustment amount
+        adjustment_type: Adjustment type
+        financial_quarter: Financial quarter
+        financial_year: Financial year
+    hint:
+      adjustment:
+        financial_quarter_and_year: The report with which the adjustment should be associated
+  table:
+    caption:
+      adjustment:
+        in_report: Adjustments added in this report
+    header:
+      adjustment:
+        financial_quarter: Financial quarter
+        value: Adjustment amount
+        adjustment_type: Adjustment type
+
+  summary:
+    headings:
+      adjustment:
+        timestamp: Time posted
+        creator: Posted by
+        value: Amount
+        adjustment_type: Adjustment type
+        report: Report
+        activity: Activity
+        financial_period: Financial period
+        comment: Comment
   activerecord:
     errors:
       models:

--- a/config/locales/models/adjustment_form.en.yml
+++ b/config/locales/models/adjustment_form.en.yml
@@ -1,0 +1,20 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        adjustment_form:
+          attributes:
+            financial_quarter:
+              blank: Select a financial quarter
+            financial_year:
+              blank: Select a financial year
+            comment:
+              blank: Enter a comment explaining the adjustment
+            value:
+              blank: Enter an amount
+            adjustment_type:
+              blank: Select the type of adjustment
+            report_id:
+              blank: Select a report to associate with the adjustment
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
       resources :outgoing_transfers, except: [:index]
       resources :incoming_transfers, except: [:index]
       resources :refunds, except: [:index]
+      resources :adjustments, only: [:new, :create, :show]
     end
 
     resource :search, only: [:show]

--- a/db/migrate/20210913150920_create_adjustment_details.rb
+++ b/db/migrate/20210913150920_create_adjustment_details.rb
@@ -1,0 +1,14 @@
+class CreateAdjustmentDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :adjustment_details, id: :uuid do |t|
+      t.uuid :adjustment_id
+      t.uuid :user_id
+      t.string :adjustment_type
+
+      t.timestamps
+    end
+    add_index :adjustment_details, :adjustment_id
+    add_index :adjustment_details, :user_id
+    add_index :adjustment_details, :adjustment_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_09_104830) do
+ActiveRecord::Schema.define(version: 2021_09_13_150920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -85,6 +85,17 @@ ActiveRecord::Schema.define(version: 2021_09_09_104830) do
     t.index ["parent_id"], name: "index_activities_on_parent_id"
     t.index ["roda_identifier"], name: "index_activities_on_roda_identifier"
     t.index ["transparency_identifier"], name: "index_activities_on_transparency_identifier", unique: true
+  end
+
+  create_table "adjustment_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "adjustment_id"
+    t.uuid "user_id"
+    t.string "adjustment_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["adjustment_id"], name: "index_adjustment_details_on_adjustment_id"
+    t.index ["adjustment_type"], name: "index_adjustment_details_on_adjustment_type"
+    t.index ["user_id"], name: "index_adjustment_details_on_user_id"
   end
 
   create_table "budgets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/adjustment_details.rb
+++ b/spec/factories/adjustment_details.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :adjustment_detail do
+    adjustment_id { create(:adjustment) }
+    user { create(:delivery_partner_user) }
+    adjustment_type { "Actual" }
+  end
+end

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
 
     after(:create) do |adjustment, _evaluator|
       create(:flexible_comment, commentable: adjustment)
+      create(:adjustment_detail, adjustment: adjustment)
       adjustment.reload
     end
   end

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :adjustment do
+    transaction_type { "1" }
+    disbursement_channel { "1" }
+    currency { "gbp" }
+    ingested { false }
+    financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
+    financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
+    value { BigDecimal("110.01") }
+
+    association :parent_activity, factory: :project_activity
+    association :report
+
+    receiving_organisation_name { nil }
+    receiving_organisation_reference { nil }
+    receiving_organisation_type { nil }
+
+    after(:create) do |adjustment, _evaluator|
+      create(:flexible_comment, commentable: adjustment)
+      adjustment.reload
+    end
+  end
+end

--- a/spec/features/staff/users_can_create_an_adjustment_spec.rb
+++ b/spec/features/staff/users_can_create_an_adjustment_spec.rb
@@ -1,0 +1,116 @@
+RSpec.feature "Users can create an adjustment (correcting spend in an approved report)" do
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:activity) { create(:project_activity, organisation: organisation) }
+
+  before { authenticate!(user: user) }
+
+  scenario "can create an adjustment for an activity" do
+    given_an_active_report_exists
+    and_i_am_looking_at_the_activity_financials_tab
+
+    when_i_submit_the_new_adjustment_form_correctly
+    then_i_expect_to_see_the_new_adjustment
+    and_the_adjustment_should_not_appear_in_the_list_of_actuals
+    and_i_can_drill_down_to_the_details_of_the_adjustment
+    and_i_can_navigate_back_to_the_associated_activity_or_report
+  end
+
+  scenario "must supply the required information to create an adjustment" do
+    given_an_active_report_exists
+    and_i_am_looking_at_the_activity_financials_tab
+
+    when_i_submit_the_new_adjustment_form_incorrectly
+    then_i_expect_to_see_how_i_need_to_correct_the_form
+  end
+
+  def given_an_active_report_exists
+    create(
+      :report,
+      :active,
+      fund: activity.associated_fund,
+      organisation: activity.organisation,
+      financial_quarter: 1,
+      financial_year: 2021
+    )
+  end
+
+  def and_i_am_looking_at_the_activity_financials_tab
+    visit organisation_activity_financials_path(
+      organisation_id: activity.organisation.id,
+      activity_id: activity.id
+    )
+  end
+
+  def when_i_submit_the_new_adjustment_form_correctly
+    click_on t("page_content.adjustment.button.create")
+    fill_in "adjustment_form[value]", with: "100.01"
+    select "Actual", from: "adjustment_form[adjustment_type]"
+    choose "2", name: "adjustment_form[financial_quarter]"
+    select "2021-2022", from: "adjustment_form[financial_year]"
+    fill_in "adjustment_form[comment]", with: "There was a typo in the original 'actual'"
+    click_on(t("default.button.submit"))
+  end
+
+  def when_i_submit_the_new_adjustment_form_incorrectly
+    click_on t("page_content.adjustment.button.create")
+    click_on(t("default.button.submit"))
+  end
+
+  def then_i_expect_to_see_the_new_adjustment
+    expect(page).to have_content(t("action.adjustment.create.success"))
+    adjustment = activity.adjustments.first
+
+    fail "Expect activity to have an adjustment" unless adjustment
+    within ".adjustments" do
+      within "#adjustment_#{adjustment.id}" do
+        expect(page).to have_css(".financial-period", text: "FQ2 2021-2022")
+        expect(page).to have_css(".value", text: "£100.01")
+        expect(page).to have_css(".type", text: "Actual")
+        expect(page).to have_css(
+          ".report a[href='#{report_path(adjustment.report)}']",
+          text: "Report"
+        )
+      end
+    end
+  end
+
+  def and_the_adjustment_should_not_appear_in_the_list_of_actuals
+    expect(page).not_to have_css(".transactions td", text: "£100.01")
+  end
+
+  def and_i_can_drill_down_to_the_details_of_the_adjustment
+    within first(".adjustment") do
+      click_on "View"
+    end
+    expect(page).to have_content(user.email)
+    expect(page).to have_content("£100.01")
+    expect(page).to have_content("Actual")
+    expect(page).to have_content("FQ2 2021-2022")
+    expect(page).to have_content("There was a typo in the original 'actual'")
+  end
+
+  def and_i_can_navigate_back_to_the_associated_activity_or_report
+    expect(page).to have_link(
+      "View",
+      href: organisation_activity_financials_path(
+        organisation_id: activity.organisation.id,
+        activity_id: activity.id
+      )
+    )
+
+    expect(page).to have_link(
+      "View",
+      href: report_path(activity.adjustments.first.report)
+    )
+  end
+
+  def then_i_expect_to_see_how_i_need_to_correct_the_form
+    expect(page).to have_content("Select a financial quarter")
+    expect(page).to have_content("Select a financial year")
+    expect(page).to have_content("Select the type of adjustment")
+    expect(page).to have_content("Enter a comment explaining the adjustment")
+    expect(page).to have_content("Enter an amount")
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -609,6 +609,7 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:budgets) }
     it { should have_many(:actuals) }
     it { should have_many(:refunds) }
+    it { should have_many(:adjustments) }
     it { should have_many(:source_transfers) }
     it { should have_many(:destination_transfers) }
     it { should have_many(:matched_efforts) }

--- a/spec/models/adjustment_detail_spec.rb
+++ b/spec/models/adjustment_detail_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe AdjustmentDetail, type: :model do
+  it { should belong_to(:adjustment) }
+  it { should belong_to(:user) }
+
+  it { should validate_inclusion_of(:adjustment_type).in_array(["Refund", "Actual"]) }
+end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Adjustment, type: :model do
+  it { should have_one(:comment) }
+
+  describe "Single table inheritance from Transaction" do
+    it "should inherit from the Transaction class " do
+      expect(Adjustment.ancestors).to include(Transaction)
+      expect(Adjustment.table_name).to eq("transactions")
+      expect(Adjustment.inheritance_column).to eq("type")
+    end
+
+    it "should have the _type_ of 'Adjustment'" do
+      expect(Adjustment.new.type).to eq("Adjustment")
+    end
+  end
+
+  describe "validations" do
+    let(:adjustment) do
+      Adjustment.new.tap do |adjustment|
+        adjustment.build_comment(comment: nil)
+        adjustment.valid?
+      end
+    end
+
+    it "validates associated comment with a helpful message" do
+      expect(adjustment.errors[:comment])
+        .to include("Enter a comment explaining the adjustment")
+    end
+  end
+
+  describe "associated comment" do
+    let(:adjustment) { create(:adjustment) }
+
+    context "when the comment is edited and the adjustment is saved" do
+      before do
+        adjustment.comment.comment = "Edited comment"
+        adjustment.save
+      end
+
+      it "autosaves the associated comment" do
+        expect(adjustment.comment.reload.comment).to eq("Edited comment")
+      end
+    end
+  end
+
+  describe "#value" do
+    let(:negative) { BigDecimal("-100.01") }
+    let(:positive) { BigDecimal("100.01") }
+
+    context "when a negative value is given" do
+      let(:negative_adjustment) { create(:adjustment, value: negative) }
+
+      it "persists a negative" do
+        expect(negative_adjustment.value).to eq(negative)
+      end
+    end
+
+    context "when a positive value is given" do
+      let(:positive_adjustment) { create(:adjustment, value: positive) }
+
+      it "persists a positive" do
+        expect(positive_adjustment.value).to eq(positive)
+      end
+    end
+  end
+end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
       it { is_expected.to forbid_action(:create_refund) }
+      it { is_expected.to forbid_action(:create_adjustment) }
 
       it { is_expected.to permit_action(:create_child) }
       it { is_expected.to permit_action(:create_transfer) }
@@ -36,6 +37,7 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:destroy) }
       it { is_expected.to forbid_action(:redact_from_iati) }
       it { is_expected.to forbid_action(:create_refund) }
+      it { is_expected.to forbid_action(:create_adjustment) }
 
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to permit_action(:create_transfer) }
@@ -44,6 +46,7 @@ RSpec.describe ActivityPolicy do
         let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
 
         it { is_expected.to permit_action(:create_refund) }
+        it { is_expected.to forbid_action(:create_adjustment) }
       end
     end
 
@@ -53,6 +56,7 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:redact_from_iati) }
       it { is_expected.to forbid_action(:create_refund) }
+      it { is_expected.to forbid_action(:create_adjustment) }
 
       it { is_expected.to forbid_action(:create) }
       it { is_expected.to forbid_action(:edit) }
@@ -77,6 +81,7 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to forbid_action(:create_transfer) }
       it { is_expected.to forbid_action(:create_refund) }
+      it { is_expected.to forbid_action(:create_adjustment) }
     end
   end
 
@@ -96,6 +101,7 @@ RSpec.describe ActivityPolicy do
       it { is_expected.to forbid_action(:create_child) }
       it { is_expected.to forbid_action(:create_transfer) }
       it { is_expected.to forbid_action(:create_refund) }
+      it { is_expected.to forbid_action(:create_adjustment) }
     end
 
     context "when the activity is a programme" do
@@ -112,6 +118,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
         it { is_expected.to forbid_action(:create_refund) }
+        it { is_expected.to forbid_action(:create_adjustment) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -130,6 +137,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
         it { is_expected.to forbid_action(:create_refund) }
+        it { is_expected.to forbid_action(:create_adjustment) }
 
         context "and there is an editable report for the users organisation" do
           before do
@@ -139,6 +147,7 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to permit_action(:create_child) }
           it { is_expected.to forbid_action(:create_transfer) }
           it { is_expected.to forbid_action(:create_refund) }
+          it { is_expected.to forbid_action(:create_adjustment) }
         end
       end
     end
@@ -157,6 +166,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
         it { is_expected.to forbid_action(:create_refund) }
+        it { is_expected.to forbid_action(:create_adjustment) }
       end
 
       context "and the users organisation is the extending organisation" do
@@ -165,6 +175,10 @@ RSpec.describe ActivityPolicy do
         end
 
         context "and there is no editable report for the users organisation" do
+          before do
+            report.update(state: :approved)
+          end
+
           it { is_expected.to permit_action(:show) }
 
           it { is_expected.to forbid_action(:create) }
@@ -176,6 +190,7 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to forbid_action(:create_child) }
           it { is_expected.to forbid_action(:create_transfer) }
           it { is_expected.to forbid_action(:create_refund) }
+          it { is_expected.to forbid_action(:create_adjustment) }
         end
 
         context "and there is an editable report for the users organisation" do
@@ -194,6 +209,7 @@ RSpec.describe ActivityPolicy do
           it { is_expected.to permit_action(:create_child) }
           it { is_expected.to permit_action(:create_transfer) }
           it { is_expected.to permit_action(:create_refund) }
+          it { is_expected.to permit_action(:create_adjustment) }
         end
       end
     end
@@ -212,6 +228,7 @@ RSpec.describe ActivityPolicy do
         it { is_expected.to forbid_action(:create_child) }
         it { is_expected.to forbid_action(:create_transfer) }
         it { is_expected.to forbid_action(:create_refund) }
+        it { is_expected.to forbid_action(:create_adjustment) }
       end
 
       context "and the users organisation is the extending organisation" do

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -12,35 +12,38 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity, organisation: user.organisation, extending_organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
+      it "controls actions as expected" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:edit)
+        is_expected.to permit_action(:update)
+        is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:redact_from_iati)
+        is_expected.to forbid_action(:create_refund)
+        is_expected.to forbid_action(:create_adjustment)
 
-      it { is_expected.to forbid_action(:destroy) }
-      it { is_expected.to forbid_action(:redact_from_iati) }
-      it { is_expected.to forbid_action(:create_refund) }
-      it { is_expected.to forbid_action(:create_adjustment) }
-
-      it { is_expected.to permit_action(:create_child) }
-      it { is_expected.to permit_action(:create_transfer) }
+        is_expected.to permit_action(:create_child)
+        is_expected.to permit_action(:create_transfer)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
+      it "controls actions as expected" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:edit)
+        is_expected.to permit_action(:update)
 
-      it { is_expected.to forbid_action(:destroy) }
-      it { is_expected.to forbid_action(:redact_from_iati) }
-      it { is_expected.to forbid_action(:create_refund) }
-      it { is_expected.to forbid_action(:create_adjustment) }
+        is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:redact_from_iati)
+        is_expected.to forbid_action(:create_refund)
+        is_expected.to forbid_action(:create_adjustment)
 
-      it { is_expected.to forbid_action(:create_child) }
-      it { is_expected.to permit_action(:create_transfer) }
+        is_expected.to forbid_action(:create_child)
+        is_expected.to permit_action(:create_transfer)
+      end
 
       context "and there is an active report" do
         let(:activity) { create(:programme_activity, :with_report, organisation: user.organisation) }
@@ -53,35 +56,39 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:redact_from_iati) }
-      it { is_expected.to forbid_action(:create_refund) }
-      it { is_expected.to forbid_action(:create_adjustment) }
+      it "controls actions as expected" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:redact_from_iati)
+        is_expected.to forbid_action(:create_refund)
+        is_expected.to forbid_action(:create_adjustment)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
 
-      it { is_expected.to forbid_action(:create_child) }
-      it { is_expected.to forbid_action(:create_transfer) }
+        is_expected.to forbid_action(:create_child)
+        is_expected.to forbid_action(:create_transfer)
+      end
     end
 
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:redact_from_iati) }
+      it "controls actions as expected" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:redact_from_iati)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
 
-      it { is_expected.to forbid_action(:create_child) }
-      it { is_expected.to forbid_action(:create_transfer) }
-      it { is_expected.to forbid_action(:create_refund) }
-      it { is_expected.to forbid_action(:create_adjustment) }
+        is_expected.to forbid_action(:create_child)
+        is_expected.to forbid_action(:create_transfer)
+        is_expected.to forbid_action(:create_refund)
+        is_expected.to forbid_action(:create_adjustment)
+      end
     end
   end
 
@@ -91,34 +98,38 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
-      it { is_expected.to forbid_action(:redact_from_iati) }
+      it "controls actions as expected" do
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:redact_from_iati)
 
-      it { is_expected.to forbid_action(:create_child) }
-      it { is_expected.to forbid_action(:create_transfer) }
-      it { is_expected.to forbid_action(:create_refund) }
-      it { is_expected.to forbid_action(:create_adjustment) }
+        is_expected.to forbid_action(:create_child)
+        is_expected.to forbid_action(:create_transfer)
+        is_expected.to forbid_action(:create_refund)
+        is_expected.to forbid_action(:create_adjustment)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it { is_expected.to forbid_action(:show) }
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
-        it { is_expected.to forbid_action(:redact_from_iati) }
+        it "controls actions as expected" do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:redact_from_iati)
 
-        it { is_expected.to forbid_action(:create_child) }
-        it { is_expected.to forbid_action(:create_transfer) }
-        it { is_expected.to forbid_action(:create_refund) }
-        it { is_expected.to forbid_action(:create_adjustment) }
+          is_expected.to forbid_action(:create_child)
+          is_expected.to forbid_action(:create_transfer)
+          is_expected.to forbid_action(:create_refund)
+          is_expected.to forbid_action(:create_adjustment)
+        end
       end
 
       context "and the users organisation is the extending organisation" do
@@ -126,28 +137,32 @@ RSpec.describe ActivityPolicy do
           activity.update(extending_organisation: user.organisation)
         end
 
-        it { is_expected.to permit_action(:show) }
+        it "controls actions as expected" do
+          is_expected.to permit_action(:show)
 
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
-        it { is_expected.to forbid_action(:redact_from_iati) }
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:redact_from_iati)
 
-        it { is_expected.to forbid_action(:create_child) }
-        it { is_expected.to forbid_action(:create_transfer) }
-        it { is_expected.to forbid_action(:create_refund) }
-        it { is_expected.to forbid_action(:create_adjustment) }
+          is_expected.to forbid_action(:create_child)
+          is_expected.to forbid_action(:create_transfer)
+          is_expected.to forbid_action(:create_refund)
+          is_expected.to forbid_action(:create_adjustment)
+        end
 
         context "and there is an editable report for the users organisation" do
           before do
             report.update(state: :active)
           end
 
-          it { is_expected.to permit_action(:create_child) }
-          it { is_expected.to forbid_action(:create_transfer) }
-          it { is_expected.to forbid_action(:create_refund) }
-          it { is_expected.to forbid_action(:create_adjustment) }
+          it "controls actions as expected" do
+            is_expected.to permit_action(:create_child)
+            is_expected.to forbid_action(:create_transfer)
+            is_expected.to forbid_action(:create_refund)
+            is_expected.to forbid_action(:create_adjustment)
+          end
         end
       end
     end
@@ -156,17 +171,19 @@ RSpec.describe ActivityPolicy do
       let(:activity) { create(:project_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it { is_expected.to forbid_action(:show) }
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
-        it { is_expected.to forbid_action(:redact_from_iati) }
+        it "controls actions as expected" do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:redact_from_iati)
 
-        it { is_expected.to forbid_action(:create_child) }
-        it { is_expected.to forbid_action(:create_transfer) }
-        it { is_expected.to forbid_action(:create_refund) }
-        it { is_expected.to forbid_action(:create_adjustment) }
+          is_expected.to forbid_action(:create_child)
+          is_expected.to forbid_action(:create_transfer)
+          is_expected.to forbid_action(:create_refund)
+          is_expected.to forbid_action(:create_adjustment)
+        end
       end
 
       context "and the users organisation is the extending organisation" do
@@ -179,18 +196,20 @@ RSpec.describe ActivityPolicy do
             report.update(state: :approved)
           end
 
-          it { is_expected.to permit_action(:show) }
+          it "controls actions as expected" do
+            is_expected.to permit_action(:show)
 
-          it { is_expected.to forbid_action(:create) }
-          it { is_expected.to forbid_action(:edit) }
-          it { is_expected.to forbid_action(:update) }
-          it { is_expected.to forbid_action(:destroy) }
-          it { is_expected.to forbid_action(:redact_from_iati) }
+            is_expected.to forbid_action(:create)
+            is_expected.to forbid_action(:edit)
+            is_expected.to forbid_action(:update)
+            is_expected.to forbid_action(:destroy)
+            is_expected.to forbid_action(:redact_from_iati)
 
-          it { is_expected.to forbid_action(:create_child) }
-          it { is_expected.to forbid_action(:create_transfer) }
-          it { is_expected.to forbid_action(:create_refund) }
-          it { is_expected.to forbid_action(:create_adjustment) }
+            is_expected.to forbid_action(:create_child)
+            is_expected.to forbid_action(:create_transfer)
+            is_expected.to forbid_action(:create_refund)
+            is_expected.to forbid_action(:create_adjustment)
+          end
         end
 
         context "and there is an editable report for the users organisation" do
@@ -198,18 +217,20 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it { is_expected.to permit_action(:show) }
-          it { is_expected.to permit_action(:create) }
-          it { is_expected.to permit_action(:edit) }
-          it { is_expected.to permit_action(:update) }
+          it "controls actions as expected" do
+            is_expected.to permit_action(:show)
+            is_expected.to permit_action(:create)
+            is_expected.to permit_action(:edit)
+            is_expected.to permit_action(:update)
 
-          it { is_expected.to forbid_action(:destroy) }
-          it { is_expected.to forbid_action(:redact_from_iati) }
+            is_expected.to forbid_action(:destroy)
+            is_expected.to forbid_action(:redact_from_iati)
 
-          it { is_expected.to permit_action(:create_child) }
-          it { is_expected.to permit_action(:create_transfer) }
-          it { is_expected.to permit_action(:create_refund) }
-          it { is_expected.to permit_action(:create_adjustment) }
+            is_expected.to permit_action(:create_child)
+            is_expected.to permit_action(:create_transfer)
+            is_expected.to permit_action(:create_refund)
+            is_expected.to permit_action(:create_adjustment)
+          end
         end
       end
     end
@@ -218,17 +239,19 @@ RSpec.describe ActivityPolicy do
       let(:activity) { create(:third_party_project_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it { is_expected.to forbid_action(:show) }
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
-        it { is_expected.to forbid_action(:redact_from_iati) }
+        it "controls actions as expected" do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:redact_from_iati)
 
-        it { is_expected.to forbid_action(:create_child) }
-        it { is_expected.to forbid_action(:create_transfer) }
-        it { is_expected.to forbid_action(:create_refund) }
-        it { is_expected.to forbid_action(:create_adjustment) }
+          is_expected.to forbid_action(:create_child)
+          is_expected.to forbid_action(:create_transfer)
+          is_expected.to forbid_action(:create_refund)
+          is_expected.to forbid_action(:create_adjustment)
+        end
       end
 
       context "and the users organisation is the extending organisation" do
@@ -237,17 +260,19 @@ RSpec.describe ActivityPolicy do
         end
 
         context "and there is no editable report for the users organisation" do
-          it { is_expected.to permit_action(:show) }
+          it "controls actions as expected" do
+            is_expected.to permit_action(:show)
 
-          it { is_expected.to forbid_action(:create) }
-          it { is_expected.to forbid_action(:edit) }
-          it { is_expected.to forbid_action(:update) }
-          it { is_expected.to forbid_action(:destroy) }
-          it { is_expected.to forbid_action(:redact_from_iati) }
+            is_expected.to forbid_action(:create)
+            is_expected.to forbid_action(:edit)
+            is_expected.to forbid_action(:update)
+            is_expected.to forbid_action(:destroy)
+            is_expected.to forbid_action(:redact_from_iati)
 
-          it { is_expected.to forbid_action(:create_child) }
-          it { is_expected.to forbid_action(:create_transfer) }
-          it { is_expected.to forbid_action(:create_refund) }
+            is_expected.to forbid_action(:create_child)
+            is_expected.to forbid_action(:create_transfer)
+            is_expected.to forbid_action(:create_refund)
+          end
         end
 
         context "and there is an editable report for the users organisation" do
@@ -255,17 +280,19 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it { is_expected.to permit_action(:show) }
-          it { is_expected.to permit_action(:create) }
-          it { is_expected.to permit_action(:edit) }
-          it { is_expected.to permit_action(:update) }
+          it "controls actions as expected" do
+            is_expected.to permit_action(:show)
+            is_expected.to permit_action(:create)
+            is_expected.to permit_action(:edit)
+            is_expected.to permit_action(:update)
 
-          it { is_expected.to forbid_action(:destroy) }
-          it { is_expected.to forbid_action(:redact_from_iati) }
+            is_expected.to forbid_action(:destroy)
+            is_expected.to forbid_action(:redact_from_iati)
 
-          it { is_expected.to forbid_action(:create_child) }
-          it { is_expected.to permit_action(:create_transfer) }
-          it { is_expected.to permit_action(:create_refund) }
+            is_expected.to forbid_action(:create_child)
+            is_expected.to permit_action(:create_transfer)
+            is_expected.to permit_action(:create_refund)
+          end
         end
       end
     end

--- a/spec/policies/adjustment_policy_spec.rb
+++ b/spec/policies/adjustment_policy_spec.rb
@@ -1,0 +1,191 @@
+require "rails_helper"
+
+RSpec.describe AdjustmentPolicy do
+  let(:adjustment) do
+    create(:adjustment, parent_activity: activity, report: report)
+  end
+
+  let(:report) { create(:report, state: :active) }
+
+  subject { described_class.new(user, adjustment) }
+
+  context "when signed in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity, organisation: user.organisation) }
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to permit_action(:show)
+
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity, organisation: user.organisation) }
+      let(:report) do
+        fund = activity.associated_fund
+        create(:report, :active, fund: fund, organisation: activity.organisation)
+      end
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to permit_action(:show)
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity, organisation: create(:delivery_partner_organisation)) }
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to permit_action(:show)
+
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+
+    context "when the activity is a third party project" do
+      let(:activity) { create(:third_party_project_activity, organisation: create(:delivery_partner_organisation)) }
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to permit_action(:show)
+
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+  end
+
+  context "when signed in as a Delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    context "when the activity is a fund" do
+      let(:activity) { create(:fund_activity) }
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+
+    context "when the activity is a programme" do
+      let(:activity) { create(:programme_activity) }
+
+      it "applies the expected controls" do
+        aggregate_failures do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:new)
+          is_expected.to forbid_action(:create)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      let(:activity) { create(:project_activity) }
+
+      context "and the activity does not belong to the users organisation" do
+        it "applies the expected controls" do
+          aggregate_failures do
+            is_expected.to forbid_action(:show)
+            is_expected.to forbid_action(:new)
+            is_expected.to forbid_action(:create)
+          end
+        end
+      end
+
+      context "and the activity does belong to the users organisation" do
+        before do
+          activity.update(organisation: user.organisation)
+        end
+
+        context "when there is no active report" do
+          let(:report) { create(:report, state: :approved) }
+
+          it "applies the expected controls" do
+            aggregate_failures do
+              is_expected.to permit_action(:show)
+
+              is_expected.to forbid_action(:new)
+              is_expected.to forbid_action(:create)
+            end
+          end
+        end
+
+        context "when there is an active report" do
+          let(:report) { create(:report, state: :active) }
+
+          context "and the report is not for the organisation or fund of the activity" do
+            it "applies the expected controls" do
+              aggregate_failures do
+                is_expected.to permit_action(:show)
+
+                is_expected.to forbid_action(:new)
+                is_expected.to forbid_action(:create)
+              end
+            end
+          end
+
+          context "and the report is for the organisation but not the fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation)
+            end
+
+            it "applies the expected controls" do
+              aggregate_failures do
+                is_expected.to permit_action(:show)
+
+                is_expected.to forbid_action(:new)
+                is_expected.to forbid_action(:create)
+              end
+            end
+          end
+
+          context "and the report is for the organisation and fund of the activity" do
+            before do
+              report.update(organisation: activity.organisation, fund: activity.associated_fund)
+            end
+
+            context "when the report is not the one in which the transaction was created" do
+              it "applies the expected controls" do
+                aggregate_failures do
+                  is_expected.to permit_action(:show)
+                  is_expected.to permit_action(:new)
+                  is_expected.to permit_action(:create)
+                end
+              end
+            end
+
+            context "when the report is the one in which the transaction was created" do
+              before do
+                adjustment.update(report: report)
+              end
+
+              it "applies the expected controls" do
+                aggregate_failures do
+                  is_expected.to permit_action(:show)
+                  is_expected.to permit_action(:new)
+                  is_expected.to permit_action(:create)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/create_adjustment_spec.rb
+++ b/spec/services/create_adjustment_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe CreateAdjustment do
+  let(:activity) { double("activity", id: "xyz321") }
+  let(:report) { double("report", state: "active", id: "abc123") }
+  let(:user) { double("user") }
+  let(:adjustment) do
+    double(
+      "adjustment",
+      errors: [],
+      build_comment: double,
+      build_detail: double
+    )
+  end
+
+  let(:creator) { described_class.new(activity: activity) }
+
+  describe "#call" do
+    before do
+      allow(Report).to receive(:find).and_return(report)
+      allow(Report).to receive(:for_activity).and_return([report])
+      allow(Adjustment).to receive(:new).and_return(adjustment)
+      allow(adjustment).to receive(:save).and_return(adjustment)
+    end
+
+    let(:valid_attributes) do
+      {report: report,
+       value: BigDecimal("100.01"),
+       comment: "A typo in the original value",
+       user: user,
+       adjustment_type: "Actual",
+       financial_quarter: 2,
+       financial_year: 2020,}
+    end
+
+    it "uses Report#for_activity to verify that the given report is associated " \
+          "with the given Activity" do
+      creator.call(attributes: valid_attributes)
+
+      expect(Report).to have_received(:for_activity).with(activity)
+    end
+
+    it "initialises an Adjustment with the given attrs" do
+      creator.call(attributes: valid_attributes)
+
+      expect(Adjustment).to have_received(:new).with(
+        parent_activity: activity,
+        report: report,
+        value: BigDecimal("100.01"),
+        financial_quarter: 2,
+        financial_year: 2020
+      )
+    end
+
+    it "builds a comment" do
+      creator.call(attributes: valid_attributes)
+
+      expect(adjustment).to have_received(:build_comment)
+        .with(
+          comment: "A typo in the original value",
+          commentable: adjustment
+        )
+    end
+
+    it "builds a detail with the user and the adjustment type" do
+      creator.call(attributes: valid_attributes)
+
+      expect(adjustment).to have_received(:build_detail)
+        .with(
+          user: user,
+          adjustment_type: "Actual"
+        )
+    end
+
+    it "attempts to persist the new Adjustment" do
+      creator.call(attributes: valid_attributes)
+
+      expect(adjustment).to have_received(:save)
+    end
+
+    context "when creation is successful" do
+      it "returns a Result object with a *true* flag" do
+        expect(creator.call(attributes: valid_attributes)).to eq(
+          Result.new(true, adjustment)
+        )
+      end
+    end
+
+    context "when creation is unsuccessful" do
+      before { allow(adjustment).to receive(:errors).and_return(["validation error"]) }
+
+      it "returns a Result object with a *false* flag" do
+        expect(creator.call(attributes: valid_attributes)).to eq(
+          Result.new(false, adjustment)
+        )
+      end
+    end
+
+    context "when an error is raised by the Adjustment model" do
+      before do
+        allow(Adjustment).to receive(:new).and_raise(
+          Exception, "Unexpected error"
+        )
+      end
+
+      it "allows the error to bubble up to the caller" do
+        expect { creator.call(attributes: valid_attributes) }
+          .to raise_error(Exception, "Unexpected error")
+      end
+    end
+
+    context "when the given report is not in the *active* state" do
+      before do
+        allow(report).to receive(:state).and_return("approved")
+      end
+
+      it "raises an error with a message identifying the problem report" do
+        expect { creator.call(attributes: {report: report}) }
+          .to raise_error(
+            CreateAdjustment::AdjustmentError,
+            "Report #abc123 is not in the active state"
+          )
+      end
+
+      it "does not try to create an Adjustment" do
+        begin
+          creator.call(attributes: {report: report})
+        rescue CreateAdjustment::AdjustmentError
+          # we're interested in what does or doesn't happen after the error is raised
+        end
+
+        expect(Adjustment).not_to have_received(:new)
+      end
+    end
+
+    context "when the given report is not associated with the activity" do
+      before { allow(Report).to receive(:for_activity).and_return([]) }
+
+      it "raises an error with a message identifying the problem report" do
+        expect { creator.call(attributes: {report: report}) }
+          .to raise_error(
+            CreateAdjustment::AdjustmentError,
+            "Report #abc123 is not associated with Activity #xyz321"
+          )
+      end
+
+      it "does not try to create an Adjustment" do
+        begin
+          creator.call(attributes: {report: report})
+        rescue CreateAdjustment::AdjustmentError
+          # we're interested in what does or doesn't happen after the error is raised
+        end
+
+        expect(Adjustment).not_to have_received(:new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## User story

- So that BEIS can generate accurate reports for SID
- As a DP
- I want to adjust "actual spend" in historic periods in
  line with corrections agreed with BEIS

Trello: https://trello.com/c/Ffp6B5aB/2049-dp-posts-an-adjustment-via-form

## FINANCIAL PERIOD

It's not clear exactly how adjustments should be located in
time, so for now an adjustment:

- is automatically associated with a report in the "active" state, and
- must be assigned to an explicit financial period

## COMMENTS

It's agreed that it's essential that an adjustment includes
an explanation (or narrative) describing the background for
and rationale for the adjustment.

This is done with the new FlexibleComment class which is
going to replace the existing Comment class:

- `Refund` (done)
- `Adjustment` (here)
- `Activity` (to follow, "soon")

## ADJUSTMENT TYPE

Adjustments must also be labelled as applying to either:

1. an Actual spend, or
2. a Refund

When reviewing spending BEIS use the "Download spending
breakdown as CSV file" link on a report page. This uses
`ActivitySpendingBreakdown` to output a CSV.
The downloaded file includes 3 columns per financial period
which concernAdjustment and Refund. To
represent spending, taking proper account of adjustments and
refunds, these columns should be calculated as follows:

i) *actual spend*: this should EXCLUDE refunds and any
   adjustments to refunds (but INCLUDE adjustments to actual
   spend)

ii) *actual refund:* this should INCLUDE any adjustments to
    refunds

iii) *actual net*: this is the total of actual spend LESS
     refunds. It should INCLUDE adjustments to both refunds
     and actuals

## PRESENTATION

Similar to the approach taken with Refunds, we show
Adjustments in their own section of the Financials tab.

Each Adjustment listed on the Activity Financials tab links
to a 'show' view which provides full detail on the
individual Adjustment, including when it was posted, by
whom, the type of adjustment and the important narrative
comment. We also provide links to the associated Report and
Activity.

## Screenshots of UI changes

### Form, with error messages:


![adjustments_no_report_selection](https://user-images.githubusercontent.com/20245/133980117-52954800-63c3-4757-ba20-6ac0d2bc47f1.png)


### Adjustment section on Activity (Financials tab):

![list_of_adjustments](https://user-images.githubusercontent.com/20245/133225590-9de686f1-bec9-45e8-b0c9-5ecf30003b9f.png)


### An individual adjustment in detail:

![adjustment_details](https://user-images.githubusercontent.com/20245/133225642-b36bae0d-a1d2-4725-941a-a9ecfcdec215.png)


## Technical design

### What are adjustments?

Adjustments are financial entries which are used to correct
mistakes. They are used _after_ a report has been approved;
before that point entries (actuals, refunds) can be "changed"
or edited. Design options which were considered:

#### 1) Replicate transaction

Make a new table which is very similar to Transaction. This
was discounted as:

- if an actual is a transaction then it follows that an adjustment
  is a transaction

- duplicating the common fields (`value`, `activity_id`, `report_id`,
  `financial_year`, `financial_quarter`) is likely to have an
  ongoing maintenance cost as our understanding of RODA finance develops

#### 2) Sub-class transaction

Use single-table inheritance to say that Adjustment "is a transaction"
`Adjustment < Transaction`. This feels like a correct approach,
and is attractive. It would require a significant change to the
existing Transaction class and involve a data migration, e.g.
to set the `Transaction#type` on existing records to 'actual'
as distinct from `'adjustment'`

This is the approach taken here, and follows on from the earlier work of:

- modelling actual spend with the `Actual` class as a subclass of `Transaction` using single table inheritance on the `transactions` table
- refactoring Refund to also using STI on Transaction

#### 3) Extend transaction

~~The approach **proposed in this PR** is to introduce a small
`Adjustment` entity to model the concept and meta-data (just
`user_id` and `comment`) for this type of correction.
Adjustment delegates as much as possible to Transaction.~~

**Following discussion and agreement to use approach 3 of STI this PR has been reworked**

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
