### PR TITLE
(2158) Introduce SpendingBreakdown::Export

### DIFF
--- a/app/services/spending_breakdown/export.rb
+++ b/app/services/spending_breakdown/export.rb
@@ -1,0 +1,154 @@
+class SpendingBreakdown::Export
+  HEADERS = [
+    "RODA identifier",
+    "Delivery partner identifier",
+    "Delivery partner organisation",
+    "Title",
+    "Level",
+    "Activity status",
+  ]
+
+  def initialize(source_fund:, organisation: nil)
+    @organisation = organisation
+    @source_fund = source_fund
+    @activities = activities
+    @actuals = actuals
+    @refunds = refunds
+  end
+
+  def headers
+    return HEADERS if @actuals.empty? && @refunds.empty?
+
+    HEADERS + headers_from_financial_quarters.flatten
+  end
+
+  def rows
+    @activities.map do |activity|
+      activity_data(activity) + financial_data(activity)
+    end
+  end
+
+  def filename
+    [
+      @source_fund.short_name,
+      @organisation&.beis_organisation_reference,
+      "spending_breakdown.csv",
+    ].reject(&:blank?).join("_")
+  end
+
+  private
+
+  def financial_data(activity)
+    build_row(all_totals_for_activity(activity), activity)
+  end
+
+  def all_totals_for_activity(activity)
+    Transaction.joins("LEFT OUTER JOIN adjustment_details ON adjustment_details.adjustment_id = transactions.id")
+      .where(parent_activity_id: activity.id)
+      .select(:financial_quarter, :financial_year, :parent_activity_id, :value, :type, "adjustment_details.adjustment_type")
+      .group(:parent_activity_id, :financial_quarter, :financial_year, :type, "adjustment_details.adjustment_type")
+      .order(:parent_activity_id, :financial_quarter, :financial_year)
+      .sum(:value)
+  end
+
+  def build_row(totals, activity)
+    rows = financial_quarter_range.map { |fq|
+      actual_overview = TransactionOverview.new(:actual, activity, totals, fq)
+      refund_overview = TransactionOverview.new(:refund, activity, totals, fq)
+
+      net_total = actual_overview.net_total + refund_overview.net_total
+
+      [actual_overview.net_total, refund_overview.net_total, net_total]
+    }
+    rows.flatten!
+  end
+
+  def activity_data(activity)
+    [
+      activity.roda_identifier,
+      activity.delivery_partner_identifier,
+      activity.organisation.name,
+      activity.title,
+      I18n.t("table.body.activity.level.#{activity.level}"),
+      I18n.t("activity.programme_status.#{activity.programme_status}"),
+    ]
+  end
+
+  def activities
+    if @organisation.nil?
+      Activity.where(source_fund_code: @source_fund.id).includes(:organisation)
+    else
+      Activity.includes(:organisation).where(organisation_id: @organisation.id, source_fund_code: @source_fund.id)
+        .or(Activity.includes(:organisation).where(extending_organisation_id: @organisation.id, source_fund_code: @source_fund.id))
+    end
+  end
+
+  def actuals
+    Actual.where(parent_activity_id: activity_ids)
+  end
+
+  def refunds
+    Refund.where(parent_activity_id: activity_ids)
+  end
+
+  def activity_ids
+    @activities.pluck(:id)
+  end
+
+  def financial_quarters_with_acutals
+    return [] unless @actuals.present?
+    @actuals.map(&:own_financial_quarter).uniq
+  end
+
+  def financial_quarters_with_refunds
+    return [] unless @refunds.present?
+    @refunds.map(&:own_financial_quarter).uniq
+  end
+
+  def financial_quarters
+    financial_quarters_with_acutals + financial_quarters_with_refunds
+  end
+
+  def headers_from_financial_quarters
+    financial_quarter_range.map do |financial_quarter|
+      [
+        "Actual spend #{financial_quarter}",
+        "Refund #{financial_quarter}",
+        "Actual net #{financial_quarter}",
+      ]
+    end
+  end
+
+  def financial_quarter_range
+    @_financial_quarter_range ||= Range.new(*financial_quarters.minmax)
+  end
+
+  class TransactionOverview
+    TRANSACTION_TYPES = {
+      actual: "Actual",
+      refund: "Refund",
+    }
+
+    def initialize(transaction_type, activity, totals, financial_quarter)
+      @transaction_type = TRANSACTION_TYPES[transaction_type]
+      @activity = activity
+      @totals = totals
+      @financial_quarter = financial_quarter.to_i
+      @financial_year = financial_quarter.financial_year.start_year
+    end
+
+    def net_total
+      total + adjustments_total
+    end
+
+    private
+
+    def total
+      @totals.fetch([@activity.id, @financial_quarter, @financial_year, @transaction_type, nil], 0)
+    end
+
+    def adjustments_total
+      @totals.fetch([@activity.id, @financial_quarter, @financial_year, "Adjustment", @transaction_type], 0)
+    end
+  end
+end

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -17,8 +17,21 @@ FactoryBot.define do
 
     after(:create) do |adjustment, _evaluator|
       create(:flexible_comment, commentable: adjustment)
-      create(:adjustment_detail, adjustment: adjustment)
       adjustment.reload
+    end
+
+    trait :refund do
+      after(:create) do |adjustment, _evaluator|
+        create(:adjustment_detail, adjustment: adjustment, adjustment_type: "Refund")
+        adjustment.reload
+      end
+    end
+
+    trait :actual do
+      after(:create) do |adjustment, _evaluator|
+        create(:adjustment_detail, adjustment: adjustment, adjustment_type: "Actual")
+        adjustment.reload
+      end
     end
   end
 end

--- a/spec/services/spending_breakdown/export_spec.rb
+++ b/spec/services/spending_breakdown/export_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe SpendingBreakdown::Export do
+  let!(:organisation) { create(:delivery_partner_organisation, beis_organisation_reference: "BC") }
+  let!(:activity) { create(:project_activity, organisation: organisation) }
+  let!(:source_fund) { Fund.new(activity.source_fund_code) }
+  let!(:actual) { create(:actual, parent_activity: activity, value: 100, financial_quarter: 1, financial_year: 2020) }
+  let!(:refund) { create(:refund, parent_activity: activity, value: -200, financial_quarter: 1, financial_year: 2020) }
+
+  let!(:positive_actual_adjustment) { create(:adjustment, :actual, parent_activity: activity, value: 200, financial_quarter: 1, financial_year: 2020) }
+  let!(:negative_actual_adjustment) { create(:adjustment, :actual, parent_activity: activity, value: -100, financial_quarter: 1, financial_year: 2020) }
+
+  let!(:positive_refund_adjustment) { create(:adjustment, :refund, parent_activity: activity, value: 50, financial_quarter: 1, financial_year: 2020) }
+  let!(:negative_refund_adjustment) { create(:adjustment, :refund, parent_activity: activity, value: -200, financial_quarter: 1, financial_year: 2020) }
+
+  let!(:actual_fq4) { create(:actual, parent_activity: activity, value: 100, financial_quarter: 4, financial_year: 2020) }
+  let!(:refund_fq4) { create(:refund, parent_activity: activity, value: -200, financial_quarter: 4, financial_year: 2020) }
+
+  let!(:positive_actual_adjustment_fq4) { create(:adjustment, :actual, parent_activity: activity, value: 200, financial_quarter: 4, financial_year: 2020) }
+  let!(:negative_actual_adjustment_fq4) { create(:adjustment, :actual, parent_activity: activity, value: -100, financial_quarter: 4, financial_year: 2020) }
+
+  let!(:positive_refund_adjustment_fq4) { create(:adjustment, :refund, parent_activity: activity, value: 50, financial_quarter: 4, financial_year: 2020) }
+  let!(:negative_refund_adjustment_fq4) { create(:adjustment, :refund, parent_activity: activity, value: -200, financial_quarter: 4, financial_year: 2020) }
+
+  subject { SpendingBreakdown::Export.new(organisation: organisation, source_fund: source_fund) }
+
+  def value_for_header(header_name)
+    subject.rows.first[subject.headers.index(header_name)]
+  end
+
+  describe "#filename" do
+    context "when an organisation IS used in construction" do
+      it "includes the organisation reference" do
+        newton_fund = Fund.new(1)
+        breakdown = SpendingBreakdown::Export.new(
+          source_fund: newton_fund,
+          organisation: organisation
+        )
+        expect(breakdown.filename).to eq("NF_BC_spending_breakdown.csv")
+      end
+    end
+
+    context "when NO organisation is used in construction" do
+      it "leaves out the organisation reference" do
+        newton_fund = Fund.new(1)
+        breakdown = SpendingBreakdown::Export.new(source_fund: newton_fund)
+
+        expect(breakdown.filename).to eq("NF_spending_breakdown.csv")
+      end
+    end
+  end
+
+  describe "#headers" do
+    it "includes the five headings that describe the activity" do
+      expect(subject.headers).to include(
+        "RODA identifier",
+        "Delivery partner identifier",
+        "Delivery partner organisation",
+        "Title",
+        "Level",
+        "Activity status",
+      )
+    end
+
+    it "includes the three headings that describe the finances for financial quarter 1 2020-2021" do
+      expect(subject.headers).to include(
+        "Actual spend FQ1 2020-2021",
+        "Refund FQ1 2020-2021",
+        "Actual net FQ1 2020-2021",
+      )
+    end
+
+    it "includes the three headings that describe the finances for financial quarter 4 2020-2021" do
+      expect(subject.headers).to include(
+        "Actual spend FQ4 2020-2021",
+        "Refund FQ4 2020-2021",
+        "Actual net FQ4 2020-2021",
+      )
+    end
+
+    it "includes the three headings that describe the finances for financial quarters inbetween" do
+      expect(subject.headers).to include(
+        "Actual spend FQ2 2020-2021",
+        "Refund FQ2 2020-2021",
+        "Actual net FQ2 2020-2021",
+      )
+      expect(subject.headers).to include(
+        "Actual spend FQ3 2020-2021",
+        "Refund FQ3 2020-2021",
+        "Actual net FQ3 2020-2021",
+      )
+    end
+  end
+
+  describe "#rows" do
+    describe "non financial data" do
+      it "contains the appropriate values" do
+        aggregate_failures do
+          expect(value_for_header("RODA identifier")).to eql(activity.roda_identifier)
+          expect(value_for_header("Delivery partner identifier")).to eql(activity.delivery_partner_identifier)
+          expect(value_for_header("Delivery partner organisation")).to eql(activity.organisation.name)
+          expect(value_for_header("Title")).to eql(activity.title)
+          expect(value_for_header("Level")).to eql("Project (level C)")
+          expect(value_for_header("Activity status")).to eql("Spend in progress")
+        end
+      end
+    end
+
+    describe "financial data" do
+      it "contains the financial data for financial quarter 1 2020-2021" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ1 2020-2021").to_s).to eql("200.0")
+          expect(value_for_header("Refund FQ1 2020-2021").to_s).to eql("-350.0")
+          expect(value_for_header("Actual net FQ1 2020-2021").to_s).to eql("-150.0")
+        end
+      end
+
+      it "contains the financial data for financial quarter 4 2020-2021" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ4 2020-2021").to_s).to eql("200.0")
+          expect(value_for_header("Refund FQ4 2020-2021").to_s).to eql("-350.0")
+          expect(value_for_header("Actual net FQ4 2020-2021").to_s).to eql("-150.0")
+        end
+      end
+
+      it "contains zero values for the financial quarters inbetween" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ2 2020-2021").to_s).to eql("0")
+          expect(value_for_header("Refund FQ2 2020-2021").to_s).to eql("0")
+          expect(value_for_header("Actual net FQ2 2020-2021").to_s).to eql("0")
+
+          expect(value_for_header("Actual spend FQ3 2020-2021").to_s).to eql("0")
+          expect(value_for_header("Refund FQ3 2020-2021").to_s).to eql("0")
+          expect(value_for_header("Actual net FQ3 2020-2021").to_s).to eql("0")
+        end
+      end
+
+      context "where there are additional activities" do
+        before do
+          create_list(:project_activity, 4, organisation: organisation)
+        end
+
+        it "includes a row for each" do
+          expect(subject.rows.count).to eq(5)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
In the spirit of keeping PRs small, here is the first version of the new spending 
breakdown report. I'll be working and opening PRs to keep things managable 
and as concise as possible!

The intention is for this to replace the existing
ActivitySpendingBreakdown class.

The previous class is based on the principle that the spending breakdown
is related to a report, BEIS finance users are not concerned with the
report time period, they are more interested in all the data the application
contains to date. 

Here we introduce a class that takes a fund and optional organisation
and returns all the actual spend and refund values.

Now that we have the new Adjustment model, we also want to include the
correct type of adjustments in the calculations:

Actual spend total = Total actuals for an activity in a financial quarter  +
        Total actual adjustments in the same financial quarter

Refund total = Total refunds for an activity in a financial quarter +
        Total refund adjustments in the same financial quarter

Example:
```
Q1 2020-2021
-------------------------
Actual spend: 1,000
Actual spend: 10,000
-------------------------
Actual adjustment: -100
Actual adjustment: 50
-------------------------
Total: 10,950
```

The 'Net total' is the result of adding the Actual spend total to the
refund total.

This class follows our new pattern for csv exports of providing three
public methods to produce everything needed to export a csv.

This commit does not include the Forecasts in the file, that will
follow.

This commit does not include a way for users to intact with this class,
that will follow.

You can confirm the class functions on the Rails console, something like:

```
fund = Fund.new(1)
org = Organistation.delivery_partner.last
sb = SpendingBreakdown::Export.new organistion: org source_fund: fund

sb.filename
sb.headers
sb.rows
```