### PR TITLE
Fix/2097 total of forecasts should not include past values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,9 @@
 
 ## [unreleased]
 
+- Fix "Total forecasted" (in Activity financial summary) to exclude periods 
+  already reported
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-84...HEAD
 [release-83]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-83...release-84
 [release-83]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-82...release-83

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -262,10 +262,15 @@ class Activity < ApplicationRecord
     Budget.direct.where(parent_activity_id: id).sum(:value)
   end
 
-  def total_forecasted
+  def future_forecasts
     activity_ids = descendants.pluck(:id).append(id)
-    overview = ForecastOverview.new(activity_ids)
-    overview.latest_values.sum(:value)
+    ForecastOverview.new(activity_ids)
+      .latest_values
+      .select { |forecast| forecast.later_period_than?(latest_report) }
+  end
+
+  def total_forecasted
+    future_forecasts.sum(&:value)
   end
 
   def own_and_descendants_actuals

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -142,6 +142,9 @@ class Activity < ApplicationRecord
 
   has_one :commitment, dependent: :destroy
 
+  has_many :reports,
+    ->(activity) { unscope(:where).for_activity(activity).in_historical_order }
+
   enum level: {
     fund: "fund",
     programme: "programme",
@@ -221,6 +224,10 @@ class Activity < ApplicationRecord
 
   def self.by_roda_identifier(identifier)
     find_by(roda_identifier: identifier)
+  end
+
+  def latest_report
+    reports.first
   end
 
   def descendants

--- a/app/models/concerns/has_financial_quarter.rb
+++ b/app/models/concerns/has_financial_quarter.rb
@@ -1,6 +1,12 @@
 module HasFinancialQuarter
   extend ActiveSupport::Concern
 
+  def later_period_than?(other)
+    return true if other&.financial_period.blank?
+
+    financial_period.last > other.financial_period.last
+  end
+
   def own_financial_quarter
     if financial_year.present? && financial_quarter.present?
       FinancialQuarter.new(financial_year, financial_quarter)

--- a/app/services/activity/tab.rb
+++ b/app/services/activity/tab.rb
@@ -39,7 +39,7 @@ class Activity
     def financials
       @actuals = policy_scope(Actual).where(parent_activity: @activity).order("date DESC")
       @budgets = policy_scope(Budget).where(parent_activity: @activity).order("financial_year DESC")
-      @forecasts = policy_scope(@activity.latest_forecasts)
+      @forecasts = policy_scope(@activity.latest_forecasts).includes([:parent_activity])
       @refunds = policy_scope(Refund).where(parent_activity: @activity).order("financial_year DESC")
       @adjustments = policy_scope(Adjustment).where(parent_activity: @activity).order("date DESC")
 

--- a/app/views/staff/activities/financials.html.haml
+++ b/app/views/staff/activities/financials.html.haml
@@ -43,7 +43,7 @@
                     = @activity.total_spend
                 .govuk-summary-list__row
                   %dt.govuk-summary-list__key
-                    Total forecasted spend to date
+                    Total forecasted spend
                   %dd.govuk-summary-list__value
                     = @activity.total_forecasted
 

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -153,7 +153,7 @@ RSpec.feature "Users can view an activity" do
       within ".financial-summary" do
         expect(page).to have_content "Total spend to date £60.00"
         expect(page).to have_content "Total budget to date £65.00"
-        expect(page).to have_content "Total forecasted spend to date £70.00"
+        expect(page).to have_content "Total forecasted spend £30.00" # only upcoming periods
       end
       expect(page).to have_content actual.value
       expect(page).to have_content budget.value

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -113,12 +113,38 @@ RSpec.feature "Users can view an activity" do
 
     scenario "the financial summary and activity financials can be viewed" do
       activity = create(:programme_activity, organisation: user.organisation)
-      actual = create(:actual, parent_activity: activity, value: 10)
-      budget = create(:budget, parent_activity: activity, value: 10)
 
-      create(:actual, parent_activity: activity, value: 50)
+      q3_21_report = create(
+        :report,
+        :active,
+        organisation: user.organisation,
+        fund: activity.associated_fund
+      )
+
+      actual = create(
+        :actual,
+        parent_activity: activity,
+        value: 10,
+        report: q3_21_report,
+        financial_quarter: 3,
+        financial_year: 2021
+      )
+
+      create(
+        :actual,
+        parent_activity:
+        activity,
+        value: 50,
+        report: q3_21_report,
+        financial_quarter: 3,
+        financial_year: 2021
+      )
+
+      budget = create(:budget, parent_activity: activity, value: 10)
       create(:budget, parent_activity: activity, value: 55)
-      ForecastHistory.new(activity, financial_year: 2020, financial_quarter: 3).set_value(70)
+
+      ForecastHistory.new(activity, financial_year: 2021, financial_quarter: 3).set_value(40)
+      ForecastHistory.new(activity, financial_year: 2021, financial_quarter: 4).set_value(30)
 
       visit organisation_activity_financials_path(activity.organisation, activity)
       within ".govuk-tabs__list-item--selected" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -638,6 +638,40 @@ RSpec.describe Activity, type: :model do
     it { should have_one(:commitment) }
   end
 
+  describe "has_one #latest_report association" do
+    let(:activity) do
+      create(:project_activity)
+    end
+
+    let!(:latest_report) do
+      create(
+        :report,
+        :active,
+        organisation: activity.organisation,
+        fund: activity.associated_fund,
+        financial_quarter: 3,
+        financial_year: 2021
+      )
+    end
+
+    let!(:_earlier_report) do
+      create(
+        :report,
+        :approved,
+        organisation: activity.organisation,
+        fund: activity.associated_fund,
+        financial_quarter: 2,
+        financial_year: 2021
+      )
+    end
+
+    describe "#latest_report" do
+      it "returns the most recent report" do
+        expect(activity.latest_report).to eq(latest_report)
+      end
+    end
+  end
+
   describe "#parent_activities" do
     context "when the activity is a fund" do
       it "returns an empty array" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1547,6 +1547,22 @@ RSpec.describe Activity, type: :model do
         expect(programme2_projects[1].total_forecasted).to eq(10240)
       end
 
+      context "when a report exists for forecasted periods ('quarter')" do
+        before do
+          create(
+            :report,
+            :approved,
+            organisation: programme1.organisation,
+            fund: programme1.associated_fund,
+            **quarter
+          )
+        end
+
+        it "includes only forecasts for later periods ('quarter.succ')" do
+          expect(programme1.total_forecasted).to eq([40, 640].sum)
+        end
+      end
+
       context "when a level A/B forecast is revised" do
         let(:programme) { programme2 }
 

--- a/spec/models/concerns/has_financial_quarter_spec.rb
+++ b/spec/models/concerns/has_financial_quarter_spec.rb
@@ -37,6 +37,31 @@ RSpec.describe HasFinancialQuarter do
     end
   end
 
+  describe "later_period_than?(other)" do
+    let(:q2_2021) { TestReport.new(2, 2021) }
+    let(:q3_2021) { TestReport.new(3, 2021) }
+
+    it "returns TRUE when the period being compared is earlier" do
+      expect(q3_2021).to be_later_period_than(q2_2021)
+    end
+
+    it "returns FALSE when the period being compared is later" do
+      expect(q2_2021).not_to be_later_period_than(q3_2021)
+    end
+
+    it "returns FALSE when the period being compared is the same" do
+      expect(q3_2021).not_to be_later_period_than(q3_2021)
+    end
+
+    it "returns TRUE when the object compared is missing" do
+      expect(q3_2021).to be_later_period_than(nil)
+    end
+
+    it "returns TRUE when the period being compared is blank or missing" do
+      expect(q3_2021).to be_later_period_than(TestReport.new(nil, nil))
+    end
+  end
+
   describe "#first_day_of_financial_period" do
     it "returns the first day of the financial period" do
       report = TestReport.new(4, 2021)


### PR DESCRIPTION
Trello: https://trello.com/c/iIgqfYUE/2097-total-of-forecasts-should-not-include-past-values

## Changes in this PR

Previously an activity's "financials" summary showed a total of all forecasts, irrespective of whether ~~actual spend had been reported~~ a report has been made for any of those forecasted periods.

We now total only the forecasts for periods which have not ~~had spend reported~~ been reported on.

## Screenshots of UI changes

![total_forecasted_spend](https://user-images.githubusercontent.com/20245/140402454-c311c623-58b6-43ad-975d-d9981c616b28.png)

A good example activity is shown above (RODA ID NF-MOBRCSSP-512) 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
