### PR TITLE
(2158) Feature: spending breakdown includes forecasts

### DIFF
--- a/app/services/spending_breakdown/export.rb
+++ b/app/services/spending_breakdown/export.rb
@@ -16,7 +16,7 @@ class SpendingBreakdown::Export
   def headers
     return HEADERS if actuals.empty? && refunds.empty? && forecasts.empty?
 
-    HEADERS + headers_from_financial_quarters.flatten! + forecasts_headers
+    HEADERS + headers_from_financial_quarters + forecasts_headers
   end
 
   def rows
@@ -126,14 +126,14 @@ class SpendingBreakdown::Export
     financial_quarters_with_acutals + financial_quarters_with_refunds
   end
 
-  def headers_from_financial_quarters
-    financial_quarter_range.map do |financial_quarter|
+  def actual_and_refund_headers
+    all_actual_and_refund_financial_quarter_range.map { |financial_quarter|
       [
         "Actual spend #{financial_quarter}",
         "Refund #{financial_quarter}",
         "Actual net #{financial_quarter}",
       ]
-    end
+    }.flatten!
   end
 
   def forecasts_headers

--- a/app/services/spending_breakdown/export.rb
+++ b/app/services/spending_breakdown/export.rb
@@ -71,13 +71,14 @@ class SpendingBreakdown::Export
   end
 
   def activity_data(activity)
+    activity_presenter = ActivityCsvPresenter.new(activity)
     [
-      activity.roda_identifier,
-      activity.delivery_partner_identifier,
-      activity.organisation.name,
-      activity.title,
-      I18n.t("table.body.activity.level.#{activity.level}"),
-      I18n.t("activity.programme_status.#{activity.programme_status}"),
+      activity_presenter.roda_identifier,
+      activity_presenter.delivery_partner_identifier,
+      activity_presenter.organisation.name,
+      activity_presenter.title,
+      activity_presenter.level,
+      activity_presenter.programme_status,
     ]
   end
 

--- a/spec/services/spending_breakdown/export_spec.rb
+++ b/spec/services/spending_breakdown/export_spec.rb
@@ -1,32 +1,26 @@
 RSpec.describe SpendingBreakdown::Export do
-  let!(:organisation) { create(:delivery_partner_organisation, beis_organisation_reference: "BC") }
-  let!(:activity) { create(:project_activity, organisation: organisation) }
-  let!(:source_fund) { Fund.new(activity.source_fund_code) }
-  let!(:actual) { create(:actual, parent_activity: activity, value: 100, financial_quarter: 1, financial_year: 2020) }
-  let!(:refund) { create(:refund, parent_activity: activity, value: -200, financial_quarter: 1, financial_year: 2020) }
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
 
-  let!(:positive_actual_adjustment) { create(:adjustment, :actual, parent_activity: activity, value: 200, financial_quarter: 1, financial_year: 2020) }
-  let!(:negative_actual_adjustment) { create(:adjustment, :actual, parent_activity: activity, value: -100, financial_quarter: 1, financial_year: 2020) }
+    @organisation = create(:delivery_partner_organisation, beis_organisation_reference: "BC")
+    @activity = create(:project_activity, organisation: @organisation)
+    @source_fund = Fund.new(1)
 
-  let!(:positive_refund_adjustment) { create(:adjustment, :refund, parent_activity: activity, value: 50, financial_quarter: 1, financial_year: 2020) }
-  let!(:negative_refund_adjustment) { create(:adjustment, :refund, parent_activity: activity, value: -200, financial_quarter: 1, financial_year: 2020) }
+    create_q1_2020_actual_and_adjustments
+    create_q4_2020_actual_and_adjustments
 
-  let!(:actual_fq4) { create(:actual, parent_activity: activity, value: 100, financial_quarter: 4, financial_year: 2020) }
-  let!(:refund_fq4) { create(:refund, parent_activity: activity, value: -200, financial_quarter: 4, financial_year: 2020) }
+    create_q1_2020_refund_and_adjustments
+    create_q4_2020_refund_and_adjustments
 
-  let!(:positive_actual_adjustment_fq4) { create(:adjustment, :actual, parent_activity: activity, value: 200, financial_quarter: 4, financial_year: 2020) }
-  let!(:negative_actual_adjustment_fq4) { create(:adjustment, :actual, parent_activity: activity, value: -100, financial_quarter: 4, financial_year: 2020) }
+    create_old_report_and_forecasts
+  end
 
-  let!(:positive_refund_adjustment_fq4) { create(:adjustment, :refund, parent_activity: activity, value: 50, financial_quarter: 4, financial_year: 2020) }
-  let!(:negative_refund_adjustment_fq4) { create(:adjustment, :refund, parent_activity: activity, value: -200, financial_quarter: 4, financial_year: 2020) }
+  after(:all) do
+    DatabaseCleaner.clean
+  end
 
-  let!(:report) { create(:report, :approved, organisation: organisation, fund: activity.associated_fund, financial_quarter: 1, financial_year: 2019) }
-  let!(:old_forecasti_fq1) { ForecastHistory.new(activity, report: report, financial_quarter: 1, financial_year: 2020).set_value(5_000) }
-  let!(:old_forecasti_fq4) { ForecastHistory.new(activity, report: report, financial_quarter: 4, financial_year: 2020).set_value(2_500) }
-  let!(:forecast_fq1) { ForecastHistory.new(activity, report: report, financial_quarter: 1, financial_year: 2021).set_value(20_000) }
-  let!(:forecast_fq4) { ForecastHistory.new(activity, report: report, financial_quarter: 4, financial_year: 2021).set_value(10_000) }
-
-  subject { SpendingBreakdown::Export.new(organisation: organisation, source_fund: source_fund) }
+  subject { SpendingBreakdown::Export.new(organisation: @organisation, source_fund: @source_fund) }
 
   def value_for_header(header_name)
     subject.rows.first[subject.headers.index(header_name)]
@@ -38,7 +32,7 @@ RSpec.describe SpendingBreakdown::Export do
         newton_fund = Fund.new(1)
         breakdown = SpendingBreakdown::Export.new(
           source_fund: newton_fund,
-          organisation: organisation
+          organisation: @organisation
         )
         expect(breakdown.filename).to eq("NF_BC_spending_breakdown.csv")
       end
@@ -128,10 +122,10 @@ RSpec.describe SpendingBreakdown::Export do
   describe "#rows" do
     it "contains the appropriate activity values" do
       aggregate_failures do
-        expect(value_for_header("RODA identifier")).to eql(activity.roda_identifier)
-        expect(value_for_header("Delivery partner identifier")).to eql(activity.delivery_partner_identifier)
-        expect(value_for_header("Delivery partner organisation")).to eql(activity.organisation.name)
-        expect(value_for_header("Title")).to eql(activity.title)
+        expect(value_for_header("RODA identifier")).to eql(@activity.roda_identifier)
+        expect(value_for_header("Delivery partner identifier")).to eql(@activity.delivery_partner_identifier)
+        expect(value_for_header("Delivery partner organisation")).to eql(@activity.organisation.name)
+        expect(value_for_header("Title")).to eql(@activity.title)
         expect(value_for_header("Level")).to eql("Project (level C)")
         expect(value_for_header("Activity status")).to eql("Spend in progress")
       end
@@ -180,12 +174,135 @@ RSpec.describe SpendingBreakdown::Export do
 
     context "where there are additional activities" do
       before do
-        create_list(:project_activity, 4, organisation: organisation)
+        create_list(:project_activity, 4, organisation: @organisation)
       end
 
       it "includes a row for each" do
         expect(subject.rows.count).to eq(5)
       end
     end
+  end
+
+  def create_q1_2020_actual_and_adjustments
+    @actual = create(
+      :actual,
+      parent_activity: @activity,
+      value: 100,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :actual,
+      parent_activity: @activity,
+      value: 200,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :actual,
+      parent_activity: @activity,
+      value: -100,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+  end
+
+  def create_q4_2020_actual_and_adjustments
+    create(
+      :actual,
+      parent_activity: @activity,
+      value: 100,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :actual,
+      parent_activity: @activity,
+      value: 200,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :actual,
+      parent_activity: @activity,
+      value: -100,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+  end
+
+  def create_q1_2020_refund_and_adjustments
+    @refund = create(
+      :refund,
+      parent_activity: @activity,
+      value: -200,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :refund,
+      parent_activity: @activity,
+      value: 50,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :refund,
+      parent_activity: @activity,
+      value: -200,
+      financial_quarter: 1,
+      financial_year: 2020
+    )
+  end
+
+  def create_q4_2020_refund_and_adjustments
+    create(
+      :refund,
+      parent_activity: @activity,
+      value: -200,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :refund,
+      parent_activity: @activity,
+      value: 50,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+    create(
+      :adjustment,
+      :refund,
+      parent_activity: @activity,
+      value: -200,
+      financial_quarter: 4,
+      financial_year: 2020
+    )
+  end
+
+  def create_old_report_and_forecasts
+    report = create(
+      :report,
+      :approved,
+      organisation: @organisation,
+      fund: @activity.associated_fund,
+      financial_quarter: 1,
+      financial_year: 2019
+    )
+    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2020)
+      .set_value(5_000)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2020)
+      .set_value(2_500)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2021)
+      .set_value(20_000)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2021)
+      .set_value(10_000)
   end
 end

--- a/spec/services/spending_breakdown/export_spec.rb
+++ b/spec/services/spending_breakdown/export_spec.rb
@@ -126,69 +126,65 @@ RSpec.describe SpendingBreakdown::Export do
   end
 
   describe "#rows" do
-    describe "non financial data" do
-      it "contains the appropriate values" do
-        aggregate_failures do
-          expect(value_for_header("RODA identifier")).to eql(activity.roda_identifier)
-          expect(value_for_header("Delivery partner identifier")).to eql(activity.delivery_partner_identifier)
-          expect(value_for_header("Delivery partner organisation")).to eql(activity.organisation.name)
-          expect(value_for_header("Title")).to eql(activity.title)
-          expect(value_for_header("Level")).to eql("Project (level C)")
-          expect(value_for_header("Activity status")).to eql("Spend in progress")
-        end
+    it "contains the appropriate activity values" do
+      aggregate_failures do
+        expect(value_for_header("RODA identifier")).to eql(activity.roda_identifier)
+        expect(value_for_header("Delivery partner identifier")).to eql(activity.delivery_partner_identifier)
+        expect(value_for_header("Delivery partner organisation")).to eql(activity.organisation.name)
+        expect(value_for_header("Title")).to eql(activity.title)
+        expect(value_for_header("Level")).to eql("Project (level C)")
+        expect(value_for_header("Activity status")).to eql("Spend in progress")
       end
     end
 
-    describe "financial data" do
-      it "contains the financial data for financial quarter 1 2020-2021" do
-        aggregate_failures do
-          expect(value_for_header("Actual spend FQ1 2020-2021").to_s).to eql("200.0")
-          expect(value_for_header("Refund FQ1 2020-2021").to_s).to eql("-350.0")
-          expect(value_for_header("Actual net FQ1 2020-2021").to_s).to eql("-150.0")
-        end
+    it "contains the financial data for financial quarter 1 2020-2021" do
+      aggregate_failures do
+        expect(value_for_header("Actual spend FQ1 2020-2021").to_s).to eql("200.0")
+        expect(value_for_header("Refund FQ1 2020-2021").to_s).to eql("-350.0")
+        expect(value_for_header("Actual net FQ1 2020-2021").to_s).to eql("-150.0")
+      end
+    end
+
+    it "contains the financial data for financial quarter 4 2020-2021" do
+      aggregate_failures do
+        expect(value_for_header("Actual spend FQ4 2020-2021").to_s).to eql("200.0")
+        expect(value_for_header("Refund FQ4 2020-2021").to_s).to eql("-350.0")
+        expect(value_for_header("Actual net FQ4 2020-2021").to_s).to eql("-150.0")
+      end
+    end
+
+    it "contains zero values for the financial quarters inbetween" do
+      aggregate_failures do
+        expect(value_for_header("Actual spend FQ2 2020-2021").to_s).to eql("0")
+        expect(value_for_header("Refund FQ2 2020-2021").to_s).to eql("0")
+        expect(value_for_header("Actual net FQ2 2020-2021").to_s).to eql("0")
+
+        expect(value_for_header("Actual spend FQ3 2020-2021").to_s).to eql("0")
+        expect(value_for_header("Refund FQ3 2020-2021").to_s).to eql("0")
+        expect(value_for_header("Actual net FQ3 2020-2021").to_s).to eql("0")
+      end
+    end
+
+    it "contains the financial data for financial quarter 1 2021-2022" do
+      expect(value_for_header("Forecast FQ1 2021-2022").to_s).to eql("20000.0")
+    end
+
+    it "contains the financial data for financial quarter 4 2021-2022" do
+      expect(value_for_header("Forecast FQ4 2021-2022").to_s).to eql("10000.0")
+    end
+
+    it "contains a zero for the financial quarters inbetween in which there are no forecasts" do
+      expect(value_for_header("Forecast FQ2 2021-2022").to_s).to eql "0"
+      expect(value_for_header("Forecast FQ3 2021-2022").to_s).to eql "0"
+    end
+
+    context "where there are additional activities" do
+      before do
+        create_list(:project_activity, 4, organisation: organisation)
       end
 
-      it "contains the financial data for financial quarter 4 2020-2021" do
-        aggregate_failures do
-          expect(value_for_header("Actual spend FQ4 2020-2021").to_s).to eql("200.0")
-          expect(value_for_header("Refund FQ4 2020-2021").to_s).to eql("-350.0")
-          expect(value_for_header("Actual net FQ4 2020-2021").to_s).to eql("-150.0")
-        end
-      end
-
-      it "contains zero values for the financial quarters inbetween" do
-        aggregate_failures do
-          expect(value_for_header("Actual spend FQ2 2020-2021").to_s).to eql("0")
-          expect(value_for_header("Refund FQ2 2020-2021").to_s).to eql("0")
-          expect(value_for_header("Actual net FQ2 2020-2021").to_s).to eql("0")
-
-          expect(value_for_header("Actual spend FQ3 2020-2021").to_s).to eql("0")
-          expect(value_for_header("Refund FQ3 2020-2021").to_s).to eql("0")
-          expect(value_for_header("Actual net FQ3 2020-2021").to_s).to eql("0")
-        end
-      end
-
-      it "contains the financial data for financial quarter 1 2021-2022" do
-        expect(value_for_header("Forecast FQ1 2021-2022").to_s).to eql("20000.0")
-      end
-
-      it "contains the financial data for financial quarter 4 2021-2022" do
-        expect(value_for_header("Forecast FQ4 2021-2022").to_s).to eql("10000.0")
-      end
-
-      it "contains a zero for the financial quarters inbetween in which there are no forecasts" do
-        expect(value_for_header("Forecast FQ2 2021-2022").to_s).to eql "0"
-        expect(value_for_header("Forecast FQ3 2021-2022").to_s).to eql "0"
-      end
-
-      context "where there are additional activities" do
-        before do
-          create_list(:project_activity, 4, organisation: organisation)
-        end
-
-        it "includes a row for each" do
-          expect(subject.rows.count).to eq(5)
-        end
+      it "includes a row for each" do
+        expect(subject.rows.count).to eq(5)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Following on from #1361 this work introduces Forecasts to the Spending breakdown export.

As before this in not yet exposed to users, but you can interact with the class on the Rails console.

We want to display all Forecasts for the financial quarters not already covered by Actual spend and Refunds. We do this by taking the end of the range for Actual spend and Refunds and applying that as the start of the range of Forecasts.

Forecasts are already stored as a single total per financial quarter and activity so there is no need to sum them. We do have to utilise the `ForecastOverview` class which means we lose some control of the queries. Fortunately the `ForecastOverview` can be use with multiple activity ids allowing us to load all required latest values from the relevant forecasts - which keeps the class responsive loading the data.

To keep the code approachable we convert the Forecast data to the same hash structure as the ActiveRecord query on Transaction, which allows us to use `fetch` as our interface to the correct forecasts (also taking care of returning 0 when there is no forecast).

I thought a lot about IF the code should return 0 for a quarter with no forecast and decideded that this was the right thing to do. Whilst there is a difference between 'I have forecasted zero spend for that activity and quarter' and 'I have not forecastsed that activity and quarter' I felt from a finance persepective, who utiltise this report, the difference was not important.

Once the class is working we refactor to make improvements and then spend some time speeding up the spec.

