### PR TITLE
(2246) feature: Introduce Activity Implementing Organisation Column

### DIFF
--- a/app/models/export/activity_implementing_organisation_column.rb
+++ b/app/models/export/activity_implementing_organisation_column.rb
@@ -1,0 +1,37 @@
+class Export::ActivityImplementingOrganisationColumn
+  def initialize(activities_relation:)
+    @activities = valid_activities(activities_relation)
+  end
+
+  def headers
+    ["Implementing organisations"]
+  end
+
+  def rows
+    return [] if @activities.empty?
+
+    @activities.includes(:extending_organisation, :implementing_organisations).map { |activity|
+      implementing_organisation_names = if activity.programme?
+        extending_organisation_name_for_activity(activity)
+      else
+        implementing_organisation_names_for_actvity(activity)
+      end
+      [activity.id, [implementing_organisation_names.join("|")]]
+    }.to_h
+  end
+
+  private
+
+  def extending_organisation_name_for_activity(activity)
+    [activity.extending_organisation.name]
+  end
+
+  def implementing_organisation_names_for_actvity(activity)
+    activity.implementing_organisations.map { |organisation| organisation.name }
+  end
+
+  def valid_activities(activities)
+    raise ArgumentError.new("activities must be an ActiveRecord:Relation") unless activities.is_a?(ActiveRecord::Relation)
+    activities
+  end
+end

--- a/spec/models/export/activity_implementing_organisation_column_spec.rb
+++ b/spec/models/export/activity_implementing_organisation_column_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe Export::ActivityImplementingOrganisationColumn do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+
+    @activity_with_single_organisation = activity_with_single_organisation
+    @activity_with_multiple_organisations = activity_with_multiple_organisations
+    @level_b_activity_with_extending_organisation = level_b_activity_with_extending_organisation
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  context "when there are activities" do
+    subject { described_class.new(activities_relation: Activity.all) }
+
+    describe "#headers" do
+      it "returns the correct header" do
+        expect(subject.headers).to match_array(["Implementing organisations"])
+      end
+    end
+
+    describe "#rows" do
+      context "when the activity is level C (project)" do
+        context "when the activity has only a single implementing organisation" do
+          it "returns the name of the organisation" do
+            row_value = subject.rows.fetch(@activity_with_single_organisation.id)
+            organisation_name = @activity_with_single_organisation.implementing_organisations.first.name
+
+            expect(row_value).to eq [organisation_name]
+          end
+        end
+
+        context "when the activity has multiple implementing organisations" do
+          it "returns all implementing organistion names sperated with a pipe (|)" do
+            row_value = subject.rows.fetch(@activity_with_multiple_organisations.id)
+
+            expect(row_value.first).to include("|")
+
+            implementing_organisation_name =
+              @activity_with_multiple_organisations.implementing_organisations.first.name
+            other_implementing_organisation_name =
+              @activity_with_multiple_organisations.implementing_organisations.last.name
+            implementing_organisations_names = row_value.first.split("|")
+
+            expect(implementing_organisations_names).to include(implementing_organisation_name)
+            expect(implementing_organisations_names).to include(other_implementing_organisation_name)
+          end
+        end
+      end
+
+      context "when the activity is level B (programme)" do
+        it "returns the name of the extending organisation which is considered the implementing organisation" do
+          row_value = subject.rows.fetch(@level_b_activity_with_extending_organisation.id)
+          organisation_name = @level_b_activity_with_extending_organisation.extending_organisation.name
+
+          expect(row_value).to eq [organisation_name]
+        end
+      end
+    end
+  end
+
+  context "when there are no activities" do
+    subject { described_class.new(activities_relation: Activity.none) }
+
+    describe "#headers" do
+      it "returns the header" do
+        expect(subject.headers).to match_array(["Implementing organisations"])
+      end
+    end
+
+    describe "#rows" do
+      it "returns an empty array" do
+        expect(subject.rows).to eq []
+      end
+    end
+  end
+
+  context "when the activities are not an Activerecord::Relation" do
+    it "raises an argument error" do
+      expect { described_class.new(activities_relation: []) }.to raise_error(ArgumentError)
+    end
+  end
+
+  def activity_with_single_organisation
+    activity = create(:project_activity)
+    organisations = create(:implementing_organisation, activity: activity)
+    activity.implementing_organisations = [organisations]
+    activity
+  end
+
+  def activity_with_multiple_organisations
+    activity = create(:project_activity)
+    organisations = create_list(:implementing_organisation, 2, activity: activity)
+    activity.implementing_organisations = organisations
+    activity
+  end
+
+  def level_b_activity_with_extending_organisation
+    organisation = create(:delivery_partner_organisation)
+    activity = create(:programme_activity, extending_organisation: organisation)
+    activity
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Allows Implementing organisations to be exported.

Returns the name only as the only use case we have for this
right now is the report csv which only requires the name.

Multiple implementing organisations are delimited with a pipe (|).

When the activity is at Level B (a programme) there is no guarantee
there will be any implementing organisations, but the
extending organisation will have the correct organisation details, so we
use that.

We pass in an ActiveRecord::Relation of activities so we can leverage
Rails lazy loading of the organisations, failing to pass in the correct
type would cause an error, failing to pass in the correct type would
cause an error, so we check this.