### PR TITLE
(2150) Describe the intended behaviour for recipient_region

### DIFF
--- a/spec/views/staff/shared/activities/activity_spec.rb
+++ b/spec/views/staff/shared/activities/activity_spec.rb
@@ -189,6 +189,26 @@ RSpec.describe "staff/shared/activities/_activity" do
     end
   end
 
+  describe "legacy recipient_region" do
+    let(:activity) { build(:programme_activity, recipient_region: "298", benefitting_countries: benefitting_countries) }
+
+    context "when the activity has no benefitting_countries" do
+      subject { body.find(".recipient_region") }
+
+      let(:benefitting_countries) { [] }
+
+      it { is_expected.to have_content("Africa, regional") }
+    end
+
+    context "when the activity has benefitting countries" do
+      subject { body }
+
+      let(:benefitting_countries) { ["DZ", "LY"] }
+
+      it { is_expected.to_not have_css(".recipient_region") }
+    end
+  end
+
   RSpec::Matchers.define :show_the_edit_add_actions do
     match do
       expect(rendered).to have_link(t("default.link.edit"))


### PR DESCRIPTION
## Changes in this PR
- Add a spec to describe the intended behaviour of the legacy field `recipient_region`

The intended behaviour is already in place, but it needs to be explicitly described to prevent regressions.

The `recipient_region` field acts as a legacy field, in that it is not editable anymore, but it has to be shown unless the user specifically chooses to provide benefitting_countries.

This feature will become more visible once we run the data migration that undoes the previous data migration, which had populated the inferred countries from the given region.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
