### PR TITLE
(2051) Include Adjustments in CSV exports

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -424,7 +424,7 @@ class Activity < ApplicationRecord
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    ActualOverview.new(self, report).value_for_report_quarter
+    ActualOverview.new(activity: self, report: report).value_for_report_quarter
   end
 
   def forecasted_total_for_report_financial_quarter(report:)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -20,6 +20,8 @@ class Transaction < ApplicationRecord
 
   before_validation :set_financial_quarter_from_date
 
+  scope :with_adjustment_details, -> { joins("LEFT OUTER JOIN adjustment_details ON transactions.id = adjustment_details.adjustment_id") }
+
   private
 
   def set_financial_quarter_from_date

--- a/app/services/actual_overview.rb
+++ b/app/services/actual_overview.rb
@@ -37,7 +37,7 @@ class ActualOverview
   def scope
     if @include_adjustments
       Transaction
-        .joins("LEFT OUTER JOIN adjustment_details ON transactions.id = adjustment_details.adjustment_id")
+        .with_adjustment_details
         .where(type: "Actual")
         .or(
           Transaction

--- a/app/services/actual_overview.rb
+++ b/app/services/actual_overview.rb
@@ -35,7 +35,20 @@ class ActualOverview
   end
 
   def scope
-    @include_adjustments ? Transaction.where(type: ["Actual", "Adjustment"]) : Actual
+    if @include_adjustments
+      Transaction
+        .joins("LEFT OUTER JOIN adjustment_details ON transactions.id = adjustment_details.adjustment_id")
+        .where(type: "Actual")
+        .or(
+          Transaction
+            .where(
+              type: "Adjustment",
+              adjustment_details: {adjustment_type: "Actual"}
+            )
+        )
+    else
+      Actual
+    end
   end
 
   class AllQuarters

--- a/app/services/actual_overview.rb
+++ b/app/services/actual_overview.rb
@@ -1,7 +1,8 @@
 class ActualOverview
-  def initialize(activity, report)
+  def initialize(activity:, report:, include_adjustments: false)
     @activity = activity
     @report = report
+    @include_adjustments = include_adjustments
   end
 
   def all_quarters
@@ -27,10 +28,14 @@ class ActualOverview
   private
 
   def actual_relation
-    Actual
+    scope
       .joins(:report)
       .where(parent_activity_id: @activity.id)
       .merge(Report.historically_up_to(@report))
+  end
+
+  def scope
+    @include_adjustments ? Transaction.where(type: ["Actual", "Adjustment"]) : Actual
   end
 
   class AllQuarters

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -150,10 +150,6 @@ class Report
           variance_data
       end
 
-      private
-
-      attr_reader :activity, :report_presenter, :previous_report_quarters, :following_report_quarters
-
       def activity_data
         ACTIVITY_HEADERS.map do |_key, value|
           activity_presenter.send(value)
@@ -161,8 +157,6 @@ class Report
       end
 
       def previous_quarter_actuals
-        actual_quarters = ActualOverview.new(activity: activity_presenter, report: report_presenter).all_quarters
-
         previous_report_quarters.map do |quarter|
           value = actual_quarters.value_for(**quarter)
           "%.2f" % value
@@ -170,8 +164,6 @@ class Report
       end
 
       def next_quarter_forecasts
-        forecast_quarters = ForecastOverview.new(activity_presenter).snapshot(report_presenter).all_quarters
-
         following_report_quarters.map do |quarter|
           value = forecast_quarters.value_for(**quarter)
           "%.2f" % value
@@ -180,7 +172,7 @@ class Report
 
       def variance_data
         [
-          activity_presenter.variance_for_report_financial_quarter(report: report_presenter),
+          variance_for_report_financial_quarter,
           activity_presenter.comment_for_report(report_id: report_presenter.id)&.comment,
           activity_presenter.source_fund&.name,
           activity_presenter.extending_organisation&.beis_organisation_reference,
@@ -188,8 +180,24 @@ class Report
         ]
       end
 
+      private
+
+      attr_reader :activity, :report_presenter, :previous_report_quarters, :following_report_quarters
+
       def activity_presenter
         @activity_presenter ||= ActivityCsvPresenter.new(activity)
+      end
+
+      def forecast_quarters
+        @forecast_quarters ||= ForecastOverview.new(activity_presenter).snapshot(report_presenter).all_quarters
+      end
+
+      def actual_quarters
+        @actual_quarters ||= ActualOverview.new(activity: activity_presenter, report: report_presenter, include_adjustments: true).all_quarters
+      end
+
+      def variance_for_report_financial_quarter
+        forecast_quarters.value_for(**report_presenter.own_financial_quarter) - actual_quarters.value_for(**report_presenter.own_financial_quarter)
       end
     end
   end

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -161,7 +161,7 @@ class Report
       end
 
       def previous_quarter_actuals
-        actual_quarters = ActualOverview.new(activity_presenter, report_presenter).all_quarters
+        actual_quarters = ActualOverview.new(activity: activity_presenter, report: report_presenter).all_quarters
 
         previous_report_quarters.map do |quarter|
           value = actual_quarters.value_for(**quarter)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Transaction, type: :model do
 
   it { should have_many(:historical_events) }
 
+  describe ".with_adjustment_details" do
+    it "should optionally join the adjustment details table" do
+      scope = Adjustment.with_adjustment_details
+
+      expect(scope.to_sql).to include("LEFT OUTER JOIN adjustment_details ON transactions.id = adjustment_details.adjustment_id")
+    end
+  end
+
   describe "validations" do
     it { should validate_presence_of(:value) }
     it { should validate_presence_of(:financial_year) }

--- a/spec/services/actual_overview_spec.rb
+++ b/spec/services/actual_overview_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe ActualOverview do
     create_actual(financial_year: 2018, financial_quarter: 3, value: 80)
     create_actual(financial_year: 2018, financial_quarter: 4, value: 160)
 
-    create_adjustment(financial_year: 2017, financial_quarter: 1, value: 20)
-    create_adjustment(financial_year: 2017, financial_quarter: 4, value: -5)
+    create_adjustment(financial_year: 2017, financial_quarter: 1, value: 20, adjustment_type: :actual)
+    create_adjustment(financial_year: 2017, financial_quarter: 4, value: -5, adjustment_type: :actual)
+    create_adjustment(financial_year: 2017, financial_quarter: 4, value: 900, adjustment_type: :refund)
 
     reporting_cycle.tick
     create_actual(financial_year: 2017, financial_quarter: 2, value: 320)
@@ -34,7 +35,8 @@ RSpec.describe ActualOverview do
     create_actual(financial_year: 2018, financial_quarter: 2, value: 1_280)
     create_actual(financial_year: 2018, financial_quarter: 3, value: 2_560)
 
-    create_adjustment(financial_year: 2017, financial_quarter: 2, value: -20)
+    create_adjustment(financial_year: 2017, financial_quarter: 2, value: -20, adjustment_type: :actual)
+    create_adjustment(financial_year: 2017, financial_quarter: 2, value: 1000, adjustment_type: :refund)
 
     reporting_cycle.tick
     create_actual(financial_year: 2017, financial_quarter: 3, value: 5_120)
@@ -43,7 +45,8 @@ RSpec.describe ActualOverview do
     create_actual(financial_year: 2018, financial_quarter: 3, value: 40_960)
     create_actual(financial_year: 2018, financial_quarter: 4, value: 81_920)
 
-    create_adjustment(financial_year: 2017, financial_quarter: 3, value: -100)
+    create_adjustment(financial_year: 2017, financial_quarter: 3, value: -100, adjustment_type: :actual)
+    create_adjustment(financial_year: 2017, financial_quarter: 3, value: -9999, adjustment_type: :refund)
   end
 
   def create_actual(attributes)
@@ -51,7 +54,8 @@ RSpec.describe ActualOverview do
   end
 
   def create_adjustment(attributes)
-    create(:adjustment, parent_activity: project, report: reporting_cycle.report, **attributes)
+    adjustment_type = attributes.delete(:adjustment_type)
+    create(:adjustment, adjustment_type, parent_activity: project, report: reporting_cycle.report, **attributes)
   end
 
   shared_examples_for "actual report history" do

--- a/spec/services/report/export_spec.rb
+++ b/spec/services/report/export_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Report::Export do
 
       all_quarters = ActualOverview::AllQuarters.new(actuals)
       actual_overview = double("ActualOverview", all_quarters: all_quarters, value_for_report_quarter: 0)
-      expect(ActualOverview).to receive(:new).with(activity_presenter, report_presenter).at_least(:once).and_return(actual_overview)
+      expect(ActualOverview).to receive(:new).with(activity: activity_presenter, report: report_presenter).at_least(:once).and_return(actual_overview)
 
       expect(actual_columns).to eq(["20.00", "40.00", "80.00", "0.00"])
     end


### PR DESCRIPTION
This adds an argument to the `ActualOverview` class to include any adjustments, which is then used in the `Report::Export` class to make sure the calculations of Actuals are returned with the adjustments (either negative or positive) included. There was a bit of added complexity when I realised Adjustments could apply to Refunds as well as Actuals - detail is in the commit message.