### PR TITLE
(1943) Record redactions from IATI in activity change history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -888,6 +888,8 @@
 
 ## [unreleased]
 
+- Record redactions from IATI in the activity's change history
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-83...HEAD
 [release-83]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-82...release-83
 [release-82]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-81...release-82

--- a/app/controllers/staff/activity_redactions_controller.rb
+++ b/app/controllers/staff/activity_redactions_controller.rb
@@ -11,7 +11,12 @@ class Staff::ActivityRedactionsController < Staff::BaseController
     authorize @activity, :redact_from_iati?
 
     @activity.update(publish_to_iati: activity_params["publish_to_iati"])
-    @activity.child_activities.update(publish_to_iati: activity_params["publish_to_iati"])
+    record_historical_event(@activity)
+
+    @activity.child_activities.each do |child_activity|
+      child_activity.update(publish_to_iati: activity_params["publish_to_iati"])
+      record_historical_event(child_activity)
+    end
 
     redirect_to organisation_activity_path(@activity.organisation, @activity)
   end
@@ -24,5 +29,15 @@ class Staff::ActivityRedactionsController < Staff::BaseController
 
   def activity_params
     params.require(:activity).permit(:publish_to_iati)
+  end
+
+  def record_historical_event(activity)
+    reference = activity.publish_to_iati ? "Activity published to IATI" : "Activity redacted from IATI"
+    HistoryRecorder.new(user: current_user).call(
+      changes: {publish_to_iati: activity.saved_change_to_attribute(:publish_to_iati)},
+      reference: reference,
+      activity: activity,
+      trackable: activity
+    )
   end
 end

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -32,6 +32,23 @@ RSpec.feature "Users can edit an activity" do
       within ".publish_to_iati" do
         expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
+
+      expect_change_to_be_recorded_as_historical_event(
+        field: "publish_to_iati",
+        previous_value: true,
+        new_value: false,
+        reference: "Activity redacted from IATI",
+        activity: project_activity,
+        report: nil
+      )
+      expect_change_to_be_recorded_as_historical_event(
+        field: "publish_to_iati",
+        previous_value: true,
+        new_value: false,
+        reference: "Activity redacted from IATI",
+        activity: third_party_project_activity,
+        report: nil
+      )
     end
 
     context "when the activity is a fund level activity" do
@@ -55,6 +72,7 @@ RSpec.feature "Users can edit an activity" do
             field: "description",
             previous_value: activity.description,
             new_value: updated_description,
+            reference: "Update to Activity purpose",
             activity: activity,
             report: nil # no report in this scenario. Realistic or failure in setup?
           )
@@ -184,6 +202,7 @@ RSpec.feature "Users can edit an activity" do
           field: "policy_marker_gender",
           previous_value: "not_assessed",
           new_value: "significant_objective",
+          reference: "Update to Activity policy_markers",
           activity: activity,
           report: report
         )
@@ -376,14 +395,16 @@ def expect_change_to_be_recorded_as_historical_event(
   field:,
   previous_value:,
   new_value:,
+  reference:,
   activity:,
   report:
 )
-  historical_event = HistoricalEvent.last
+  historical_event = activity.historical_events.last
   aggregate_failures do
     expect(historical_event.value_changed).to eq(field)
     expect(historical_event.previous_value).to eq(previous_value)
     expect(historical_event.new_value).to eq(new_value)
+    expect(historical_event.reference).to eq(reference)
     expect(historical_event.activity).to eq(activity)
     expect(historical_event.report).to eq(report)
   end


### PR DESCRIPTION
## Changes in this PR
- Record redactions from IATI in the activity's change history

## Screenshots of UI changes

### After
<img width="1120" alt="Screenshot 2021-10-25 at 13 22 19" src="https://user-images.githubusercontent.com/579522/138694295-85843f5f-cf22-40af-88e8-695fd1071979.png">
<img width="1082" alt="Screenshot 2021-10-25 at 13 23 31" src="https://user-images.githubusercontent.com/579522/138694379-247453be-f4a8-4904-9202-582864686a69.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
