### PR TITLE
(2188) Chore: Split Region from BenefittingCountry

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -51,7 +51,7 @@ module FormHelper
   end
 
   def benefitting_regions_for_form
-    BenefittingCountry::Region.all_for_level_code(BENEFITTING_SUB_REGION_2_CODE)
+    BenefittingRegion.all_for_level_code(BENEFITTING_SUB_REGION_2_CODE)
   end
 
   def benefitting_countries_in_region_for_form(region)

--- a/app/models/benefitting_country.rb
+++ b/app/models/benefitting_country.rb
@@ -27,7 +27,7 @@ class BenefittingCountry
       codes.filter_map { |code| find_by_code(code) if find_by_code(code).present? }
         .map { |c| c.regions }
         .inject(:&)
-        .max_by { |r| r.level.code } || Region.find_by_code(Region::DEVELOPING_COUNTRIES_CODE)
+        .max_by { |r| r.level.code } || BenefittingRegion.find_by_code(BenefittingRegion::DEVELOPING_COUNTRIES_CODE)
     end
 
     private
@@ -39,74 +39,9 @@ class BenefittingCountry
         recipient_code: country["recipient_code"],
         graduated: country["graduated"],
         regions: country["regions"].map { |region|
-          Region.find_by_code(region)
+          BenefittingRegion.find_by_code(region)
         }
       )
-    end
-  end
-
-  class Region
-    include ActiveModel::Model
-    attr_accessor :name, :code, :level
-
-    DEVELOPING_COUNTRIES_CODE = "998"
-
-    class << self
-      def all
-        @all ||= Codelist.new(type: "benefitting_regions", source: "beis").map { |region| new_from_hash(region) }
-      end
-
-      def all_for_level_code(level_code = 3)
-        level = BenefittingCountry::Region::Level.find_by_code(level_code)
-        all.select { |region| region.level == level }
-      end
-
-      def find_by_code(code)
-        all.find { |region| region.code == code }
-      end
-
-      private
-
-      def new_from_hash(region)
-        new(
-          name: region["name"],
-          code: region["code"],
-          level: Level.find_by_code(region["level"]),
-        )
-      end
-    end
-
-    def hash
-      code.hash
-    end
-
-    def eql?(other)
-      code == other.code
-    end
-
-    def ==(other)
-      code == other.code
-    end
-
-    class Level
-      include ActiveModel::Model
-      attr_accessor :name, :code
-
-      class << self
-        def all
-          @all ||= Codelist.new(type: "benefitting_region_levels", source: "beis").map { |level| new_from_hash(level) }
-        end
-
-        def find_by_code(code)
-          all.find { |level| level.code == code }
-        end
-
-        private
-
-        def new_from_hash(level)
-          new(name: level["name"], code: level["code"])
-        end
-      end
     end
   end
 end

--- a/app/models/benefitting_region.rb
+++ b/app/models/benefitting_region.rb
@@ -1,0 +1,64 @@
+class BenefittingRegion
+  include ActiveModel::Model
+  attr_accessor :name, :code, :level
+
+  DEVELOPING_COUNTRIES_CODE = "998"
+
+  class << self
+    def all
+      @all ||= Codelist.new(type: "benefitting_regions", source: "beis").map { |region| new_from_hash(region) }
+    end
+
+    def all_for_level_code(level_code = 3)
+      level = BenefittingRegion::Level.find_by_code(level_code)
+      all.select { |region| region.level == level }
+    end
+
+    def find_by_code(code)
+      all.find { |region| region.code == code }
+    end
+
+    private
+
+    def new_from_hash(region)
+      new(
+        name: region["name"],
+        code: region["code"],
+        level: Level.find_by_code(region["level"]),
+      )
+    end
+  end
+
+  def hash
+    code.hash
+  end
+
+  def eql?(other)
+    code == other.code
+  end
+
+  def ==(other)
+    code == other.code
+  end
+
+  class Level
+    include ActiveModel::Model
+    attr_accessor :name, :code
+
+    class << self
+      def all
+        @all ||= Codelist.new(type: "benefitting_region_levels", source: "beis").map { |level| new_from_hash(level) }
+      end
+
+      def find_by_code(code)
+        all.find { |level| level.code == code }
+      end
+
+      private
+
+      def new_from_hash(level)
+        new(name: level["name"], code: level["code"])
+      end
+    end
+  end
+end

--- a/spec/features/staff/users_can_add_benefitting_countries_in_one_step_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_in_one_step_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "users can add benefitting countries" do
 
     scenario "the user with JavaScript enabled can select whole regions at once", js: true do
       activity.benefitting_countries = nil
-      caribbean_region = BenefittingCountry::Region.find_by_code("1031")
+      caribbean_region = BenefittingRegion.find_by_code("1031")
       countries_in_region = BenefittingCountry.non_graduated_for_region(caribbean_region)
       country_codes = countries_in_region.map { |country| country.code }
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1489,7 +1489,7 @@ RSpec.describe Activity, type: :model do
 
     context "when there are countries present" do
       let(:benefitting_countries) { ["ZA", "ZW"] }
-      let(:region) { BenefittingCountry::Region.new }
+      let(:region) { BenefittingRegion.new }
 
       it "returns a region" do
         expect(BenefittingCountry).to receive(:region_from_country_codes).with(benefitting_countries).and_return(region)
@@ -1508,7 +1508,7 @@ RSpec.describe Activity, type: :model do
 
     context "when there is an unexpcted country" do
       let(:benefitting_countries) { ["UK", "DZ", "LY"] }
-      let(:region) { BenefittingCountry::Region.find_by_code("189") }
+      let(:region) { BenefittingRegion.find_by_code("189") }
 
       it "handles the unexpected country and returns the region that can be derived" do
         expect(subject).to eql(region)
@@ -1517,7 +1517,7 @@ RSpec.describe Activity, type: :model do
 
     context "when there is a graduated country" do
       let(:benefitting_countries) { ["SC", "KM", "BI"] }
-      let(:region) { BenefittingCountry::Region.find_by_code("1027") }
+      let(:region) { BenefittingRegion.find_by_code("1027") }
 
       it "handles graduated countries including them in the region calculation" do
         expect(subject).to eql(region)

--- a/spec/models/benefitting_country_spec.rb
+++ b/spec/models/benefitting_country_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 
 RSpec.describe BenefittingCountry do
-  let(:region) { BenefittingCountry::Region::Level.new(code: 1, name: "Region") }
-  let(:subregion1) { BenefittingCountry::Region::Level.new(code: 2, name: "Sub-region 1") }
-  let(:subregion2) { BenefittingCountry::Region::Level.new(code: 3, name: "Sub-region 2") }
+  let(:region) { BenefittingRegion::Level.new(code: 1, name: "Region") }
+  let(:subregion1) { BenefittingRegion::Level.new(code: 2, name: "Sub-region 1") }
+  let(:subregion2) { BenefittingRegion::Level.new(code: 3, name: "Sub-region 2") }
 
-  let(:africa) { BenefittingCountry::Region.new(name: "Africa, regional", code: "298", level: region) }
-  let(:south_of_sahara) { BenefittingCountry::Region.new(name: "South of Sahara, regional", code: "289", level: subregion1) }
-  let(:middle_africa) { BenefittingCountry::Region.new(name: "Middle Africa, regional", code: "1028", level: subregion2) }
-  let(:eastern_africa) { BenefittingCountry::Region.new(name: "Eastern Africa, regional", code: "1027", level: subregion2) }
-  let(:southern_africa) { BenefittingCountry::Region.new(name: "Southern Africa, regional", code: "102", level: subregion2) }
-  let(:north_of_sahara) { BenefittingCountry::Region.new(name: "North of Sahara, regional", code: "189", level: subregion2) }
-  let(:asia) { BenefittingCountry::Region.new(name: "Asia, regional", code: "798", level: region) }
-  let(:middle_east) { BenefittingCountry::Region.new(name: "Middle East, regional", code: "589", level: subregion1) }
+  let(:africa) { BenefittingRegion.new(name: "Africa, regional", code: "298", level: region) }
+  let(:south_of_sahara) { BenefittingRegion.new(name: "South of Sahara, regional", code: "289", level: subregion1) }
+  let(:middle_africa) { BenefittingRegion.new(name: "Middle Africa, regional", code: "1028", level: subregion2) }
+  let(:eastern_africa) { BenefittingRegion.new(name: "Eastern Africa, regional", code: "1027", level: subregion2) }
+  let(:southern_africa) { BenefittingRegion.new(name: "Southern Africa, regional", code: "102", level: subregion2) }
+  let(:north_of_sahara) { BenefittingRegion.new(name: "North of Sahara, regional", code: "189", level: subregion2) }
+  let(:asia) { BenefittingRegion.new(name: "Asia, regional", code: "798", level: region) }
+  let(:middle_east) { BenefittingRegion.new(name: "Middle East, regional", code: "589", level: subregion1) }
 
   let(:graduated_countries) do
     [
@@ -182,39 +182,6 @@ RSpec.describe BenefittingCountry do
 
       it "gets the most specific region" do
         expect(subject.code).to eq("298")
-      end
-    end
-  end
-end
-
-RSpec.describe BenefittingCountry::Region do
-  let(:region) { BenefittingCountry::Region::Level.new(code: 1, name: "Region") }
-  let(:subregion1) { BenefittingCountry::Region::Level.new(code: 2, name: "Sub-region 1") }
-  let(:subregion2) { BenefittingCountry::Region::Level.new(code: 3, name: "Sub-region 2") }
-
-  let(:africa) { BenefittingCountry::Region.new(name: "Africa, regional", code: "298", level: region) }
-  let(:south_of_sahara) { BenefittingCountry::Region.new(name: "South of Sahara, regional", code: "289", level: subregion1) }
-  let(:middle_africa) { BenefittingCountry::Region.new(name: "Middle Africa, regional", code: "1028", level: subregion2) }
-
-  let(:regions) { [africa, south_of_sahara, middle_africa] }
-  let(:region_levels) { [region, subregion1, subregion2] }
-
-  before do
-    allow(described_class).to receive(:all).and_return(regions)
-    allow(described_class::Level).to receive(:all).and_return(region_levels)
-  end
-
-  describe ".all_for_level" do
-    subject { described_class.all_for_level_code(code) }
-
-    context "with level 3 (sub region 3)" do
-      let(:code) { 3 }
-
-      it "returns all the regions for a given level" do
-        expect(subject.count).to eql 1
-        expect(subject).not_to include africa
-        expect(subject).not_to include south_of_sahara
-        expect(subject).to include middle_africa
       end
     end
   end

--- a/spec/models/benefitting_region_spec.rb
+++ b/spec/models/benefitting_region_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe BenefittingRegion do
+  let(:region) { BenefittingRegion::Level.new(code: 1, name: "Region") }
+  let(:subregion1) { BenefittingRegion::Level.new(code: 2, name: "Sub-region 1") }
+  let(:subregion2) { BenefittingRegion::Level.new(code: 3, name: "Sub-region 2") }
+
+  let(:africa) { BenefittingRegion.new(name: "Africa, regional", code: "298", level: region) }
+  let(:south_of_sahara) { BenefittingRegion.new(name: "South of Sahara, regional", code: "289", level: subregion1) }
+  let(:middle_africa) { BenefittingRegion.new(name: "Middle Africa, regional", code: "1028", level: subregion2) }
+
+  let(:regions) { [africa, south_of_sahara, middle_africa] }
+  let(:region_levels) { [region, subregion1, subregion2] }
+
+  before do
+    allow(described_class).to receive(:all).and_return(regions)
+    allow(described_class::Level).to receive(:all).and_return(region_levels)
+  end
+
+  describe ".all_for_level" do
+    subject { described_class.all_for_level_code(code) }
+
+    context "with level 3 (sub region 3)" do
+      let(:code) { 3 }
+
+      it "returns all the regions for a given level" do
+        expect(subject.count).to eql 1
+        expect(subject).not_to include africa
+        expect(subject).not_to include south_of_sahara
+        expect(subject).to include middle_africa
+      end
+    end
+  end
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe ActivityPresenter do
     before { expect(activity).to receive(:benefitting_region).at_least(:once).and_return(region) }
 
     context "when there is a benefitting region" do
-      let(:region) { BenefittingCountry::Region.new(name: "Some region") }
+      let(:region) { BenefittingRegion.new(name: "Some region") }
 
       it { is_expected.to eq(region.name) }
     end


### PR DESCRIPTION
In #1344 It was noted in a review that BenefittingCountry::Region was becoming a
first class citizen and we felt it should be split out in to its own
file.

We took the opportunity to rename it BenefittingRegion to keep the link
with the concept it is modelling as clear as we can.
