### PR TITLE
Fix: Comments for report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -860,6 +860,8 @@
 
 ## [unreleased]
 
+- Consolidate links to commnents on the report, variance tab
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-78...HEAD
 [release-78]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-77...release-78
 [release-77]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-76...release-77

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -444,7 +444,7 @@ class Activity < ApplicationRecord
   end
 
   def comments_for_report(report_id:)
-    comments.find_by(report_id: report_id)
+    comments.where(report_id: report_id)
   end
 
   def requires_collaboration_type?

--- a/app/views/staff/activities/comments.html.haml
+++ b/app/views/staff/activities/comments.html.haml
@@ -25,7 +25,7 @@
 
           .govuk-body
             - if policy(:comment).create? && @report
-              = a11y_action_link(t("page_content.comment.add"), new_activity_comment_path(@activity, report_id: @report.id))
+              = link_to(t("page_content.comment.add"), new_activity_comment_path(@activity, report_id: @report.id),  class: "govuk-button")
 
           %ul.govuk-list.activity_comments
             - @comments.each do |comment|

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -25,12 +25,10 @@
         %td.govuk-table__cell= number_to_currency activity.variance_for_report_financial_quarter(report: @report)
         - unless readonly
           %td.govuk-table__cell
-            - if activity.comments_for_report(report_id: @report.id).present?
+            - if policy(:comment).create?
+              = a11y_action_link(t("table.body.report.view_and_add_comments"), organisation_activity_comments_path(activity.organisation, activity), "about #{activity.roda_identifier}")
+            - else
               = a11y_action_link(t("table.body.report.view_comments"), organisation_activity_comments_path(activity.organisation, activity), "about #{activity.roda_identifier}")
-            - elsif policy(:comment).create?
-              = a11y_action_link(t("table.body.report.add_comment"), new_activity_comment_path(activity, report_id: @report.id), "about #{activity.roda_identifier}")
-          %td.govuk-table__cell
-            = a11y_action_link(t("default.link.view"), organisation_activity_path(activity.organisation, activity), activity.roda_identifier)
 
   %tfoot.govuk-table_footer
     %tr.govuk-table__row

--- a/app/views/staff/shared/reports/_table_variance.html.haml
+++ b/app/views/staff/shared/reports/_table_variance.html.haml
@@ -25,7 +25,7 @@
         %td.govuk-table__cell= number_to_currency activity.variance_for_report_financial_quarter(report: @report)
         - unless readonly
           %td.govuk-table__cell
-            - if activity.comments_for_report(report_id: @report.id)
+            - if activity.comments_for_report(report_id: @report.id).present?
               = a11y_action_link(t("table.body.report.view_comments"), organisation_activity_comments_path(activity.organisation, activity), "about #{activity.roda_identifier}")
             - elsif policy(:comment).create?
               = a11y_action_link(t("table.body.report.add_comment"), new_activity_comment_path(activity, report_id: @report.id), "about #{activity.roda_identifier}")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -31,6 +31,7 @@ en:
         add_comment: Add comment
         view_comments: View comments
         comment: Comment
+        view_and_add_comments: View and add new comments
   tabs:
     report:
       summary:

--- a/spec/features/staff/users_can_create_a_comment_spec.rb
+++ b/spec/features/staff/users_can_create_a_comment_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe "Users can create a comment" do
       context "when the report is editable" do
         scenario "the user can create a comment" do
           visit organisation_activity_comments_path(activity.organisation, activity)
+          expect(page).to have_css(".govuk-button")
           click_on t("page_content.comment.add")
           fill_in "comment[comment]", with: "Amendments have been made"
           click_button t("default.button.submit")

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -324,7 +324,6 @@ RSpec.feature "Users can view reports" do
             expect(page).to have_content "£1,000.00"
             expect(page).to have_content "£1,100.00"
             expect(page).to have_content "£100.00"
-            expect(page).to have_link t("default.link.view"), href: organisation_activity_path(activity.organisation, activity)
           end
 
           within "tfoot tr:first-child td" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1088,16 +1088,22 @@ RSpec.describe Activity, type: :model do
       project = create(:project_activity, :with_report)
       report = Report.for_activity(project).first
       comment = create(:comment, activity_id: project.id, report_id: report.id, comment: "Here's my comment")
-      expect(project.comments_for_report(report_id: report.id)).to eq comment
-      expect(project.comments_for_report(report_id: report.id).comment).to eq "Here's my comment"
+      expect(project.comments_for_report(report_id: report.id)).to include(comment)
+      expect(project.comments_for_report(report_id: report.id).first.comment).to eq "Here's my comment"
     end
 
-    it "does not return any other comments associated to this activity" do
+    it "does not return any other comments associated to this activity but in another report" do
       project = create(:project_activity, :with_report)
       report = Report.for_activity(project).first
       comment = create(:comment, activity_id: project.id, report_id: create(:report).id)
-      expect(project.comments_for_report(report_id: report.id)).to_not eq comment
-      expect(project.comments_for_report(report_id: report.id)).to be_nil
+      expect(project.comments_for_report(report_id: report.id)).not_to include(comment)
+      expect(project.comments_for_report(report_id: report.id)).to eq []
+    end
+
+    it "returns an empty array when there are no comments" do
+      project = create(:project_activity, :with_report)
+      report = Report.for_activity(project).first
+      expect(project.comments_for_report(report_id: report.id)).to eq []
     end
   end
 

--- a/spec/support/comment_form.rb
+++ b/spec/support/comment_form.rb
@@ -15,7 +15,8 @@ class CommentForm
     def create(report:)
       visit report_path(report)
       click_on I18n.t("tabs.report.variance.heading")
-      click_on I18n.t("table.body.report.add_comment")
+      click_on I18n.t("table.body.report.view_and_add_comments")
+      click_on I18n.t("page_content.comment.add")
 
       new(report: report)
     end

--- a/spec/views/staff/shared/reports/_table_variance_spec.rb
+++ b/spec/views/staff/shared/reports/_table_variance_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "staff/shared/reports/_table_variance" do
+  before do
+    assign(:report, create(:report))
+    activity = build_stubbed(:project_activity)
+    policy = double("policy")
+    allow(policy).to receive(:create?).and_return(create_comment)
+    allow(view).to receive(:organisation_activity_comments_path)
+      .and_return("This is not the path you are looking for")
+
+    without_partial_double_verification do
+      allow(view).to receive(:policy).with(:comment).and_return(policy)
+    end
+
+    render partial: "staff/shared/reports/table_variance", locals: {
+      activities: [activity],
+      readonly: false,
+    }
+  end
+
+  context "when the user can add a comment" do
+    let(:create_comment) { true }
+
+    it "shows a link to view and add to an activity's comments" do
+      expect(rendered).to have_content(t("table.body.report.view_and_add_comments"))
+    end
+  end
+
+  context "when the user cannot add a comment" do
+    let(:create_comment) { false }
+
+    it "shows a link to view an activity's comments" do
+      expect(rendered).to have_content(t("table.body.report.view_comments"))
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
This is a fix to a bug we have in the new comment work that we found whilst working on the report csv.

The `comments_for_report` method on actvity still assumes that there is only ever one comment per activity, per report and so uses `find_by` returning the first found comment or nil.

In the report csv we attempt to map over the result of this method and if there are no comments, blow up sliently and produce an empty csv file.

As we now allow multiple comments per report, per activity, we have also updated the links against variance in a report as we want to direct uses to the activity comments rather than a specific comment, where they can then add or view the comments.

We have also styled the add comment link as a button as it is the primary action in the scope of the comment tab.

## Screenshots of UI changes

### Before
![Screenshot 2021-10-06 at 08-46-55 FQ1 2021-2022 Q1 Report - FY 21 22 variance - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/136163590-50c36b74-b846-4494-a89d-75f718d5c5e7.png)


### After
![Screenshot 2021-10-06 at 08-46-23 FQ1 2021-2022 Q1 Report - FY 21 22 variance - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/136163575-abc09202-3f2a-4997-b6f0-74ca5cf922c2.png)

