### PR TITLE
(2229) Track changes to refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -871,6 +871,8 @@
 
 ## [unreleased]
 
+- Record changes to refunds and show them in the activity's Change history
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-80...HEAD
 [release-80]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-79...release-80
 [release-79]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-78...release-79

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -52,6 +52,7 @@ class Staff::RefundsController < Staff::ActivitiesController
 
     result = UpdateRefund.new(
       refund: Refund.find(id),
+      user: current_user
     ).call(attributes: refund_params)
 
     if result.success?

--- a/app/services/update_refund.rb
+++ b/app/services/update_refund.rb
@@ -1,13 +1,17 @@
 class UpdateRefund
-  def initialize(refund:)
+  def initialize(refund:, user:)
     @refund = refund
+    @user = user
   end
 
   def call(attributes: {})
     assign_refund_and_comment(attributes)
+    changes = refund.changes
+    changes[:comment] = refund.comment.changes[:body] if refund.comment.changes[:body]
     success = refund.save
 
     if success
+      record_historical_event(changes)
       Result.new(true, refund)
     else
       Result.new(false, refund)
@@ -16,11 +20,21 @@ class UpdateRefund
 
   private
 
-  attr_reader :refund
+  attr_reader :refund, :user
 
   def assign_refund_and_comment(attrs)
     refund.comment.body = attrs.delete(:comment)
     refund.value = attrs.delete(:value)&.to_s
     refund.assign_attributes(attrs)
+  end
+
+  def record_historical_event(changes)
+    HistoryRecorder.new(user: user).call(
+      changes: changes,
+      reference: "Update to Refund",
+      activity: refund.parent_activity,
+      trackable: refund,
+      report: refund.report
+    )
   end
 end

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature "Users can edit a refund" do
       }).and change { refund.comment.reload.body }.to("Comment goes here")
 
       expect(page).to have_content(t("action.refund.update.success"))
+
+      and_the_refund_update_appears_in_the_change_history
     end
 
     scenario "they can delete a refund" do
@@ -72,5 +74,23 @@ RSpec.feature "Users can edit a refund" do
 
   def and_i_see_the_refund_value_field_with_a_negative_amount
     expect(page).to have_field("refund_form[value]", with: "-110.01")
+  end
+
+  def and_the_refund_update_appears_in_the_change_history
+    visit organisation_activity_historical_events_path(
+      organisation_id: activity.organisation.id,
+      activity_id: activity.id
+    )
+    within(".historical-events") do
+      expect(page).to have_css(".refund .property", text: "value")
+      expect(page).to have_css(".refund .previous-value", text: "")
+      expect(page).to have_css(".refund .new-value", text: "-100.0")
+      expect(page).to have_css(".refund .property", text: "comment")
+      expect(page).to have_css(".refund .new-value", text: "Comment goes here")
+      expect(page).to have_css(
+        ".refund .report a[href='#{report_path(activity.refunds.first.report)}']",
+        text: activity.refunds.first.report.financial_quarter_and_year
+      )
+    end
   end
 end

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe HistoricalEvent, type: :model do
           .to("Adjustment")
       end
     end
+
+    context "when the change being tracked is on a Refund (subclass of Transaction)" do
+      let(:trackable) { create(:refund) }
+      let(:event) { HistoricalEvent.new(trackable: trackable) }
+
+      it "associates with the expected Refund object" do
+        expect(event.trackable_id).to eq(trackable.id)
+        expect(event.trackable).to eq(trackable)
+      end
+
+      it "correctly sets the subclass at the point of validation" do
+        expect { event.valid? }
+          .to change { event.trackable_type }
+          .from("Transaction")
+          .to("Refund")
+      end
+    end
   end
 
   describe "flexible 'value' fields which handle a range of data types" do

--- a/spec/services/update_refund_spec.rb
+++ b/spec/services/update_refund_spec.rb
@@ -1,25 +1,65 @@
 require "rails_helper"
 
 RSpec.describe UpdateRefund do
-  let(:refund) { create(:refund) }
+  let(:refund) { create(:refund, value: BigDecimal("101.01"), financial_quarter: 1) }
+  let(:user) { create(:delivery_partner_user) }
+  let(:history_recorder) { instance_double(HistoryRecorder, call: double) }
+  let(:updater) { described_class.new(refund: refund, user: user) }
+  let!(:original_comment) { refund.comment.body }
+
+  before do
+    allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
+  end
 
   describe "#call" do
-    it "returns a successful result" do
-      allow(refund).to receive(:valid?).and_return(true)
-      allow(refund).to receive(:save).and_return(true)
+    context "when the update is successful" do
+      let(:expected_changes) do
+        {
+          "value" => [-BigDecimal("101.01"), -BigDecimal("202.02")],
+          "financial_quarter" => [1, 2],
+          "comment" => [original_comment, "Updated text"],
+        }
+      end
 
-      result = described_class.new(refund: refund).call(attributes: {})
+      before do
+        allow(refund).to receive(:save).and_return(true)
+      end
 
-      expect(result.success?).to be true
+      it "returns a successful result" do
+        result = updater.call(attributes: {})
+
+        expect(result.success?).to be true
+      end
+
+      it "uses HistoryRecorder to record a historical event" do
+        updater.call(attributes: {value: "202.02", financial_quarter: "2", comment: "Updated text"})
+
+        expect(HistoryRecorder).to have_received(:new).with(user: user)
+        expect(history_recorder).to have_received(:call).with(
+          changes: expected_changes,
+          reference: "Update to Refund",
+          activity: refund.parent_activity,
+          trackable: refund,
+          report: refund.report
+        )
+      end
     end
 
     context "when the refund isn't valid" do
-      it "returns a failed result" do
+      before do
         allow(refund).to receive(:valid?).and_return(false)
+      end
 
-        result = described_class.new(refund: refund).call(attributes: {})
+      it "returns a failed result" do
+        result = updater.call(attributes: {})
 
         expect(result.success?).to be false
+      end
+
+      it "does not record a historical event" do
+        updater.call(attributes: {})
+
+        expect(HistoryRecorder).to_not have_received(:new)
       end
     end
 
@@ -27,7 +67,7 @@ RSpec.describe UpdateRefund do
       it "sets the attributes passed in as refund attributes" do
         attributes = ActionController::Parameters.new(comment: "abc").permit!
 
-        result = described_class.new(refund: refund).call(attributes: attributes)
+        result = updater.call(attributes: attributes)
 
         expect(result.object.comment.body).to eq("abc")
       end
@@ -37,7 +77,7 @@ RSpec.describe UpdateRefund do
       it "raises an error" do
         attributes = ActionController::Parameters.new(foo: "bar").permit!
 
-        expect { described_class.new(refund: refund).call(attributes: attributes) }
+        expect { updater.call(attributes: attributes) }
           .to raise_error(ActiveModel::UnknownAttributeError)
       end
     end


### PR DESCRIPTION
## Changes in this PR
- Record changes to refunds and show them in the activity’s Change history.

## Screenshots of UI changes

### After
<img width="1035" alt="Screenshot 2021-10-13 at 16 17 43" src="https://user-images.githubusercontent.com/579522/137163535-772ad0dd-9c5e-4949-af67-b8c04b985ad5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
