### PR TITLE
(2118) A delivery partner user can export their own external income data

### DIFF
--- a/app/controllers/concerns/auth.rb
+++ b/app/controllers/concerns/auth.rb
@@ -13,7 +13,7 @@ module Auth
         t("page_content.errors.not_authorised.explanation")
       end
 
-      render "pages/errors/not_authorised", status: 401, locals: {error_message: error_message}
+      render "pages/errors/not_authorised", formats: [:html], status: 401, locals: {error_message: error_message}
     end
   end
 

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -12,7 +12,7 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
   def show
     authorize [:export, @organisation], :show?
 
-    add_breadcrumb t("breadcrumbs.export.index"), exports_path
+    add_breadcrumb(t("breadcrumbs.export.index"), exports_path) if policy([:export, Organisation]).index?
     add_breadcrumb t("breadcrumbs.export.organisation.show", name: @organisation.name), :exports_organisation_path
 
     @xml_downloads = Iati::XmlDownload.all_for_organisation(@organisation)

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -15,7 +15,7 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
     add_breadcrumb(t("breadcrumbs.export.index"), exports_path) if policy([:export, Organisation]).index?
     add_breadcrumb t("breadcrumbs.export.organisation.show", name: @organisation.name), :exports_organisation_path
 
-    @xml_downloads = Iati::XmlDownload.all_for_organisation(@organisation)
+    @xml_downloads = Iati::XmlDownload.all_for_organisation(@organisation) if policy([:export, @organisation]).show_xml?
   end
 
   def transactions

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -5,7 +5,7 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
   before_action do
     @reporting_organisation = Organisation.service_owner
     @organisation = Organisation.find(params[:id])
-    authorize :export, :show?
+    authorize [:export, @organisation], :show?
   end
 
   def show

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -2,7 +2,8 @@ class Staff::ExportsController < Staff::BaseController
   include Secured
 
   def index
-    authorize :export
+    authorize [:export, Organisation]
+
     add_breadcrumb t("breadcrumbs.export.index"), :exports_path
 
     @organisations = policy_scope(Organisation).delivery_partner

--- a/app/policies/export/organisation_policy.rb
+++ b/app/policies/export/organisation_policy.rb
@@ -6,6 +6,19 @@ module Export
 
     def show?
       return true if user.service_owner?
+      return true if user.delivery_partner? && user.organisation == record
+    end
+
+    def show_external_income?
+      show?
+    end
+
+    def show_transactions?
+      return true if user.service_owner?
+    end
+
+    def show_xml?
+      return true if user.service_owner?
     end
   end
 end

--- a/app/policies/export/organisation_policy.rb
+++ b/app/policies/export/organisation_policy.rb
@@ -1,0 +1,11 @@
+module Export
+  class OrganisationPolicy < ApplicationPolicy
+    def index?
+      user.service_owner?
+    end
+
+    def show?
+      return true if user.service_owner?
+    end
+  end
+end

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -1,9 +1,0 @@
-class ExportPolicy < ApplicationPolicy
-  def index?
-    user.service_owner?
-  end
-
-  def show?
-    user.service_owner?
-  end
-end

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -15,6 +15,9 @@
       - if policy([:export, Organisation]).index?
         %li{ class: navigation_item_class(exports_path) }
           = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"
+      - elsif policy([:export, current_user.organisation]).show?
+        %li{ class: navigation_item_class(exports_organisation_path(id: current_user.organisation_id)) }
+          = link_to t("page_title.export.index"), exports_organisation_path(id: current_user.organisation_id), class: "govuk-header__link"
 
       - if policy(Organisation).index?
         %li{ class: navigation_item_class(organisations_path) }

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -12,7 +12,7 @@
       %li{ class: navigation_item_class(organisation_activities_path(organisation_id: current_user.organisation_id)) }
         = link_to t("page_title.activity.index"), organisation_activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
 
-      - if policy(:export).index?
+      - if policy([:export, Organisation]).index?
         %li{ class: navigation_item_class(exports_path) }
           = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"
 

--- a/app/views/staff/exports/organisations/show.html.haml
+++ b/app/views/staff/exports/organisations/show.html.haml
@@ -15,8 +15,11 @@
             %th.govuk-table__header{scope: "col"}= t("table.export.organisation.format")
             %th.govuk-table__header{scope: "col"}= t("table.export.organisation.actions")
         %tbody.govuk-table__body
-          = render partial: "row", locals: { report: "All transactions", format: "CSV", download_url: transactions_exports_organisation_path(@organisation, format: "csv") }
-          - @xml_downloads.each do |download|
-            = render partial: "row", locals: { report: download.title, format: "XML", download_url: download.path }
-          - Fund.all.each do |fund|
-            = render partial: "row", locals: { report: "#{fund.name} external income", format: "CSV", download_url: external_income_exports_organisation_path(@organisation, fund_id: fund.id, format: "csv") }
+          - if policy([:export, @organisation]).show_transactions?
+            = render partial: "row", locals: { report: "All transactions", format: "CSV", download_url: transactions_exports_organisation_path(@organisation, format: "csv") }
+          - if policy([:export, @organisation]).show_xml?
+            - @xml_downloads.each do |download|
+              = render partial: "row", locals: { report: download.title, format: "XML", download_url: download.path }
+          - if policy([:export, @organisation]).show_external_income?
+            - Fund.all.each do |fund|
+              = render partial: "row", locals: { report: "#{fund.name} external income", format: "CSV", download_url: external_income_exports_organisation_path(@organisation, fund_id: fund.id, format: "csv") }

--- a/spec/controllers/staff/exports/organisations_controller_spec.rb
+++ b/spec/controllers/staff/exports/organisations_controller_spec.rb
@@ -13,9 +13,21 @@ RSpec.describe Staff::Exports::OrganisationsController do
     end
   end
 
-  shared_examples "does not allow the user to download the XML" do
-    it "does not allow the user to download XML" do
+  shared_examples "responds with a 401" do
+    it "does not allow the user to access the export" do
       expect(response.status).to eq(401)
+    end
+  end
+
+  shared_examples "allows the user to access the export" do
+    it "responds with a 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "sets the CSV headers correctly" do
+      expect(response.headers.to_h).to include({
+        "Content-Type" => "text/csv",
+      })
     end
   end
 
@@ -30,12 +42,28 @@ RSpec.describe Staff::Exports::OrganisationsController do
   context "when logged in as a delivery partner" do
     let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
+    describe "#external_income" do
+      before do
+        get :external_income, params: {id: organisation.id, fund_id: fund.id, format: :csv}
+      end
+
+      include_examples "allows the user to access the export"
+    end
+
+    describe "#transactions" do
+      before do
+        get :transactions, params: {id: organisation.id, format: :csv}
+      end
+
+      include_examples "responds with a 401"
+    end
+
     describe "#programme_activities" do
       before do
         get :programme_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "does not allow the user to download the XML"
+      include_examples "responds with a 401"
     end
 
     describe "#project_activities" do
@@ -43,7 +71,7 @@ RSpec.describe Staff::Exports::OrganisationsController do
         get :project_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "does not allow the user to download the XML"
+      include_examples "responds with a 401"
     end
 
     describe "#third_party_project_activities" do
@@ -51,12 +79,28 @@ RSpec.describe Staff::Exports::OrganisationsController do
         get :third_party_project_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "does not allow the user to download the XML"
+      include_examples "responds with a 401"
     end
   end
 
   context "when logged in as a BEIS user" do
     let(:user) { create(:beis_user) }
+
+    describe "#external_income" do
+      before do
+        get :external_income, params: {id: organisation.id, fund_id: fund.id, format: :csv}
+      end
+
+      include_examples "allows the user to access the export"
+    end
+
+    describe "#transactions" do
+      before do
+        get :transactions, params: {id: organisation.id, format: :csv}
+      end
+
+      include_examples "allows the user to access the export"
+    end
 
     describe "#programme_activities" do
       before do

--- a/spec/controllers/staff/exports/organisations_controller_spec.rb
+++ b/spec/controllers/staff/exports/organisations_controller_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Staff::Exports::OrganisationsController do
   context "when logged in as a delivery partner" do
     let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
+    describe "#show" do
+      it "only adds a breadcrumb for the current page" do
+        allow(controller).to receive(:add_breadcrumb).with(any_args)
+
+        expect(controller).to_not receive(:add_breadcrumb).with(t("breadcrumbs.export.index"), exports_path)
+        expect(controller).to receive(:add_breadcrumb).with(t("breadcrumbs.export.organisation.show", name: organisation.name), :exports_organisation_path)
+
+        get "show", params: {id: organisation.id}
+      end
+    end
+
     describe "#external_income" do
       before do
         get :external_income, params: {id: organisation.id, fund_id: fund.id, format: :csv}
@@ -85,6 +96,17 @@ RSpec.describe Staff::Exports::OrganisationsController do
 
   context "when logged in as a BEIS user" do
     let(:user) { create(:beis_user) }
+
+    describe "#show" do
+      it "adds the breadcrumb for the exports index and the current page" do
+        allow(controller).to receive(:add_breadcrumb).with(any_args)
+
+        expect(controller).to receive(:add_breadcrumb).with(t("breadcrumbs.export.index"), exports_path)
+        expect(controller).to receive(:add_breadcrumb).with(t("breadcrumbs.export.organisation.show", name: organisation.name), :exports_organisation_path)
+
+        get "show", params: {id: organisation.id}
+      end
+    end
 
     describe "#external_income" do
       before do

--- a/spec/controllers/staff/exports/organisations_controller_spec.rb
+++ b/spec/controllers/staff/exports/organisations_controller_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe Staff::Exports::OrganisationsController do
 
         get "show", params: {id: organisation.id}
       end
+
+      it "does not fetch the XML downloads" do
+        get "show", params: {id: organisation.id}
+
+        expect(assigns(:xml_downloads)).to be_nil
+      end
     end
 
     describe "#external_income" do
@@ -105,6 +111,12 @@ RSpec.describe Staff::Exports::OrganisationsController do
         expect(controller).to receive(:add_breadcrumb).with(t("breadcrumbs.export.organisation.show", name: organisation.name), :exports_organisation_path)
 
         get "show", params: {id: organisation.id}
+      end
+
+      it "fetches the XML downloads" do
+        get "show", params: {id: organisation.id}
+
+        expect(assigns(:xml_downloads)).to be_an(Array)
       end
     end
 

--- a/spec/policies/export/organisation_policy_spec.rb
+++ b/spec/policies/export/organisation_policy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ExportPolicy do
+RSpec.describe Export::OrganisationPolicy do
   subject { described_class.new(user, :export) }
 
   context "for a BEIS user" do

--- a/spec/policies/export/organisation_policy_spec.rb
+++ b/spec/policies/export/organisation_policy_spec.rb
@@ -1,13 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Export::OrganisationPolicy do
-  subject { described_class.new(user, :export) }
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  subject { described_class.new(user, organisation) }
 
   context "for a BEIS user" do
     let(:user) { create(:beis_user) }
 
     it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:show_external_income) }
+    it { is_expected.to permit_action(:show_transactions) }
+    it { is_expected.to permit_action(:show_xml) }
   end
 
   context "for a delivery partner" do
@@ -15,5 +20,19 @@ RSpec.describe Export::OrganisationPolicy do
 
     it { is_expected.to forbid_action(:index) }
     it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:show_external_income) }
+    it { is_expected.to forbid_action(:show_transactions) }
+    it { is_expected.to forbid_action(:show_xml) }
+
+    context "when the user's organisation matches the organisation" do
+      let(:organisation) { user.organisation }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:show_external_income) }
+
+      it { is_expected.to forbid_action(:index) }
+      it { is_expected.to forbid_action(:show_transactions) }
+      it { is_expected.to forbid_action(:show_xml) }
+    end
   end
 end

--- a/spec/views/staff/exports/organisations/show_spec.rb
+++ b/spec/views/staff/exports/organisations/show_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe "staff/exports/organisations/show" do
+  let(:organisation) { build(:delivery_partner_organisation, id: SecureRandom.uuid) }
+  let(:xml_downloads) do
+    [
+      double("Iati::XmlDownload", title: "XML Download 1", path: "http://example.com/1"),
+      double("Iati::XmlDownload", title: "XML Download 2", path: "http://example.com/2"),
+    ]
+  end
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:policy) do |record|
+        Pundit.policy(user, record)
+      end
+      allow(view).to receive(:current_user).and_return(user)
+    end
+
+    assign(:xml_downloads, xml_downloads)
+    assign(:organisation, organisation)
+
+    render
+  end
+
+  context "when the current user is a BEIS user" do
+    let(:user) { build(:beis_user) }
+
+    it "shows the link to download all transactions" do
+      expect(rendered).to have_export_row(report: "All transactions", path: transactions_exports_organisation_path(organisation, format: "csv"))
+    end
+
+    it "shows the links to download the XML" do
+      expect(rendered).to have_export_row(report: "XML Download 1", path: "http://example.com/1")
+      expect(rendered).to have_export_row(report: "XML Download 2", path: "http://example.com/2")
+    end
+
+    it "shows the links to download the external income" do
+      expect(rendered).to have_export_row(report: "Newton Fund external income", path: external_income_exports_organisation_path(organisation, fund_id: 1, format: "csv"))
+      expect(rendered).to have_export_row(report: "Global Challenges Research Fund external income", path: external_income_exports_organisation_path(organisation, fund_id: 2, format: "csv"))
+    end
+  end
+
+  context "when the current user is a delivery partner" do
+    let(:user) { build(:delivery_partner_user, organisation: organisation) }
+
+    it "does not show the link to download all transactions" do
+      expect(rendered).to_not have_export_row(report: "All transactions", path: transactions_exports_organisation_path(organisation, format: "csv"))
+    end
+
+    it "does not show the links to download the XML" do
+      expect(rendered).to_not have_export_row(report: "XML Download 1", path: "http://example.com/1")
+      expect(rendered).to_not have_export_row(report: "XML Download 2", path: "http://example.com/2")
+    end
+
+    it "shows the links to download the external income" do
+      expect(rendered).to have_export_row(report: "Newton Fund external income", path: external_income_exports_organisation_path(organisation, fund_id: 1, format: "csv"))
+      expect(rendered).to have_export_row(report: "Global Challenges Research Fund external income", path: external_income_exports_organisation_path(organisation, fund_id: 2, format: "csv"))
+    end
+  end
+
+  RSpec::Matchers.define :have_export_row do |args|
+    match do |actual|
+      export_row = export_row(actual, args)
+
+      expect(export_row).to_not be_nil
+      expect(export_row).to have_content(args[:report])
+      expect(export_row).to have_link(href: args[:path])
+    end
+
+    def export_row(actual, args)
+      body = Capybara.string(actual)
+      rows = body.all(".govuk-table__row")
+      rows.find { |r| r.has_css?("td.govuk-table__cell", text: args[:report]) }
+    end
+  end
+end

--- a/spec/views/staff/shared/navigation_spec.rb
+++ b/spec/views/staff/shared/navigation_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "shared/_navigation" do
+  let(:policy_stub) { double("policy") }
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:policy) do |record|
+        Pundit.policy(user, record)
+      end
+      allow(view).to receive(:current_user).and_return(user)
+      allow(user).to receive(:organisation_id).and_return(SecureRandom.uuid)
+    end
+
+    render
+  end
+
+  context "when the current user is a BEIS user" do
+    let(:user) { build(:beis_user) }
+
+    it "shows the link to the exports index" do
+      expect(rendered).to have_link(t("page_title.export.index"), href: exports_path)
+    end
+
+    it "does not show the link to an organisation export page" do
+      expect(rendered).to_not have_link(t("page_title.export.index"), href: exports_organisation_path(id: user.organisation_id))
+    end
+  end
+
+  context "when the current user is a delivery partner" do
+    let(:user) { build(:delivery_partner_user) }
+
+    it "does not show the link to the exports index" do
+      expect(rendered).to_not have_link(t("page_title.export.index"), href: exports_path)
+    end
+
+    it "shows the link to the delivery partner's organisation export page" do
+      expect(rendered).to have_link(t("page_title.export.index"), href: exports_organisation_path(id: user.organisation_id))
+    end
+  end
+end


### PR DESCRIPTION
This builds on the existing work to allow DP users to see the export page, as well as download their own external income data. I had to make a teeny tweak to the policy we use for exports, but hopefully this is more logical now. There's also a bunch of view specs added to test the template logic.

![image](https://user-images.githubusercontent.com/109774/132209153-664836c0-fad9-4918-bf5e-727324d12aef.png)
