### PR TITLE
Feature/refactor refunds to sti

### DIFF
--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -93,11 +93,11 @@ class Staff::RefundsController < Staff::ActivitiesController
         "id",
         "value",
         "financial_year",
-        "financial_quarter",
-        "comment"
+        "financial_quarter"
       ))
       .merge(report: refund.report,
-             parent_activity: refund.parent_activity)
+             parent_activity: refund.parent_activity,
+             comment: refund.comment.comment)
       .merge(persisted: true)
   end
 

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -4,13 +4,12 @@ class Staff::RefundsController < Staff::ActivitiesController
 
   def new
     @activity = activity
-    @refund = Refund.new
-    @report = Report.editable_for_activity(@activity)
+    @refund = RefundForm.new
 
     @refund.parent_activity = @activity
     @refund.report = @report
 
-    authorize @refund
+    authorize(@refund, policy_class: RefundPolicy)
 
     prepare_default_activity_trail(@activity)
     add_breadcrumb t("breadcrumb.refund.new"), new_activity_refund_path(@activity)
@@ -19,9 +18,12 @@ class Staff::RefundsController < Staff::ActivitiesController
   def create
     @activity = activity
     authorize @activity
+    @refund = RefundForm.new(refund_params)
+
+    return render :new unless @refund.valid?
 
     result = CreateRefund.new(activity: @activity)
-      .call(attributes: refund_params)
+      .call(attributes: @refund.attributes)
     @refund = result.object
 
     if result.success?
@@ -34,20 +36,22 @@ class Staff::RefundsController < Staff::ActivitiesController
 
   def edit
     @activity = activity
-    @refund = Refund.find(id)
+    @refund = RefundForm.new(attributes_for_editing)
 
-    authorize @refund
+    authorize(@refund, policy_class: RefundPolicy)
 
     prepare_default_activity_trail(@activity)
-    add_breadcrumb t("breadcrumb.refund.edit"), edit_activity_refund_path(@activity, @refund)
+    add_breadcrumb t("breadcrumb.refund.edit"), edit_activity_refund_path(@activity, @refund.id)
   end
 
   def update
-    @refund = Refund.find(id)
-    authorize @refund
+    @refund = RefundForm.new(attributes_for_editing.merge(refund_params))
+    authorize(@refund, policy_class: RefundPolicy)
+
+    return render :edit unless @refund.valid?
 
     result = UpdateRefund.new(
-      refund: @refund,
+      refund: Refund.find(id),
     ).call(attributes: refund_params)
 
     if result.success?
@@ -72,12 +76,29 @@ class Staff::RefundsController < Staff::ActivitiesController
   private
 
   def refund_params
-    params.require(:refund).permit(
+    params.require(:refund_form).permit(
       :value,
       :financial_quarter,
       :financial_year,
       :comment
     )
+  end
+
+  def attributes_for_editing
+    refund = Refund.find(id)
+
+    HashWithIndifferentAccess
+      .new
+      .merge(refund.attributes.slice(
+        "id",
+        "value",
+        "financial_year",
+        "financial_quarter",
+        "comment"
+      ))
+      .merge(report: refund.report,
+             parent_activity: refund.parent_activity)
+      .merge(persisted: true)
   end
 
   def activity_id

--- a/app/models/flexible_comment.rb
+++ b/app/models/flexible_comment.rb
@@ -1,0 +1,11 @@
+class FlexibleComment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+
+  before_create :set_commentable_type
+
+  validates :comment, presence: true
+
+  def set_commentable_type
+    self.commentable_type = commentable.class.to_s
+  end
+end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -1,8 +1,15 @@
 class Refund < ApplicationRecord
   include HasFinancialQuarter
+  has_one :comment,
+    -> { where(commentable_type: "Refund") },
+    foreign_key: :commentable_id,
+    dependent: :destroy,
+    autosave: true,
+    class_name: "FlexibleComment"
 
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report
+  validates_associated :comment
 
   validates :financial_quarter, presence: true
   validates :financial_year, presence: true

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -7,4 +7,13 @@ class Refund < Transaction
     class_name: "FlexibleComment"
 
   validates_associated :comment
+
+  def value=(amount)
+    big_decimal = begin
+                    BigDecimal(amount)
+                  rescue ArgumentError, TypeError
+                    return
+                  end
+    write_attribute(:value, -big_decimal.abs)
+  end
 end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -1,5 +1,4 @@
-class Refund < ApplicationRecord
-  include HasFinancialQuarter
+class Refund < Transaction
   has_one :comment,
     -> { where(commentable_type: "Refund") },
     foreign_key: :commentable_id,
@@ -7,11 +6,5 @@ class Refund < ApplicationRecord
     autosave: true,
     class_name: "FlexibleComment"
 
-  belongs_to :parent_activity, class_name: "Activity"
-  belongs_to :report
   validates_associated :comment
-
-  validates :financial_quarter, presence: true
-  validates :financial_year, presence: true
-  validates :value, presence: true
 end

--- a/app/models/refund_form.rb
+++ b/app/models/refund_form.rb
@@ -1,0 +1,35 @@
+class RefundForm
+  include ActiveModel::Model
+
+  attr_accessor :financial_quarter, :financial_year, :report,
+    :value, :comment, :parent_activity, :id
+
+  validates :financial_quarter, presence: true
+  validates :financial_year, presence: true
+  validates :value, presence: true
+  validates :comment, presence: true
+
+  def initialize(params = {})
+    @financial_quarter = params[:financial_quarter]
+    @financial_year = params[:financial_year]
+    @value = params[:value]
+    @comment = params[:comment]
+    @parent_activity = params[:parent_activity]
+    @report = params[:report]
+    @id = params[:id]
+    @persisted = params[:persisted]
+  end
+
+  def attributes
+    {
+      financial_quarter: financial_quarter,
+      financial_year: financial_year,
+      value: value,
+      comment: comment,
+    }
+  end
+
+  def persisted?
+    @persisted.present?
+  end
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -9,6 +9,7 @@ class Transaction < ApplicationRecord
   belongs_to :parent_activity, class_name: "Activity"
   belongs_to :report, optional: true
   has_many :historical_events, dependent: :destroy, as: :trackable
+  has_many :comments, dependent: :destroy, class_name: "FlexibleComment", as: :commentable
 
   validates_with TransactionOrganisationValidator
   validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }

--- a/app/services/create_refund.rb
+++ b/app/services/create_refund.rb
@@ -10,7 +10,7 @@ class CreateRefund
   def call(attributes:)
     refund.parent_activity = activity
     refund.report = report
-    refund.assign_attributes(attributes)
+    assign_refund_and_comment(attributes)
 
     result = if refund.valid?
       Result.new(refund.save, refund)
@@ -19,5 +19,13 @@ class CreateRefund
     end
 
     result
+  end
+
+  private
+
+  def assign_refund_and_comment(attrs)
+    refund.build_comment(comment: attrs.delete(:comment), commentable: refund)
+    refund.value = attrs.delete(:value)&.to_s
+    refund.assign_attributes(attrs)
   end
 end

--- a/app/services/update_refund.rb
+++ b/app/services/update_refund.rb
@@ -4,8 +4,7 @@ class UpdateRefund
   end
 
   def call(attributes: {})
-    refund.assign_attributes(attributes)
-
+    assign_refund_and_comment(attributes)
     success = refund.save
 
     if success
@@ -18,4 +17,10 @@ class UpdateRefund
   private
 
   attr_reader :refund
+
+  def assign_refund_and_comment(attrs)
+    refund.comment.comment = attrs.delete(:comment)
+    refund.value = attrs.delete(:value)&.to_s
+    refund.assign_attributes(attrs)
+  end
 end

--- a/app/views/staff/refunds/_form.html.haml
+++ b/app/views/staff/refunds/_form.html.haml
@@ -1,7 +1,8 @@
 = f.govuk_error_summary
 
 = f.govuk_text_field :value,
-  label: { text: t("form.label.refund.value"), tag: :p, size: 's' }
+  label: { text: t("form.label.refund.value"), tag: :p, size: 's' },
+  hint: { text: t("form.hint.refund.value") }
 
 = f.govuk_fieldset legend: { text: t("form.label.refund.financial_quarter") } do
   .govuk-grid-row

--- a/app/views/staff/refunds/_form.html.haml
+++ b/app/views/staff/refunds/_form.html.haml
@@ -1,6 +1,7 @@
 = f.govuk_error_summary
 
-= f.govuk_text_field :value
+= f.govuk_text_field :value,
+  label: { text: t("form.label.refund.value"), tag: :p, size: 's' }
 
 = f.govuk_fieldset legend: { text: t("form.label.refund.financial_quarter") } do
   .govuk-grid-row
@@ -16,7 +17,9 @@
         list_of_financial_years(FinancialYear.previous_ten),
         :id,
         :name,
-        label: { text: t("form.label.refund.financial_year"), tag: :p, size: 's' }
+        label: { text: t("form.label.refund.financial_year"), tag: :p, size: 's' },
+        options: { include_blank: true }
 
-= f.govuk_text_area :comment
+= f.govuk_text_area :comment,
+  hint: { text: t("form.hint.refund.comment") }
 

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -30,6 +30,7 @@ en:
       refund:
         financial_quarter_and_year: The financial quarter the refund applies to
         comment: The reason for posting the refund
+        value: Your refund is stored as a negative amount
   table:
     caption:
       refund:

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -43,6 +43,8 @@ en:
       models:
         refund:
           attributes:
+            comment:
+              invalid: Enter a comment describing the need for the refund
             financial_year:
               blank: Select a financial year
             financial_quarter:

--- a/config/locales/models/refund.en.yml
+++ b/config/locales/models/refund.en.yml
@@ -23,12 +23,13 @@ en:
   form:
     label:
       refund:
-        value: Transaction amount
+        value: Refund amount
         financial_quarter: Financial Quarter
         financial_year: Financial Year
     hint:
       refund:
         financial_quarter_and_year: The financial quarter the refund applies to
+        comment: The reason for posting the refund
   table:
     caption:
       refund:
@@ -37,3 +38,16 @@ en:
       refund:
         financial_quarter: Financial quarter
         value: Refund amount
+  activerecord:
+    errors:
+      models:
+        refund:
+          attributes:
+            financial_year:
+              blank: Select a financial year
+            financial_quarter:
+              blank: Select a financial quarter
+            value:
+              blank: Enter a refund amount
+              inclusion: Refund amount must be between 0.01 and 99,999,999,999.00
+              not_a_number: "Refund amount must be a valid number"

--- a/config/locales/models/refund_form.en.yml
+++ b/config/locales/models/refund_form.en.yml
@@ -1,0 +1,17 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        refund_form:
+          attributes:
+            financial_year:
+              blank: Select a financial year
+            financial_quarter:
+              blank: Select a financial quarter
+            comment:
+              blank: Enter a comment describing the need for the refund
+            value:
+              blank: Enter a refund amount
+              inclusion: Refund amount must be between 0.01 and 99,999,999,999.00
+              not_a_number: "Refund amount must be a valid number"

--- a/db/migrate/20210906173836_create_flexible_comments.rb
+++ b/db/migrate/20210906173836_create_flexible_comments.rb
@@ -1,0 +1,13 @@
+class CreateFlexibleComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :flexible_comments, id: :uuid do |t|
+      t.uuid :commentable_id
+      t.string :commentable_type
+      t.text :comment
+
+      t.timestamps
+    end
+    add_index :flexible_comments, :commentable_id
+    add_index :flexible_comments, :commentable_type
+  end
+end

--- a/db/migrate/20210909104830_drop_refunds.rb
+++ b/db/migrate/20210909104830_drop_refunds.rb
@@ -1,0 +1,17 @@
+class DropRefunds < ActiveRecord::Migration[6.1]
+  def up
+    Refund.table_name = "refunds"
+    begin
+      Refund.connection
+      raise "We expected the Refunds table to be empty" unless Refund.count.zero?
+
+      drop_table :refunds
+    rescue ActiveRecord::StatementInvalid => e
+      puts "Refunds already deleted: #{e}"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_123425) do
+ActiveRecord::Schema.define(version: 2021_09_06_173836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -132,6 +132,16 @@ ActiveRecord::Schema.define(version: 2021_09_07_123425) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["activity_id"], name: "index_external_incomes_on_activity_id"
     t.index ["organisation_id"], name: "index_external_incomes_on_organisation_id"
+  end
+
+  create_table "flexible_comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "commentable_id"
+    t.string "commentable_type"
+    t.text "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["commentable_id"], name: "index_flexible_comments_on_commentable_id"
+    t.index ["commentable_type"], name: "index_flexible_comments_on_commentable_type"
   end
 
   create_table "forecasts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_06_173836) do
+ActiveRecord::Schema.define(version: 2021_09_09_104830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -253,19 +253,6 @@ ActiveRecord::Schema.define(version: 2021_09_06_173836) do
     t.index ["destination_id"], name: "index_outgoing_transfers_on_destination_id"
     t.index ["report_id"], name: "index_outgoing_transfers_on_report_id"
     t.index ["source_id"], name: "index_outgoing_transfers_on_source_id"
-  end
-
-  create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "parent_activity_id"
-    t.uuid "report_id"
-    t.integer "financial_year"
-    t.integer "financial_quarter"
-    t.decimal "value", precision: 13, scale: 2
-    t.text "comment"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["parent_activity_id"], name: "index_refunds_on_parent_activity_id"
-    t.index ["report_id"], name: "index_refunds_on_report_id"
   end
 
   create_table "reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/flexible_comments.rb
+++ b/spec/factories/flexible_comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :flexible_comment do
+    commentable { association(:refund) }
+    comment { "A narrative explaining some scenario" }
+  end
+end

--- a/spec/factories/refunds.rb
+++ b/spec/factories/refunds.rb
@@ -1,11 +1,19 @@
 FactoryBot.define do
   factory :refund do
-    association :parent_activity, factory: :project_activity
-    association :report
-
+    transaction_type { "1" }
+    disbursement_channel { "1" }
+    currency { "gbp" }
+    ingested { false }
     financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
     financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
     value { BigDecimal("110.01") }
+
+    association :parent_activity, factory: :project_activity
+    association :report
+
+    receiving_organisation_name { nil }
+    receiving_organisation_reference { nil }
+    receiving_organisation_type { nil }
 
     after(:create) do |refund, _evaluator|
       create(:flexible_comment, commentable: refund)

--- a/spec/factories/refunds.rb
+++ b/spec/factories/refunds.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     financial_quarter { FinancialQuarter.for_date(Date.today).quarter }
     financial_year { FinancialQuarter.for_date(Date.today).financial_year.start_year }
     value { BigDecimal("110.01") }
-    comment { Faker::Lorem.paragraph }
+
+    after(:create) do |refund, _evaluator|
+      create(:flexible_comment, commentable: refund)
+      refund.reload
+    end
   end
 end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -63,7 +63,8 @@ RSpec.feature "Users can create a refund" do
   end
 
   def then_i_expect_to_see_how_i_need_to_correct_the_refund_form
-    expect(page).to have_content("Financial quarter can't be blank")
-    expect(page).to have_content("Value can't be blank")
+    expect(page).to have_content("Select a financial quarter")
+    expect(page).to have_content("Select a financial year")
+    expect(page).to have_content("Enter a refund amount")
   end
 end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -28,6 +28,12 @@ RSpec.feature "Users can create a refund" do
         expect(page).to have_content("£100")
       end
     end
+
+    scenario "must supply the required information to create a refund" do
+      given_i_am_on_the_new_refund_form
+      and_i_submit_the_new_refund_form_incorrectly
+      then_i_expect_to_see_how_i_need_to_correct_the_refund_form
+    end
   end
 
   context "when logged in as a BEIS user" do
@@ -42,5 +48,22 @@ RSpec.feature "Users can create a refund" do
       let(:user) { create(:delivery_partner_user, organisation: organisation) }
       let(:activity) { create(:project_activity, :with_report, organisation: organisation) }
     end
+  end
+
+  def given_i_am_on_the_new_refund_form
+    visit organisation_activity_financials_path(
+      organisation_id: activity.organisation.id,
+      activity_id: activity.id
+    )
+    click_on t("page_content.refund.button.create")
+  end
+
+  def and_i_submit_the_new_refund_form_incorrectly
+    click_on(t("default.button.submit"))
+  end
+
+  def then_i_expect_to_see_how_i_need_to_correct_the_refund_form
+    expect(page).to have_content("Financial quarter can't be blank")
+    expect(page).to have_content("Value can't be blank")
   end
 end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature "Users can create a refund" do
 
       click_on t("page_content.refund.button.create")
 
-      fill_in "refund[value]", with: "100"
-      choose "4", name: "refund[financial_quarter]"
-      select "2019-2020", from: "refund[financial_year]"
-      fill_in "refund[comment]", with: "Comment goes here"
+      fill_in "refund_form[value]", with: "100"
+      choose "4", name: "refund_form[financial_quarter]"
+      select "2019-2020", from: "refund_form[financial_year]"
+      fill_in "refund_form[comment]", with: "Comment goes here"
 
       expect { click_on(t("default.button.submit")) }.to change(Refund, :count).by(1)
 

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Users can create a refund" do
       )
 
       click_on t("page_content.refund.button.create")
+      then_i_see_that_my_refund_amount_will_be_negative
 
       fill_in "refund_form[value]", with: "100"
       choose "4", name: "refund_form[financial_quarter]"
@@ -25,7 +26,7 @@ RSpec.feature "Users can create a refund" do
 
       within "##{newly_created_refund.id}" do
         expect(page).to have_content("Q4 2019-2020")
-        expect(page).to have_content("£100")
+        expect(page).to have_content("-£100")
       end
     end
 
@@ -48,6 +49,10 @@ RSpec.feature "Users can create a refund" do
       let(:user) { create(:delivery_partner_user, organisation: organisation) }
       let(:activity) { create(:project_activity, :with_report, organisation: organisation) }
     end
+  end
+
+  def then_i_see_that_my_refund_amount_will_be_negative
+    expect(page).to have_content("Your refund is stored as a negative amount")
   end
 
   def given_i_am_on_the_new_refund_form

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -27,13 +27,12 @@ RSpec.feature "Users can edit a refund" do
       expect {
         click_on(t("default.button.submit"))
       }.to change {
-        refund.reload.attributes.slice("financial_year", "financial_quarter", "value", "comment")
+        refund.reload.attributes.slice("financial_year", "financial_quarter", "value")
       }.to({
         "financial_year" => 2019,
         "financial_quarter" => 4,
         "value" => BigDecimal("100"),
-        "comment" => "Comment goes here",
-      })
+      }).and change { refund.comment.reload.comment }.to("Comment goes here")
 
       expect(page).to have_content(t("action.refund.update.success"))
     end
@@ -68,6 +67,6 @@ RSpec.feature "Users can edit a refund" do
     page.has_css?(
       "#refund-form-financial-year-field option[value='#{refund.financial_year}'][selected='selected']"
     )
-    expect(page).to have_field("refund_form[comment]", with: refund.comment)
+    expect(page).to have_field("refund_form[comment]", with: refund.comment.comment)
   end
 end

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -19,10 +19,10 @@ RSpec.feature "Users can edit a refund" do
     end
 
     scenario "they can edit a refund for an activity" do
-      fill_in "refund[value]", with: "100"
-      choose "4", name: "refund[financial_quarter]"
-      select "2019-2020", from: "refund[financial_year]"
-      fill_in "refund[comment]", with: "Comment goes here"
+      fill_in "refund_form[value]", with: "100"
+      choose "4", name: "refund_form[financial_quarter]"
+      select "2019-2020", from: "refund_form[financial_year]"
+      fill_in "refund_form[comment]", with: "Comment goes here"
 
       expect {
         click_on(t("default.button.submit"))

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Users can edit a refund" do
         click_on "Edit refund"
       end
       then_i_see_the_refund_values_prefilled_as_expected
+      and_i_see_the_refund_value_field_with_a_negative_amount
     end
 
     scenario "they can edit a refund for an activity" do
@@ -31,7 +32,7 @@ RSpec.feature "Users can edit a refund" do
       }.to({
         "financial_year" => 2019,
         "financial_quarter" => 4,
-        "value" => BigDecimal("100"),
+        "value" => BigDecimal("-100"),
       }).and change { refund.comment.reload.comment }.to("Comment goes here")
 
       expect(page).to have_content(t("action.refund.update.success"))
@@ -59,7 +60,6 @@ RSpec.feature "Users can edit a refund" do
   end
 
   def then_i_see_the_refund_values_prefilled_as_expected
-    expect(page).to have_field("refund_form[value]", with: "110.01")
     expect(page).to have_checked_field(
       "refund_form[financial_quarter]",
       with: refund.financial_quarter
@@ -68,5 +68,9 @@ RSpec.feature "Users can edit a refund" do
       "#refund-form-financial-year-field option[value='#{refund.financial_year}'][selected='selected']"
     )
     expect(page).to have_field("refund_form[comment]", with: refund.comment.comment)
+  end
+
+  def and_i_see_the_refund_value_field_with_a_negative_amount
+    expect(page).to have_field("refund_form[value]", with: "-110.01")
   end
 end

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Users can edit a refund" do
       within "##{refund.id}" do
         click_on "Edit refund"
       end
+      then_i_see_the_refund_values_prefilled_as_expected
     end
 
     scenario "they can edit a refund for an activity" do
@@ -56,5 +57,17 @@ RSpec.feature "Users can edit a refund" do
       let(:activity) { create(:project_activity, organisation: organisation) }
       let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
     end
+  end
+
+  def then_i_see_the_refund_values_prefilled_as_expected
+    expect(page).to have_field("refund_form[value]", with: "110.01")
+    expect(page).to have_checked_field(
+      "refund_form[financial_quarter]",
+      with: refund.financial_quarter
+    )
+    page.has_css?(
+      "#refund-form-financial-year-field option[value='#{refund.financial_year}'][selected='selected']"
+    )
+    expect(page).to have_field("refund_form[comment]", with: refund.comment)
   end
 end

--- a/spec/features/staff/users_can_view_actuals_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_within_report_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Users can view actuals in tab within a report" do
 
           activity.refunds.each do |refund|
             within ".refunds" do
-              expect(page).to have_content(refund.value)
+              expect(page).to have_content(TransactionPresenter.new(refund).value)
               expect(page).to have_content(refund.financial_quarter_and_year)
             end
           end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Refund, type: :model do
   let(:refund) { build(:refund) }
+  it { should have_one(:comment) }
 
   it { should belong_to(:parent_activity) }
   it { should belong_to(:report) }
@@ -9,4 +10,32 @@ RSpec.describe Refund, type: :model do
   it { should validate_presence_of(:financial_quarter) }
   it { should validate_presence_of(:financial_year) }
   it { should validate_presence_of(:value) }
+  describe "validations" do
+    let(:refund) do
+      Refund.new.tap do |refund|
+        refund.build_comment(comment: nil)
+        refund.valid?
+      end
+    end
+
+    it "validates associated comment with a helpful message" do
+      expect(refund.errors[:comment])
+        .to include("Enter a comment describing the need for the refund")
+    end
+  end
+
+  describe "associated comment" do
+    let(:refund) { create(:refund) }
+
+    context "when the comment is edited and the refund is saved" do
+      before do
+        refund.comment.comment = "Edited comment"
+        refund.save
+      end
+
+      it "autosaves the associated comment" do
+        expect(refund.comment.reload.comment).to eq("Edited comment")
+      end
+    end
+  end
 end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -43,4 +43,46 @@ RSpec.describe Refund, type: :model do
       end
     end
   end
+
+  describe "#value" do
+    describe "always stores a negative #value" do
+      context "when given a positive value" do
+        let(:refund) { create(:refund, value: "100.01") }
+
+        it "stores a negative value" do
+          expect(refund.reload.value.to_s).to eq("-100.01")
+        end
+      end
+
+      context "when given a negative value" do
+        let(:refund) { create(:refund, value: "-100.01") }
+
+        it "stores a negative value" do
+          expect(refund.reload.value.to_s).to eq("-100.01")
+        end
+      end
+    end
+
+    context "when value is missing" do
+      let(:refund) { build(:refund, value: nil) }
+
+      it "is invalid" do
+        refund.valid?
+
+        expect(refund.errors.messages[:value])
+          .to eq(["Enter a refund amount", "Refund amount must be a valid number"])
+      end
+    end
+
+    context "when value is not a number" do
+      let(:refund) { build(:refund, value: "rubbish") }
+
+      it "is invalid" do
+        refund.valid?
+
+        expect(refund.errors.messages[:value])
+          .to eq(["Enter a refund amount", "Refund amount must be a valid number"])
+      end
+    end
+  end
 end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -1,15 +1,20 @@
 require "rails_helper"
 
 RSpec.describe Refund, type: :model do
-  let(:refund) { build(:refund) }
   it { should have_one(:comment) }
 
-  it { should belong_to(:parent_activity) }
-  it { should belong_to(:report) }
+  describe "Single table inheritance from Transaction" do
+    it "should inherit from the Transaction class " do
+      expect(Refund.ancestors).to include(Transaction)
+      expect(Refund.table_name).to eq("transactions")
+      expect(Refund.inheritance_column).to eq("type")
+    end
 
-  it { should validate_presence_of(:financial_quarter) }
-  it { should validate_presence_of(:financial_year) }
-  it { should validate_presence_of(:value) }
+    it "should have the _type_ of 'Refund'" do
+      expect(Refund.new.type).to eq("Refund")
+    end
+  end
+
   describe "validations" do
     let(:refund) do
       Refund.new.tap do |refund|

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -297,14 +297,14 @@ RSpec.describe Report, type: :model do
   end
 
   describe "#summed_refunds" do
-    it "sums all of the refunds belonging to a report" do
+    it "sums all of the refunds belonging to a report (NB: negative values)" do
       report = create(:report)
 
       create(:refund, report: report, value: 25)
       create(:refund, report: report, value: 75)
       create(:refund, report: report, value: 100)
 
-      expect(report.summed_refunds).to eq(200)
+      expect(report.summed_refunds).to eq(-200)
     end
   end
 end

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateRefund do
         it "sets the correct attributes" do
           expect(refund.parent_activity).to eq(activity)
           expect(refund.report).to eq(report)
-          expect(refund.value).to eq(100.10)
+          expect(refund.value).to eq(-100.10)
           expect(refund.financial_quarter).to eq(1)
           expect(refund.financial_year).to eq(2020)
           expect(refund.comment.comment).to eq("Some words")

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CreateRefund do
           expect(refund.value).to eq(100.10)
           expect(refund.financial_quarter).to eq(1)
           expect(refund.financial_year).to eq(2020)
-          expect(refund.comment).to eq("Some words")
+          expect(refund.comment.comment).to eq("Some words")
         end
       end
 

--- a/spec/services/update_refund_spec.rb
+++ b/spec/services/update_refund_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UpdateRefund do
 
         result = described_class.new(refund: refund).call(attributes: attributes)
 
-        expect(result.object.comment).to eq("abc")
+        expect(result.object.comment.comment).to eq("abc")
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

This PR adapts `Refund` to use our new Single Table Inheritance approach of representing the following flavours of `Transaction` as records backed by the `transactions` table:

- `Actual` (done)
- `Refund` (here)
- `Adjustment` (following in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1319 which will tweaked)

## Linked metadata

Whilst Actuals, Refunds and Adjustments are variants of Transaction with minimal differences:

- `Refund` is always negative
- `Adjustment` is associated with a `Report` in the approved state and can be either positive or negative

There are also some differences in the associated information (or 'metadata') around them:

- `Refund` must have a comment
- `Adjustment` must have a comment and an associated user

Our plan is to link these attributes through `has_many` or `has_one` associations. In the case of `Report`, this involves storing the `Refund#comment` in an associated entity. Rather than go down the rabbit-hole of refactoring the existing `Comment` model for this purpose we introduce a new `FlexibleComment` model which we intend to supersede `Comment`. The refactoring plan for `Comment` is:

- adjust `Refund` to use `FlexibleComment` (here)
- adjust `Adjustment` to use `FlexibleComment` (coming as part of the tweaked https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1319)
- migrate existing `Activity` commenting to use `FlexibleComment`  (soon)

## Refunds are always negative

The handling of calculations involving transactions is clearest if a transaction always has a value which is either positive or negative:

- `Actual`: always _positive_, indicating the movement of funds out of a fund, programme or project. This is "spend"
- `Refund`: always _negative_, indicating the movement of funds into a fund
- `Adjustment`: either _negative_ or _positive_, to effect a correction to an error in approved actuals or refunds

Consider these two cases: 

### 1. Calculation of total Actual, incl refund and positive adjustment

```
Actual      £30,000
Refund     -£10,000
Adjustment   £5,000
-------------------
TOTAL       £25,000

```

### 2. Calculation of total Actual, incl refund and negative adjustment

```
Actual      £30,000
Refund     -£10,000
Adjustment  -£5,000
-------------------
TOTAL       £15,000

```

In all cases we sum the transactions.

This is the default approach. If we need to breakout refunds separately and exclude them from a presentation of "total actual", we can do this using the scopes we have on `Transaction` through our STI classes e.g. as:

```
Actual.total + Adjustment.total
```

To make the `Refund#value` reliably negative we override the `value=` setter.

### Refund value form field:

<img width="857" alt="negative" src="https://user-images.githubusercontent.com/20245/132691456-309ee255-d34c-4f14-94ba-5a66ab00593c.png">

### Refund list on financials tab:

<img width="1147" alt="refund_presenter" src="https://user-images.githubusercontent.com/20245/132691505-11458e76-ed13-4495-9dfa-e1b6f7558edd.png">



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
