### PR TITLE
Add a support doc for resetting a user's MFA setting

### DIFF
--- a/doc/0_index_of_contents.md
+++ b/doc/0_index_of_contents.md
@@ -78,3 +78,7 @@
   (support_tasks/create_new_report.md)](./support_tasks/create_new_report.md)**:
   Manually create a new report, most commonly required when a new delivery
   partner joins ODA reporting.
+
+- **[Reset a user's MFA
+  (support_tasks/reset_mfa.md)](./support_tasks/reset_mfa.md)**:
+  Reset a user's multi-factor authentication settings, so that they can configure a new method, e.g. if they have a new mobile phone number.

--- a/doc/support_tasks/reset_mfa.md
+++ b/doc/support_tasks/reset_mfa.md
@@ -1,0 +1,14 @@
+# Reset a user's multi-factor authentication
+
+In the case where a user can't complete MFA because their phone number has
+changed, support will need to manually reset the user's MFA settings via the
+Auth0 control panel:
+
+- log into Auth0 with an admin account
+- switch to the 'roda-production' tenant (or whichever environment is appropriate)
+- locate the user via the 'Users' section in 'User Management'
+- Reset MFA, eg via the 'Actions' drop-down
+- ask the user to log in again and to supply a valid mobile number when prompted
+
+This will allow the user to continue using SMS-based two-factor authentication
+for RODA.


### PR DESCRIPTION
In the scenario where a user can't complete MFA because their phone number has
changed, support will need to manually reset the user's MFA settings via the
Auth0 control panel.