### PR TITLE
(2085) Show activity summary on all activity tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -824,6 +824,7 @@
 ## [unreleased]
 
 - BEIS users have a link to delivery partners reports on the homepage
+- Show the activity summary on all activity tabs
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-73...HEAD
 [release-73]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-72...release-73

--- a/app/views/staff/activities/children.html.haml
+++ b/app/views/staff/activities/children.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       - if @activity.project? || @activity.third_party_project?

--- a/app/views/staff/activities/comments.html.haml
+++ b/app/views/staff/activities/comments.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       .govuk-tabs

--- a/app/views/staff/activities/details.html.haml
+++ b/app/views/staff/activities/details.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       - if @activity.project? || @activity.third_party_project?

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       - if @activity.project? || @activity.third_party_project?

--- a/app/views/staff/activities/historical_events.html.haml
+++ b/app/views/staff/activities/historical_events.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       .govuk-tabs

--- a/app/views/staff/activities/other_funding.html.haml
+++ b/app/views/staff/activities/other_funding.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       .govuk-tabs

--- a/app/views/staff/activities/transfers.html.haml
+++ b/app/views/staff/activities/transfers.html.haml
@@ -6,6 +6,11 @@
       %h1.govuk-heading-xl
         = @activity.title
 
+  - unless @activity.fund?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/activities/activity_summary", locals: { activity_presenter: @activity }
+
   .govuk-grid-row
     .govuk-grid-column-full
       .govuk-tabs

--- a/app/views/staff/shared/activities/_activity_summary.html.haml
+++ b/app/views/staff/shared/activities/_activity_summary.html.haml
@@ -1,0 +1,31 @@
+%dl.govuk-summary-list.activity-summary
+  - if current_user.service_owner?
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("summary.label.activity.delivery_partner_organisation")
+      %dd.govuk-summary-list__value
+        = activity_presenter.extending_organisation.name
+
+  .govuk-summary-list__row.fund
+    %dt.govuk-summary-list__key
+      Fund
+    %dd.govuk-summary-list__value
+      = activity_presenter.source_fund.name
+
+  .govuk-summary-list__row.programme_status
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.programme_status")
+    %dd.govuk-summary-list__value
+      = activity_presenter.programme_status
+
+  .govuk-summary-list__row.roda_identifier
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.roda_identifier")
+    %dd.govuk-summary-list__value
+      = activity_presenter.roda_identifier
+
+  .govuk-summary-list__row.identifier
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.delivery_partner_identifier")
+    %dd.govuk-summary-list__value
+      = activity_presenter.delivery_partner_identifier

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -255,6 +255,7 @@ en:
         gdi: GDI
         geography: Benefitting recipient geography
         delivery_partner_identifier: Delivery partner identifier
+        delivery_partner_organisation: Delivery partner organisation
         intended_beneficiaries: Intended beneficiaries
         objectives: Aims/Objectives
         oda_eligibility: ODA eligibility

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -242,11 +242,11 @@ end
 
 def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   if activity.delivery_partner_identifier.blank?
-    within(".identifier") do
+    within(".activity-details .identifier") do
       expect(page).to have_link(href: activity_step_path(activity, :identifier))
     end
   else
-    within(".identifier") do
+    within(".activity-details .identifier") do
       expect(page).to_not have_link(href: activity_step_path(activity, :identifier))
     end
   end
@@ -274,7 +274,7 @@ def assert_all_edit_links_go_to_the_correct_form_step(activity:)
   end
 
   unless activity.fund?
-    within(".programme_status") do
+    within(".activity-details .programme_status") do
       expect(page).to have_link(href: activity_step_path(activity, :programme_status))
     end
   end


### PR DESCRIPTION
## Changes in this PR
- Show the activity summary for all activities except funds. (Most of the fields don’t make sense for fund-level activities.)

## Screenshots of UI changes

### After

#### Delivery partner view
<img width="968" alt="Screenshot 2021-09-16 at 17 07 25" src="https://user-images.githubusercontent.com/579522/133647038-50819ad1-a059-45e6-bbab-cbe1e0f83fb6.png">

#### BEIS user view
<img width="1034" alt="Screenshot 2021-09-16 at 17 06 43" src="https://user-images.githubusercontent.com/579522/133647066-9fb461be-ba10-4654-9827-db5a32750b22.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
