### PR TITLE
Don't return headers if there are no forecasts

### DIFF
--- a/app/services/spending_breakdown/export.rb
+++ b/app/services/spending_breakdown/export.rb
@@ -148,7 +148,11 @@ class SpendingBreakdown::Export
   end
 
   def all_forecast_financial_quarter_range
-    @_forecast_quarter_range ||= Range.new(all_actual_and_refund_financial_quarter_range.last.succ, *all_financial_quarters_with_forecasts.max)
+    @_forecast_quarter_range ||= begin
+      return [] if all_financial_quarters_with_forecasts.blank?
+
+      Range.new(all_actual_and_refund_financial_quarter_range.last.succ, all_financial_quarters_with_forecasts.max)
+    end
   end
 
   class TransactionOverview

--- a/spec/services/spending_breakdown/export_spec.rb
+++ b/spec/services/spending_breakdown/export_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe SpendingBreakdown::Export do
         "Forecast FQ3 2021-2022",
       )
     end
+
+    context "when there are no forecasts" do
+      before do
+        allow(subject).to receive(:forecasts).and_return([])
+      end
+
+      it "should not return any forecast headers" do
+        expect(subject.headers.any? { |header| header.match(/Forecast/) }).to eq(false)
+      end
+    end
   end
 
   describe "#rows" do


### PR DESCRIPTION
We discovered a bug when downloading a spending breakdown for an organisation / fund that has no forecasts set. This results in the following error:

```
ArgumentError: wrong number of arguments (given 1, expected 2..3)
```

This is because when we try to build the headers for forecasts, we call `Range.new` with the first argument being the financial quarter after the last one we have actuals for (`all_actual_and_refund_financial_quarter_range.last.succ`) and the second argument being the `max` value of all the Financial Quarters we have forecasts for (`all_financial_quarters_with_forecasts.max`).

If we have no forecasts, this argument is `nil`, and that's what gives us the error.

To get round this, we check if `all_financial_quarters_with_forecasts` is blank first (i.e. an empty array). If it is, we
return an empty array for the range. I've also removed the splat (`*`) from the second argument, as it didn't offer any value.