### PR TITLE
(2024) Track changes to forecasts

### DIFF
--- a/spec/support/matchers/historical_event_matcher.rb
+++ b/spec/support/matchers/historical_event_matcher.rb
@@ -1,0 +1,29 @@
+RSpec::Matchers.define :create_a_historical_forecast_event do |args|
+  match(notify_expectation_failures: true) do |actual|
+    expect { actual.call }.to change { HistoricalEvent.count }.by(1)
+
+    historical_event =
+      HistoricalEvent.order(:created_at).last
+    forecast =
+      Forecast.unscoped.where(parent_activity_id: args[:activity].id).order(:created_at).last
+
+    expect(historical_event.reference).to eq("Revising a forecast for #{args[:financial_quarter]}")
+    expect(historical_event.user).to eq(user)
+    expect(historical_event.activity).to eq(args[:activity])
+    expect(historical_event.trackable_id).to eq(forecast.id)
+    expect(historical_event.report).to eq(args[:report])
+    expect(historical_event.value_changed).to eq("value")
+    expect(historical_event.previous_value).to eq(args[:previous_value])
+    expect(historical_event.new_value).to eq(args[:new_value])
+  end
+
+  supports_block_expectations
+end
+
+RSpec::Matchers.define :not_create_a_historical_event do |args|
+  match(notify_expectation_failures: true) do |actual|
+    expect { actual.call }.to change { HistoricalEvent.count }.by(0)
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
This records a historical event when a forecast is changed by a delivery partner, outside of its original reporting cycle. If a forecast is created and then edited in the same reporting cycle, or created/edited by a service owner (who do not do these things during reporting cycles), we do nothing.

I've also attempted to clean up and rationalise the forecast history specs to make them easier to follow. Whether or not this has worked is another matter entirely!