### PR TITLE
(2203) Add comments tab to report

### DIFF
--- a/app/controllers/staff/report_comments_controller.rb
+++ b/app/controllers/staff/report_comments_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Staff::ReportCommentsController < Staff::BaseController
+  include Secured
+  include Reports::Breadcrumbed
+
+  def show
+    @report = Report.find(params["report_id"])
+    authorize @report
+
+    prepare_default_report_trail @report
+
+    @report_presenter = ReportPresenter.new(@report)
+    @grouped_comments = Report::GroupedCommentsFetcher.new(report: @report, user: current_user).all
+
+    render "staff/reports/comments"
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,6 +14,7 @@ class Report < ApplicationRecord
   has_many :historical_events
   has_many :refunds
   has_many :new_activities, class_name: "Activity", foreign_key: :originating_report_id
+  has_many :comments
 
   validate :activity_must_be_a_fund
   validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit

--- a/app/services/report/grouped_comments_fetcher.rb
+++ b/app/services/report/grouped_comments_fetcher.rb
@@ -1,0 +1,31 @@
+class Report
+  class GroupedCommentsFetcher
+    def initialize(report:, user:)
+      @report = report
+      @user = user
+    end
+
+    def all
+      comments.group_by(&:activity)
+    end
+
+    private
+
+    attr_reader :report, :user
+
+    def comments
+      if user.delivery_partner?
+        report.comments.includes(
+          owner: [:organisation],
+          activity: [
+            parent: [
+              parent: [:parent],
+            ],
+          ]
+        )
+      else
+        report.comments.includes(:activity)
+      end
+    end
+  end
+end

--- a/app/views/staff/reports/_tab_list.html.haml
+++ b/app/views/staff/reports/_tab_list.html.haml
@@ -5,3 +5,4 @@
   = render partial: "staff/reports/tab", locals: { name: "actuals", path: report_actuals_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "variance", path: report_variance_path(@report), active_tab: active_tab }
   = render partial: "staff/reports/tab", locals: { name: "budgets", path: report_budgets_path(@report), active_tab: active_tab }
+  = render partial: "staff/reports/tab", locals: { name: "comments", path: report_comments_path(@report), active_tab: active_tab }

--- a/app/views/staff/reports/comments.html.haml
+++ b/app/views/staff/reports/comments.html.haml
@@ -1,0 +1,44 @@
+=content_for :page_title_prefix, t("page_title.report.comments",report_description: @report_presenter.description, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+
+  = render "staff/reports/meta"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .govuk-tabs
+        %h2.govuk-tabs__title
+          Contents
+
+        = render partial: "staff/reports/tab_list", locals: { active_tab: "comments" }
+
+        .govuk-tabs__panel
+          %h2.govuk-heading-l
+            = t("page_content.tab_content.comments.heading")
+
+          %table.govuk-table
+            %thead.govuk-table__head
+              %tr.govuk-table__row
+                %th.govuk-table__cell{ class: "govuk-!-width-one-quarter" }
+                  = t("table.header.comments.activity_roda_identifier")
+                %th.govuk-table__cell{ class: "govuk-!-width-one-quarter" }
+                  = t("table.header.comments.date")
+                %th.govuk-table__cell
+                  = t("table.header.comments.comment")
+                %th.govuk-table__cell
+                  %span.govuk-visually-hidden
+                    = t("table.header.default.actions")
+
+            - @grouped_comments.each do |activity, comments|
+              %tbody.govuk-table__body{id: activity.id}
+                - comments.each_with_index do |comment, index|
+                  %tr.govuk-table__row
+                    - if defined?(index) && index == 0
+                      %th.govuk-table__cell{rowspan: comments.count, scope: "rowgroup"}
+                        = activity.roda_identifier
+                    %td.govuk-table__cell= I18n.l(comment.created_at.to_date)
+                    %td.govuk-table__cell= comment.comment
+                    - if policy(comment).update?
+                      %td.govuk-table__cell
+                        = a11y_action_link(t("default.link.edit"), edit_activity_comment_path(activity, comment), t("table.body.report.comment").downcase)
+

--- a/config/locales/models/comment.en.yml
+++ b/config/locales/models/comment.en.yml
@@ -19,6 +19,15 @@ en:
       edit: Edit comment
       edit_about_activity: Edit comment about %{activity}
       index_html: "This tab shows all the comments for this activity.<br>New comments can only be added whilst there is an active report."
+    tab_content:
+      comments:
+        heading: Comments
+  table:
+    header:
+      comments:
+        activity_roda_identifier: Activity RODA Identifier
+        date: Date
+        comment: Comment
   action:
     comment:
       create:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -30,6 +30,7 @@ en:
           You have no current reports. Once active, any new reports will appear here. You can view approved reports in the Approved tab.
         add_comment: Add comment
         view_comments: View comments
+        comment: Comment
   tabs:
     report:
       summary: Summary
@@ -40,6 +41,7 @@ en:
       budgets: Budgets
       current: Current
       approved: Approved
+      comments: Comments
   page_content:
     reports:
       title: Reports
@@ -139,6 +141,7 @@ en:
       actuals: "%{report_financial_quarter} %{report_description} actuals"
       budgets: "%{report_financial_quarter} %{report_description} budgets"
       activities: "%{report_financial_quarter} %{report_description} activities"
+      comments: "%{report_financial_quarter} %{report_description} comments"
   breadcrumb:
     report:
       upload_activities: Upload bulk activity data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
       get "actuals" => "report_actuals#show"
       get "budgets" => "report_budgets#show"
       get "activities" => "report_activities#show"
+      get "comments" => "report_comments#show"
     end
 
     concern :transactionable do

--- a/spec/controllers/staff/report_comments_controller_spec.rb
+++ b/spec/controllers/staff/report_comments_controller_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Staff::ReportCommentsController do
+  describe "show" do
+    let(:report) { build(:report, id: SecureRandom.uuid) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+
+      allow(Report).to receive(:find).with(report.id).and_return(report)
+
+      get "show", params: {report_id: report.id}
+    end
+
+    context "when signed in as a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "responds with a 200" do
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when signed in as a delivery partner" do
+      let(:user) { create(:delivery_partner_user) }
+
+      context "when the report belongs to the user's organisation" do
+        let(:report) { build(:report, :active, id: SecureRandom.uuid, organisation: user.organisation) }
+
+        it "responds with a 200" do
+          expect(response.status).to eq(200)
+        end
+
+        context "when the report is inactive" do
+          let(:report) { build(:report, :inactive, id: SecureRandom.uuid, organisation: user.organisation) }
+
+          it "responds with a 401" do
+            expect(response.status).to eq(401)
+          end
+        end
+      end
+
+      context "when the report does not belong to the user's organisation" do
+        let(:report) { build(:report, id: SecureRandom.uuid) }
+
+        it "responds with a 401" do
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/report/grouped_comments_fetcher_spec.rb
+++ b/spec/services/report/grouped_comments_fetcher_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe Report::GroupedCommentsFetcher do
+  let(:report) { build(:report) }
+  let(:comment_relation) { double("ActiveRecord::Relation") }
+
+  let(:activities) do
+    [
+      build(:project_activity, id: SecureRandom.uuid),
+      build(:project_activity, id: SecureRandom.uuid),
+      build(:project_activity, id: SecureRandom.uuid),
+    ]
+  end
+
+  let(:comments) do
+    [
+      build_list(:comment, 3, activity: activities[0]),
+      build_list(:comment, 2, activity: activities[1]),
+    ]
+  end
+
+  let(:grouped_comments) do
+    {
+      activities[0] => comments[0],
+      activities[1] => comments[1],
+    }
+  end
+
+  subject { described_class.new(report: report, user: user) }
+
+  before do
+    allow(report).to receive(:comments).and_return(comment_relation)
+  end
+
+  context "when the user is a delivery partner" do
+    let(:user) { build(:delivery_partner_user) }
+
+    it "returns comments, grouped by activity" do
+      expect(comment_relation).to receive(:includes).with(
+        owner: [:organisation],
+        activity: [
+          parent: [
+            parent: [:parent],
+          ],
+        ]
+      ).and_return(comments.flatten)
+
+      expect(subject.all).to eq(grouped_comments)
+    end
+  end
+
+  context "when the user is a service owner" do
+    let(:user) { build(:beis_user) }
+
+    it "returns comments, grouped by activity" do
+      expect(comment_relation).to receive(:includes).with(:activity).and_return(comments.flatten)
+
+      expect(subject.all).to eq(grouped_comments)
+    end
+  end
+end

--- a/spec/support/report_page.rb
+++ b/spec/support/report_page.rb
@@ -1,0 +1,49 @@
+class ReportPage
+  include Rails.application.routes.url_helpers
+  include Capybara::DSL
+  include RSpec::Matchers
+
+  def initialize(report)
+    visit reports_path
+
+    within "##{report.id}" do
+      click_on I18n.t("default.link.show")
+    end
+  end
+
+  def visit_comments_page
+    within ".govuk-tabs" do
+      click_on I18n.t("tabs.report.comments")
+    end
+  end
+
+  def has_comments_grouped_by_activity?(activities:, comments:)
+    within ".govuk-table" do
+      expect(page.find_all("th[scope=rowgroup]").count).to eq(activities.count)
+      expect(page.find_all("tbody tr").count).to eq(comments.count)
+
+      activities.each do |activity|
+        comments_for_activity = comments.select { |c| c.activity_id == activity.id }
+
+        within "tbody##{activity.id}" do
+          within "th" do
+            expect(page).to have_content(activity.roda_identifier)
+          end
+
+          comments_for_activity.each do |comment|
+            expect(page).to have_content(I18n.l(comment.created_at.to_date))
+            expect(page).to have_content(comment.comment)
+          end
+        end
+      end
+    end
+  end
+
+  def has_edit_buttons_for_comments?(comments)
+    within ".govuk-table" do
+      comments.all? do |comment|
+        page.has_link?(href: edit_activity_comment_path(comment.activity, comment))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a comments tab to the Report page, showing a list of all comments made in a reporting period, grouped by their activity

![image](https://user-images.githubusercontent.com/109774/135633223-f9809c9a-6e87-471a-b1a4-91c75579d8e6.png)
