### PR TITLE
(2051) Include refunds in the report exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -835,6 +835,8 @@
 
 ## [unreleased]
 
+- Include refunds in the report CSV exports
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-75...HEAD
 [release-75]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-74...release-75
 [release-74]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-73...release-74

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -424,7 +424,7 @@ class Activity < ApplicationRecord
   end
 
   def actual_total_for_report_financial_quarter(report:)
-    ActualOverview.new(report: report).value_for_report_quarter(self)
+    Actual::Overview.new(report: report).value_for_report_quarter(self)
   end
 
   def forecasted_total_for_report_financial_quarter(report:)

--- a/app/services/actual/overview.rb
+++ b/app/services/actual/overview.rb
@@ -1,0 +1,5 @@
+class Actual
+  class Overview
+    include TransactionOverview
+  end
+end

--- a/app/services/refund/overview.rb
+++ b/app/services/refund/overview.rb
@@ -1,0 +1,5 @@
+class Refund
+  class Overview
+    include TransactionOverview
+  end
+end

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -41,7 +41,7 @@ class Report
     end
 
     def actual_quarters
-      @actual_quarters ||= ActualOverview.new(report: report_presenter, include_adjustments: true).all_quarters
+      @actual_quarters ||= Actual::Overview.new(report: report_presenter, include_adjustments: true).all_quarters
     end
 
     def report_presenter

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -6,7 +6,7 @@ class Report
 
     def headers
       Row::ACTIVITY_HEADERS.keys +
-        previous_twelve_quarter_actuals_headers +
+        previous_twelve_quarter_actual_and_refund_headers +
         next_twenty_quarter_forecasts_headers +
         variance_headers
     end
@@ -19,6 +19,7 @@ class Report
           previous_report_quarters: previous_report_quarters,
           following_report_quarters: following_report_quarters,
           actual_quarters: actual_quarters,
+          refund_quarters: refund_quarters,
         ).call
       end
     end
@@ -42,6 +43,10 @@ class Report
 
     def actual_quarters
       @actual_quarters ||= Actual::Overview.new(report: report_presenter, include_adjustments: true).all_quarters
+    end
+
+    def refund_quarters
+      @refund_quarters ||= Refund::Overview.new(report: report_presenter, include_adjustments: true).all_quarters
     end
 
     def report_presenter
@@ -70,8 +75,10 @@ class Report
       end
     end
 
-    def previous_twelve_quarter_actuals_headers
-      previous_report_quarters.map { |quarter| "ACT #{quarter}" }
+    def previous_twelve_quarter_actual_and_refund_headers
+      previous_report_quarters.map { |quarter|
+        ["ACT #{quarter}", "REFUND #{quarter}"]
+      }.flatten
     end
 
     def next_twenty_quarter_forecasts_headers
@@ -141,17 +148,18 @@ class Report
         "Link to activity in RODA",
       ]
 
-      def initialize(activity:, report_presenter:, previous_report_quarters:, following_report_quarters:, actual_quarters:)
+      def initialize(activity:, report_presenter:, previous_report_quarters:, following_report_quarters:, actual_quarters:, refund_quarters:)
         @activity = activity
         @report_presenter = report_presenter
         @previous_report_quarters = previous_report_quarters
         @following_report_quarters = following_report_quarters
         @actual_quarters = actual_quarters
+        @refund_quarters = refund_quarters
       end
 
       def call
         activity_data +
-          previous_quarter_actuals +
+          previous_quarter_actuals_and_refunds +
           next_quarter_forecasts +
           variance_data
       end
@@ -162,11 +170,13 @@ class Report
         end
       end
 
-      def previous_quarter_actuals
-        previous_report_quarters.map do |quarter|
-          value = actual_quarters.value_for(activity: activity, **quarter)
-          "%.2f" % value
-        end
+      def previous_quarter_actuals_and_refunds
+        previous_report_quarters.map { |quarter|
+          [
+            actual_value(quarter),
+            refund_value(quarter),
+          ]
+        }.flatten
       end
 
       def next_quarter_forecasts
@@ -188,7 +198,7 @@ class Report
 
       private
 
-      attr_reader :activity, :report_presenter, :previous_report_quarters, :following_report_quarters, :actual_quarters
+      attr_reader :activity, :report_presenter, :previous_report_quarters, :following_report_quarters, :actual_quarters, :refund_quarters
 
       def activity_presenter
         @activity_presenter ||= ActivityCsvPresenter.new(activity)
@@ -200,6 +210,16 @@ class Report
 
       def variance_for_report_financial_quarter
         forecast_quarters.value_for(**report_presenter.own_financial_quarter) - actual_quarters.value_for(activity: activity, **report_presenter.own_financial_quarter)
+      end
+
+      def actual_value(quarter)
+        value = actual_quarters.value_for(activity: activity, **quarter)
+        "%.2f" % value
+      end
+
+      def refund_value(quarter)
+        value = refund_quarters.value_for(activity: activity, **quarter)
+        "%.2f" % value
       end
     end
   end

--- a/app/services/transaction_overview.rb
+++ b/app/services/transaction_overview.rb
@@ -1,4 +1,4 @@
-class ActualOverview
+module TransactionOverview
   def initialize(report:, include_adjustments: false)
     @report = report
     @include_adjustments = include_adjustments
@@ -37,20 +37,25 @@ class ActualOverview
   end
 
   def scope
+    scope = Transaction.where(type: transaction_class)
+
     if @include_adjustments
-      Transaction
+      scope = scope
         .with_adjustment_details
-        .where(type: "Actual")
         .or(
           Transaction
             .where(
               type: "Adjustment",
-              adjustment_details: {adjustment_type: "Actual"}
+              adjustment_details: {adjustment_type: transaction_class}
             )
         )
-    else
-      Actual
     end
+
+    scope
+  end
+
+  def transaction_class
+    @transaction_class ||= self.class.name.split("::").first
   end
 
   class AllQuarters

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   config.include ActivityHelpers
   config.include StripAttributes::Matchers
   config.include TimeTravelHelpers
+  config.include TransactionHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/actual/overview_spec.rb
+++ b/spec/services/actual/overview_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe ActualOverview do
+RSpec.describe Actual::Overview do
   let(:delivery_partner) { create(:delivery_partner_organisation) }
   let(:project) { create(:project_activity, organisation: delivery_partner) }
   let(:reporting_cycle) { ReportingCycle.new(project, 4, 2018) }
   let(:include_adjustments) { false }
-  let(:overview) { ActualOverview.new(report: report, include_adjustments: include_adjustments) }
+  let(:overview) { described_class.new(report: report, include_adjustments: include_adjustments) }
 
   #   Report:     2018-Q4     2019-Q1     2019-Q2
   #   Quarter

--- a/spec/services/actual/overview_spec.rb
+++ b/spec/services/actual/overview_spec.rb
@@ -49,31 +49,6 @@ RSpec.describe Actual::Overview do
     create_adjustment(financial_year: 2017, financial_quarter: 3, value: -9999, adjustment_type: :refund)
   end
 
-  def create_actual(attributes)
-    create(:actual, parent_activity: project, report: reporting_cycle.report, **attributes)
-  end
-
-  def create_adjustment(attributes)
-    adjustment_type = attributes.delete(:adjustment_type)
-    create(:adjustment, adjustment_type, parent_activity: project, report: reporting_cycle.report, **attributes)
-  end
-
-  shared_examples_for "actual report history" do
-    it "returns the actual value for a particular quarter" do
-      expected_values.each do |quarter, year, amount|
-        value = overview.value_for(financial_quarter: quarter, financial_year: year, activity: project)
-        expect(value).to eq(amount)
-      end
-    end
-
-    it "returns the actual value for a particular quarter using a bulk load" do
-      expected_values.each do |quarter, year, amount|
-        value = overview.all_quarters.value_for(financial_quarter: quarter, financial_year: year, activity: project)
-        expect(value).to eq(amount)
-      end
-    end
-  end
-
   context "for the first report" do
     let(:report) { Report.for_activity(project).find_by(financial_quarter: 4, financial_year: 2018) }
 
@@ -90,7 +65,7 @@ RSpec.describe Actual::Overview do
       ]
     }
 
-    it_should_behave_like "actual report history"
+    it_should_behave_like "transaction report history"
 
     context "when adjustments are included" do
       let(:include_adjustments) { true }
@@ -107,7 +82,7 @@ RSpec.describe Actual::Overview do
         ]
       }
 
-      it_should_behave_like "actual report history"
+      it_should_behave_like "transaction report history"
     end
   end
 
@@ -127,7 +102,7 @@ RSpec.describe Actual::Overview do
       ]
     }
 
-    it_should_behave_like "actual report history"
+    it_should_behave_like "transaction report history"
 
     context "when adjustments are included" do
       let(:include_adjustments) { true }
@@ -144,7 +119,7 @@ RSpec.describe Actual::Overview do
         ]
       }
 
-      it_should_behave_like "actual report history"
+      it_should_behave_like "transaction report history"
     end
   end
 
@@ -164,7 +139,7 @@ RSpec.describe Actual::Overview do
       ]
     }
 
-    it_should_behave_like "actual report history"
+    it_should_behave_like "transaction report history"
 
     context "when adjustments are included" do
       let(:include_adjustments) { true }
@@ -181,7 +156,7 @@ RSpec.describe Actual::Overview do
         ]
       }
 
-      it_should_behave_like "actual report history"
+      it_should_behave_like "transaction report history"
     end
   end
 end

--- a/spec/services/refund/overview_spec.rb
+++ b/spec/services/refund/overview_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe Refund::Overview do
+  let(:delivery_partner) { create(:delivery_partner_organisation) }
+  let(:project) { create(:project_activity, organisation: delivery_partner) }
+  let(:reporting_cycle) { ReportingCycle.new(project, 4, 2018) }
+  let(:include_adjustments) { false }
+  let(:overview) { described_class.new(report: report, include_adjustments: include_adjustments) }
+
+  #   Report:     2018-Q4     2019-Q1     2019-Q2
+  #   Quarter
+  #   -------------------------------------------
+  #   2017-Q1         -5
+  #   2017-Q2                    -800
+  #   2017-Q3                              -4,000
+  #   2017-Q4         -10         -40
+  #   2018-Q1         -30                    -900
+  #   2018-Q2                  -1,000        -480
+  #   2018-Q3         -10         -60        -910
+  #   2018-Q4        -120                    -810
+
+  before do
+    reporting_cycle.tick
+    create_refund(financial_year: 2017, financial_quarter: 1, value: 5)
+    create_refund(financial_year: 2017, financial_quarter: 4, value: 10)
+    create_refund(financial_year: 2018, financial_quarter: 1, value: 30)
+    create_refund(financial_year: 2018, financial_quarter: 3, value: 10)
+    create_refund(financial_year: 2018, financial_quarter: 4, value: 120)
+
+    create_adjustment(financial_year: 2017, financial_quarter: 4, value: 20, adjustment_type: :refund)
+
+    reporting_cycle.tick
+    create_refund(financial_year: 2017, financial_quarter: 2, value: 800)
+    create_refund(financial_year: 2017, financial_quarter: 4, value: 40)
+    create_refund(financial_year: 2018, financial_quarter: 2, value: 1_000)
+    create_refund(financial_year: 2018, financial_quarter: 3, value: 60)
+
+    create_adjustment(financial_year: 2017, financial_quarter: 2, value: 70, adjustment_type: :refund)
+
+    reporting_cycle.tick
+    create_refund(financial_year: 2017, financial_quarter: 3, value: 4_000)
+    create_refund(financial_year: 2018, financial_quarter: 1, value: 900)
+    create_refund(financial_year: 2018, financial_quarter: 2, value: 480)
+    create_refund(financial_year: 2018, financial_quarter: 3, value: 910)
+    create_refund(financial_year: 2018, financial_quarter: 4, value: 810)
+
+    create_adjustment(financial_year: 2017, financial_quarter: 3, value: 40, adjustment_type: :refund)
+  end
+
+  context "for the first report" do
+    let(:report) { Report.for_activity(project).find_by(financial_quarter: 4, financial_year: 2018) }
+
+    let(:expected_values) {
+      [
+        [1, 2017, -5],
+        [2, 2017, 0],
+        [3, 2017, 0],
+        [4, 2017, -10],
+        [1, 2018, -30],
+        [2, 2018, 0],
+        [3, 2018, -10],
+        [4, 2018, -120],
+      ]
+    }
+
+    it_should_behave_like "transaction report history"
+
+    context "when adjustments are included" do
+      let(:include_adjustments) { true }
+      let(:expected_values) {
+        [
+          [1, 2017, -5],
+          [2, 2017, 0],
+          [3, 2017, 0],
+          [4, 2017, 10],
+          [1, 2018, -30],
+          [2, 2018, 0],
+          [3, 2018, -10],
+          [4, 2018, -120],
+        ]
+      }
+
+      it_should_behave_like "transaction report history"
+    end
+  end
+
+  context "for the middle report" do
+    let(:report) { Report.for_activity(project).find_by(financial_quarter: 1, financial_year: 2019) }
+
+    let(:expected_values) {
+      [
+        [1, 2017, -5],
+        [2, 2017, -800],
+        [3, 2017, 0],
+        [4, 2017, -50],
+        [1, 2018, -30],
+        [2, 2018, -1_000],
+        [3, 2018, -70],
+        [4, 2018, -120],
+      ]
+    }
+
+    it_should_behave_like "transaction report history"
+
+    context "when adjustments are included" do
+      let(:include_adjustments) { true }
+      let(:expected_values) {
+        [
+          [1, 2017, -5],
+          [2, 2017, -730],
+          [3, 2017, 0],
+          [4, 2017, -30],
+          [1, 2018, -30],
+          [2, 2018, -1_000],
+          [3, 2018, -70],
+          [4, 2018, -120],
+        ]
+      }
+
+      it_should_behave_like "transaction report history"
+    end
+  end
+
+  context "for the latest report" do
+    let(:report) { Report.for_activity(project).find_by(financial_quarter: 2, financial_year: 2019) }
+
+    let(:expected_values) {
+      [
+        [1, 2017, -5],
+        [2, 2017, -800],
+        [3, 2017, -4000],
+        [4, 2017, -50],
+        [1, 2018, -930],
+        [2, 2018, -1_480],
+        [3, 2018, -980],
+        [4, 2018, -930],
+      ]
+    }
+
+    it_should_behave_like "transaction report history"
+
+    context "when adjustments are included" do
+      let(:include_adjustments) { true }
+      let(:expected_values) {
+        [
+          [1, 2017, -5],
+          [2, 2017, -730],
+          [3, 2017, -3960],
+          [4, 2017, -30],
+          [1, 2018, -930],
+          [2, 2018, -1_480],
+          [3, 2018, -980],
+          [4, 2018, -930],
+        ]
+      }
+
+      it_should_behave_like "transaction report history"
+    end
+  end
+end

--- a/spec/services/report/export_spec.rb
+++ b/spec/services/report/export_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Report::Export do
           report_presenter: report_presenter,
           previous_report_quarters: an_instance_of(Array),
           following_report_quarters: an_instance_of(Array),
-          actual_quarters: an_instance_of(ActualOverview::AllQuarters),
+          actual_quarters: an_instance_of(Actual::Overview::AllQuarters),
         ).and_return(stub)
         expect(stub).to receive(:call).and_return([activity.title])
       end
@@ -144,7 +144,7 @@ RSpec.describe Report::Export do
       ]
     end
 
-    let(:actual_quarters) { ActualOverview::AllQuarters.new(actuals) }
+    let(:actual_quarters) { Actual::Overview::AllQuarters.new(actuals) }
     let(:actual_index) { Report::Export::Row::ACTIVITY_HEADERS.count }
     let(:forecast_index) { actual_index + previous_report_quarters.count }
 

--- a/spec/services/report/export_spec.rb
+++ b/spec/services/report/export_spec.rb
@@ -16,17 +16,29 @@ RSpec.describe Report::Export do
     it "includes the previous twelve quarters" do
       expect(subject.headers).to include(
         "ACT FQ3 2018-2019",
+        "REFUND FQ3 2018-2019",
         "ACT FQ4 2018-2019",
+        "REFUND FQ4 2018-2019",
         "ACT FQ1 2019-2020",
+        "REFUND FQ1 2019-2020",
         "ACT FQ2 2019-2020",
+        "REFUND FQ2 2019-2020",
         "ACT FQ3 2019-2020",
+        "REFUND FQ3 2019-2020",
         "ACT FQ4 2019-2020",
+        "REFUND FQ4 2019-2020",
         "ACT FQ1 2020-2021",
+        "REFUND FQ1 2020-2021",
         "ACT FQ2 2020-2021",
+        "REFUND FQ2 2020-2021",
         "ACT FQ3 2020-2021",
+        "REFUND FQ3 2020-2021",
         "ACT FQ4 2020-2021",
+        "REFUND FQ4 2020-2021",
         "ACT FQ1 2021-2022",
-        "ACT FQ2 2021-2022"
+        "REFUND FQ1 2021-2022",
+        "ACT FQ2 2021-2022",
+        "REFUND FQ2 2021-2022"
       )
     end
 
@@ -85,6 +97,7 @@ RSpec.describe Report::Export do
           previous_report_quarters: an_instance_of(Array),
           following_report_quarters: an_instance_of(Array),
           actual_quarters: an_instance_of(Actual::Overview::AllQuarters),
+          refund_quarters: an_instance_of(Refund::Overview::AllQuarters),
         ).and_return(stub)
         expect(stub).to receive(:call).and_return([activity.title])
       end
@@ -144,7 +157,16 @@ RSpec.describe Report::Export do
       ]
     end
 
+    let(:refunds) do
+      [
+        Refund.new(financial_quarter: 1, financial_year: 2020, value: -5, parent_activity: activity),
+        Refund.new(financial_quarter: 2, financial_year: 2020, value: -10, parent_activity: activity),
+      ]
+    end
+
     let(:actual_quarters) { Actual::Overview::AllQuarters.new(actuals) }
+    let(:refund_quarters) { Refund::Overview::AllQuarters.new(refunds) }
+
     let(:actual_index) { Report::Export::Row::ACTIVITY_HEADERS.count }
     let(:forecast_index) { actual_index + previous_report_quarters.count }
 
@@ -155,6 +177,7 @@ RSpec.describe Report::Export do
         previous_report_quarters: previous_report_quarters,
         following_report_quarters: following_report_quarters,
         actual_quarters: actual_quarters,
+        refund_quarters: refund_quarters,
       )
     end
 
@@ -171,8 +194,8 @@ RSpec.describe Report::Export do
       let(:forecast_snapshot) { double("ForecastOverview::Snapshot", all_quarters: forecast_quarters, value_for_report_quarter: 0) }
       let(:forecast_overview) { double("ForecastOverview") }
 
-      it "includes the actuals for the previous quarters" do
-        expect(subject.previous_quarter_actuals).to eq(["20.00", "40.00", "80.00", "0.00"])
+      it "includes the actuals and refunds for the previous quarters" do
+        expect(subject.previous_quarter_actuals_and_refunds).to eq(["20.00", "-5.00", "40.00", "-10.00", "80.00", "0.00", "0.00", "0.00"])
       end
 
       it "includes the forecasts for the next quarters" do

--- a/spec/support/shared_examples/transaction_report_history.rb
+++ b/spec/support/shared_examples/transaction_report_history.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples_for "transaction report history" do
+  it "returns the transaction value for a particular quarter" do
+    expected_values.each do |quarter, year, amount|
+      value = overview.value_for(financial_quarter: quarter, financial_year: year, activity: project)
+      expect(value).to eq(amount)
+    end
+  end
+
+  it "returns the transaction value for a particular quarter using a bulk load" do
+    expected_values.each do |quarter, year, amount|
+      value = overview.all_quarters.value_for(financial_quarter: quarter, financial_year: year, activity: project)
+      expect(value).to eq(amount)
+    end
+  end
+end

--- a/spec/support/transaction_helpers.rb
+++ b/spec/support/transaction_helpers.rb
@@ -1,0 +1,14 @@
+module TransactionHelpers
+  def create_actual(attributes)
+    create(:actual, parent_activity: project, report: reporting_cycle.report, **attributes)
+  end
+
+  def create_refund(attributes)
+    create(:refund, parent_activity: project, report: reporting_cycle.report, **attributes)
+  end
+
+  def create_adjustment(attributes)
+    adjustment_type = attributes.delete(:adjustment_type)
+    create(:adjustment, adjustment_type, parent_activity: project, report: reporting_cycle.report, **attributes)
+  end
+end


### PR DESCRIPTION
This creates a Refund Overview class, which shares functionality with the Actual Overview to return the value of all of the refunds for an activity within the previous twelve quarters. 