### PR TITLE
(2254) Fix: allow adjustment to be associated with any editable report

### DIFF
--- a/app/services/create_adjustment.rb
+++ b/app/services/create_adjustment.rb
@@ -70,8 +70,8 @@ class CreateAdjustment
   end
 
   def bail_if_report_not_acceptable
-    if report.state != "active"
-      msg = "Report ##{report.id} is not in the active state"
+    unless Report::EDITABLE_STATES.include?(report.state)
+      msg = "Report ##{report.id} is not in an editable state"
     end
     unless valid_reports_for_activity.include?(report)
       msg = "Report ##{report.id} is not associated with Activity ##{activity.id}"

--- a/spec/services/create_adjustment_spec.rb
+++ b/spec/services/create_adjustment_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe CreateAdjustment do
       end
     end
 
-    context "when the given report is not in the *active* state" do
+    context "when the given report is not in an *editable* state" do
       before do
         allow(report).to receive(:state).and_return("approved")
       end
@@ -152,7 +152,7 @@ RSpec.describe CreateAdjustment do
         expect { creator.call(attributes: {report: report}) }
           .to raise_error(
             CreateAdjustment::AdjustmentError,
-            "Report #abc123 is not in the active state"
+            "Report #abc123 is not in an editable state"
           )
       end
 
@@ -164,6 +164,18 @@ RSpec.describe CreateAdjustment do
         end
 
         expect(Adjustment).not_to have_received(:new)
+      end
+    end
+
+    context "when the given report is in any *editable* state" do
+      Report::EDITABLE_STATES.each do |editable_state|
+        before do
+          allow(report).to receive(:state).and_return(editable_state)
+        end
+
+        it "does not raise an error when report is in *#{editable_state}* state" do
+          expect { creator.call(attributes: valid_attributes) }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
We understand that corrections requiring adjustments may fall
into these 2 categories:

1. once all reports are approved and BEIS are preparing the
SID submission, errors maybe indentified and adjustments agreed
with DPs. To post these adjustments, new reports (`active` state)
will be created.

2. during assurance, errors may be identified. In this case
the `submitted` (not yet `approved`) report will be moved into
the `awaiting_changes` state and the adjustments can be posted.

See https://trello.com/c/WLTtbks2/2254-bug-allow-adjustment-to-be-associated-with-any-editable-report-and-more
The error handling part is coming in another PR which will replace https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1411