### PR TITLE
(2246) Feature new forecast columns export

### DIFF
--- a/app/models/export/activity_forecast_columns.rb
+++ b/app/models/export/activity_forecast_columns.rb
@@ -1,0 +1,61 @@
+class Export::ActivityForecastColumns
+  def initialize(activities:)
+    @activities = activities
+  end
+
+  def headers
+    return [] if @activities.empty?
+
+    forecast_financial_quarter_range.map do |financial_quarter|
+      "Forecast #{financial_quarter}"
+    end
+  end
+
+  def rows
+    return [] if @activities.empty?
+
+    @activities.map { |activity|
+      [activity.id, forecast_data(activity)]
+    }.to_h
+  end
+
+  private
+
+  def forecast_data(activity)
+    forecast_financial_quarter_range.map { |fq|
+      forecasts_to_hash.fetch([activity.id, fq.quarter, fq.financial_year.start_year], 0)
+    }
+  end
+
+  def activity_ids
+    @activities.pluck(:id)
+  end
+
+  def forecasts
+    overview = ForecastOverview.new(activity_ids)
+    @_forecasts ||= overview.latest_values
+  end
+
+  def forecasts_to_hash
+    @_forecasts_to_hash ||= forecasts.each_with_object({}) { |forecast, hash|
+      hash[[forecast.parent_activity_id, forecast.financial_quarter, forecast.financial_year]] = forecast.value
+    }
+  end
+
+  def all_financial_quarters_with_forecasts
+    return [] unless forecasts.present?
+    forecasts.map(&:own_financial_quarter).uniq
+  end
+
+  def forecast_financial_quarter_range
+    @_forecast_quarter_range ||= begin
+      return [] if all_financial_quarters_with_forecasts.blank?
+
+      Range.new(all_financial_quarters_with_forecasts.min, all_financial_quarters_with_forecasts.max)
+    end
+  end
+
+  def report_financial_quarter(report)
+    FinancialQuarter.new(report.financial_year, report.financial_quarter)
+  end
+end

--- a/spec/models/export/activity_forecast_columns_spec.rb
+++ b/spec/models/export/activity_forecast_columns_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe Export::ActivityForecastColumns do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+    @activity = create(:project_activity)
+    @organisation = create(:delivery_partner_organisation, beis_organisation_reference: "BC")
+    @source_fund = Fund.new(1)
+    other_activities = create_list(:project_activity, 4)
+
+    @activities = [@activity] + other_activities
+
+    create_old_report_and_forecasts
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  subject { Export::ActivityForecastColumns.new(activities: @activities) }
+
+  let(:attributes) { [:roda_identifier, :delivery_partner_identifier] }
+
+  describe "#headers" do
+    it "includes the heading that describe the finances for the future financial quarter FQ1 2021-2022" do
+      expect(subject.headers).to include(
+        "Forecast FQ1 2021-2022",
+      )
+    end
+
+    it "includes the heading that describe the finances for the future financial quarter FQ4 2021-2022" do
+      expect(subject.headers).to include(
+        "Forecast FQ4 2021-2022",
+      )
+    end
+
+    it "includes the headings that describe the finances for the future financial quarters inbetween" do
+      expect(subject.headers).to include(
+        "Forecast FQ2 2021-2022",
+        "Forecast FQ3 2021-2022",
+      )
+    end
+  end
+
+  describe "#rows" do
+    it "contains the financial data for financial quarter 1 2021-2022" do
+      expect(value_for_header("Forecast FQ1 2021-2022").to_s).to eql("20000.0")
+    end
+
+    it "contains the financial data for financial quarter 4 2021-2022" do
+      expect(value_for_header("Forecast FQ4 2021-2022").to_s).to eql("10000.0")
+    end
+
+    it "contains a zero for the financial quarters inbetween in which there are no forecasts" do
+      expect(value_for_header("Forecast FQ2 2021-2022").to_s).to eql "0"
+      expect(value_for_header("Forecast FQ3 2021-2022").to_s).to eql "0"
+    end
+
+    it "includes a row for each acitvity" do
+      expect(subject.rows.count).to eq(5)
+    end
+
+    context "when there are no activities" do
+      subject { Export::ActivityForecastColumns.new(activities: []) }
+
+      it "returns an empty array" do
+        expect(subject.headers).to eql []
+        expect(subject.rows).to eql []
+      end
+    end
+  end
+
+  def value_for_header(header_name)
+    values = subject.rows.fetch(@activity.id)
+    values[subject.headers.index(header_name)]
+  end
+
+  def create_old_report_and_forecasts
+    report = create(
+      :report,
+      :approved,
+      organisation: @organisation,
+      fund: @activity.associated_fund,
+      financial_quarter: 1,
+      financial_year: 2019
+    )
+    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2020)
+      .set_value(5_000)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2020)
+      .set_value(2_500)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 1, financial_year: 2021)
+      .set_value(20_000)
+    ForecastHistory.new(@activity, report: report, financial_quarter: 4, financial_year: 2021)
+      .set_value(10_000)
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Number 7️⃣ in the series!

We extract the forecast columns out of the spending breakdown class. 

We then extend it to allow it to produce a 'snapshot' of forecasts which shows the forecasts values as they were when reported.

We also allow it to take a 'starting financial quarter', this sets the first financial quarter in the series and can be used in exports that require the latest forecasted values but only for a specific set of financal quarters, for example in the spending breakdown export.
