### PR TITLE
(2262) Fix: allow adjustments for all editable reports

### DIFF
--- a/app/policies/adjustment_policy.rb
+++ b/app/policies/adjustment_policy.rb
@@ -1,14 +1,14 @@
 class AdjustmentPolicy < ApplicationPolicy
   def new?
     return false if record.parent_activity.level.nil?
-    return true if delivery_partner_user? && active_report_exists?
+    return true if delivery_partner_user? && editable_report_exists?
 
     false
   end
 
   def create?
     return false if record.parent_activity.level.nil?
-    return true if delivery_partner_user? && active_report_exists?
+    return true if delivery_partner_user? && editable_report_exists?
 
     false
   end
@@ -20,12 +20,12 @@ class AdjustmentPolicy < ApplicationPolicy
 
   private
 
-  def active_report_exists?
-    active_report.any?
+  def editable_report_exists?
+    editable_report.present?
   end
 
-  def active_report
-    Report.for_activity(record.parent_activity).where(state: "active")
+  def editable_report
+    Report.editable_for_activity(record.parent_activity)
   end
 
   def activity_is_a_programme?

--- a/spec/policies/adjustment_policy_spec.rb
+++ b/spec/policies/adjustment_policy_spec.rb
@@ -170,6 +170,20 @@ RSpec.describe AdjustmentPolicy do
               end
             end
 
+            context "when the report is in an editable state" do
+              Report::EDITABLE_STATES.each do |state|
+                before { report.update(state: state) }
+
+                it "applies the expected controls when report in #{state} state" do
+                  aggregate_failures do
+                    is_expected.to permit_action(:show)
+                    is_expected.to permit_action(:new)
+                    is_expected.to permit_action(:create)
+                  end
+                end
+              end
+            end
+
             context "when the report is the one in which the transaction was created" do
               before do
                 adjustment.update(report: report)


### PR DESCRIPTION
The "Add adjustment" facility was only available to
activities with an `active` report, rather than both of the
"editable" states -- i.e. in the common scenario that a
report was moved by BEIS to the `awaiting_changes` state, so
that a correction could be made, the DP wasn't able to post
an adjustment...

Trello: https://trello.com/c/be8gro0p/2262-bug-add-adjustment-missing-when-report-in-awaitingchanges-state
