### PR TITLE
(2246) Introduce ActivityActualsColumns

### DIFF
--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -1,0 +1,96 @@
+class Export::ActivityActualsColumns
+  def initialize(activities:, include_breakdown: false, report: nil)
+    @activities = activities
+    @include_breakdown = include_breakdown
+    @report = report
+  end
+
+  def headers
+    return [] if @activities.empty?
+
+    financial_quarter_range.map { |financial_quarter|
+      if @include_breakdown
+        [
+          "Actual spend #{financial_quarter}",
+          "Refund #{financial_quarter}",
+          "Actual net #{financial_quarter}",
+        ]
+      else
+        ["Actual net #{financial_quarter}"]
+      end
+    }.flatten
+  end
+
+  def rows
+    return [] if @activities.empty?
+
+    @activities.map { |activity|
+      actual_and_refund_data(activity)
+    }.to_h
+  end
+
+  private
+
+  def actual_and_refund_data(activity)
+    build_columns(all_totals_for_activity(activity), activity)
+  end
+
+  def build_columns(totals, activity)
+    columns = financial_quarter_range.map { |fq|
+      actual_overview = Export::FinancialQuarterActivityTotals.new(type: :actual, activity: activity, totals: totals, financial_quarter: fq)
+      refund_overview = Export::FinancialQuarterActivityTotals.new(type: :refund, activity: activity, totals: totals, financial_quarter: fq)
+
+      net_total = actual_overview.net_total + refund_overview.net_total
+
+      if @include_breakdown
+        [actual_overview.net_total, refund_overview.net_total, net_total]
+      else
+        [net_total]
+      end
+    }
+    [activity.id, columns.flatten]
+  end
+
+  def all_totals_for_activity(activity)
+    Export::AllActivityTotals.new(activity: activity).call
+  end
+
+  def reports_up_to(report)
+    return if report.nil?
+    Report.historically_up_to(report).pluck(:id)
+  end
+
+  def actual_spend
+    actual_spend_scope = Actual.where(parent_activity_id: activity_ids)
+    actual_spend_scope = actual_spend_scope.where(report_id: reports_up_to(@report)) unless @report.nil?
+    @_actual_spend ||= actual_spend_scope
+  end
+
+  def refunds
+    refund_scope = Refund.where(parent_activity_id: activity_ids)
+    refund_scope = refund_scope.where(report_id: reports_up_to(@report)) unless @report.nil?
+    @_refunds ||= refund_scope
+  end
+
+  def activity_ids
+    @activity_ids ||= @activities.pluck(:id)
+  end
+
+  def all_financial_quarters_with_actuals
+    return [] unless actual_spend.present?
+    actual_spend.map(&:own_financial_quarter).uniq
+  end
+
+  def all_financial_quarters_with_refunds
+    return [] unless refunds.present?
+    refunds.map(&:own_financial_quarter).uniq
+  end
+
+  def financial_quarters
+    all_financial_quarters_with_actuals + all_financial_quarters_with_refunds
+  end
+
+  def financial_quarter_range
+    @_financial_quarter_range ||= Range.new(*financial_quarters.minmax)
+  end
+end

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -1,0 +1,252 @@
+RSpec.describe Export::ActivityActualsColumns do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+    @activity = create(:project_activity)
+    other_activities = create_list(:project_activity, 4)
+
+    @activities = [@activity] + other_activities
+
+    @q1_report = create(:report, financial_quarter: 1, financial_year: 2020)
+    @q2_report = create(:report, financial_quarter: 2, financial_year: 2020)
+    @q3_report = create(:report, financial_quarter: 3, financial_year: 2020)
+    @q4_report = create(:report, financial_quarter: 4, financial_year: 2020)
+
+    create_fixtures(
+      <<~TABLE
+        |transaction|report|financial_period|value|
+        | Actual    |q1    | q1             |  100|
+        | Adj. Act. |q2    | q1             |  200|
+        | Adj. Act. |q2    | q1             | -100|
+        | Refund    |q1    | q1             | -200|
+        | Adj. Ref. |q2    | q1             |   50|
+        | Adj. Ref. |q2    | q1             | -200|
+        | Actual    |q3    | q3             |  100|
+        | Refund    |q3    | q3             | -200|
+        | Adj. Act. |q4    | q3             |  200|
+        | Adj. Act. |q4    | q3             | -100|
+        | Adj. Ref. |q4    | q3             |  100|
+        | Adj. Ref. |q4    | q3             | -200|
+        | Actual    |q4    | q4             |  300|
+      TABLE
+    )
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  subject { described_class.new(activities: @activities, include_breakdown: breakdown, report: report) }
+
+  context "when a breakdown is not requested" do
+    let(:breakdown) { false }
+    let(:report) { nil }
+
+    describe "#headers" do
+      it "contains the headers for financial quarters in which there is actual spend" do
+        expect(subject.headers).to match_array(
+          [
+            "Actual net FQ1 2020-2021",
+            "Actual net FQ2 2020-2021",
+            "Actual net FQ3 2020-2021",
+            "Actual net FQ4 2020-2021",
+          ]
+        )
+      end
+    end
+
+    describe "#rows" do
+      it "contains the financial data for FQ1 2020-2021 including later adjustments" do
+        expect(value_for_header("Actual net FQ1 2020-2021"))
+          .to eq BigDecimal(100 + 200 + -100 + -200 + 50 + -200)
+      end
+
+      it "contains the financial data for FQ3 2020-2021 including later adjustments" do
+        expect(value_for_header("Actual net FQ3 2020-2021"))
+          .to eq BigDecimal(100 + 200 + -100 + -200 + 100 + -200)
+      end
+
+      it "contains the financial data for FQ4 2020-2021" do
+        expect(value_for_header("Actual net FQ4 2020-2021"))
+          .to eq BigDecimal(300)
+      end
+
+      it "contains zero values for the financial quarters inbetween" do
+        expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
+      end
+
+      it "includes a row for each activity" do
+        expect(subject.rows.count).to eq(5)
+      end
+    end
+
+    context "when the Q3 2020-2021 report is passed" do
+      let(:report) { create(:report, financial_quarter: 3, financial_year: 2020) }
+
+      describe "#headers" do
+        it "contains the headers for financial  quarters up to and including the report" do
+          expect(subject.headers).to match_array(
+            [
+              "Actual net FQ1 2020-2021",
+              "Actual net FQ2 2020-2021",
+              "Actual net FQ3 2020-2021",
+            ]
+          )
+        end
+
+        it "does not contain headers for the financial quarters after the report" do
+          expect(subject.headers).not_to include("Actual net FQ4 2020-201")
+        end
+      end
+
+      describe "#rows" do
+        it "contains the financial data for FQ1 2020-2021 as of Q3 2020-2021" do
+          expect(value_for_header("Actual net FQ1 2020-2021"))
+            .to eq BigDecimal(100 + 200 + -100 + -200 + 50 + -200)
+        end
+
+        it "contains the financial data for FQ3 2020-2021 as of Q3 2020-2021" do
+          expect(value_for_header("Actual net FQ3 2020-2021"))
+            .to eq BigDecimal(100 + -200)
+        end
+
+        it "contains zero values for the financial quarters inbetween" do
+          expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
+        end
+
+        it "includes a row for each activity" do
+          expect(subject.rows.count).to eq(5)
+        end
+      end
+    end
+  end
+
+  context "when a breakdown is requested" do
+    let(:breakdown) { true }
+    let(:report) { nil }
+
+    describe "#headers" do
+      it "contains the headings that describe the finances for FQ1 2020-2021" do
+        expect(subject.headers).to include(
+          "Actual spend FQ1 2020-2021",
+          "Refund FQ1 2020-2021",
+          "Actual net FQ1 2020-2021",
+        )
+      end
+
+      it "contains the headings that describe the finances for FQ3 2020-2021" do
+        expect(subject.headers).to include(
+          "Actual spend FQ3 2020-2021",
+          "Refund FQ3 2020-2021",
+          "Actual net FQ3 2020-2021",
+        )
+      end
+
+      it "contains the headings that describe the finances for FQ4 2020-2021" do
+        expect(subject.headers).to include(
+          "Actual spend FQ4 2020-2021",
+          "Refund FQ4 2020-2021",
+          "Actual net FQ4 2020-2021",
+        )
+      end
+
+      it "contains the headings that describe the finances for financial quarters inbetween" do
+        expect(subject.headers).to include(
+          "Actual spend FQ2 2020-2021",
+          "Refund FQ2 2020-2021",
+          "Actual net FQ2 2020-2021",
+        )
+      end
+    end
+
+    describe "#rows" do
+      it "contains the financial data for FQ1 2020-2021" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ1 2020-2021"))
+            .to eq BigDecimal(100 + 200 + -100)
+          expect(value_for_header("Refund FQ1 2020-2021"))
+            .to eq BigDecimal(-200 + 50 + -200)
+          expect(value_for_header("Actual net FQ1 2020-2021"))
+            .to eq BigDecimal(100 + 200 + -100 + -200 + 50 + -200)
+        end
+      end
+
+      it "contains the financial data for FQ3 2020-2021" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ3 2020-2021"))
+            .to eq BigDecimal(100 + 200 + -100)
+          expect(value_for_header("Refund FQ3 2020-2021"))
+            .to eq BigDecimal(-200 + 100 + -200)
+          expect(value_for_header("Actual net FQ3 2020-2021"))
+            .to eq BigDecimal(100 + 200 + -100 + -200 + 100 + -200)
+        end
+      end
+
+      it "contains the financial data for FQ4 2020-2021" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ4 2020-2021"))
+            .to eq BigDecimal(300)
+          expect(value_for_header("Refund FQ4 2020-2021"))
+            .to eq 0
+          expect(value_for_header("Actual net FQ4 2020-2021"))
+            .to eq BigDecimal(300)
+        end
+      end
+
+      it "contains zero values for the financial quarters inbetween" do
+        aggregate_failures do
+          expect(value_for_header("Actual spend FQ2 2020-2021")).to eq 0
+          expect(value_for_header("Refund FQ2 2020-2021")).to eq 0
+          expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
+        end
+      end
+
+      it "includes a row for each activity" do
+        expect(subject.rows.count).to eq(5)
+      end
+    end
+
+    context "when there are no activities" do
+      subject { described_class.new(activities: [], include_breakdown: breakdown) }
+
+      it "returns an empty array" do
+        expect(subject.headers).to eql []
+        expect(subject.rows).to eql []
+      end
+    end
+  end
+
+  private
+
+  def value_for_header(header_name)
+    values = subject.rows.fetch(@activity.id)
+    values[subject.headers.index(header_name)]
+  end
+
+  def create_fixtures(table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      case row["transaction"].strip
+      when "Actual"
+        create(:actual, fixture_attrs(row))
+      when "Adj. Act."
+        create(:adjustment, :actual, fixture_attrs(row))
+      when "Adj. Ref."
+        create(:adjustment, :refund, fixture_attrs(row))
+      when "Refund"
+        create(:refund, fixture_attrs(row))
+      else
+        raise "don't know what to do"
+      end
+    end
+  end
+
+  def fixture_attrs(row)
+    {
+      parent_activity: @activity,
+      value: row["value"].strip,
+      financial_quarter: row["financial_period"][/\d/],
+      financial_year: 2020,
+      report: instance_variable_get("@#{row["report"].strip}_report"),
+    }
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Number 5️⃣ !

This work extracts the code that collects the actuals. Actuals are Actual spend + adjustments, Refunds + adjustments and the Net total, the previous two added together and renders them ready for a CSV file out of the existing `Export::SpendingBreakdown`.

We've already extracted `Export::AllActivityTotals` and `Export::FinancialQuarterActivityTotals` that do a large part of the work. With those two classes tested, we can have more confidence that the values this one is using are the correct ones, so here we are just looking at the layout of the columns and that 0 values have been added in the correct columns.

The next step will be to use this in the `Export:SpendingBreakdown` but i wanted to keep the PR size down and this can be reviewd in isolation.

This takes a bunch of activities and two optional arguments:

- report
- include_breakdown

With a report, the totals are scoped to the values that were added up to and including the report, any later values or adjustments will not be included, this behaviour relies on the `Export::AllActivityTotals` class.

With `include_breakdown` set to true, it will split the spend out into 3 columns as per the spending breakdown report:

- Actual spend + adjustments
- Refunds + adjustmetns
- Net spend (previous two added together)

Otherwise a the single Net spend is returned, this will allow this class to support both the spending breakdown report and the report csv file.


