### PR TITLE
Fix: Spending breakdown export not cached

### DIFF
--- a/app/services/export/spending_breakdown.rb
+++ b/app/services/export/spending_breakdown.rb
@@ -23,7 +23,7 @@ class Export::SpendingBreakdown
   end
 
   def headers
-    return @activity_attributes.headers if @actual_columns.rows.empty? && @forecast_columns.rows.empty?
+    return @activity_attributes.headers if actuals_rows.empty? && forecast_rows.empty?
 
     @activity_attributes.headers +
       @delivery_partner_organisations.headers +
@@ -32,13 +32,16 @@ class Export::SpendingBreakdown
   end
 
   def rows
-    return [] if @actual_columns.rows.empty? && @forecast_columns.rows.empty?
+    return [] if actuals_rows.empty? && forecast_rows.empty?
+
+    attribute_row_data = @activity_attributes.rows
+    delivery_partner_organisations_row_data = @delivery_partner_organisations.rows
 
     activities.map do |activity|
-      @activity_attributes.rows.fetch(activity.id, nil) +
-        @delivery_partner_organisations.rows.fetch(activity.id, nil) +
-        @actual_columns.rows.fetch(activity.id, nil) +
-        @forecast_columns.rows.fetch(activity.id, nil)
+      attribute_row_data.fetch(activity.id, nil) +
+        delivery_partner_organisations_row_data.fetch(activity.id, nil) +
+        actuals_rows.fetch(activity.id, nil) +
+        forecast_rows.fetch(activity.id, nil)
     end
   end
 
@@ -52,8 +55,16 @@ class Export::SpendingBreakdown
 
   private
 
+  def actuals_rows
+    @_actuals_rows ||= @actual_columns.rows
+  end
+
+  def forecast_rows
+    @_forecast_rows ||= @forecast_columns.rows
+  end
+
   def first_forecast_financial_quarter
-    return nil if @actual_columns.rows.empty?
+    return nil if actuals_rows.empty?
     @actual_columns.last_financial_quarter.succ
   end
 

--- a/spec/services/export/spending_breakdown_spec.rb
+++ b/spec/services/export/spending_breakdown_spec.rb
@@ -177,6 +177,40 @@ RSpec.describe Export::SpendingBreakdown do
       expect(value_for_header("Forecast FQ3 2021-2022")).to eq 0
     end
 
+    it "attibute rows are only create once" do
+      rows_data_double = double(Hash, fetch: [], empty?: false)
+
+      attribute_double = double(rows: rows_data_double)
+      allow(Export::ActivityAttributesColumns).to receive(:new).and_return(attribute_double)
+
+      delivery_partner_organisation_double = double(rows: rows_data_double)
+      allow(Export::ActivityDeliveryPartnerOrganisationColumn).to receive(:new).and_return(delivery_partner_organisation_double)
+
+      actuals_double = double(rows: rows_data_double, last_financial_quarter: FinancialQuarter.new(2, 2021))
+      allow(Export::ActivityActualsColumns).to receive(:new).and_return(actuals_double)
+
+      forecasts_double = double(rows: rows_data_double)
+      allow(Export::ActivityForecastColumns).to receive(:new).and_return(forecasts_double)
+
+      subject.rows
+
+      expect(attribute_double)
+        .to have_received(:rows)
+        .once
+
+      expect(delivery_partner_organisation_double)
+        .to have_received(:rows)
+        .once
+
+      expect(actuals_double)
+        .to have_received(:rows)
+        .once
+
+      expect(forecasts_double)
+        .to have_received(:rows)
+        .once
+    end
+
     context "where there are additional activities" do
       before do
         create_list(:project_activity, 4, organisation: @organisation)


### PR DESCRIPTION
## Changes in this PR
When we moved the spending breakdown report to the new `Export` classes
we missed that we only need to load the `row` data once and then loop
over the rows to collate the data together, instead we loaded the entire
data set for each wow which  makes the export take far too long as all
the expensive calls are happening for each row instead of once for all
rows!