### PR TITLE
(2272) Fix: benefitting country percentage split calculation

### DIFF
--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -39,18 +39,12 @@ module ActivityHelper
   def benefitting_countries_with_percentages(benefitting_countries)
     return [] if benefitting_countries.blank?
 
-    # Get an equal percentage split between all the countries
-    # (together with the remainder if possible)
-    percentage, remainder = 100.divmod(benefitting_countries.count)
-
     benefitting_countries.map do |country|
-      # If we're at the last item, add the remainder to the percentage
-      # split
-      percentage += remainder if country == benefitting_countries.last
-
-      OpenStruct.new(code: country,
-                     name: country_name_from_code(country),
-                     percentage: percentage.to_f)
+      OpenStruct.new(
+        code: country,
+        name: country_name_from_code(country),
+        percentage: 100 / benefitting_countries.count.to_f
+      )
     end
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -87,23 +87,20 @@ RSpec.describe ActivityHelper, type: :helper do
       expect(countries.last.percentage).to eq(50.0)
     end
 
-    it "appends the remainder to the last item if the country list count is an odd number" do
+    it "handles the case when all countries are selected" do
+      codes = Codelist.new(type: "benefitting_countries", source: "beis").map { |c| c["code"] }
+      countries = benefitting_countries_with_percentages(codes)
+
+      expect(countries.first.percentage).to eq 100 / countries.count.to_f
+      expect(countries.last.percentage).to eq 100 / countries.count.to_f
+    end
+
+    it "handles the case when three coutries are selected" do
       codes = ["AG", "LC", "BZ"]
       countries = benefitting_countries_with_percentages(codes)
 
-      expect(countries.count).to eql(3)
-
-      expect(countries.first.code).to eq("AG")
-      expect(countries.first.name).to eq("Antigua and Barbuda")
-      expect(countries.first.percentage).to eq(33.0)
-
-      expect(countries.second.code).to eq("LC")
-      expect(countries.second.name).to eq("Saint Lucia")
-      expect(countries.second.percentage).to eq(33.0)
-
-      expect(countries.last.code).to eq("BZ")
-      expect(countries.last.name).to eq("Belize")
-      expect(countries.last.percentage).to eq(34.0)
+      expect(countries.first.percentage).to eq 100 / countries.count.to_f
+      expect(countries.last.percentage).to eq 100 / countries.count.to_f
     end
 
     it "returns an empty array if the codes are nil or empty" do


### PR DESCRIPTION
## Changes in this PR
The old calculation using `divmod` fails for numbers > 100.

As we have ~180 countries and selecting all of them is something that
happens we need the percentage calculation to work.

What matters to us right now is that the IATI XML is valid and NOT that
the percentage is accurate (it is not and for BEIS is may be impossible
to make it accurate).

I tested what percentages can be valid in the IATI XML for both 3
countries and 180 and this simpler calculation satisfies the validator.