### PR TITLE
(2246) feature: Variance column

### DIFF
--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -23,8 +23,7 @@ class Export::ActivityActualsColumns
 
   def rows
     return [] if @activities.empty?
-
-    @activities.map { |activity|
+    @_rows ||= @activities.map { |activity|
       actual_and_refund_data(activity)
     }.to_h
   end

--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -32,6 +32,10 @@ class Export::ActivityActualsColumns
     financial_quarter_range.max
   end
 
+  def rows_for_last_financial_quarter
+    rows.each_with_object({}) { |(key, values), obj| obj[key] = values.last }
+  end
+
   private
 
   def actual_and_refund_data(activity)

--- a/app/models/export/activity_forecast_columns.rb
+++ b/app/models/export/activity_forecast_columns.rb
@@ -25,6 +25,10 @@ class Export::ActivityForecastColumns
     }.to_h
   end
 
+  def rows_for_first_financial_quarter
+    rows.each_with_object({}) { |(key, values), rows| rows[key] = values.first }
+  end
+
   private
 
   def forecast_data(activity)

--- a/app/models/export/activity_forecast_columns.rb
+++ b/app/models/export/activity_forecast_columns.rb
@@ -48,9 +48,16 @@ class Export::ActivityForecastColumns
   end
 
   def forecasts_to_hash
-    @_forecasts_to_hash ||= forecasts.each_with_object({}) { |forecast, hash|
-      hash[[forecast.parent_activity_id, forecast.financial_quarter, forecast.financial_year]] = forecast.value
-    }
+    @_forecasts_to_hash ||=
+      forecasts.each_with_object({}) { |forecast, hash|
+        hash[
+          [
+            forecast.parent_activity_id,
+            forecast.financial_quarter,
+            forecast.financial_year,
+          ]
+        ] = forecast.value
+      }
   end
 
   def all_financial_quarters_with_forecasts

--- a/app/models/export/activity_variance_column.rb
+++ b/app/models/export/activity_variance_column.rb
@@ -1,0 +1,20 @@
+class Export::ActivityVarianceColumn
+  def initialize(activities:, net_actual_spend_column_data:, forecast_column_data:, financial_quarter:)
+    @activities = activities
+    @net_actual_spend_column_data = net_actual_spend_column_data
+    @forecast_column_data = forecast_column_data
+    @financial_quarter = financial_quarter
+  end
+
+  def headers
+    ["Variance #{@financial_quarter}"]
+  end
+
+  def rows
+    return [] if @activities.empty?
+
+    @activities.map { |activity|
+      [activity.id, @forecast_column_data.fetch(activity.id, nil) - @net_actual_spend_column_data.fetch(activity.id, nil)]
+    }.to_h
+  end
+end

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -222,7 +222,23 @@ RSpec.describe Export::ActivityActualsColumns do
     end
   end
 
-  private
+  context "when #rows is called multiple times" do
+    let(:breakdown) { false }
+    let(:report) { nil }
+
+    before do
+      totals_double = double(call: {"fake_activity_id" => []})
+      allow(Export::AllActivityTotals).to receive(:new).and_return(totals_double)
+
+      3.times { subject.rows }
+    end
+
+    it "builds totals for the activities only once" do
+      expect(Export::AllActivityTotals)
+        .to have_received(:new)
+        .exactly(@activities.count).times
+    end
+  end
 
   def value_for_header(header_name)
     values = subject.rows.fetch(@activity.id)

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -119,6 +119,16 @@ RSpec.describe Export::ActivityActualsColumns do
         end
       end
     end
+
+    describe "rows_for_last_financial_quarter" do
+      it "returns the rows for the last column in the set (Q4 2020)" do
+        last_column_data = subject.rows_for_last_financial_quarter
+        value_for_activity = last_column_data.fetch(@activity.id)
+
+        expect(value_for_activity).to eq BigDecimal(300)
+        expect(last_column_data.count).to eq 5
+      end
+    end
   end
 
   context "when a breakdown is requested" do

--- a/spec/models/export/activity_forecast_columns_spec.rb
+++ b/spec/models/export/activity_forecast_columns_spec.rb
@@ -241,6 +241,24 @@ RSpec.describe Export::ActivityForecastColumns do
         expect(value_for_header("Forecast FQ4 2021-2022").to_s).to eql("20000.0")
       end
     end
+
+    context "when #rows is called multiple times" do
+      let(:starting_financial_quarter) { nil }
+      let(:report) { nil }
+
+      before do
+        forecast_overview_double = double(latest_values: [])
+        allow(ForecastOverview).to receive(:new).and_return(forecast_overview_double)
+
+        3.times { subject.rows }
+      end
+
+      it "gets the forecast overview only once" do
+        expect(ForecastOverview)
+          .to have_received(:new)
+          .once
+      end
+    end
   end
 
   def value_for_header(header_name)

--- a/spec/models/export/activity_forecast_columns_spec.rb
+++ b/spec/models/export/activity_forecast_columns_spec.rb
@@ -216,6 +216,20 @@ RSpec.describe Export::ActivityForecastColumns do
         expect(subject.rows).to eql []
       end
     end
+
+    context "when the Q1 2020-2021 report is passed in" do
+      let(:report) { create(:report, financial_quarter: 1, financial_year: 2020) }
+
+      describe "#rows_for_first_financial_quarter" do
+        it "returns the rows for the first column in the set (Q1 2020-2021)" do
+          first_column_of_forecasts = subject.rows_for_first_financial_quarter
+          activity_value = first_column_of_forecasts.fetch(@activity.id)
+
+          expect(activity_value).to eq BigDecimal(10_000)
+          expect(first_column_of_forecasts.count).to eq 5
+        end
+      end
+    end
   end
 
   context "when there is a starting financial quarter" do

--- a/spec/models/export/activity_variance_column_spec.rb
+++ b/spec/models/export/activity_variance_column_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe Export::ActivityVarianceColumn do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+    @activity = create(:project_activity)
+    other_activities = create_list(:project_activity, 4)
+
+    @activities = [@activity] + other_activities
+
+    q1_2021_report = create(
+      :report,
+      :approved,
+      organisation: @activity.organisation,
+      fund: @activity.associated_fund,
+      financial_quarter: 1,
+      financial_year: 2021
+    )
+    forecasts_for_report_from_table(q1_2021_report,
+      <<~TABLE
+        |financial_quarter|financial_year|value|
+        |2                |2021          |20000|
+        |3                |2021          |30000|
+        |4                |2021          |40000|
+      TABLE
+    )
+
+    @q2_report = create(:report, financial_quarter: 2, financial_year: 2021)
+
+    actuals_from_table(
+      <<~TABLE
+        |transaction|report|financial_period|value|
+        | Actual    |q2    | q2             |40000|
+      TABLE
+    )
+
+    @last_net_actual_spend_column =
+      Export::ActivityActualsColumns
+        .new(activities: @activities)
+        .rows_for_last_financial_quarter
+    @first_foecast_column =
+      Export::ActivityForecastColumns
+        .new(activities: @activities)
+        .rows_for_first_financial_quarter
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  subject {
+    Export::ActivityVarianceColumn.new(
+      activities: @activities,
+      net_actual_spend_column_data: @last_net_actual_spend_column,
+      forecast_column_data: @first_foecast_column,
+      financial_quarter: FinancialQuarter.new(2021, 2)
+    )
+  }
+
+  describe "#headers" do
+    it "returns the header for the last financial quarter of the net actual spend" do
+      expect(subject.headers).to eq ["Variance FQ2 2021-2022"]
+    end
+  end
+
+  describe "#rows" do
+    it "returns the variance" do
+      variance_for_activity = subject.rows.fetch(@activity.id)
+      expect(variance_for_activity).to eq BigDecimal(20000 - 40000)
+    end
+  end
+
+  private
+
+  def actuals_from_table(table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      case row["transaction"].strip
+      when "Actual"
+        create(:actual, fixture_attrs(row))
+      when "Refund"
+        create(:refund, fixture_attrs(row))
+      else
+        raise "don't know what to do"
+      end
+    end
+  end
+
+  def forecasts_for_report_from_table(report, table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      ForecastHistory.new(
+        @activity,
+        report: report,
+        financial_quarter: row["financial_quarter"].to_i,
+        financial_year: row["financial_year"].to_i,
+      ).set_value(row["value"].to_i)
+    end
+  end
+
+  def fixture_attrs(row)
+    {
+      parent_activity: @activity,
+      value: row["value"].strip,
+      financial_quarter: row["financial_period"][/\d/],
+      financial_year: 2021,
+      report: instance_variable_get("@#{row["report"].strip}_report"),
+    }
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Welcome to 9️⃣ !

This is the variance column. At this point I kept this one simple with some baked in assumptions. The main one being that this is only ever used to export a report and so has a  fixed financial quarter and so the variance will be the last financial quarter from the actuals and the first financial quarter from the forecasts.

I can see nice ways to improve this later with further refactoring on the underlying data structure, but I would like to complete this Export epic work so we can deliver on the user need and come back if there is the opportunity (and yes I know that is a classic thing to say! 😄 )