### PR TITLE
(2119) A BEIS user can export external income for all delivery partner organisations in a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -818,6 +818,7 @@
 
 - Added a new accepted channel of delivery code, "22000" ("Donor country-based NGO")
 - Force word wrapping in table cells showing invalid upload values
+- Allow a BEIS user to export external income for all delivery partner organisations
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-72...HEAD
 [release-72]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-71...release-72

--- a/app/controllers/staff/exports/organisations_controller.rb
+++ b/app/controllers/staff/exports/organisations_controller.rb
@@ -40,7 +40,7 @@ class Staff::Exports::OrganisationsController < Staff::BaseController
 
     respond_to do |format|
       format.csv do
-        export = QuarterlyExternalIncomeExport.new(@organisation, fund)
+        export = QuarterlyExternalIncomeExport.new(organisation: @organisation, source_fund: fund)
 
         stream_csv_download(filename: export.filename, headers: export.headers) do |csv|
           export.rows.each { |row| csv << row }

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -2,7 +2,7 @@ class Staff::ExportsController < Staff::BaseController
   include Secured
 
   def index
-    authorize [:export, Organisation]
+    authorize :export, :index?
 
     add_breadcrumb t("breadcrumbs.export.index"), :exports_path
 

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -1,5 +1,6 @@
 class Staff::ExportsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   def index
     authorize :export, :index?
@@ -7,5 +8,21 @@ class Staff::ExportsController < Staff::BaseController
     add_breadcrumb t("breadcrumbs.export.index"), :exports_path
 
     @organisations = policy_scope(Organisation).delivery_partner
+  end
+
+  def external_income
+    authorize :export, :show_external_income?
+
+    fund = Fund.new(params[:fund_id])
+
+    respond_to do |format|
+      format.csv do
+        export = QuarterlyExternalIncomeExport.new(source_fund: fund)
+
+        stream_csv_download(filename: export.filename, headers: export.headers) do |csv|
+          export.rows.each { |row| csv << row }
+        end
+      end
+    end
   end
 end

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -2,4 +2,8 @@ class ExportPolicy < ApplicationPolicy
   def index?
     user.service_owner?
   end
+
+  def show_external_income?
+    user.service_owner?
+  end
 end

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -1,0 +1,5 @@
+class ExportPolicy < ApplicationPolicy
+  def index?
+    user.service_owner?
+  end
+end

--- a/app/services/quarterly_external_income_export.rb
+++ b/app/services/quarterly_external_income_export.rb
@@ -9,7 +9,7 @@ class QuarterlyExternalIncomeExport
     "ODA",
   ]
 
-  def initialize(organisation, source_fund)
+  def initialize(organisation:, source_fund:)
     @organisation = organisation
     @source_fund = source_fund
   end

--- a/app/views/staff/exports/index.html.haml
+++ b/app/views/staff/exports/index.html.haml
@@ -8,6 +8,29 @@
 
   .govuk-grid-row.activity-page
     .govuk-grid-column-full
+
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "col"}
+              = t("table.export.header.fund")
+            %th.govuk-table__header{scope: "col"}
+              = t("table.export.header.format")
+            %th.govuk-table__header{scope: "col"}
+              = t("table.header.default.actions")
+        %tbody.govuk-table__body
+          - Fund.all.each do |fund|
+            %tr.govuk-table__row
+              %td.govuk-table__cell
+                = t("table.export.external_income.name", fund: fund.name)
+              %td.govuk-table__cell
+                CSV
+              %td.govuk-table__cell
+                = a11y_action_link("Download", external_income_exports_path(fund_id: fund.id, format: "csv"), "for #{fund.name}", ["govuk-link--no-visited-state"])
+
+      %h1.govuk-heading-m
+        = t("page_content.export.organisations.title")
+
       %table.govuk-table
         %thead.govuk-table__head
           %tr.govuk-table__row

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -8,6 +8,10 @@ en:
       index: Exports
       organisation:
         show: Exports for %{name}
+  page_content:
+    export:
+      organisations:
+        title: Exports for delivery partner organisations
   table:
     export:
       organisation:
@@ -15,6 +19,11 @@ en:
         actions: Actions
         download: Download
         format: Format
+      header:
+        fund: Fund
+        format: Format
+      external_income:
+        name: External income for %{fund}
   breadcrumbs:
     export:
       index: Exports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
       get "organisations/(:role)/new", to: "organisations#new", as: :new_organisation
     end
 
-    resources :exports, only: [:index]
+    resources :exports, only: [:index] do
+      get "external_income", on: :collection
+    end
 
     namespace :exports do
       resources :organisations, only: [:show] do

--- a/spec/controllers/staff/exports_controller_spec.rb
+++ b/spec/controllers/staff/exports_controller_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Staff::ExportsController do
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
+  let(:fund) { Fund.by_short_name("NF") }
+
+  describe "#external_income" do
+    before do
+      get "external_income", params: {fund_id: fund.id, format: :csv}
+    end
+
+    context "when logged in as a delivery partner" do
+      let(:user) { create(:delivery_partner_user) }
+
+      it "does not allow the user to access the report" do
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when logged in as a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "responds with a 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "sets the CSV headers correctly" do
+        expect(response.headers.to_h).to include({
+          "Content-Type" => "text/csv",
+        })
+      end
+
+      it "returns a CSV of all of the exports" do
+        expect(CSV.parse(response.body.delete_prefix("\uFEFF")).first).to match_array(QuarterlyExternalIncomeExport::HEADERS)
+      end
+    end
+  end
+end

--- a/spec/features/staff/beis_users_can_download_exports_spec.rb
+++ b/spec/features/staff/beis_users_can_download_exports_spec.rb
@@ -69,4 +69,73 @@ RSpec.feature "BEIS users can download exports" do
       },
     ])
   end
+
+  scenario "downloading the external income for all delivery partners" do
+    delivery_partner1, delivery_partner2 = create_list(:delivery_partner_organisation, 2)
+    project1 = create(:project_activity, :newton_funded, organisation: delivery_partner1)
+    project2 = create(:project_activity, :newton_funded, organisation: delivery_partner2)
+
+    ext_income1 = create(:external_income, activity: project1, financial_year: 2019, financial_quarter: 3, amount: 120)
+    ext_income2 = create(:external_income, activity: project2, financial_year: 2021, financial_quarter: 1, amount: 240)
+    ext_income3 = create(:external_income, activity: project2, financial_year: 2021, financial_quarter: 2, amount: 100)
+
+    visit external_income_exports_path(fund_id: Fund.by_short_name("NF").id, format: "csv")
+    document = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
+
+    expect(document.size).to eq(3)
+
+    expect(document).to match_array([
+      {
+        "RODA identifier" => project1.roda_identifier,
+        "Delivery partner identifier" => project1.delivery_partner_identifier,
+        "Delivery partner organisation" => delivery_partner1.name,
+        "Title" => project1.title,
+        "Level" => "Project (level C)",
+        "Providing organisation" => ext_income1.organisation.name,
+        "ODA" => "Yes",
+        "FQ3 2019-2020" => "120.00",
+        "FQ4 2019-2020" => "0.00",
+        "FQ1 2020-2021" => "0.00",
+        "FQ2 2020-2021" => "0.00",
+        "FQ3 2020-2021" => "0.00",
+        "FQ4 2020-2021" => "0.00",
+        "FQ1 2021-2022" => "0.00",
+        "FQ2 2021-2022" => "0.00",
+      },
+      {
+        "RODA identifier" => project2.roda_identifier,
+        "Delivery partner identifier" => project2.delivery_partner_identifier,
+        "Delivery partner organisation" => delivery_partner2.name,
+        "Title" => project2.title,
+        "Level" => "Project (level C)",
+        "Providing organisation" => ext_income2.organisation.name,
+        "ODA" => "Yes",
+        "FQ3 2019-2020" => "0.00",
+        "FQ4 2019-2020" => "0.00",
+        "FQ1 2020-2021" => "0.00",
+        "FQ2 2020-2021" => "0.00",
+        "FQ3 2020-2021" => "0.00",
+        "FQ4 2020-2021" => "0.00",
+        "FQ1 2021-2022" => "240.00",
+        "FQ2 2021-2022" => "0.00",
+      },
+      {
+        "RODA identifier" => project2.roda_identifier,
+        "Delivery partner identifier" => project2.delivery_partner_identifier,
+        "Delivery partner organisation" => delivery_partner2.name,
+        "Title" => project2.title,
+        "Level" => "Project (level C)",
+        "Providing organisation" => ext_income3.organisation.name,
+        "ODA" => "Yes",
+        "FQ3 2019-2020" => "0.00",
+        "FQ4 2019-2020" => "0.00",
+        "FQ1 2020-2021" => "0.00",
+        "FQ2 2020-2021" => "0.00",
+        "FQ3 2020-2021" => "0.00",
+        "FQ4 2020-2021" => "0.00",
+        "FQ1 2021-2022" => "0.00",
+        "FQ2 2021-2022" => "100.00",
+      },
+    ])
+  end
 end

--- a/spec/features/staff/beis_users_can_download_exports_spec.rb
+++ b/spec/features/staff/beis_users_can_download_exports_spec.rb
@@ -79,7 +79,9 @@ RSpec.feature "BEIS users can download exports" do
     ext_income2 = create(:external_income, activity: project2, financial_year: 2021, financial_quarter: 1, amount: 240)
     ext_income3 = create(:external_income, activity: project2, financial_year: 2021, financial_quarter: 2, amount: 100)
 
-    visit external_income_exports_path(fund_id: Fund.by_short_name("NF").id, format: "csv")
+    visit exports_path
+    click_link "Download for Newton Fund"
+
     document = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
 
     expect(document.size).to eq(3)

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ExportPolicy do
+  let(:user) { build_stubbed(:beis_user) }
+
+  subject { described_class.new(user, :export) }
+
+  context "as a BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    it { is_expected.to permit_action(:index) }
+  end
+
+  context "as a Delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    it { is_expected.to_not permit_action(:index) }
+  end
+end

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe ExportPolicy do
     let(:user) { create(:beis_user) }
 
     it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show_external_income) }
   end
 
   context "as a Delivery partner user" do
     let(:user) { create(:delivery_partner_user) }
 
     it { is_expected.to_not permit_action(:index) }
+    it { is_expected.to_not permit_action(:show_external_income) }
   end
 end

--- a/spec/services/quarterly_external_income_export_spec.rb
+++ b/spec/services/quarterly_external_income_export_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QuarterlyExternalIncomeExport do
 
   let(:project) { build(:project_activity, source_fund: fund, organisation: delivery_partner, id: SecureRandom.uuid) }
   let(:source_fund) { Fund.new(fund.source_fund_code) }
-  let(:export) { QuarterlyExternalIncomeExport.new(delivery_partner, source_fund) }
+  let(:export) { QuarterlyExternalIncomeExport.new(organisation: delivery_partner, source_fund: source_fund) }
 
   let(:external_income_relation) { double("ActiveRecord::Relation") }
 

--- a/spec/services/quarterly_external_income_export_spec.rb
+++ b/spec/services/quarterly_external_income_export_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe QuarterlyExternalIncomeExport do
       project,
     ])
 
-    allow(ExternalIncome).to receive(:includes).with(:activity, :organisation).and_return(external_income_relation)
+    allow(ExternalIncome).to receive(:includes).with(activity: :organisation).and_return(external_income_relation)
+    allow(external_income_relation).to receive(:includes).with(:organisation).and_return(external_income_relation)
     allow(external_income_relation).to receive(:where).with(activity_id: [project.id]).and_return(external_income_relation)
     allow(external_income_relation).to receive(:order).with(:activity_id, :financial_year, :financial_quarter).and_return(external_income)
   end
@@ -39,6 +40,12 @@ RSpec.describe QuarterlyExternalIncomeExport do
     it "concatenates the fund short name and the DP org short name" do
       expect(export.filename).to eql("#{source_fund.short_name}_#{delivery_partner.beis_organisation_reference}_external_income.csv")
     end
+  end
+
+  it "fetches the external income for the delivery partner organisation" do
+    expect(Activity).to receive(:where).with(organisation_id: delivery_partner.id, source_fund_code: source_fund.id)
+
+    export.rows
   end
 
   it "exports one quarter of external income for a single project" do
@@ -71,6 +78,24 @@ RSpec.describe QuarterlyExternalIncomeExport do
         [project.roda_identifier, "10.00", "0.00", "0.00", "0.00"],
         [project.roda_identifier, "0.00", "0.00", "0.00", "20.00"],
       ])
+    end
+  end
+
+  context "when the organisation is not provided" do
+    let(:export) { QuarterlyExternalIncomeExport.new(source_fund: source_fund) }
+
+    it "fetches the external income for all delivery partners" do
+      expect(Activity).to receive(:where).with(source_fund_code: source_fund.id).and_return([
+        project,
+      ])
+
+      export.rows
+    end
+
+    describe "#filename" do
+      it "only includes the fund short name in the export" do
+        expect(export.filename).to eql("#{source_fund.short_name}_external_income.csv")
+      end
     end
   end
 end


### PR DESCRIPTION
This builds on the external income export work to allow BEIS users to export data about External Income for all delivery partners. This is now listed on the BEIS users' export page like so:

![image](https://user-images.githubusercontent.com/109774/133233878-91aecbe6-02df-45e1-a906-2581981cc776.png)
