### PR TITLE
(2273) fix: Remove Benefitting country code

### DIFF
--- a/vendor/data/codelists/BEIS/benefitting_countries.yml
+++ b/vendor/data/codelists/BEIS/benefitting_countries.yml
@@ -1180,12 +1180,6 @@ data:
     graduated: no
     regions:
       - "89"
-  - name: States Ex-Yugoslavia unspecified
-    recipient_code: "88"
-    code: A region on IATI code 88
-    graduated: no
-    regions:
-      - "89"
   - name: Moldova
     recipient_code: "93"
     code: MD


### PR DESCRIPTION
## Changes in this PR
This benefitting country 'States Ex-Yugoslavia unspecified' is not valid
if published to IATI, which implies it is not valid elsewhere.

These benefitting countries were supplied by BEIS and there is probably
some logic to this one that we do not know about, but we cannot support
a benefitting country code of 'A region on IATI code 88' and nor can
IATI.

By removing this we stand more chance of surfacing any business logic
here and in the meantime:

- no new activities can be created that benefit this invalid
  county/region
- existing activities can be published to IATI that include all
  benefitting countries, which means 'developing countries, unspecified'
  and is real need

I've checked in production and we have no activities with this
benefitting country set with:

`Activity.where("'A region on IATI code 88' = ANY(benefitting_countries)")`

We did have one activity that was benefitting this country, which led to
the discovery of the issue, but we have manually removed this country on
that activity.

Remember, activities whose scope is so broad have ALL benefitting
countries selected which is also interpreted by BEIS as 'Developing
countries, unspecified' which is why that activity had this set, not
because it actually benefits 'States Ex-Yugoslavia unspecified'.

