### PR TITLE
(2250) Create historical events when creating a refund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -878,6 +878,7 @@
 ## [unreleased]
 
 - BEIS users create reports manually
+- Create historical events when creating a refund
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-81...HEAD
 [release-81]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-80...release-81

--- a/app/controllers/staff/refunds_controller.rb
+++ b/app/controllers/staff/refunds_controller.rb
@@ -22,7 +22,11 @@ class Staff::RefundsController < Staff::ActivitiesController
 
     return render :new unless @refund.valid?
 
-    CreateRefund.new(activity: @activity).call(attributes: @refund.attributes)
+    CreateRefund.new(
+      activity: @activity,
+      user: current_user
+    ).call(attributes: @refund.attributes)
+
     flash[:notice] = t("action.refund.create.success")
     redirect_to organisation_activity_path(@activity.organisation, @activity)
   end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -5,29 +5,12 @@ RSpec.feature "Users can create a refund" do
     before { authenticate!(user: user) }
 
     scenario "they can create a refund for an activity" do
-      visit organisation_activity_financials_path(
-        organisation_id: activity.organisation.id,
-        activity_id: activity.id
-      )
-
-      click_on t("page_content.refund.button.create")
+      given_i_am_on_the_new_refund_form
       then_i_see_that_my_refund_amount_will_be_negative
-
-      fill_in "refund_form[value]", with: "100"
-      choose "4", name: "refund_form[financial_quarter]"
-      select "2019-2020", from: "refund_form[financial_year]"
-      fill_in "refund_form[comment]", with: "Comment goes here"
-
-      expect { click_on(t("default.button.submit")) }.to change(Refund, :count).by(1)
-
-      expect(page).to have_content(t("action.refund.create.success"))
-
-      newly_created_refund = Refund.last
-
-      within "##{newly_created_refund.id}" do
-        expect(page).to have_content("Q4 2019-2020")
-        expect(page).to have_content("-£100")
-      end
+      and_i_submit_the_new_refund_form_correctly
+      then_a_new_refund_should_be_created
+      and_i_expect_to_see_that_a_new_refund_has_been_created
+      and_new_historical_events_should_be_created
     end
 
     scenario "must supply the required information to create a refund" do
@@ -56,20 +39,54 @@ RSpec.feature "Users can create a refund" do
   end
 
   def given_i_am_on_the_new_refund_form
-    visit organisation_activity_financials_path(
-      organisation_id: activity.organisation.id,
-      activity_id: activity.id
-    )
-    click_on t("page_content.refund.button.create")
+    @refund_form = RefundsForm.create(activity: activity)
   end
 
   def and_i_submit_the_new_refund_form_incorrectly
-    click_on(t("default.button.submit"))
+    @refund_form.complete
+  end
+
+  def and_i_submit_the_new_refund_form_correctly
+    @refund_form.complete(
+      value: "100",
+      financial_quarter: 4,
+      financial_year: 2019,
+      comment: "Comment goes here"
+    )
   end
 
   def then_i_expect_to_see_how_i_need_to_correct_the_refund_form
     expect(page).to have_content("Select a financial quarter")
     expect(page).to have_content("Select a financial year")
     expect(page).to have_content("Enter a refund amount")
+  end
+
+  def then_a_new_refund_should_be_created
+    expect(Refund.count).to eq(1)
+  end
+
+  def and_i_expect_to_see_that_a_new_refund_has_been_created
+    expect(page).to have_content(t("action.refund.create.success"))
+
+    newly_created_refund = Refund.last
+
+    within "##{newly_created_refund.id}" do
+      expect(page).to have_content(@refund_form.financial_quarter_and_year)
+      expect(page).to have_content(@refund_form.value_with_currency)
+    end
+  end
+
+  def and_new_historical_events_should_be_created
+    historical_events = HistoricalEvent.where(trackable_id: Refund.last.id)
+
+    expect(historical_events.count).to eq(4)
+    expect(historical_event_for_value(historical_events, "value").new_value).to eq(@refund_form.value)
+    expect(historical_event_for_value(historical_events, "financial_quarter").new_value).to eq(@refund_form.financial_quarter)
+    expect(historical_event_for_value(historical_events, "financial_year").new_value).to eq(@refund_form.financial_year)
+    expect(historical_event_for_value(historical_events, "comment").new_value).to eq(@refund_form.comment)
+  end
+
+  def historical_event_for_value(events, value)
+    events.find { |e| e.value_changed == value }
   end
 end

--- a/spec/support/refunds_form.rb
+++ b/spec/support/refunds_form.rb
@@ -1,0 +1,78 @@
+class RefundsForm
+  include Capybara::DSL
+  include RSpec::Matchers
+  include ActionView::Helpers::NumberHelper
+
+  attr_reader :activity, :financial_quarter, :financial_year, :comment
+
+  def initialize(activity:)
+    @activity = activity
+  end
+
+  class << self
+    include Rails.application.routes.url_helpers
+    include Capybara::DSL
+
+    def create(activity:)
+      visit organisation_activity_financials_path(
+        organisation_id: activity.organisation.id,
+        activity_id: activity.id
+      )
+      click_on I18n.t("page_content.refund.button.create")
+
+      new(activity: activity)
+    end
+  end
+
+  def complete(value: nil, financial_quarter: nil, financial_year: nil, comment: nil)
+    @value = value
+    @financial_quarter = financial_quarter
+    @financial_year = financial_year
+    @comment = comment
+
+    fill_in_value
+    fill_in_financial_quarter
+    fill_in_financial_year
+    fill_in_comment
+
+    click_on(I18n.t("default.button.submit"))
+  end
+
+  def value
+    return nil if @value.nil?
+
+    -@value.to_d.abs
+  end
+
+  def value_with_currency
+    number_to_currency(value, unit: "£")
+  end
+
+  def financial_quarter_and_year
+    FinancialQuarter.new(financial_year, financial_quarter)
+  end
+
+  private
+
+  def fill_in_value
+    fill_in "refund_form[value]", with: @value
+  end
+
+  def fill_in_financial_quarter
+    return unless @financial_quarter.present?
+
+    choose @financial_quarter.to_s, name: "refund_form[financial_quarter]"
+  end
+
+  def fill_in_financial_year
+    return unless @financial_year.present?
+
+    within "select[name=\"refund_form[financial_year]\"]" do
+      find("option[value='#{@financial_year}']").select_option
+    end
+  end
+
+  def fill_in_comment
+    fill_in "refund_form[comment]", with: @comment
+  end
+end


### PR DESCRIPTION
This updates the `CreateRefund` class to record historical events when a Refund is created. I've also tweaked the feature test to use a form object to work in conjunction with the gherkin-style expectation methods to tighten up the specs.