### PR TITLE
(2151) Undo benefitting countries data migration for specific situations

### DIFF
--- a/db/data/20210913122102_respect_legacy_recipient_region.rb
+++ b/db/data/20210913122102_respect_legacy_recipient_region.rb
@@ -1,0 +1,10 @@
+# Run me with `rails runner db/data/20210913122102_respect_legacy_recipient_region.rb`
+
+# For activities where no country was originally specified
+# we need to remove the benefitting countries that we added in the 20210804154421 data migration
+activities_to_update = Activity.where.not(recipient_region: nil).where(recipient_country: nil, intended_beneficiaries: nil)
+total_activities_to_update = activities_to_update.count
+
+puts "Removing benefitting_countries from #{total_activities_to_update}..."
+
+activities_to_update.update_all(benefitting_countries: nil)


### PR DESCRIPTION
## Changes in this PR
- Undo benefitting countries data migration for specific situations

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
