### PR TITLE
Fix (2222) Populate currency and transaction_type properties for Refund and Adjustment records

### DIFF
--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -16,6 +16,9 @@ class Adjustment < Transaction
   validates_associated :comment
   validates_associated :detail
 
+  attribute :currency, :string, default: "GBP"
+  attribute :transaction_type, :string, default: Transaction::TRANSACTION_TYPE_DISBURSEMENT
+
   delegate :adjustment_type, to: :detail
 
   def adjustment_type=(variant)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -8,6 +8,9 @@ class Refund < Transaction
 
   validates_associated :comment
 
+  attribute :currency, :string, default: "GBP"
+  attribute :transaction_type, :string, default: Transaction::TRANSACTION_TYPE_DISBURSEMENT
+
   def value=(amount)
     big_decimal = begin
                     BigDecimal(amount)

--- a/db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb
+++ b/db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb
@@ -1,0 +1,21 @@
+# Run me with `rails runner db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb`
+
+# Refunds and Adjustments were being created with blank attributes:
+# - currency
+# - transaction_type
+#
+# This isn't causing an immediate problem, but they are "transactions" and so
+# ought to conform to te normal transaction behaviour.
+
+finder = Transaction.where(currency: nil, transaction_type: nil)
+
+puts "Fixing up #{finder.count} transactions..."
+
+finder.each do |transaction|
+  transaction.update_columns(
+    transaction_type: Transaction::TRANSACTION_TYPE_DISBURSEMENT,
+    currency: "GBP"
+  )
+end
+
+puts "-> there are now #{finder.reload.count} transactions still to fix"

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Adjustment, type: :model do
     it "should have the _type_ of 'Adjustment'" do
       expect(Adjustment.new.type).to eq("Adjustment")
     end
+
+    it "should have the _transaction_type_ of '3' for 'Disbursement'" do
+      expect(Adjustment.new.transaction_type).to eq("3")
+    end
+
+    it "should have the _currency_ of 'GBP'" do
+      expect(Adjustment.new.currency).to eq("GBP")
+    end
   end
 
   describe "validations" do

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Refund, type: :model do
     it "should have the _type_ of 'Refund'" do
       expect(Refund.new.type).to eq("Refund")
     end
+
+    it "should have the _transaction_type_ of '3' for 'Disbursement'" do
+      expect(Refund.new.transaction_type).to eq("3")
+    end
+
+    it "should have the _currency_ of 'GBP'" do
+      expect(Refund.new.currency).to eq("GBP")
+    end
   end
 
   describe "validations" do


### PR DESCRIPTION
Refunds and Adjustments were being created with blank attributes:

- `currency` should be "GBP"
- `transaction_type` should be "3" for "Disbursement"

This isn't causing an immediate problem, but both refunds and adjustments are "transactions" and so
ought to conform to the normal transaction behaviour.

In this PR we:

- add attribute initialisers to `Refund` and `Adjustment`
- add a data migration to fix up existing records 
  (to be run with `rails runner db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb`) 


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
