### PR TITLE
(2271) Data migration: fix implementing org on level B activities

### DIFF
--- a/db/data/20211027111140_copy_extending_organisation_to_implementing_organisation_at_level_b.rb
+++ b/db/data/20211027111140_copy_extending_organisation_to_implementing_organisation_at_level_b.rb
@@ -1,0 +1,21 @@
+# Run me with `rails runner db/data/20211027111140_copy_extending_organisation_to_implementing_organisation_at_level_b.rb`
+#
+level_b_acitivities_without_implementing_organisations =
+  Activity
+    .includes(:extending_organisation)
+    .where(level: :programme)
+    .where.not(extending_organisation_id: nil)
+    .select { |activity| activity.implementing_organisations.empty? }
+
+level_b_acitivities_without_implementing_organisations.each do |activity|
+  extending_organisation = activity.extending_organisation
+
+  implementing_organisation = ImplementingOrganisation.create!(
+    name: extending_organisation.name,
+    reference: extending_organisation.iati_reference,
+    organisation_type: extending_organisation.organisation_type,
+    activity_id: activity.id
+  )
+
+  puts "Created implementing organisation #{implementing_organisation.name} for activity #{activity.roda_identifier}\n"
+end


### PR DESCRIPTION
## Changes in this PR
This is a short term fix for implementing organisation on all level B
activities that have an extending organisation (all of them).

We take the extending organisation and use it to create a new
implementing organisation on activities that do not have any.

This will mean IATI data at level B will include an implementing
organisation which is not currently the case.

There is a longer term issue to fix: When creating new level B
activities the implementing organisation should be set to the delivery
partner, but that work will take longer and so we are correcting the
data here to enable IATI publishing to happen in the short term.

https://trello.com/c/lirfmCWM
