### PR TITLE
(2246) feature: Introduce ActivityChangeStateColumn

### DIFF
--- a/app/models/export/activity_change_state_column.rb
+++ b/app/models/export/activity_change_state_column.rb
@@ -1,0 +1,40 @@
+class Export::ActivityChangeStateColumn
+  def initialize(activities:, report:)
+    @activities = activities
+    @report = report
+  end
+
+  def headers
+    ["Change state"]
+  end
+
+  def rows
+    return [] if @activities.empty?
+
+    @activities.map { |activity|
+      [activity.id, state_of(activity: activity)]
+    }.to_h
+  end
+
+  private
+
+  def state_of(activity:)
+    return nil unless all_activities_for_report.include?(activity.id)
+    return "New" if all_new_activities.include?(activity.id)
+    return "Changed" if all_changed_activities.include?(activity.id)
+    "Unchanged"
+  end
+
+  def all_activities_for_report
+    @_all_activities_for_report ||=
+      Activity::ProjectsForReportFinder.new(report: @report).call.pluck(:id)
+  end
+
+  def all_new_activities
+    @_all_new_activities ||= @report.new_activities.pluck(:id)
+  end
+
+  def all_changed_activities
+    @_all_changed_activities ||= @report.activities_updated.pluck(:id)
+  end
+end

--- a/spec/models/export/activity_change_state_column_spec.rb
+++ b/spec/models/export/activity_change_state_column_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Export::ActivityChangeStateColumn do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+    @new_activity = create(:project_activity)
+    @changed_activity = create(:project_activity)
+    @unchanged_activity = create(:project_activity)
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  context "when there are rows" do
+    let(:report) { build_stubbed(:report) }
+    let(:activities) { [@new_activity, @changed_activity, @unchanged_activity] }
+
+    before do
+      changed_activities = double(ActiveRecord::Relation, pluck: [@changed_activity.id])
+      allow(report).to receive(:activities_updated).and_return(changed_activities)
+
+      new_activities = double(ActiveRecord::Relation, pluck: [@new_activity.id])
+      allow(report).to receive(:new_activities).and_return(new_activities)
+
+      finder = double(Activity::ProjectsForReportFinder, call: activities)
+      allow(Activity::ProjectsForReportFinder).to receive(:new).and_return(finder)
+    end
+
+    subject { described_class.new(activities: activities, report: report) }
+
+    describe "#headers" do
+      it "returns the correct headers" do
+        expect(subject.headers).to eq ["Change state"]
+      end
+    end
+
+    describe "#rows" do
+      it "returns nil when the activity is not in the report" do
+        expect(subject.rows.fetch("activity-id-not-in-report", nil)).to be_nil
+      end
+
+      it "returns 'New' for an acitvity that was created in the report" do
+        expect(subject.rows.fetch(@new_activity.id)).to eq "New"
+      end
+
+      it "returns 'Changed' for an acitvity with changes to it's attributes in the report" do
+        expect(subject.rows.fetch(@changed_activity.id)).to eq "Changed"
+      end
+
+      it "returns 'Unchanged' for an activity that neither applies" do
+        expect(subject.rows.fetch(@unchanged_activity.id)).to eq "Unchanged"
+      end
+    end
+  end
+
+  context "when there are no rows" do
+    let(:report) { build_stubbed(:report) }
+    let(:activities) { [] }
+    subject { described_class.new(activities: activities, report: report) }
+
+    describe "#headers" do
+      it "returns the headers" do
+        expect(subject.headers).to eq ["Change state"]
+      end
+    end
+
+    describe "#rows" do
+      it "returns an empty array" do
+        expect(subject.rows).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
This requires a `Report` in order to work out if change has occurred, the
report gives the context in order to do so.

I am sticking with passing in the activities even though we could use
`all_report_activities`, if the activity is not in the report we return
nil - I think this is preferable over throwing an error that may not be
immediately clear.

