### PR TITLE
(2259) Fix: always display adjustments on activity financials tab

### DIFF
--- a/app/views/staff/shared/activities/_adjustments.html.haml
+++ b/app/views/staff/shared/activities/_adjustments.html.haml
@@ -5,4 +5,4 @@
 
     - if policy(activity).create_adjustment?
       = link_to(t("page_content.adjustment.button.create"), new_activity_adjustment_path(activity), class: "govuk-button")
-      = render partial: '/staff/shared/adjustments/table', locals: { adjustments: adjustment_presenters }
+    = render partial: '/staff/shared/adjustments/table', locals: { adjustments: adjustment_presenters }

--- a/spec/features/staff/users_can_view_adjustments_spec.rb
+++ b/spec/features/staff/users_can_view_adjustments_spec.rb
@@ -1,0 +1,68 @@
+RSpec.feature "Users can view adjustments (irrespective of report state)" do
+  let(:organisation) { create(:delivery_partner_organisation) }
+
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  let(:activity) { create(:project_activity, organisation: organisation) }
+
+  before { authenticate!(user: user) }
+
+  scenario "can view adjustments for an activity" do
+    given_an_active_report_exists
+    and_an_adjustment_exists
+    and_the_report_is_no_longer_editable
+    and_i_am_looking_at_the_activity_financials_tab
+
+    then_i_expect_to_see_the_adjustment
+  end
+
+  def given_an_active_report_exists
+    create(
+      :report,
+      :active,
+      fund: activity.associated_fund,
+      organisation: activity.organisation,
+      financial_quarter: 1,
+      financial_year: 2021
+    )
+  end
+
+  def and_an_adjustment_exists
+    create(
+      :adjustment,
+      :actual,
+      parent_activity: activity,
+      value: "100.01",
+      financial_quarter: 4,
+      financial_year: 2020,
+      report: Report.editable_for_activity(activity)
+    )
+  end
+
+  def and_the_report_is_no_longer_editable
+    Report.editable_for_activity(activity).update_columns(state: "submitted")
+  end
+
+  def and_i_am_looking_at_the_activity_financials_tab
+    visit organisation_activity_financials_path(
+      organisation_id: activity.organisation.id,
+      activity_id: activity.id
+    )
+  end
+
+  def then_i_expect_to_see_the_adjustment
+    adjustment = activity.adjustments.first
+
+    fail "Expect activity to have an adjustment" unless adjustment
+    within ".adjustments" do
+      within "#adjustment_#{adjustment.id}" do
+        expect(page).to have_css(".financial-period", text: "FQ4 2020-2021")
+        expect(page).to have_css(".value", text: "£100.01")
+        expect(page).to have_css(".type", text: "Actual")
+        expect(page).to have_css(
+          ".report a[href='#{report_path(adjustment.report)}']",
+          text: "Report"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The "partial view" displaying adjustments was only being
rendered when it was permissible to *create* an adjustment
(i.e. when there's an editable report).

We now show the list of adjustments always.

Trello: https://trello.com/c/kh8HrhE8/2259-bug