### PR TITLE
(2216) Chore: remove geography fields no longer required  from interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,6 +844,7 @@
 - Improve the Report CSV download experience, includes moving the link that
   triggers the download
 - Fix up activities' benefitting countries where backfilled overenthusiastically
+- No longer show 'requires additional benefitting countries' in activity details
 
 ## [unreleased]
 

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -84,11 +84,6 @@ class ActivityPresenter < SimpleDelegator
     country.nil? ? translate("page_content.activity.unknown_country") : country.name
   end
 
-  def requires_additional_benefitting_countries
-    return if super.nil?
-    translate("activity.requires_additional_benefitting_countries.#{super}")
-  end
-
   def intended_beneficiaries
     return if super.blank?
     sentence_of_benefitting_countries(super)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -336,7 +336,6 @@ module Activities
         }
 
         if @method == :create
-          attributes[:requires_additional_benefitting_countries] = (@row["Recipient Country"] && @row["Intended Beneficiaries"]).present?
           attributes[:call_present] = (@row["Call open date"] && @row["Call close date"]).present?
         end
 

--- a/app/views/staff/activity_forms/requires_additional_benefitting_countries.html.haml
+++ b/app/views/staff/activity_forms/requires_additional_benefitting_countries.html.haml
@@ -1,5 +1,0 @@
-= render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset(:requires_additional_benefitting_countries, legend: { text: t("form.legend.activity.requires_additional_benefitting_countries"), size: "xl", tag: "h1" }) do
-    = f.hidden_field :requires_additional_benefitting_countries, value: nil
-    = f.govuk_radio_button :requires_additional_benefitting_countries, :true, label: { text: t("form.label.activity.requires_additional_benefitting_countries.true") }
-    = f.govuk_radio_button :requires_additional_benefitting_countries, :false, label: { text: t("form.label.activity.requires_additional_benefitting_countries.false") }

--- a/app/views/staff/shared/activities/_activity.html.haml
+++ b/app/views/staff/shared/activities/_activity.html.haml
@@ -214,43 +214,33 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :benefitting_countries)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("summary.label.activity.benefitting_countries"))
 
-  - if activity_presenter.benefitting_countries?
-    .govuk-summary-list__row.benefitting_region
-      %dt.govuk-summary-list__key
-        = t("summary.label.activity.benefitting_region")
-      %dd.govuk-summary-list__value
-        = activity_presenter.benefitting_region
-      %dd.govuk-summary-list__actions
-  - elsif activity_presenter.recipient_region?
-    .govuk-summary-list__row.recipient_region
-      %dt.govuk-summary-list__key
-        = t("summary.label.activity.recipient_region")
-      %dd.govuk-summary-list__value
-        = activity_presenter.recipient_region
-      %dd.govuk-summary-list__actions
-
-  - if activity_presenter.recipient_country?
-    .govuk-summary-list__row.recipient_country
-      %dt.govuk-summary-list__key
-        = t("summary.label.activity.recipient_country")
-      %dd.govuk-summary-list__value
-        = activity_presenter.recipient_country
-      %dd.govuk-summary-list__actions
-
-  .govuk-summary-list__row.requires_additional_benefitting_countries
+  .govuk-summary-list__row.benefitting_region
     %dt.govuk-summary-list__key
-      = t("summary.label.activity.requires_additional_benefitting_countries")
+      = t("summary.label.activity.benefitting_region")
     %dd.govuk-summary-list__value
-      = activity_presenter.requires_additional_benefitting_countries
+      = activity_presenter.benefitting_region
     %dd.govuk-summary-list__actions
 
-  - if activity_presenter.requires_additional_benefitting_countries?
-    .govuk-summary-list__row.intended_beneficiaries
-      %dt.govuk-summary-list__key
-        = t("summary.label.activity.intended_beneficiaries")
-      %dd.govuk-summary-list__value
-        = activity_presenter.intended_beneficiaries
-      %dd.govuk-summary-list__actions
+  .govuk-summary-list__row.recipient_region
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.recipient_region_html")
+    %dd.govuk-summary-list__value
+      = activity_presenter.recipient_region
+    %dd.govuk-summary-list__actions
+
+  .govuk-summary-list__row.recipient_country
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.recipient_country_html")
+    %dd.govuk-summary-list__value
+      = activity_presenter.recipient_country
+    %dd.govuk-summary-list__actions
+
+  .govuk-summary-list__row.intended_beneficiaries
+    %dt.govuk-summary-list__key
+      = t("summary.label.activity.intended_beneficiaries_html")
+    %dd.govuk-summary-list__value
+      = activity_presenter.intended_beneficiaries
+    %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.gdi
     %dt.govuk-summary-list__key

--- a/config/locales/codelists/2_03/iati.en.yml
+++ b/config/locales/codelists/2_03/iati.en.yml
@@ -452,9 +452,6 @@ en:
       "920": SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)
       "930": Refugees in Donor Countries
       "998": Unallocated / Unspecified
-    requires_additional_benefitting_countries:
-      "true": "Yes"
-      "false": "No"
     status:
       "1": Pipeline/identification
       "2": Implementation

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -256,7 +256,7 @@ en:
         geography: Benefitting recipient geography
         delivery_partner_identifier: Delivery partner identifier
         delivery_partner_organisation: Delivery partner organisation
-        intended_beneficiaries: Intended beneficiaries
+        intended_beneficiaries_html: 'Intended beneficiaries</br><span class="govuk-body-s">Legacy field: not editable</span>'
         objectives: Aims/Objectives
         oda_eligibility: ODA eligibility
         oda_eligibility_lead: ODA eligibility lead
@@ -277,9 +277,9 @@ en:
         policy_marker_nutrition: Nutrition Policy
         programme_status: Activity status
         projects: Projects (level C)
-        recipient_country: Recipient country
-        recipient_region: Recipient region
         requires_additional_benefitting_countries: Other benefitting countries?
+        recipient_country_html: 'Recipient country</br><span class="govuk-body-s">Legacy field: not editable</span>'
+        recipient_region_html: 'Recipient region</br><span class="govuk-body-s">Legacy field: not editable</span>'
         sustainable_development_goals: Sustainable Development Goals
         sector: Economic/societal area
         sector_category: Focus area category

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -71,9 +71,6 @@ en:
         description: Description
         recipient_country: What country will benefit from this activity?
         recipient_region: What region will benefit from this activity?
-        requires_additional_benefitting_countries:
-          "true": "Yes"
-          "false": "No"
         sdg_1: First most relevant goal
         sdg_2: Second most relevant goal (optional)
         sdg_3: Third most relevant goal (optional)
@@ -153,7 +150,6 @@ en:
             principal_objective_and_in_support_of_an_action_programme: Principal objective AND in support of an action programme
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
-        requires_additional_benefitting_countries: Does this activity have other benefitting countries?
         sdgs_apply: Which Sustainable Development Goals does this activity meet?
         sector: Which %{sector_category} sector is the focus area for this %{level}?
         sector_category: What area of the economy or society is the %{level} helping?
@@ -277,7 +273,6 @@ en:
         policy_marker_nutrition: Nutrition Policy
         programme_status: Activity status
         projects: Projects (level C)
-        requires_additional_benefitting_countries: Other benefitting countries?
         recipient_country_html: 'Recipient country</br><span class="govuk-body-s">Legacy field: not editable</span>'
         recipient_region_html: 'Recipient region</br><span class="govuk-body-s">Legacy field: not editable</span>'
         sustainable_development_goals: Sustainable Development Goals
@@ -431,7 +426,6 @@ en:
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?
         region: What region will benefit from this activity?
-        requires_additional_benefitting_countries: Additional benefitting countries
         roda_identifier: Enter your unique RODA identifier
         sector: Which %{sector_category} sector is the focus area for this %{level}
         sector_category: What is the focus area category for this %{level}?
@@ -480,8 +474,6 @@ en:
               blank: Select a parent activity
             delivery_partner_identifier:
               blank: Enter a unique identifier
-            requires_additional_benefitting_countries:
-              blank: Select an option
             title:
               blank: Enter a title
             description:

--- a/db/migrate/20210929155655_remove_additionl_benefitting_countries_required.rb
+++ b/db/migrate/20210929155655_remove_additionl_benefitting_countries_required.rb
@@ -1,0 +1,5 @@
+class RemoveAdditionlBenefittingCountriesRequired < ActiveRecord::Migration[6.1]
+  def change
+    remove_column(:activities, :requires_additional_benefitting_countries, :boolean, if_exists: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_150920) do
+ActiveRecord::Schema.define(version: 2021_09_29_155655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 2021_09_13_150920) do
     t.date "call_close_date"
     t.string "intended_beneficiaries", array: true
     t.string "roda_identifier"
-    t.boolean "requires_additional_benefitting_countries"
     t.string "gdi"
     t.integer "total_applications"
     t.integer "total_awards"

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -16,7 +16,6 @@ FactoryBot.define do
     geography { :recipient_region }
     recipient_region { "489" }
     recipient_country { nil }
-    requires_additional_benefitting_countries { true }
     intended_beneficiaries { ["CU", "DM", "DO"] }
     benefitting_countries { nil }
     gdi { "4" }

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -346,24 +346,6 @@ RSpec.describe ActivityPresenter do
     end
   end
 
-  describe "#requires_additional_benefitting_countries" do
-    context "when requires_additional_benefitting_countries exists" do
-      it "returns the locale value for this option" do
-        activity = build(:project_activity, requires_additional_benefitting_countries: "true")
-        result = described_class.new(activity)
-        expect(result.requires_additional_benefitting_countries).to eq("Yes")
-      end
-    end
-
-    context "when requires_additional_benefitting_countries is not required" do
-      it "returns the locale value for this option" do
-        activity = build(:project_activity, requires_additional_benefitting_countries: "false")
-        result = described_class.new(activity)
-        expect(result.requires_additional_benefitting_countries).to eq("No")
-      end
-    end
-  end
-
   describe "#intended_beneficiaries" do
     it_behaves_like "a code translator", "intended_beneficiaries", {type: "recipient_country"}, "Array"
 

--- a/spec/support/activity_helpers.rb
+++ b/spec/support/activity_helpers.rb
@@ -42,7 +42,7 @@ module ActivityHelpers
     expect(page).to have_content t("summary.label.activity.actual_end_date")
     expect(page).to have_content activity_presenter.actual_end_date
 
-    expect(page).to have_content t("summary.label.activity.recipient_region")
+    expect(page).to have_content t("summary.label.activity.benefitting_countries")
     expect(page).to have_content activity_presenter.recipient_region
 
     expect(page).to have_content t("summary.label.activity.aid_type")

--- a/spec/views/staff/shared/activities/activity_spec.rb
+++ b/spec/views/staff/shared/activities/activity_spec.rb
@@ -185,27 +185,48 @@ RSpec.describe "staff/shared/activities/_activity" do
 
       let(:benefitting_countries) { [] }
 
-      it { is_expected.to_not have_css(".benefitting_region") }
+      it { is_expected.to have_css(".benefitting_region") }
     end
   end
 
-  describe "legacy recipient_region" do
-    let(:activity) { build(:programme_activity, recipient_region: "298", benefitting_countries: benefitting_countries) }
+  describe "legacy geography recipient_region, recipient_country and intended_beneficiaries" do
+    context "when there is a value" do
+      let(:activity) {
+        build(
+          :programme_activity,
+          recipient_region: "298",
+          recipient_country: "UG",
+          intended_beneficiaries: ["UG"]
+        )
+      }
 
-    context "when the activity has no benefitting_countries" do
-      subject { body.find(".recipient_region") }
+      it "is shown at all times and has a helpful 'read only' label" do
+        expect(body.find(".recipient_region .govuk-summary-list__value")).to have_content("Africa, regional")
+        expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")
 
-      let(:benefitting_countries) { [] }
+        expect(body.find(".recipient_country .govuk-summary-list__value")).to have_content("Uganda")
+        expect(body.find(".recipient_country .govuk-summary-list__key")).to have_content("Legacy field: not editable")
 
-      it { is_expected.to have_content("Africa, regional") }
+        expect(body.find(".intended_beneficiaries .govuk-summary-list__value")).to have_content("Uganda")
+        expect(body.find(".intended_beneficiaries .govuk-summary-list__key")).to have_content("Legacy field: not editable")
+      end
     end
 
-    context "when the activity has benefitting countries" do
-      subject { body }
+    context "when there is NOT a value" do
+      let(:activity) {
+        build(
+          :programme_activity,
+          recipient_region: nil,
+          recipient_country: nil,
+          intended_beneficiaries: []
+        )
+      }
 
-      let(:benefitting_countries) { ["DZ", "LY"] }
-
-      it { is_expected.to_not have_css(".recipient_region") }
+      it "is shown at all times and has a helpful 'read only' label" do
+        expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")
+        expect(body.find(".recipient_country .govuk-summary-list__key")).to have_content("Legacy field: not editable")
+        expect(body.find(".intended_beneficiaries .govuk-summary-list__key")).to have_content("Legacy field: not editable")
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR
The `requires_additional_benefitting_countries` is no longer valuable since we replaced `recipient_region`, `recipient_country` and `intended_beneficiaries` with `benefitting_countries` and `benefitting_region`.

Here we remove the column and any associated items.

We also decided to always show ALL the related geography attributes regardless of their state to help users:

- understand what data an activity does or does not have, rather than hiding that
- understand how they could migrate the data to the new values

We also added a 'read only` flag to the label to help users understand why the values in the old fields can longer been changed.

## Screenshots of UI changes

![Screenshot 2021-09-29 at 17-31-32 Activity AMS Coherence and Impact - Global Health Policy Workshops - Details - Report you](https://user-images.githubusercontent.com/480578/135310905-bd821b83-9829-4672-9270-30d090d672f4.png)


