### PR TITLE
(2246) Refactor: spending breakdown uses activity actuals columns

### DIFF
--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -29,6 +29,10 @@ class Export::ActivityActualsColumns
     }.to_h
   end
 
+  def last_financial_quarter
+    financial_quarter_range.max
+  end
+
   private
 
   def actual_and_refund_data(activity)

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -214,6 +214,12 @@ RSpec.describe Export::ActivityActualsColumns do
         expect(subject.rows).to eql []
       end
     end
+
+    describe "#last_financial_quarter" do
+      it "returns the last financial quarter in the set" do
+        expect(subject.last_financial_quarter).to eql FinancialQuarter.new(2020, 4)
+      end
+    end
   end
 
   private

--- a/spec/services/export/spending_breakdown_spec.rb
+++ b/spec/services/export/spending_breakdown_spec.rb
@@ -7,13 +7,62 @@ RSpec.describe Export::SpendingBreakdown do
     @activity = create(:project_activity, organisation: @organisation)
     @source_fund = Fund.new(1)
 
-    create_q1_2020_actual_and_adjustments
-    create_q4_2020_actual_and_adjustments
+    q1_2019_report = create(
+      :report,
+      :approved,
+      organisation: @organisation,
+      fund: @activity.associated_fund,
+      financial_quarter: 1,
+      financial_year: 2019
+    )
 
-    create_q1_2020_refund_and_adjustments
-    create_q4_2020_refund_and_adjustments
+    ForecastHistory
+      .new(@activity, report: q1_2019_report, financial_quarter: 1, financial_year: 2020)
+      .set_value(10_000)
+    ForecastHistory
+      .new(@activity, report: q1_2019_report, financial_quarter: 4, financial_year: 2020)
+      .set_value(5_00)
+    ForecastHistory
+      .new(@activity, report: q1_2019_report, financial_quarter: 1, financial_year: 2021)
+      .set_value(10_000)
+    ForecastHistory
+      .new(@activity, report: q1_2019_report, financial_quarter: 4, financial_year: 2021)
+      .set_value(20_000)
 
-    create_old_report_and_forecasts
+    q4_2019_report = create(
+      :report,
+      :approved,
+      organisation: @organisation,
+      fund: @activity.associated_fund,
+      financial_quarter: 4,
+      financial_year: 2019
+    )
+
+    ForecastHistory
+      .new(@activity, report: q4_2019_report, financial_quarter: 1, financial_year: 2020)
+      .set_value(5_000)
+    ForecastHistory
+      .new(@activity, report: q4_2019_report, financial_quarter: 4, financial_year: 2020)
+      .set_value(2_500)
+    ForecastHistory
+      .new(@activity, report: q4_2019_report, financial_quarter: 1, financial_year: 2021)
+      .set_value(20_000)
+    ForecastHistory
+      .new(@activity, report: q4_2019_report, financial_quarter: 4, financial_year: 2021)
+      .set_value(10_000)
+
+    @q1_report = create(:report, financial_quarter: 1, financial_year: 2020)
+    @q2_report = create(:report, financial_quarter: 2, financial_year: 2020)
+
+    create_fixtures(
+      <<~TABLE
+        |transaction|report|financial_period|value|
+        | Actual    |q1    | q1             |  100|
+        | Adj. Act. |q2    | q1             |  200|
+        | Refund    |q1    | q1             | -200|
+        | Adj. Ref. |q2    | q1             |   50|
+      TABLE
+    )
   end
 
   after(:all) do
@@ -63,7 +112,7 @@ RSpec.describe Export::SpendingBreakdown do
       expect(subject.headers).to include("Delivery partner organisation")
     end
 
-    it "includes the three headings that describe the finances for financial quarter 1 2020-2021" do
+    it "includes the three headings that describe the finances for FQ1 2020-2021" do
       expect(subject.headers).to include(
         "Actual spend FQ1 2020-2021",
         "Refund FQ1 2020-2021",
@@ -71,44 +120,22 @@ RSpec.describe Export::SpendingBreakdown do
       )
     end
 
-    it "includes the three headings that describe the finances for financial quarter 4 2020-2021" do
-      expect(subject.headers).to include(
-        "Actual spend FQ4 2020-2021",
-        "Refund FQ4 2020-2021",
-        "Actual net FQ4 2020-2021",
-      )
-    end
-
-    it "includes the three headings that describe the finances for financial quarters inbetween" do
-      expect(subject.headers).to include(
-        "Actual spend FQ2 2020-2021",
-        "Refund FQ2 2020-2021",
-        "Actual net FQ2 2020-2021",
-      )
-      expect(subject.headers).to include(
-        "Actual spend FQ3 2020-2021",
-        "Refund FQ3 2020-2021",
-        "Actual net FQ3 2020-2021",
-      )
-    end
-
     it "does NOT contain forecasts for financial quarters where there is actual spend or refund values" do
       expect(subject.headers).not_to include "Forecast FQ1 2020-2021"
-      expect(subject.headers).not_to include "Forecast FQ4 2020-2021"
     end
 
     it "includes the correct headers at the boundry between actual spend and refunds and forecasts" do
-      expect(subject.headers).not_to include "Forecast FQ4 2020-2021"
-      expect(subject.headers).not_to include "Actual spend FQ1 2021-2022"
+      expect(subject.headers).not_to include "Forecast FQ1 2020-2021"
+      expect(subject.headers).not_to include "Actual spend FQ2 2020-2021"
     end
 
-    it "includes the heading that describe the finances for the future financial quarter FQ1 2021-2022" do
+    it "includes the heading that describe the forecast for FQ1 2021-2022" do
       expect(subject.headers).to include(
         "Forecast FQ1 2021-2022",
       )
     end
 
-    it "includes the heading that describe the finances for the future financial quarter FQ4 2021-2022" do
+    it "includes the heading that describe the forecast for FQ4 2021-2022" do
       expect(subject.headers).to include(
         "Forecast FQ4 2021-2022",
       )
@@ -139,43 +166,23 @@ RSpec.describe Export::SpendingBreakdown do
 
     it "contains the financial data for financial quarter 1 2020-2021" do
       aggregate_failures do
-        expect(value_for_header("Actual spend FQ1 2020-2021").to_s).to eql("200.0")
-        expect(value_for_header("Refund FQ1 2020-2021").to_s).to eql("-350.0")
-        expect(value_for_header("Actual net FQ1 2020-2021").to_s).to eql("-150.0")
+        expect(value_for_header("Actual spend FQ1 2020-2021")).to eq BigDecimal(100 + 200)
+        expect(value_for_header("Refund FQ1 2020-2021")).to eq BigDecimal(-200 + 50)
+        expect(value_for_header("Actual net FQ1 2020-2021")).to eq BigDecimal(100 + 200 + -200 + 50)
       end
     end
 
-    it "contains the financial data for financial quarter 4 2020-2021" do
-      aggregate_failures do
-        expect(value_for_header("Actual spend FQ4 2020-2021").to_s).to eql("200.0")
-        expect(value_for_header("Refund FQ4 2020-2021").to_s).to eql("-350.0")
-        expect(value_for_header("Actual net FQ4 2020-2021").to_s).to eql("-150.0")
-      end
+    it "contains the latest version of the forecast for FQ1 2021-2022" do
+      expect(value_for_header("Forecast FQ1 2021-2022")).to eq BigDecimal(20_000)
     end
 
-    it "contains zero values for the financial quarters inbetween" do
-      aggregate_failures do
-        expect(value_for_header("Actual spend FQ2 2020-2021").to_s).to eql("0")
-        expect(value_for_header("Refund FQ2 2020-2021").to_s).to eql("0")
-        expect(value_for_header("Actual net FQ2 2020-2021").to_s).to eql("0")
-
-        expect(value_for_header("Actual spend FQ3 2020-2021").to_s).to eql("0")
-        expect(value_for_header("Refund FQ3 2020-2021").to_s).to eql("0")
-        expect(value_for_header("Actual net FQ3 2020-2021").to_s).to eql("0")
-      end
-    end
-
-    it "contains the financial data for financial quarter 1 2021-2022" do
-      expect(value_for_header("Forecast FQ1 2021-2022").to_s).to eql("20000.0")
-    end
-
-    it "contains the financial data for financial quarter 4 2021-2022" do
-      expect(value_for_header("Forecast FQ4 2021-2022").to_s).to eql("10000.0")
+    it "contains the latest versions of the forecast for 2021-2022" do
+      expect(value_for_header("Forecast FQ4 2021-2022")).to eq BigDecimal(10_000)
     end
 
     it "contains a zero for the financial quarters inbetween in which there are no forecasts" do
-      expect(value_for_header("Forecast FQ2 2021-2022").to_s).to eql "0"
-      expect(value_for_header("Forecast FQ3 2021-2022").to_s).to eql "0"
+      expect(value_for_header("Forecast FQ2 2021-2022")).to eq 0
+      expect(value_for_header("Forecast FQ3 2021-2022")).to eq 0
     end
 
     context "where there are additional activities" do
@@ -206,126 +213,30 @@ RSpec.describe Export::SpendingBreakdown do
     end
   end
 
-  def create_q1_2020_actual_and_adjustments
-    @actual = create(
-      :actual,
-      parent_activity: @activity,
-      value: 100,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :actual,
-      parent_activity: @activity,
-      value: 200,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :actual,
-      parent_activity: @activity,
-      value: -100,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
+  def create_fixtures(table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      case row["transaction"].strip
+      when "Actual"
+        create(:actual, fixture_attrs(row))
+      when "Adj. Act."
+        create(:adjustment, :actual, fixture_attrs(row))
+      when "Adj. Ref."
+        create(:adjustment, :refund, fixture_attrs(row))
+      when "Refund"
+        create(:refund, fixture_attrs(row))
+      else
+        raise "don't know what to do"
+      end
+    end
   end
 
-  def create_q4_2020_actual_and_adjustments
-    create(
-      :actual,
+  def fixture_attrs(row)
+    {
       parent_activity: @activity,
-      value: 100,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :actual,
-      parent_activity: @activity,
-      value: 200,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :actual,
-      parent_activity: @activity,
-      value: -100,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-  end
-
-  def create_q1_2020_refund_and_adjustments
-    @refund = create(
-      :refund,
-      parent_activity: @activity,
-      value: -200,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :refund,
-      parent_activity: @activity,
-      value: 50,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :refund,
-      parent_activity: @activity,
-      value: -200,
-      financial_quarter: 1,
-      financial_year: 2020
-    )
-  end
-
-  def create_q4_2020_refund_and_adjustments
-    create(
-      :refund,
-      parent_activity: @activity,
-      value: -200,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :refund,
-      parent_activity: @activity,
-      value: 50,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-    create(
-      :adjustment,
-      :refund,
-      parent_activity: @activity,
-      value: -200,
-      financial_quarter: 4,
-      financial_year: 2020
-    )
-  end
-
-  def create_old_report_and_forecasts
-    report = create(
-      :report,
-      :approved,
-      organisation: @organisation,
-      fund: @activity.associated_fund,
-      financial_quarter: 1,
-      financial_year: 2019
-    )
-    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2020)
-      .set_value(5_000)
-    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2020)
-      .set_value(2_500)
-    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2021)
-      .set_value(20_000)
-    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2021)
-      .set_value(10_000)
+      value: row["value"].strip,
+      financial_quarter: row["financial_period"][/\d/],
+      financial_year: 2020,
+      report: instance_variable_get("@#{row["report"].strip}_report"),
+    }
   end
 end

--- a/spec/services/export/spending_breakdown_spec.rb
+++ b/spec/services/export/spending_breakdown_spec.rb
@@ -120,35 +120,6 @@ RSpec.describe Export::SpendingBreakdown do
         "Forecast FQ3 2021-2022",
       )
     end
-
-    context "when there are no actual spend, refunds and forecasts" do
-      before do
-        allow(subject).to receive(:actuals).and_return([])
-        allow(subject).to receive(:forecasts).and_return([])
-        allow(subject).to receive(:refunds).and_return([])
-      end
-
-      it "returns the activity attribute headers only" do
-        activity_attribute_headers = [
-          "RODA identifier",
-          "Delivery partner identifier",
-          "Activity title",
-          "Activity level",
-          "Activity status",
-        ]
-        expect(subject.headers).to match_array(activity_attribute_headers)
-      end
-    end
-
-    context "when there are no forecasts" do
-      before do
-        allow(subject).to receive(:forecasts).and_return([])
-      end
-
-      it "should not return any forecast headers" do
-        expect(subject.headers.any? { |header| header.match(/Forecast/) }).to eq(false)
-      end
-    end
   end
 
   describe "#rows" do
@@ -214,6 +185,23 @@ RSpec.describe Export::SpendingBreakdown do
 
       it "includes a row for each" do
         expect(subject.rows.count).to eq(5)
+      end
+    end
+
+    context "when there are no actual spend, refunds and forecasts" do
+      let(:activities) { create_list(:project_activity, 5) }
+      subject { described_class.new(source_fund: activities.first.associated_fund, organisation: activities.first.organisation) }
+
+      it "returns the activity attribute headers only" do
+        activity_attribute_headers = [
+          "RODA identifier",
+          "Delivery partner identifier",
+          "Activity title",
+          "Activity level",
+          "Activity status",
+        ]
+        expect(subject.headers).to match_array(activity_attribute_headers)
+        expect(subject.rows).to eq []
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
Here we are at step 6️⃣ ! Now we have the `ActivityActualsColumns` class, we can use it, here in the spending breakdown report.

To complete the expected behaviour, we need to know the last finacial quarter we have actual data for and then use that to start showing forecast data. Here I extend 'ActivityActualsColumns` to return this.

In the last commit I take some steps to clean up the `spending_breakdown_spec` although the fixtures for forecasts are still a bit rough, they will be removed in coming work to split out a forecast columns class.
