### PR TITLE
(2276) Chore: delete activity rake task

### DIFF
--- a/lib/tasks/delete_activity.rake
+++ b/lib/tasks/delete_activity.rake
@@ -1,0 +1,101 @@
+desc "Deletes the activity and associations"
+namespace :activities do
+  task delete: :environment do
+    activity_id = ENV["ID"]
+
+    abort "You must specify a database ID for an activity e.g. `ID=8c3b69ec-1e9c-49ae-8e04-7c5d3826b253`)" if activity_id.nil?
+
+    activity = Activity.find activity_id
+
+    children = activity.children
+    descendents = activity.descendants
+    actuals = Actual.where(parent_activity_id: activity.id)
+    refunds = Refund.where(parent_activity_id: activity.id)
+    budgets = Budget.where(parent_activity_id: activity.id)
+    forecasts = Forecast.unscoped.where(parent_activity_id: activity.id)
+    comment_count = activity.comments.count
+    matched_effort = MatchedEffort.where(activity_id: activity.id)
+    external_income = ExternalIncome.where(activity_id: activity.id)
+    history = HistoricalEvent.where(activity_id: activity.id)
+    adjustments = Adjustment.where(parent_activity_id: activity.id)
+    implementing_organisations = ImplementingOrganisation.where(activity_id: activity.id)
+    incomming_transfers_count = IncomingTransfer.where(destination_id: activity.id).count
+    outgoing_transfers_count = OutgoingTransfer.where(source_id: activity.id).count
+
+    puts "\nActivity: #{activity.id}\n"
+    puts "==============================================\n"
+    puts "title: #{activity.title}\n"
+    puts "fund: #{activity.source_fund.name}\n"
+    puts "level: #{activity.level}\n"
+    puts "----------------------------------------------\n"
+    puts "# descendents: #{descendents.count}\n"
+    puts "# children: #{children.count}\n"
+    puts "# actual spend entires: #{actuals.count}\n"
+    puts "# refund entires: #{refunds.count}\n"
+    puts "# budget entries: #{budgets.count}\n"
+    puts "# forecast entries: #{forecasts.count}\n"
+    puts "# incoming transfer entries: #{incomming_transfers_count}"
+    puts "# outgoing transfer entries: #{outgoing_transfers_count}"
+    puts "# comments: #{comment_count}\n"
+    puts "# matched effort entries: #{matched_effort.count}\n"
+    puts "# external income entires: #{external_income.count}\n"
+    puts "# history entries: #{history.count}\n"
+    puts "# adjustment entries: #{adjustments.count}\n"
+    puts "# implementing organisations: #{implementing_organisations.count}\n"
+
+    puts "\nAre you sure you want to delete this activity, all descendants and associated entities? [y/n]\n"
+    answer = STDIN.gets.chomp
+    case answer
+    when "y"
+      delete_activity(activity_id: activity.id)
+    when "n"
+      puts "Not deleting the activity with ID #{activity.id}"
+      abort
+    else
+      puts "Unrecognised response, answer 'y' or 'n'"
+    end
+  rescue ActiveRecord::RecordNotFound
+    abort "Cannot find an activity with ID #{activity_id}"
+  end
+end
+
+def delete_activity(activity_id:)
+  activity = Activity.find(activity_id)
+
+  if activity.children.any?
+    puts "----------------------------------------------\n"
+    puts "Deleting children of activity with ID #{activity.id}\n"
+    activity.children.each do |child_activity|
+      delete_activity(activity_id: child_activity.id)
+    end
+  end
+
+  actuals_deleted = Actual.destroy_by(parent_activity_id: activity_id)
+  refunds_deleted = Refund.destroy_by(parent_activity_id: activity_id)
+  adjustments_deleted = Adjustment.destroy_by(parent_activity_id: activity_id)
+  budgets_deleted = Budget.destroy_by(parent_activity_id: activity_id)
+  forecasts_deleted = Forecast.unscoped.destroy_by(parent_activity_id: activity_id)
+  comments_deleted = activity.comments.destroy_all
+  matched_effort_deleted = MatchedEffort.destroy_by(activity_id: activity_id)
+  external_income_deleted = ExternalIncome.destroy_by(activity_id: activity_id)
+  incomming_transfers_deleted = IncomingTransfer.destroy_by(destination_id: activity_id)
+  outgoing_transfers_deleted = OutgoingTransfer.destroy_by(source_id: activity_id)
+
+  puts "\n==============================================\n"
+  puts "Deleted associations for activity with ID #{activity_id}\n"
+  puts "----------------------------------------------\n"
+  puts "#{actuals_deleted.count} acutals deleted\n"
+  puts "#{refunds_deleted.count} refunds deleted\n"
+  puts "#{adjustments_deleted.count} adjustments deleted\n"
+  puts "#{budgets_deleted.count} budgets deleted\n"
+  puts "#{forecasts_deleted.count} forecasts deleted\n"
+  puts "#{comments_deleted.count} comments deleted\n"
+  puts "#{matched_effort_deleted.count} matched effort entries deleted\n"
+  puts "#{external_income_deleted.count} external income entries deleted\n"
+  puts "#{incomming_transfers_deleted.count} incoming transfer entries deleted\n"
+  puts "#{outgoing_transfers_deleted.count} outgoing transfer entries deleted\n"
+  puts "----------------------------------------------\n"
+
+  activity.destroy
+  puts "Activity with ID #{activity.id} deleted"
+end

--- a/spec/lib/tasks/delete_activity_spec.rb
+++ b/spec/lib/tasks/delete_activity_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe "rake activities:delete", type: :task do
+  let(:user) { create(:beis_user) }
+
+  it "returns an error if the ID is blank" do
+    expect { task.execute }.to raise_error(SystemExit, /You must specify a database ID/)
+  end
+
+  it "returns an error if the activity cannot be found" do
+    ClimateControl.modify ID: "NOT-AN-ID" do
+      expect { task.execute }.to raise_error(SystemExit, /Cannot find an activity with ID/)
+    end
+  end
+
+  describe "#delete_activity" do
+    before do
+      load "lib/tasks/delete_activity.rake"
+    end
+
+    it "deletes the activity" do
+      activity = create(:project_activity)
+      expect { delete_activity(activity_id: activity.id) }.to change { Activity.count }.by(-1)
+    end
+
+    it "deletes any actuals" do
+      activity = create(:project_activity)
+      create_list(:actual, 5, parent_activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Actual.count }.by(-5)
+      expect(Actual.where(parent_activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes actual adjustments" do
+      activity = create(:project_activity)
+      adjustment = create(:adjustment, :actual, parent_activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Adjustment.count }.by(-1)
+      expect(Adjustment.where(parent_activity_id: activity.id).count).to eq 0
+      expect(AdjustmentDetail.where(adjustment_id: adjustment.id).count).to eq 0
+    end
+
+    it "deletes refunds" do
+      activity = create(:project_activity)
+      create_list(:refund, 5, parent_activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Refund.count }.by(-5)
+      expect(Refund.where(parent_activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes refund adjustments" do
+      activity = create(:project_activity)
+      adjustment = create(:adjustment, :refund, parent_activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Adjustment.count }.by(-1)
+      expect(Adjustment.where(parent_activity_id: activity.id).count).to eq 0
+      expect(AdjustmentDetail.where(adjustment_id: adjustment.id).count).to eq 0
+    end
+
+    it "deletes budgets" do
+      activity = create(:project_activity)
+      create(:budget, parent_activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Budget.count }.by(-1)
+      expect(Budget.where(parent_activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes forecasts and history" do
+      activity = create(:project_activity)
+      reporting_cycle = ReportingCycle.new(activity, 1, 2018)
+
+      forecast = ForecastHistory.new(activity, financial_quarter: 4, financial_year: 2018)
+
+      reporting_cycle.tick
+      forecast.set_value(5_000)
+
+      reporting_cycle.tick
+      forecast.set_value(2_500)
+
+      expect(Forecast.unscoped.count).to eq 2
+      expect { delete_activity(activity_id: activity.id) }.to change { Forecast.unscoped.count }.by(-2)
+      expect(Forecast.unscoped.where(parent_activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes activity comments" do
+      activity = create(:project_activity)
+      create_list(:comment, 5, commentable: activity, commentable_type: "Activity")
+      expect { delete_activity(activity_id: activity.id) }.to change { Comment.count }.by(-5)
+      expect(Comment.where(commentable: activity.id).count).to eq 0
+    end
+
+    it "deletes refund comments" do
+      activity = create(:project_activity)
+      refund = create(:refund, parent_activity_id: activity.id)
+
+      expect(Comment.where(commentable_id: refund.id).count).to eq 1
+      expect { delete_activity(activity_id: activity.id) }.to change { Comment.count }.by(-1)
+      expect(Comment.where(commentable_id: refund.id).count).to eq 0
+    end
+
+    it "deletes adjustment comments" do
+      activity = create(:project_activity)
+      adjustment = create(:adjustment, parent_activity_id: activity.id)
+
+      expect(Comment.where(commentable_id: adjustment.id).count).to eq 1
+      expect { delete_activity(activity_id: activity.id) }.to change { Comment.count }.by(-1)
+      expect(Comment.where(commentable_id: adjustment.id).count).to eq 0
+    end
+
+    it "deletes matched effort" do
+      activity = create(:project_activity)
+      create(:matched_effort, activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { MatchedEffort.count }.by(-1)
+      expect(MatchedEffort.where(activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes external income" do
+      activity = create(:project_activity)
+      create(:external_income, activity_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { ExternalIncome.count }.by(-1)
+      expect(ExternalIncome.where(activity_id: activity.id).count).to eq 0
+    end
+
+    it "deletes incomming transfers" do
+      activity = create(:project_activity)
+      create(:incoming_transfer, destination_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { IncomingTransfer.count }.by(-1)
+      expect(IncomingTransfer.where(destination_id: activity.id).count).to eq 0
+    end
+
+    it "deletes outgoing_transfers" do
+      activity = create(:project_activity)
+      create(:outgoing_transfer, source_id: activity.id)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { OutgoingTransfer.count }.by(-1)
+      expect(OutgoingTransfer.where(source_id: activity.id).count).to eq 0
+    end
+
+    it "deletes the child acitivities" do
+      activity = create(:project_activity)
+      create(:third_party_project_activity, parent: activity)
+
+      expect { delete_activity(activity_id: activity.id) }.to change { Activity.count }.by(-2)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Every report results in a bunch of activities that a developer has to
delete as the application cannot do this yet.

This rake task attempts to aid developers in performing this support
task by running the steps for a given activity database ID.

Some associations are destroyed along with the `Activity` object, others
would be orphaned. I wanted to update the documentation we have on this
and through the process of finding out, I figured we may as well wrap
the knowledge in a rake task.

Developers are encouraged to `think` about what they are doing here as
ultimately this is destructive, but they save a great deal of work on
the console by running the task and interpreting the result before performing 
the destruvtive action.