### PR TITLE
Chore: Extend Commitment

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -1,8 +1,15 @@
 class Commitment < ApplicationRecord
   belongs_to :activity
 
+  validates :value, :financial_quarter, :financial_year, presence: true
   validates :value, numericality: {
     greater_than: 0,
     less_than_or_equal_to: 99_999_999_999.00,
+  }
+  validates :financial_quarter, inclusion: {in: 1..4}
+  validates :financial_year, numericality: {
+    greater_than_or_equal_to: 2000,
+    less_than_or_equal_to: 3000,
+    only_integer: true,
   }
 end

--- a/db/migrate/20211012141009_add_financial_quarter_and_year_to_commitment.rb
+++ b/db/migrate/20211012141009_add_financial_quarter_and_year_to_commitment.rb
@@ -1,0 +1,6 @@
+class AddFinancialQuarterAndYearToCommitment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :commitments, :financial_quarter, :integer
+    add_column :commitments, :financial_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_092806) do
+ActiveRecord::Schema.define(version: 2021_10_12_141009) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -137,6 +138,8 @@ ActiveRecord::Schema.define(version: 2021_10_07_092806) do
     t.uuid "activity_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "financial_quarter"
+    t.integer "financial_year"
     t.index ["activity_id"], name: "index_commitments_on_activity_id", unique: true
   end
 

--- a/spec/factories/commitment.rb
+++ b/spec/factories/commitment.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :commitment do
     association :activity, factory: :programme_activity
     value { BigDecimal("120.45") }
+    financial_quarter { 1 }
+    financial_year { 2021 }
   end
 end

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -1,30 +1,17 @@
 RSpec.describe Commitment do
-  it { should belong_to(:activity) }
+  it "should be valid" do
+    should belong_to(:activity)
 
-  describe ".value" do
-    it "must be a number" do
-      commitment = build(:commitment, value: "not a number")
-      expect(commitment.valid?).to be false
-    end
+    should validate_presence_of(:value)
+    should validate_numericality_of(:value).is_greater_than(0)
+    should validate_numericality_of(:value).is_less_than_or_equal_to(99_999_999_999.00)
 
-    it "cannot be zero" do
-      commitment = build(:commitment, value: 0)
-      expect(commitment.valid?).to be false
-    end
+    should validate_presence_of(:financial_quarter)
+    should validate_inclusion_of(:financial_quarter).in_array((1..4).to_a)
 
-    it "cannot be negative" do
-      commitment = build(:commitment, value: -1000.00)
-      expect(commitment.valid?).to be false
-    end
-
-    it "cannot exceed 99_999_999_999_00" do
-      commitment = build(:commitment, value: 100_000_000_000_00)
-      expect(commitment.valid?).to be false
-    end
-
-    it "can be a number within the allowed range" do
-      commitment = build(:commitment, value: 100_000_00)
-      expect(commitment.valid?).to be true
-    end
+    should validate_presence_of(:financial_year)
+    should validate_numericality_of(:financial_year).only_integer
+    should validate_numericality_of(:financial_year).is_greater_than_or_equal_to(2_000)
+    should validate_numericality_of(:financial_year).is_less_than_or_equal_to(3_000)
   end
 end


### PR DESCRIPTION
Store a 'commitment date', the date in which the commitment was agreed.

For this first version this will all be supplied by BEIS in the initial
developer actioned import.

Took the opportunity to tighten up validation and use shoulda matchers in
the spec to make it a little leaner.
