### PR TITLE
(1821) Feature: show changed state of an activity in the report csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,8 @@
 
 ## [unreleased]
 
+- include activities 'change state' in the report csv
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-79...HEAD
 [release-79]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-78...release-79
 [release-78]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-77...release-78

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -2,10 +2,12 @@ class Report
   class Export
     def initialize(report:)
       @report = report
+      @change_state_column = ChangeStateColumn.new(report: @report)
     end
 
     def headers
       Row::ACTIVITY_HEADERS.keys +
+        @change_state_column.header +
         previous_twelve_quarter_actual_and_refund_headers +
         next_twenty_quarter_forecasts_headers +
         variance_headers
@@ -15,6 +17,7 @@ class Report
       activities.map do |activity|
         Row.new(
           activity: activity,
+          change_state: @change_state_column.state_of(activity: activity),
           report_presenter: report_presenter,
           previous_report_quarters: previous_report_quarters,
           following_report_quarters: following_report_quarters,
@@ -148,17 +151,19 @@ class Report
         "Link to activity in RODA",
       ]
 
-      def initialize(activity:, report_presenter:, previous_report_quarters:, following_report_quarters:, actual_quarters:, refund_quarters:)
+      def initialize(activity:, report_presenter:, previous_report_quarters:, following_report_quarters:, actual_quarters:, refund_quarters:, change_state:)
         @activity = activity
         @report_presenter = report_presenter
         @previous_report_quarters = previous_report_quarters
         @following_report_quarters = following_report_quarters
         @actual_quarters = actual_quarters
         @refund_quarters = refund_quarters
+        @change_state = change_state
       end
 
       def call
         activity_data +
+          @change_state +
           previous_quarter_actuals_and_refunds +
           next_quarter_forecasts +
           variance_data

--- a/spec/services/report/export_spec.rb
+++ b/spec/services/report/export_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Report::Export do
 
     it "includes the activity headers" do
       expect(subject.headers).to include(*Report::Export::Row::ACTIVITY_HEADERS.keys)
+      expect(subject.headers).to include("Change state")
     end
 
     it "includes the previous twelve quarters" do
@@ -84,6 +85,7 @@ RSpec.describe Report::Export do
     let(:report_presenter) { ReportPresenter.new(report) }
 
     before do
+      allow(Activity::ProjectsForReportFinder).to receive(:new).with(report: report).and_return(projects_for_report_stub)
       allow(Activity::ProjectsForReportFinder).to receive(:new).with(report: report, scope: Activity.all).and_return(projects_for_report_stub)
       allow(ReportPresenter).to receive(:new).and_return(report_presenter)
     end
@@ -98,6 +100,7 @@ RSpec.describe Report::Export do
           following_report_quarters: an_instance_of(Array),
           actual_quarters: an_instance_of(Actual::Overview::AllQuarters),
           refund_quarters: an_instance_of(Refund::Overview::AllQuarters),
+          change_state: an_instance_of(Array),
         ).and_return(stub)
         expect(stub).to receive(:call).and_return([activity.title])
       end
@@ -178,6 +181,7 @@ RSpec.describe Report::Export do
         following_report_quarters: following_report_quarters,
         actual_quarters: actual_quarters,
         refund_quarters: refund_quarters,
+        change_state: ["Changed"],
       )
     end
 
@@ -187,6 +191,10 @@ RSpec.describe Report::Export do
 
     it "includes the activity data" do
       expect(subject.activity_data).to include(activity.roda_identifier)
+    end
+
+    it "includes the change state" do
+      expect(subject.call).to include("Changed")
     end
 
     context "financial data" do


### PR DESCRIPTION
## Changes in this PR
All users need to know the 'change state' of activities in a report. As reports encapsulate the activities and changes since the last report, this is massively helpful to assure the correct changes have been made successfully.

At the moment this change is only referring to the non-financial data of an activity.

Here I introduce a `ChangeStateColumn` class to the `Report::Export`. By modelling the entire column we can optimise the number of quieres perfomred and so keep the speed of generating the report (which is horribly slow!) down. I know this approach is slightly different to what is already in the Export class, but I think it is much simpler to optimise by column of data than by row and would encourage us to do so where we can.

I decided to raise an error if an unexpected activity is passed to the ChangeStateColumn as this would really be an exceptional situaton and one that we would want to know about - I would be keen to hear the reviwers thoughts on this.

https://trello.com/c/qDuhAGEc

## Screenshots of UI changes
![Screenshot 2021-10-07 at 09 30 32](https://user-images.githubusercontent.com/480578/136348600-044d6261-90b4-429f-926b-176a65a041d9.png)

