### PR TITLE
Add data migration to fix up over-eager backfilling of benefitting_countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -843,6 +843,7 @@
 - Remove the old Report > Spending Breakdown download
 - Improve the Report CSV download experience, includes moving the link that
   triggers the download
+- Fix up activities' benefitting countries where backfilled overenthusiastically
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-75...HEAD
 [release-75]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-74...release-75

--- a/db/data/20210929_clear_additional_benefitting_countries_where_backfilling_not_appropriate.rb
+++ b/db/data/20210929_clear_additional_benefitting_countries_where_backfilling_not_appropriate.rb
@@ -1,0 +1,41 @@
+# Run me with `rails runner db/data/20210929_clear_additional_benefitting_countries_where_backfilling_not_appropriate.rb`
+
+# It seems we were over-eager in backfilling the new `Activity#benefitting_countries`
+# field, in that we added all of the countries in the legacy `recipient_region` even
+# when the legacy `recipient_country` field was present.
+#
+# Example: Activity with RODA id 'GCRF-EP_C_MS-4_2018EP/T00343X/1':
+#
+#     => {"recipient_region"=>"1027",
+#      "recipient_country"=>"UG",
+#      "intended_beneficiaries"=>nil,
+#      "requires_additional_benefitting_countries"=>false,
+#      "country_delivery_partners"=>[],
+#      "benefitting_countries"=>["UG", "BI", "KM", "DJ", "ER", "ET",
+#                                "KE", "MG", "MW", "MU", "MZ", "RW",
+#                                "SO", "SS", "SD", "TZ", "ZM", "ZW"]}
+#
+# In this script, we find the approx 4,000 activities which are affected:
+#
+# - legacy `recipient_region` is present, and
+# - legacy `recipient_country` is present, and
+# - there are no `intended_beneficiaries`, and
+# - more than 1 country is set in the new `benefitting_countries` field
+#
+# and set the benefitting countries field to the legacy recipient_country value.
+# e.g. `["UG"]` in the example above.
+
+finder = Activity
+  .where.not(recipient_country: nil)
+  .where.not(recipient_region: nil)
+  .where(intended_beneficiaries: nil)
+  .where("array_length(benefitting_countries, 1) > 1")
+
+puts "Fixing up #{finder.count} activities..."
+
+finder.each do |activity|
+  activity.benefitting_countries = [activity.recipient_country]
+  activity.save(validate: false)
+end
+
+puts "-> there are now #{finder.reload.count} activities still to fix"


### PR DESCRIPTION
It seems we were over-eager in backfilling the new `Activity#benefitting_countries`
field, in that we added all of the countries in the legacy `recipient_region` even
when the legacy `recipient_country` field was present.

Example: Activity with RODA id `'GCRF-EP_C_MS-4_2018EP/T00343X/1'`:

```
   => {"recipient_region"=>"1027",
    "recipient_country"=>"UG",
    "intended_beneficiaries"=>nil,
    "requires_additional_benefitting_countries"=>false,
    "country_delivery_partners"=>[],
    "benefitting_countries"=>["UG", "BI", "KM", "DJ", "ER", "ET",
                              "KE", "MG", "MW", "MU", "MZ", "RW",
                              "SO", "SS", "SD", "TZ", "ZM", "ZW"]}
```

In this script, we find the approx 4,000 activities which are affected:

- legacy `recipient_region` is present, and
- legacy `recipient_country` is present, and
- there are no `intended_beneficiaries`, and
- more than 1 country is set in the new `benefitting_countries` field

and set the benefitting countries field to the legacy recipient_country value.
e.g. `["UG"]` in the example above.

It should produce output something like:

```
Fixing up 4130 activities...
-> there are now 0 activities still to fix
```

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
