### PR TITLE
(2044) Feature: Add links to reports on BEIS homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -823,6 +823,8 @@
 
 ## [unreleased]
 
+- BEIS users have a link to delivery partners reports on the homepage
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-73...HEAD
 [release-73]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-72...release-73
 [release-72]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-71...release-72

--- a/app/views/staff/home/_delivery_partner_organisations_table.html.haml
+++ b/app/views/staff/home/_delivery_partner_organisations_table.html.haml
@@ -14,5 +14,6 @@
           = delivery_partner_organisation.name
         %td.govuk-table__cell
           = a11y_action_link "View details ", organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state"]
-          = a11y_action_link "View activities", organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-9"]
-          = a11y_action_link "View exports", exports_organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-9"]
+          = a11y_action_link "View activities", organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
+          = a11y_action_link "View exports", exports_organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
+          = a11y_action_link "View reports", organisation_reports_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]

--- a/spec/views/home/serice_owner_spec.rb
+++ b/spec/views/home/serice_owner_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "staff/home/service_owner" do
+  before do
+    assign(:current_user, build(:beis_user))
+    assign(:delivery_partner_organisations, build_list(:delivery_partner_organisation, 2))
+
+    stub_template "staff/shared/reports/_delivery_partners_organisations_table" => "table of delivery partners"
+    stub_template "staff/searches/_form" => "search form"
+
+    allow(view).to receive(:organisation_path).and_return("/organisations/id")
+    allow(view).to receive(:organisation_activities_path).and_return("/organisation/id/activities")
+    allow(view).to receive(:exports_organisation_path).and_return("/exports/organisation/id")
+    allow(view).to receive(:organisation_reports_path).and_return("/organisation/id/reports")
+
+    render
+  end
+
+  it "has links to a delivery partners details, activities, exports and reports" do
+    expect(rendered).to have_link("View details", href: "/organisations/id")
+    expect(rendered).to have_link("View activities", href: "/organisation/id/activities")
+    expect(rendered).to have_link("View exports", href: "/exports/organisation/id")
+    expect(rendered).to have_link("View reports", href: "/organisation/id/reports")
+  end
+end


### PR DESCRIPTION
## Changes in this PR
As with a delivery partners organisation details, activities and
exports, a BEIS user (the service owners) may want to view the reports
for a specific delivery partners.

Facilitating them to do so right from the home page we add a link.

# Screenshots of UI changes
![Screenshot 2021-09-16 at 12-18-54 - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/133603421-061d6c59-ff86-414f-bf43-0e959d15e127.png)

