### PR TITLE
(2215) Feature: Introduce Commitment

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -140,6 +140,8 @@ class Activity < ApplicationRecord
   has_many :external_incomes
   has_many :historical_events, dependent: :destroy
 
+  has_one :commitment, dependent: :destroy
+
   enum level: {
     fund: "fund",
     programme: "programme",

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -1,0 +1,8 @@
+class Commitment < ApplicationRecord
+  belongs_to :activity
+
+  validates :value, numericality: {
+    greater_than: 0,
+    less_than_or_equal_to: 99_999_999_999.00,
+  }
+end

--- a/db/migrate/20211007092806_add_commitment.rb
+++ b/db/migrate/20211007092806_add_commitment.rb
@@ -1,0 +1,9 @@
+class AddCommitment < ActiveRecord::Migration[6.1]
+  def change
+    create_table :commitments, id: :uuid do |t|
+      t.decimal :value, precision: 13, scale: 2
+      t.references :activity, type: :uuid, index: {unique: true}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_140235) do
+ActiveRecord::Schema.define(version: 2021_10_07_092806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -130,6 +130,14 @@ ActiveRecord::Schema.define(version: 2021_10_05_140235) do
     t.index ["commentable_type"], name: "index_comments_on_commentable_type"
     t.index ["owner_id"], name: "index_comments_on_owner_id"
     t.index ["report_id"], name: "index_comments_on_report_id"
+  end
+
+  create_table "commitments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "value", precision: 13, scale: 2
+    t.uuid "activity_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_commitments_on_activity_id", unique: true
   end
 
   create_table "external_incomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/commitment.rb
+++ b/spec/factories/commitment.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :commitment do
+    association :activity, factory: :programme_activity
+    value { BigDecimal("120.45") }
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -616,6 +616,7 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:external_incomes) }
     it { should have_many(:historical_events) }
     it { should have_many(:comments).with_foreign_key("commentable_id") }
+    it { should have_one(:commitment) }
   end
 
   describe "#parent_activities" do

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Commitment do
+  it { should belong_to(:activity) }
+
+  describe ".value" do
+    it "must be a number" do
+      commitment = build(:commitment, value: "not a number")
+      expect(commitment.valid?).to be false
+    end
+
+    it "cannot be zero" do
+      commitment = build(:commitment, value: 0)
+      expect(commitment.valid?).to be false
+    end
+
+    it "cannot be negative" do
+      commitment = build(:commitment, value: -1000.00)
+      expect(commitment.valid?).to be false
+    end
+
+    it "cannot exceed 99_999_999_999_00" do
+      commitment = build(:commitment, value: 100_000_000_000_00)
+      expect(commitment.valid?).to be false
+    end
+
+    it "can be a number within the allowed range" do
+      commitment = build(:commitment, value: 100_000_00)
+      expect(commitment.valid?).to be true
+    end
+  end
+end


### PR DESCRIPTION
This is the first piece of work to bring the Commitment to the applicaiton.

More PRs will follow, this one lays the groundwork.

The commitment is the total amount of funding BEIS commits at the outset
of an activity.

At this stage the primary motivation for storing the value is to output
it to the IATI XML to improve BEIS score on a forthcoming Publish What
You Fund score.

I decided to create a new table to store the commitment as it feels
right to keep all financial data out of the activity model, this also
gives flexibility later should it become apparent that multiple
commitments are required over the lifetime of an activity or we need to
store more detail about the commitment, the date range the commitment
covers for example.

There is a unique index on `activity_id` to prevent there ever being
more than one Commitment for an Activity.

To follow:

- importing commitments
- exposing commitments

- https://trello.com/c/VB5kWAJS