### PR TITLE
(2051) Cache all transactions in an ActualOverview

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -424,7 +424,7 @@ class Activity < ApplicationRecord
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    ActualOverview.new(activity: self, report: report).value_for_report_quarter
+    ActualOverview.new(report: report).value_for_report_quarter(self)
   end
 
   def forecasted_total_for_report_financial_quarter(report:)

--- a/app/services/actual_overview.rb
+++ b/app/services/actual_overview.rb
@@ -1,12 +1,11 @@
 class ActualOverview
-  def initialize(activity:, report:, include_adjustments: false)
-    @activity = activity
+  def initialize(report:, include_adjustments: false)
     @report = report
     @include_adjustments = include_adjustments
   end
 
   def all_quarters
-    group_fields = "transactions.financial_year, transactions.financial_quarter"
+    group_fields = "transactions.financial_year, transactions.financial_quarter, transactions.parent_activity_id"
 
     relation = actual_relation
       .group(group_fields)
@@ -15,13 +14,17 @@ class ActualOverview
     AllQuarters.new(relation)
   end
 
-  def value_for_report_quarter
-    value_for(**@report.own_financial_quarter)
+  def value_for_report_quarter(activity)
+    value_for(activity: activity, **@report.own_financial_quarter)
   end
 
-  def value_for(financial_quarter:, financial_year:)
+  def value_for(financial_quarter:, financial_year:, activity:)
     actual_relation
-      .where(financial_quarter: financial_quarter, financial_year: financial_year)
+      .where(
+        financial_quarter: financial_quarter,
+        financial_year: financial_year,
+        parent_activity: activity
+      )
       .sum(:value)
   end
 
@@ -30,7 +33,6 @@ class ActualOverview
   def actual_relation
     scope
       .joins(:report)
-      .where(parent_activity_id: @activity.id)
       .merge(Report.historically_up_to(@report))
   end
 
@@ -56,12 +58,12 @@ class ActualOverview
       @index = {}
 
       relation.each do |record|
-        @index[[record.financial_quarter, record.financial_year]] = record.value
+        @index[[record.financial_quarter, record.financial_year, record.parent_activity_id]] = record.value
       end
     end
 
-    def value_for(financial_quarter:, financial_year:)
-      @index.fetch([financial_quarter, financial_year], 0)
+    def value_for(financial_quarter:, financial_year:, activity:)
+      @index.fetch([financial_quarter, financial_year, activity.id], 0)
     end
   end
 end

--- a/spec/services/actual_overview_spec.rb
+++ b/spec/services/actual_overview_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ActualOverview do
   let(:project) { create(:project_activity, organisation: delivery_partner) }
   let(:reporting_cycle) { ReportingCycle.new(project, 4, 2018) }
   let(:include_adjustments) { false }
-  let(:overview) { ActualOverview.new(activity: project, report: report, include_adjustments: include_adjustments) }
+  let(:overview) { ActualOverview.new(report: report, include_adjustments: include_adjustments) }
 
   #   Report:     2018-Q4     2019-Q1     2019-Q2
   #   Quarter
@@ -61,14 +61,14 @@ RSpec.describe ActualOverview do
   shared_examples_for "actual report history" do
     it "returns the actual value for a particular quarter" do
       expected_values.each do |quarter, year, amount|
-        value = overview.value_for(financial_quarter: quarter, financial_year: year)
+        value = overview.value_for(financial_quarter: quarter, financial_year: year, activity: project)
         expect(value).to eq(amount)
       end
     end
 
     it "returns the actual value for a particular quarter using a bulk load" do
       expected_values.each do |quarter, year, amount|
-        value = overview.all_quarters.value_for(financial_quarter: quarter, financial_year: year)
+        value = overview.all_quarters.value_for(financial_quarter: quarter, financial_year: year, activity: project)
         expect(value).to eq(amount)
       end
     end


### PR DESCRIPTION
This updates the ActualOverview to removet he activity from the initializer. When returning `all_quarters`, this now groups each transaction by financial year, financial quarter AND activity ID. This means that rather than querying transactions on an activity by activity basis for the export, we can load all of a report's transactions into memory when we start building the report, and pluck them from the `AllQuarters` instance based on the financial period and the activity.

I've also had to update the `value_for_report_quarter` method to accept an activity as an argument, so we can reuse the relation in the class, but append the query to search for a specific activity.