### PR TITLE
(1862) Infer region from new beneficiary countries information

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -389,6 +389,13 @@ class Activity < ApplicationRecord
     Organisation.service_owner
   end
 
+  def benefitting_region
+    @benefitting_region ||= begin
+      return nil unless benefitting_countries.present?
+      BenefittingCountry.region_from_country_codes(benefitting_countries)
+    end
+  end
+
   def parent_level
     case level
     when "fund" then nil

--- a/app/models/benefitting_country.rb
+++ b/app/models/benefitting_country.rb
@@ -7,6 +7,16 @@ class BenefittingCountry
       @all ||= Codelist.new(type: "benefitting_countries", source: "beis").map { |country| new_from_hash(country) }
     end
 
+    def find_by_code(code)
+      all.find { |country| country.code == code }
+    end
+
+    def region_from_country_codes(codes)
+      codes.map { |c| find_by_code(c) }
+        .map { |c| c.regions }
+        .inject(:&).last || Region::DEVELOPING_COUNTRIES_REGION
+    end
+
     private
 
     def new_from_hash(country)
@@ -28,6 +38,12 @@ class BenefittingCountry
   class Region
     include ActiveModel::Model
     attr_accessor :name, :code, :level
+
+    DEVELOPING_COUNTRIES_REGION = new(
+      name: "Developing countries, unspecified",
+      code: "998",
+      level: 1,
+    )
 
     def hash
       code.hash

--- a/app/models/benefitting_country.rb
+++ b/app/models/benefitting_country.rb
@@ -14,7 +14,8 @@ class BenefittingCountry
     def region_from_country_codes(codes)
       codes.map { |c| find_by_code(c) }
         .map { |c| c.regions }
-        .inject(:&).last || Region::DEVELOPING_COUNTRIES_REGION
+        .inject(:&)
+        .max_by { |r| r.level.code } || Region.find_by_code(Region::DEVELOPING_COUNTRIES_CODE)
     end
 
     private
@@ -25,11 +26,7 @@ class BenefittingCountry
         code: country["code"],
         recipient_code: country["recipient_code"],
         regions: country["regions"].map { |region|
-          Region.new(
-            name: region["name"],
-            code: region["code"],
-            level: region["level"],
-          )
+          Region.find_by_code(region)
         }
       )
     end
@@ -39,11 +36,27 @@ class BenefittingCountry
     include ActiveModel::Model
     attr_accessor :name, :code, :level
 
-    DEVELOPING_COUNTRIES_REGION = new(
-      name: "Developing countries, unspecified",
-      code: "998",
-      level: 1,
-    )
+    DEVELOPING_COUNTRIES_CODE = "998"
+
+    class << self
+      def all
+        @all ||= Codelist.new(type: "benefitting_regions", source: "beis").map { |region| new_from_hash(region) }
+      end
+
+      def find_by_code(code)
+        all.find { |region| region.code == code }
+      end
+
+      private
+
+      def new_from_hash(region)
+        new(
+          name: region["name"],
+          code: region["code"],
+          level: Level.find_by_code(region["level"]),
+        )
+      end
+    end
 
     def hash
       code.hash
@@ -51,6 +64,27 @@ class BenefittingCountry
 
     def eql?(other)
       code == other.code
+    end
+
+    class Level
+      include ActiveModel::Model
+      attr_accessor :name, :code
+
+      class << self
+        def all
+          @all ||= Codelist.new(type: "benefitting_region_levels", source: "beis").map { |level| new_from_hash(level) }
+        end
+
+        def find_by_code(code)
+          all.find { |level| level.code == code }
+        end
+
+        private
+
+        def new_from_hash(level)
+          new(name: level["name"], code: level["code"])
+        end
+      end
     end
   end
 end

--- a/app/models/benefitting_country.rb
+++ b/app/models/benefitting_country.rb
@@ -1,0 +1,40 @@
+class BenefittingCountry
+  include ActiveModel::Model
+  attr_accessor :name, :recipient_code, :code, :regions
+
+  class << self
+    def all
+      @all ||= Codelist.new(type: "benefitting_countries", source: "beis").map { |country| new_from_hash(country) }
+    end
+
+    private
+
+    def new_from_hash(country)
+      new(
+        name: country["name"],
+        code: country["code"],
+        recipient_code: country["recipient_code"],
+        regions: country["regions"].map { |region|
+          Region.new(
+            name: region["name"],
+            code: region["code"],
+            level: region["level"],
+          )
+        }
+      )
+    end
+  end
+
+  class Region
+    include ActiveModel::Model
+    attr_accessor :name, :code, :level
+
+    def hash
+      code.hash
+    end
+
+    def eql?(other)
+      code == other.code
+    end
+  end
+end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -98,6 +98,11 @@ class ActivityPresenter < SimpleDelegator
     super.map { |item| translate("activity.recipient_country.#{item}") }.to_sentence
   end
 
+  def benefitting_region
+    return if super.blank?
+    super.name
+  end
+
   def gdi
     return if super.blank?
     translate("activity.gdi.#{super}")

--- a/app/services/export_activity_to_csv.rb
+++ b/app/services/export_activity_to_csv.rb
@@ -59,6 +59,7 @@ class ExportActivityToCsv
       "Recipient country" => -> { activity_presenter.recipient_country },
       "Intended beneficiaries" => -> { activity_presenter.intended_beneficiaries },
       "Benefitting countries" => -> { activity_presenter.benefitting_countries },
+      "Benefitting region" => -> { activity_presenter.benefitting_region },
       "GDI" => -> { activity_presenter.gdi },
       "GCRF Strategic Area" => -> { activity_presenter.gcrf_strategic_area },
       "GCRF Challenge Area" => -> { activity_presenter.gcrf_challenge_area },

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -214,7 +214,14 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :benefitting_countries)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("summary.label.activity.benefitting_countries"))
 
-  - if activity_presenter.recipient_region?
+  - if activity_presenter.benefitting_countries?
+    .govuk-summary-list__row.benefitting_region
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.benefitting_region")
+      %dd.govuk-summary-list__value
+        = activity_presenter.benefitting_region
+      %dd.govuk-summary-list__actions
+  - elsif activity_presenter.recipient_region?
     .govuk-summary-list__row.recipient_region
       %dt.govuk-summary-list__key
         = t("summary.label.activity.recipient_region")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -230,6 +230,7 @@ en:
         actual_start_date: Actual start date
         aid_type: Aid type
         benefitting_countries: Benefitting countries
+        benefitting_region: Benefitting region
         budgets: Budgets
         button:
           create: Add activity

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1481,4 +1481,29 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  describe "#benefitting_region" do
+    let(:activity) { build(:programme_activity, benefitting_countries: benefitting_countries) }
+
+    subject { activity.benefitting_region }
+
+    context "when there are countries present" do
+      let(:benefitting_countries) { ["ZA", "ZW"] }
+      let(:region) { BenefittingCountry::Region.new }
+
+      it "returns a region" do
+        expect(BenefittingCountry).to receive(:region_from_country_codes).with(benefitting_countries).and_return(region)
+        expect(subject).to eq(region)
+      end
+    end
+
+    context "when there are not benefitting countries present" do
+      let(:benefitting_countries) { [] }
+
+      it "returns nil" do
+        expect(BenefittingCountry).to_not receive(:region_from_country_codes).with(benefitting_countries)
+        expect(subject).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/benefitting_country_spec.rb
+++ b/spec/models/benefitting_country_spec.rb
@@ -8,4 +8,48 @@ RSpec.describe BenefittingCountry do
       expect(subject.count).to eq(177)
     end
   end
+
+  describe ".region_from_country_codes" do
+    subject { described_class.region_from_country_codes(codes) }
+
+    context "when the countries share a level 2 region" do
+      let(:codes) { ["AO", "GA"] }
+
+      it "gets the most specific region" do
+        expect(subject.code).to eq("1028")
+      end
+    end
+
+    context "when the countries share a level 1 region" do
+      let(:codes) { ["AO", "ZW"] }
+
+      it "gets the most specific region" do
+        expect(subject.code).to eq("289")
+      end
+    end
+
+    context "when the countries share a top-level region" do
+      let(:codes) { ["ZA", "DZ"] }
+
+      it "gets the most specific region" do
+        expect(subject.code).to eq("298")
+      end
+    end
+
+    context "when the countries don't share a region" do
+      let(:codes) { ["ZA", "LB"] }
+
+      it "returns the unspecified region" do
+        expect(subject.code).to eq("998")
+      end
+    end
+
+    context "when there are more than two countries" do
+      let(:codes) { ["KG", "TJ", "TM", "AF"] }
+
+      it "gets the most specific region" do
+        expect(subject.code).to eq("689")
+      end
+    end
+  end
 end

--- a/spec/models/benefitting_country_spec.rb
+++ b/spec/models/benefitting_country_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe BenefittingCountry do
+  describe ".all" do
+    subject { described_class.all }
+
+    it "returns all the countries" do
+      expect(subject.count).to eq(177)
+    end
+  end
+end

--- a/spec/models/benefitting_country_spec.rb
+++ b/spec/models/benefitting_country_spec.rb
@@ -1,12 +1,78 @@
 require "spec_helper"
 
 RSpec.describe BenefittingCountry do
-  describe ".all" do
-    subject { described_class.all }
+  let(:region) { BenefittingCountry::Region::Level.new(code: 1, name: "Region") }
+  let(:subregion1) { BenefittingCountry::Region::Level.new(code: 2, name: "Sub-region 1") }
+  let(:subregion2) { BenefittingCountry::Region::Level.new(code: 3, name: "Sub-region 2") }
 
-    it "returns all the countries" do
-      expect(subject.count).to eq(177)
-    end
+  let(:africa) { BenefittingCountry::Region.new(name: "Africa, regional", code: "298", level: region) }
+  let(:south_of_sahara) { BenefittingCountry::Region.new(name: "South of Sahara, regional", code: "289", level: subregion1) }
+  let(:middle_africa) { BenefittingCountry::Region.new(name: "Middle Africa, regional", code: "1028", level: subregion2) }
+  let(:eastern_africa) { BenefittingCountry::Region.new(name: "Eastern Africa, regional", code: "1027", level: subregion2) }
+  let(:southern_africa) { BenefittingCountry::Region.new(name: "Southern Africa, regional", code: "102", level: subregion2) }
+  let(:north_of_sahara) { BenefittingCountry::Region.new(name: "North of Sahara, regional", code: "189", level: subregion2) }
+  let(:asia) { BenefittingCountry::Region.new(name: "Asia, regional", code: "798", level: region) }
+  let(:middle_east) { BenefittingCountry::Region.new(name: "Middle East, regional", code: "589", level: subregion1) }
+
+  let(:countries) do
+    [
+      BenefittingCountry.new(
+        code: "AO",
+        name: "Angola",
+        regions: [
+          africa,
+          south_of_sahara,
+          middle_africa,
+        ]
+      ),
+      BenefittingCountry.new(
+        code: "GA",
+        name: "Gabon",
+        regions: [
+          africa,
+          south_of_sahara,
+          middle_africa,
+        ]
+      ),
+      BenefittingCountry.new(
+        code: "ZW",
+        name: "Zimbabwe",
+        regions: [
+          africa,
+          south_of_sahara,
+          eastern_africa,
+        ]
+      ),
+      BenefittingCountry.new(
+        code: "ZA",
+        name: "South Africa",
+        regions: [
+          africa,
+          south_of_sahara,
+          eastern_africa,
+        ]
+      ),
+      BenefittingCountry.new(
+        code: "DZ",
+        name: "Algeria",
+        regions: [
+          africa,
+          north_of_sahara,
+        ]
+      ),
+      BenefittingCountry.new(
+        code: "LB",
+        name: "Lebanon",
+        regions: [
+          asia,
+          middle_east,
+        ]
+      ),
+    ]
+  end
+
+  before do
+    allow(described_class).to receive(:all).and_return(countries)
   end
 
   describe ".region_from_country_codes" do
@@ -45,10 +111,10 @@ RSpec.describe BenefittingCountry do
     end
 
     context "when there are more than two countries" do
-      let(:codes) { ["KG", "TJ", "TM", "AF"] }
+      let(:codes) { ["AO", "GA", "AO", "ZW", "DZ"] }
 
       it "gets the most specific region" do
-        expect(subject.code).to eq("689")
+        expect(subject.code).to eq("298")
       end
     end
   end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -275,6 +275,25 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#benefitting_region" do
+    subject { described_class.new(activity).benefitting_region }
+
+    let(:activity) { build(:project_activity) }
+    before { expect(activity).to receive(:benefitting_region).at_least(:once).and_return(region) }
+
+    context "when there is a benefitting region" do
+      let(:region) { BenefittingCountry::Region.new(name: "Some region") }
+
+      it { is_expected.to eq(region.name) }
+    end
+
+    context "when there is no benefitting region" do
+      let(:region) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "#recipient_region" do
     it_behaves_like "a code translator", "recipient_region", {type: "recipient_region"}
 

--- a/spec/views/staff/shared/activities/activity_spec.rb
+++ b/spec/views/staff/shared/activities/activity_spec.rb
@@ -167,6 +167,28 @@ RSpec.describe "staff/shared/activities/_activity" do
     end
   end
 
+  describe "Benefitting region" do
+    let(:activity) { build(:programme_activity, benefitting_countries: benefitting_countries) }
+
+    context "when the activity has benefitting countries" do
+      subject { body.find(".benefitting_region") }
+
+      let(:benefitting_countries) { ["DZ", "LY"] }
+      let(:expected_region) { BenefittingCountry.find_by_code("DZ").regions.last }
+
+      it { is_expected.to have_content(expected_region.name) }
+      it { is_expected.to_not show_the_edit_add_actions }
+    end
+
+    context "when the activity has no benefitting countries" do
+      subject { body }
+
+      let(:benefitting_countries) { [] }
+
+      it { is_expected.to_not have_css(".benefitting_region") }
+    end
+  end
+
   RSpec::Matchers.define :show_the_edit_add_actions do
     match do
       expect(rendered).to have_link(t("default.link.edit"))

--- a/vendor/data/codelists/BEIS/benefitting_countries.yml
+++ b/vendor/data/codelists/BEIS/benefitting_countries.yml
@@ -1,4 +1,11 @@
 ---
+metadata:
+  title: Benefitting Countries
+  description: |
+    All delivery partners must submit what countries will benefit from an
+    activity. Each country belongs to a number of regions
+    (see benefitting_regions.yml)
+  url: https://beisodahelp.zendesk.com/hc/en-gb/articles/4406536016659
 data:
   - name: Algeria
     recipient_code: "130"

--- a/vendor/data/codelists/BEIS/benefitting_countries.yml
+++ b/vendor/data/codelists/BEIS/benefitting_countries.yml
@@ -4,2009 +4,1141 @@ data:
     recipient_code: "130"
     code: DZ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: North of Sahara, regional
-        code: "189"
-        level: 2
+      - "298"
+      - "189"
   - name: Libya
     recipient_code: "133"
     code: LY
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: North of Sahara, regional
-        code: "189"
-        level: 2
+      - "298"
+      - "189"
   - name: Morocco
     recipient_code: "136"
     code: MA
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: North of Sahara, regional
-        code: "189"
-        level: 2
+      - "298"
+      - "189"
   - name: Tunisia
     recipient_code: "139"
     code: TN
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: North of Sahara, regional
-        code: "189"
-        level: 2
+      - "298"
+      - "189"
   - name: Egypt
     recipient_code: "142"
     code: EG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: North of Sahara, regional
-        code: "189"
-        level: 2
+      - "298"
+      - "189"
   - name: Burundi
     recipient_code: "228"
     code: BI
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Comoros
     recipient_code: "233"
     code: KM
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Ethiopia
     recipient_code: "238"
     code: ET
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Kenya
     recipient_code: "248"
     code: KE
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Madagascar
     recipient_code: "252"
     code: MG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Malawi
     recipient_code: "253"
     code: MW
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Mauritius
     recipient_code: "257"
     code: MU
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Mayotte
     recipient_code: "258"
     code: YT
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Mozambique
     recipient_code: "259"
     code: MZ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Zimbabwe
     recipient_code: "265"
     code: ZW
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Rwanda
     recipient_code: "266"
     code: RW
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Seychelles
     recipient_code: "270"
     code: SC
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Eritrea
     recipient_code: "271"
     code: ER
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Somalia
     recipient_code: "273"
     code: SO
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Djibouti
     recipient_code: "274"
     code: DJ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Sudan
     recipient_code: "278"
     code: SD
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: South Sudan
     recipient_code: "279"
     code: SS
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Tanzania
     recipient_code: "282"
     code: TZ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Uganda
     recipient_code: "285"
     code: UG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Zambia
     recipient_code: "288"
     code: ZM
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Eastern Africa, regional
-        code: "1027"
-        level: 3
+      - "298"
+      - "289"
+      - "1027"
   - name: Angola
     recipient_code: "225"
     code: AO
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Cameroon
     recipient_code: "229"
     code: CM
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Central African Republic
     recipient_code: "231"
     code: CF
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Chad
     recipient_code: "232"
     code: TD
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Congo
     recipient_code: "234"
     code: CG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Democratic Republic of the Congo
     recipient_code: "235"
     code: CD
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Gabon
     recipient_code: "239"
     code: GA
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Equatorial Guinea
     recipient_code: "245"
     code: GQ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: Sao Tome and Principe
     recipient_code: "268"
     code: ST
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Middle Africa, regional
-        code: "1028"
-        level: 3
+      - "298"
+      - "289"
+      - "1028"
   - name: South Africa
     recipient_code: "218"
     code: ZA
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Southern Africa, regional
-        code: "1029"
-        level: 3
+      - "298"
+      - "289"
+      - "1029"
   - name: Botswana
     recipient_code: "227"
     code: BW
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Southern Africa, regional
-        code: "1029"
-        level: 3
+      - "298"
+      - "289"
+      - "1029"
   - name: Lesotho
     recipient_code: "249"
     code: LS
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Southern Africa, regional
-        code: "1029"
-        level: 3
+      - "298"
+      - "289"
+      - "1029"
   - name: Namibia
     recipient_code: "275"
     code: NA
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Southern Africa, regional
-        code: "1029"
-        level: 3
+      - "298"
+      - "289"
+      - "1029"
   - name: Eswatini
     recipient_code: "280"
     code: SZ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Southern Africa, regional
-        code: "1029"
-        level: 3
+      - "298"
+      - "289"
+      - "1029"
   - name: Cabo Verde
     recipient_code: "230"
     code: CV
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Benin
     recipient_code: "236"
     code: BJ
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Gambia
     recipient_code: "240"
     code: GM
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Ghana
     recipient_code: "241"
     code: GH
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Guinea
     recipient_code: "243"
     code: GN
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Guinea-Bissau
     recipient_code: "244"
     code: GW
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Côte d'Ivoire
     recipient_code: "247"
     code: CI
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Liberia
     recipient_code: "251"
     code: LR
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Mali
     recipient_code: "255"
     code: ML
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Mauritania
     recipient_code: "256"
     code: MR
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Niger
     recipient_code: "260"
     code: NE
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Nigeria
     recipient_code: "261"
     code: NG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Senegal
     recipient_code: "269"
     code: SN
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Sierra Leone
     recipient_code: "272"
     code: SL
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Saint Helena
     recipient_code: "276"
     code: SH
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Togo
     recipient_code: "283"
     code: TG
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Burkina Faso
     recipient_code: "287"
     code: BF
     regions:
-      - name: Africa, regional
-        code: "298"
-        level: 1
-      - name: South of Sahara, regional
-        code: "289"
-        level: 2
-      - name: Western Africa, regional
-        code: "1030"
-        level: 3
+      - "298"
+      - "289"
+      - "1030"
   - name: Bahamas
     recipient_code: "328"
     code: BS
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Barbados
     recipient_code: "329"
     code: BB
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Cuba
     recipient_code: "338"
     code: CU
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Dominican Republic
     recipient_code: "340"
     code: DO
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Haiti
     recipient_code: "349"
     code: HT
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Jamaica
     recipient_code: "354"
     code: JM
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Netherlands Antilles
     recipient_code: "361"
     code: AN
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Aruba
     recipient_code: "373"
     code: AW
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Trinidad and Tobago
     recipient_code: "375"
     code: TT
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Anguilla
     recipient_code: "376"
     code: AI
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Antigua and Barbuda
     recipient_code: "377"
     code: AG
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Dominica
     recipient_code: "378"
     code: DM
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Grenada
     recipient_code: "381"
     code: GD
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Saint Kitts and Nevis
     recipient_code: "382"
     code: KN
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Saint Lucia
     recipient_code: "383"
     code: LC
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Saint Vincent and the Grenadines
     recipient_code: "384"
     code: VC
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Montserrat
     recipient_code: "385"
     code: MS
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Cayman Islands
     recipient_code: "386"
     code: KY
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Turks and Caicos Islands
     recipient_code: "387"
     code: TC
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: British Virgin Islands
     recipient_code: "388"
     code: VG
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Caribbean, regional
-        code: "1031"
-        level: 3
+      - "498"
+      - "389"
+      - "1031"
   - name: Costa Rica
     recipient_code: "336"
     code: CR
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: El Salvador
     recipient_code: "342"
     code: SV
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Guatemala
     recipient_code: "347"
     code: GT
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Honduras
     recipient_code: "351"
     code: HN
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Belize
     recipient_code: "352"
     code: BZ
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Mexico
     recipient_code: "358"
     code: MX
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Nicaragua
     recipient_code: "364"
     code: NI
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Panama
     recipient_code: "366"
     code: PA
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: Caribbean & Central America, regional
-        code: "389"
-        level: 2
-      - name: Central America, regional
-        code: "1032"
-        level: 3
+      - "498"
+      - "389"
+      - "1032"
   - name: Argentina
     recipient_code: "425"
     code: AR
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Bolivia
     recipient_code: "428"
     code: BO
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Brazil
     recipient_code: "431"
     code: BR
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Colombia
     recipient_code: "437"
     code: CO
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Ecuador
     recipient_code: "440"
     code: EC
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Falkland Islands (Malvinas)
     recipient_code: "443"
     code: FK
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Guyana
     recipient_code: "446"
     code: GY
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Paraguay
     recipient_code: "451"
     code: PY
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Peru
     recipient_code: "454"
     code: PE
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Suriname
     recipient_code: "457"
     code: SR
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Venezuela
     recipient_code: "463"
     code: VE
     regions:
-      - name: America, regional
-        code: "498"
-        level: 1
-      - name: South America, regional
-        code: "489"
-        level: 2
+      - "498"
+      - "489"
   - name: Brunei Darussalam
     recipient_code: "725"
     code: BN
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Cambodia
     recipient_code: "728"
     code: KH
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: China (People's Republic of)
     recipient_code: "730"
     code: CN
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Chinese Taipei
     recipient_code: "732"
     code: TW
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Hong Kong (China)
     recipient_code: "735"
     code: HK
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Indonesia
     recipient_code: "738"
     code: ID
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Democratic People's Republic of Korea
     recipient_code: "740"
     code: KP
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Korea
     recipient_code: "742"
     code: KR
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Lao People's Democratic Republic
     recipient_code: "745"
     code: LA
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Macau (China)
     recipient_code: "748"
     code: MO
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Malaysia
     recipient_code: "751"
     code: MY
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Mongolia
     recipient_code: "753"
     code: MN
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Philippines
     recipient_code: "755"
     code: PH
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Singapore
     recipient_code: "761"
     code: SG
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Thailand
     recipient_code: "764"
     code: TH
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Timor-Leste
     recipient_code: "765"
     code: TL
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Viet Nam
     recipient_code: "769"
     code: VN
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Far East Asia, regional
-        code: "789"
-        level: 3
+      - "798"
+      - "789"
   - name: Bahrain
     recipient_code: "530"
     code: BH
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Iran
     recipient_code: "540"
     code: IR
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Iraq
     recipient_code: "543"
     code: IQ
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Israel
     recipient_code: "546"
     code: IL
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Jordan
     recipient_code: "549"
     code: JO
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: West Bank and Gaza Strip
     recipient_code: "550"
     code: PS
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Kuwait
     recipient_code: "552"
     code: KW
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Lebanon
     recipient_code: "555"
     code: LB
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Oman
     recipient_code: "558"
     code: OM
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Qatar
     recipient_code: "561"
     code: QA
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Saudi Arabia
     recipient_code: "566"
     code: SA
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Syrian Arab Republic
     recipient_code: "573"
     code: SY
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: United Arab Emirates
     recipient_code: "576"
     code: AE
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Yemen
     recipient_code: "580"
     code: YE
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: Middle East, regional
-        code: "589"
-        level: 3
+      - "798"
+      - "589"
   - name: Armenia
     recipient_code: "610"
     code: AM
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Azerbaijan
     recipient_code: "611"
     code: AZ
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Georgia
     recipient_code: "612"
     code: GE
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Kazakhstan
     recipient_code: "613"
     code: KZ
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Kyrgyzstan
     recipient_code: "614"
     code: KG
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Tajikistan
     recipient_code: "615"
     code: TJ
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Turkmenistan
     recipient_code: "616"
     code: TM
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Uzbekistan
     recipient_code: "617"
     code: UZ
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: Central Asia, regional
-        code: "619"
-        level: 3
+      - "798"
+      - "689"
+      - "619"
   - name: Afghanistan
     recipient_code: "625"
     code: AF
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Bhutan
     recipient_code: "630"
     code: BT
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Myanmar
     recipient_code: "635"
     code: MM
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Sri Lanka
     recipient_code: "640"
     code: LK
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: India
     recipient_code: "645"
     code: IN
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Maldives
     recipient_code: "655"
     code: MV
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Nepal
     recipient_code: "660"
     code: NP
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Pakistan
     recipient_code: "665"
     code: PK
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Bangladesh
     recipient_code: "666"
     code: BD
     regions:
-      - name: Asia, regional
-        code: "798"
-        level: 1
-      - name: South & Central Asia, regional
-        code: "689"
-        level: 2
-      - name: South Asia, regional
-        code: "679"
-        level: 3
+      - "798"
+      - "689"
+      - "679"
   - name: Cyprus
     recipient_code: "30"
     code: CY
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Gibraltar
     recipient_code: "35"
     code: GI
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Malta
     recipient_code: "45"
     code: MT
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Turkey
     recipient_code: "55"
     code: TR
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Kosovo
     recipient_code: "57"
     code: XK
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Slovenia
     recipient_code: "61"
     code: SI
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Croatia
     recipient_code: "62"
     code: HR
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Serbia
     recipient_code: "63"
     code: RS
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Bosnia and Herzegovina
     recipient_code: "64"
     code: BA
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Montenegro
     recipient_code: "65"
     code: ME
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: North Macedonia
     recipient_code: "66"
     code: MK
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Albania
     recipient_code: "71"
     code: AL
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Ukraine
     recipient_code: "85"
     code: UA
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Belarus
     recipient_code: "86"
     code: BY
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: States Ex-Yugoslavia unspecified
     recipient_code: "88"
     code: A region on IATI code 88
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Moldova
     recipient_code: "93"
     code: MD
     regions:
-      - name: Europe, regional
-        code: "89"
-        level: 1
+      - "89"
   - name: Fiji
     recipient_code: "832"
     code: FJ
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Melanesia, regional
-        code: "1033"
-        level: 3
+      - "889"
+      - "1033"
   - name: New Caledonia
     recipient_code: "850"
     code: NC
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Melanesia, regional
-        code: "1033"
-        level: 3
+      - "889"
+      - "1033"
   - name: Vanuatu
     recipient_code: "854"
     code: VU
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Melanesia, regional
-        code: "1033"
-        level: 3
+      - "889"
+      - "1033"
   - name: Papua New Guinea
     recipient_code: "862"
     code: PG
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Melanesia, regional
-        code: "1033"
-        level: 3
+      - "889"
+      - "1033"
   - name: Solomon Islands
     recipient_code: "866"
     code: SB
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Melanesia, regional
-        code: "1033"
-        level: 3
+      - "889"
+      - "1033"
   - name: Kiribati
     recipient_code: "836"
     code: KI
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: Nauru
     recipient_code: "845"
     code: NR
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: Northern Mariana Islands
     recipient_code: "858"
     code: MP
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: Marshall Islands
     recipient_code: "859"
     code: MH
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: Micronesia
     recipient_code: "860"
     code: FM
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: Palau
     recipient_code: "861"
     code: PW
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Micronesia, regional
-        code: "1034"
-        level: 3
+      - "889"
+      - "1034"
   - name: French Polynesia
     recipient_code: "840"
     code: PF
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Niue
     recipient_code: "856"
     code: NU
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Tokelau
     recipient_code: "868"
     code: TK
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Tonga
     recipient_code: "870"
     code: TO
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Tuvalu
     recipient_code: "872"
     code: TV
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Wallis and Futuna
     recipient_code: "876"
     code: WF
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"
   - name: Samoa
     recipient_code: "880"
     code: WS
     regions:
-      - name: Oceania, regional
-        code: "889"
-        level: 1
-      - name: Polynesia, regional
-        code: "1035"
-        level: 3
+      - "889"
+      - "1035"

--- a/vendor/data/codelists/BEIS/benefitting_countries.yml
+++ b/vendor/data/codelists/BEIS/benefitting_countries.yml
@@ -1,0 +1,2012 @@
+---
+data:
+  - name: Algeria
+    recipient_code: "130"
+    code: DZ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: North of Sahara, regional
+        code: "189"
+        level: 2
+  - name: Libya
+    recipient_code: "133"
+    code: LY
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: North of Sahara, regional
+        code: "189"
+        level: 2
+  - name: Morocco
+    recipient_code: "136"
+    code: MA
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: North of Sahara, regional
+        code: "189"
+        level: 2
+  - name: Tunisia
+    recipient_code: "139"
+    code: TN
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: North of Sahara, regional
+        code: "189"
+        level: 2
+  - name: Egypt
+    recipient_code: "142"
+    code: EG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: North of Sahara, regional
+        code: "189"
+        level: 2
+  - name: Burundi
+    recipient_code: "228"
+    code: BI
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Comoros
+    recipient_code: "233"
+    code: KM
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Ethiopia
+    recipient_code: "238"
+    code: ET
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Kenya
+    recipient_code: "248"
+    code: KE
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Madagascar
+    recipient_code: "252"
+    code: MG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Malawi
+    recipient_code: "253"
+    code: MW
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Mauritius
+    recipient_code: "257"
+    code: MU
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Mayotte
+    recipient_code: "258"
+    code: YT
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Mozambique
+    recipient_code: "259"
+    code: MZ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Zimbabwe
+    recipient_code: "265"
+    code: ZW
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Rwanda
+    recipient_code: "266"
+    code: RW
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Seychelles
+    recipient_code: "270"
+    code: SC
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Eritrea
+    recipient_code: "271"
+    code: ER
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Somalia
+    recipient_code: "273"
+    code: SO
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Djibouti
+    recipient_code: "274"
+    code: DJ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Sudan
+    recipient_code: "278"
+    code: SD
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: South Sudan
+    recipient_code: "279"
+    code: SS
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Tanzania
+    recipient_code: "282"
+    code: TZ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Uganda
+    recipient_code: "285"
+    code: UG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Zambia
+    recipient_code: "288"
+    code: ZM
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Eastern Africa, regional
+        code: "1027"
+        level: 3
+  - name: Angola
+    recipient_code: "225"
+    code: AO
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Cameroon
+    recipient_code: "229"
+    code: CM
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Central African Republic
+    recipient_code: "231"
+    code: CF
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Chad
+    recipient_code: "232"
+    code: TD
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Congo
+    recipient_code: "234"
+    code: CG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Democratic Republic of the Congo
+    recipient_code: "235"
+    code: CD
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Gabon
+    recipient_code: "239"
+    code: GA
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Equatorial Guinea
+    recipient_code: "245"
+    code: GQ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: Sao Tome and Principe
+    recipient_code: "268"
+    code: ST
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Middle Africa, regional
+        code: "1028"
+        level: 3
+  - name: South Africa
+    recipient_code: "218"
+    code: ZA
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Southern Africa, regional
+        code: "1029"
+        level: 3
+  - name: Botswana
+    recipient_code: "227"
+    code: BW
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Southern Africa, regional
+        code: "1029"
+        level: 3
+  - name: Lesotho
+    recipient_code: "249"
+    code: LS
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Southern Africa, regional
+        code: "1029"
+        level: 3
+  - name: Namibia
+    recipient_code: "275"
+    code: NA
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Southern Africa, regional
+        code: "1029"
+        level: 3
+  - name: Eswatini
+    recipient_code: "280"
+    code: SZ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Southern Africa, regional
+        code: "1029"
+        level: 3
+  - name: Cabo Verde
+    recipient_code: "230"
+    code: CV
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Benin
+    recipient_code: "236"
+    code: BJ
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Gambia
+    recipient_code: "240"
+    code: GM
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Ghana
+    recipient_code: "241"
+    code: GH
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Guinea
+    recipient_code: "243"
+    code: GN
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Guinea-Bissau
+    recipient_code: "244"
+    code: GW
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Côte d'Ivoire
+    recipient_code: "247"
+    code: CI
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Liberia
+    recipient_code: "251"
+    code: LR
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Mali
+    recipient_code: "255"
+    code: ML
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Mauritania
+    recipient_code: "256"
+    code: MR
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Niger
+    recipient_code: "260"
+    code: NE
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Nigeria
+    recipient_code: "261"
+    code: NG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Senegal
+    recipient_code: "269"
+    code: SN
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Sierra Leone
+    recipient_code: "272"
+    code: SL
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Saint Helena
+    recipient_code: "276"
+    code: SH
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Togo
+    recipient_code: "283"
+    code: TG
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Burkina Faso
+    recipient_code: "287"
+    code: BF
+    regions:
+      - name: Africa, regional
+        code: "298"
+        level: 1
+      - name: South of Sahara, regional
+        code: "289"
+        level: 2
+      - name: Western Africa, regional
+        code: "1030"
+        level: 3
+  - name: Bahamas
+    recipient_code: "328"
+    code: BS
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Barbados
+    recipient_code: "329"
+    code: BB
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Cuba
+    recipient_code: "338"
+    code: CU
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Dominican Republic
+    recipient_code: "340"
+    code: DO
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Haiti
+    recipient_code: "349"
+    code: HT
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Jamaica
+    recipient_code: "354"
+    code: JM
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Netherlands Antilles
+    recipient_code: "361"
+    code: AN
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Aruba
+    recipient_code: "373"
+    code: AW
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Trinidad and Tobago
+    recipient_code: "375"
+    code: TT
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Anguilla
+    recipient_code: "376"
+    code: AI
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Antigua and Barbuda
+    recipient_code: "377"
+    code: AG
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Dominica
+    recipient_code: "378"
+    code: DM
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Grenada
+    recipient_code: "381"
+    code: GD
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Saint Kitts and Nevis
+    recipient_code: "382"
+    code: KN
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Saint Lucia
+    recipient_code: "383"
+    code: LC
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Saint Vincent and the Grenadines
+    recipient_code: "384"
+    code: VC
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Montserrat
+    recipient_code: "385"
+    code: MS
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Cayman Islands
+    recipient_code: "386"
+    code: KY
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Turks and Caicos Islands
+    recipient_code: "387"
+    code: TC
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: British Virgin Islands
+    recipient_code: "388"
+    code: VG
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Caribbean, regional
+        code: "1031"
+        level: 3
+  - name: Costa Rica
+    recipient_code: "336"
+    code: CR
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: El Salvador
+    recipient_code: "342"
+    code: SV
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Guatemala
+    recipient_code: "347"
+    code: GT
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Honduras
+    recipient_code: "351"
+    code: HN
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Belize
+    recipient_code: "352"
+    code: BZ
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Mexico
+    recipient_code: "358"
+    code: MX
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Nicaragua
+    recipient_code: "364"
+    code: NI
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Panama
+    recipient_code: "366"
+    code: PA
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: Caribbean & Central America, regional
+        code: "389"
+        level: 2
+      - name: Central America, regional
+        code: "1032"
+        level: 3
+  - name: Argentina
+    recipient_code: "425"
+    code: AR
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Bolivia
+    recipient_code: "428"
+    code: BO
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Brazil
+    recipient_code: "431"
+    code: BR
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Colombia
+    recipient_code: "437"
+    code: CO
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Ecuador
+    recipient_code: "440"
+    code: EC
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Falkland Islands (Malvinas)
+    recipient_code: "443"
+    code: FK
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Guyana
+    recipient_code: "446"
+    code: GY
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Paraguay
+    recipient_code: "451"
+    code: PY
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Peru
+    recipient_code: "454"
+    code: PE
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Suriname
+    recipient_code: "457"
+    code: SR
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Venezuela
+    recipient_code: "463"
+    code: VE
+    regions:
+      - name: America, regional
+        code: "498"
+        level: 1
+      - name: South America, regional
+        code: "489"
+        level: 2
+  - name: Brunei Darussalam
+    recipient_code: "725"
+    code: BN
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Cambodia
+    recipient_code: "728"
+    code: KH
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: China (People's Republic of)
+    recipient_code: "730"
+    code: CN
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Chinese Taipei
+    recipient_code: "732"
+    code: TW
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Hong Kong (China)
+    recipient_code: "735"
+    code: HK
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Indonesia
+    recipient_code: "738"
+    code: ID
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Democratic People's Republic of Korea
+    recipient_code: "740"
+    code: KP
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Korea
+    recipient_code: "742"
+    code: KR
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Lao People's Democratic Republic
+    recipient_code: "745"
+    code: LA
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Macau (China)
+    recipient_code: "748"
+    code: MO
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Malaysia
+    recipient_code: "751"
+    code: MY
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Mongolia
+    recipient_code: "753"
+    code: MN
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Philippines
+    recipient_code: "755"
+    code: PH
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Singapore
+    recipient_code: "761"
+    code: SG
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Thailand
+    recipient_code: "764"
+    code: TH
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Timor-Leste
+    recipient_code: "765"
+    code: TL
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Viet Nam
+    recipient_code: "769"
+    code: VN
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Far East Asia, regional
+        code: "789"
+        level: 3
+  - name: Bahrain
+    recipient_code: "530"
+    code: BH
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Iran
+    recipient_code: "540"
+    code: IR
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Iraq
+    recipient_code: "543"
+    code: IQ
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Israel
+    recipient_code: "546"
+    code: IL
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Jordan
+    recipient_code: "549"
+    code: JO
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: West Bank and Gaza Strip
+    recipient_code: "550"
+    code: PS
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Kuwait
+    recipient_code: "552"
+    code: KW
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Lebanon
+    recipient_code: "555"
+    code: LB
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Oman
+    recipient_code: "558"
+    code: OM
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Qatar
+    recipient_code: "561"
+    code: QA
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Saudi Arabia
+    recipient_code: "566"
+    code: SA
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Syrian Arab Republic
+    recipient_code: "573"
+    code: SY
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: United Arab Emirates
+    recipient_code: "576"
+    code: AE
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Yemen
+    recipient_code: "580"
+    code: YE
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: Middle East, regional
+        code: "589"
+        level: 3
+  - name: Armenia
+    recipient_code: "610"
+    code: AM
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Azerbaijan
+    recipient_code: "611"
+    code: AZ
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Georgia
+    recipient_code: "612"
+    code: GE
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Kazakhstan
+    recipient_code: "613"
+    code: KZ
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Kyrgyzstan
+    recipient_code: "614"
+    code: KG
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Tajikistan
+    recipient_code: "615"
+    code: TJ
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Turkmenistan
+    recipient_code: "616"
+    code: TM
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Uzbekistan
+    recipient_code: "617"
+    code: UZ
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: Central Asia, regional
+        code: "619"
+        level: 3
+  - name: Afghanistan
+    recipient_code: "625"
+    code: AF
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Bhutan
+    recipient_code: "630"
+    code: BT
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Myanmar
+    recipient_code: "635"
+    code: MM
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Sri Lanka
+    recipient_code: "640"
+    code: LK
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: India
+    recipient_code: "645"
+    code: IN
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Maldives
+    recipient_code: "655"
+    code: MV
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Nepal
+    recipient_code: "660"
+    code: NP
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Pakistan
+    recipient_code: "665"
+    code: PK
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Bangladesh
+    recipient_code: "666"
+    code: BD
+    regions:
+      - name: Asia, regional
+        code: "798"
+        level: 1
+      - name: South & Central Asia, regional
+        code: "689"
+        level: 2
+      - name: South Asia, regional
+        code: "679"
+        level: 3
+  - name: Cyprus
+    recipient_code: "30"
+    code: CY
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Gibraltar
+    recipient_code: "35"
+    code: GI
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Malta
+    recipient_code: "45"
+    code: MT
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Turkey
+    recipient_code: "55"
+    code: TR
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Kosovo
+    recipient_code: "57"
+    code: XK
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Slovenia
+    recipient_code: "61"
+    code: SI
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Croatia
+    recipient_code: "62"
+    code: HR
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Serbia
+    recipient_code: "63"
+    code: RS
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Bosnia and Herzegovina
+    recipient_code: "64"
+    code: BA
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Montenegro
+    recipient_code: "65"
+    code: ME
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: North Macedonia
+    recipient_code: "66"
+    code: MK
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Albania
+    recipient_code: "71"
+    code: AL
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Ukraine
+    recipient_code: "85"
+    code: UA
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Belarus
+    recipient_code: "86"
+    code: BY
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: States Ex-Yugoslavia unspecified
+    recipient_code: "88"
+    code: A region on IATI code 88
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Moldova
+    recipient_code: "93"
+    code: MD
+    regions:
+      - name: Europe, regional
+        code: "89"
+        level: 1
+  - name: Fiji
+    recipient_code: "832"
+    code: FJ
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Melanesia, regional
+        code: "1033"
+        level: 3
+  - name: New Caledonia
+    recipient_code: "850"
+    code: NC
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Melanesia, regional
+        code: "1033"
+        level: 3
+  - name: Vanuatu
+    recipient_code: "854"
+    code: VU
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Melanesia, regional
+        code: "1033"
+        level: 3
+  - name: Papua New Guinea
+    recipient_code: "862"
+    code: PG
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Melanesia, regional
+        code: "1033"
+        level: 3
+  - name: Solomon Islands
+    recipient_code: "866"
+    code: SB
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Melanesia, regional
+        code: "1033"
+        level: 3
+  - name: Kiribati
+    recipient_code: "836"
+    code: KI
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: Nauru
+    recipient_code: "845"
+    code: NR
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: Northern Mariana Islands
+    recipient_code: "858"
+    code: MP
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: Marshall Islands
+    recipient_code: "859"
+    code: MH
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: Micronesia
+    recipient_code: "860"
+    code: FM
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: Palau
+    recipient_code: "861"
+    code: PW
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Micronesia, regional
+        code: "1034"
+        level: 3
+  - name: French Polynesia
+    recipient_code: "840"
+    code: PF
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Niue
+    recipient_code: "856"
+    code: NU
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Tokelau
+    recipient_code: "868"
+    code: TK
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Tonga
+    recipient_code: "870"
+    code: TO
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Tuvalu
+    recipient_code: "872"
+    code: TV
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Wallis and Futuna
+    recipient_code: "876"
+    code: WF
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3
+  - name: Samoa
+    recipient_code: "880"
+    code: WS
+    regions:
+      - name: Oceania, regional
+        code: "889"
+        level: 1
+      - name: Polynesia, regional
+        code: "1035"
+        level: 3

--- a/vendor/data/codelists/BEIS/benefitting_region_levels.yml
+++ b/vendor/data/codelists/BEIS/benefitting_region_levels.yml
@@ -1,0 +1,8 @@
+---
+data:
+  - name: Region
+    code: 1
+  - name: Sub-region 1
+    code: 2
+  - name: Sub-region 2
+    code: 3

--- a/vendor/data/codelists/BEIS/benefitting_region_levels.yml
+++ b/vendor/data/codelists/BEIS/benefitting_region_levels.yml
@@ -1,4 +1,10 @@
 ---
+metadata:
+  title: Region Levels
+  description: |
+    Each region (described in benefitting_regions.yml) has a level.
+    The lower the level's code, the less specific the region is
+  url: https://beisodahelp.zendesk.com/hc/en-gb/articles/4406544687379
 data:
   - name: Region
     code: 1

--- a/vendor/data/codelists/BEIS/benefitting_regions.yml
+++ b/vendor/data/codelists/BEIS/benefitting_regions.yml
@@ -1,0 +1,74 @@
+---
+data:
+  - name: Africa, regional
+    code: "298"
+    level: 1
+  - name: North of Sahara, regional
+    code: "189"
+    level: 2
+  - name: South of Sahara, regional
+    code: "289"
+    level: 2
+  - name: Eastern Africa, regional
+    code: "1027"
+    level: 3
+  - name: Middle Africa, regional
+    code: "1028"
+    level: 3
+  - name: Southern Africa, regional
+    code: "1029"
+    level: 3
+  - name: Western Africa, regional
+    code: "1030"
+    level: 3
+  - name: America, regional
+    code: "498"
+    level: 1
+  - name: Caribbean & Central America, regional
+    code: "389"
+    level: 2
+  - name: Caribbean, regional
+    code: "1031"
+    level: 3
+  - name: Central America, regional
+    code: "1032"
+    level: 3
+  - name: South America, regional
+    code: "489"
+    level: 2
+  - name: Asia, regional
+    code: "798"
+    level: 1
+  - name: Far East Asia, regional
+    code: "789"
+    level: 3
+  - name: Middle East, regional
+    code: "589"
+    level: 3
+  - name: South & Central Asia, regional
+    code: "689"
+    level: 2
+  - name: Central Asia, regional
+    code: "619"
+    level: 3
+  - name: South Asia, regional
+    code: "679"
+    level: 3
+  - name: Europe, regional
+    code: "89"
+    level: 1
+  - name: Oceania, regional
+    code: "889"
+    level: 1
+  - name: Melanesia, regional
+    code: "1033"
+    level: 3
+  - name: Micronesia, regional
+    code: "1034"
+    level: 3
+  - name: Polynesia, regional
+    code: "1035"
+    level: 3
+  - name: Developing countries, unspecified
+    code: "998"
+    level: 1

--- a/vendor/data/codelists/BEIS/benefitting_regions.yml
+++ b/vendor/data/codelists/BEIS/benefitting_regions.yml
@@ -1,4 +1,11 @@
 ---
+metadata:
+  title: Benefitting Regions
+  description: |
+    A list of all the regions that Benefitting Countries belong to (see
+    benefitting_countries.yml). Each region has a level (see region_levels.yml).
+    The lower the level, the less specific the region in
+  url: https://beisodahelp.zendesk.com/hc/en-gb/articles/4406544674707
 data:
   - name: Africa, regional
     code: "298"


### PR DESCRIPTION
This adds a new BEIS codelist that contains everything we know about benefitting countries, and uses this to infer a region when given an activity's benefitting countries. This is then presented to the user in the activity details page, as well as the report download and XML view.