### PR TITLE
Increase deploy timeout

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -5,7 +5,7 @@ resource "cloudfoundry_app" "beis-roda-app" {
   space        = cloudfoundry_space.space.id
   instances    = 2
   disk_quota   = 3072
-  timeout      = 120
+  timeout      = 300
   docker_image = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
   docker_credentials = {
     username = "${var.docker_username}"

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -7,7 +7,7 @@ resource "cloudfoundry_app" "beis-roda-worker" {
   health_check_type = "none"
   memory            = 1024
   disk_quota        = 3072
-  timeout           = 120
+  timeout           = 300
   docker_image      = "thedxw/beis-report-official-development-assistance:${var.docker_image}"
   docker_credentials = {
     username = "${var.docker_username}"


### PR DESCRIPTION
We've been having some issues deploying, with the odd timeout causing our deploys to fail. After speaking to the GOV.UK PasS team, they've advised us that they've increased the maximum deploy timeout at their end, so have advised us to try increasing our maximum timeout to see if that helps.