### PR TITLE
(2246) Allow users to download legacy report csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -910,6 +910,8 @@
 - Report csv export is includes all actual spend
 - Report csv export variance is calculate from net actual spend
 - Report csv performance improvements
+- Legacy version of report csv download is available whilst the new version is
+  validated by BEIS
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-86...HEAD
 [release-86]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-85...release-86

--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -30,7 +30,7 @@ class Staff::ReportsController < Staff::BaseController
         render :show
       end
       format.csv do
-        send_csv
+        send_csv(legacy: legacy?)
       end
     end
   end
@@ -87,6 +87,11 @@ class Staff::ReportsController < Staff::BaseController
 
   private
 
+  def legacy?
+    return true if params[:legacy]
+    false
+  end
+
   def id
     params[:id]
   end
@@ -106,8 +111,13 @@ class Staff::ReportsController < Staff::BaseController
     params.require(:report).permit(:deadline, :description)
   end
 
-  def send_csv
-    export = Export::Report.new(report: @report)
+  def send_csv(legacy: false)
+    export =
+      if legacy
+        Report::Export.new(report: @report)
+      else
+        Export::Report.new(report: @report)
+      end
 
     stream_csv_download(filename: export.filename, headers: export.headers) do |csv|
       export.rows.each do |row|

--- a/app/views/staff/reports/_download.haml
+++ b/app/views/staff/reports/_download.haml
@@ -4,4 +4,6 @@
   %p.govuk-body
     Download a CSV file to review offline. For guidance on reviewing and submitting your report, see the
     = link_to_new_tab " guidance in the help centre", "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005604902-Review-and-Submit-your-Data"
-  = link_to t("action.report.download.button"), report_path(report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+  .govuk-button-group
+    = link_to t("action.report.download.button"), report_path(report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+    = link_to "Download report as legacy CSV file", report_path(report_presenter, format: :csv, legacy: true), class: "govuk-link"

--- a/spec/controllers/staff/reports_controller_spec.rb
+++ b/spec/controllers/staff/reports_controller_spec.rb
@@ -1,19 +1,41 @@
-require "rails_helper"
-
 RSpec.describe Staff::ReportsController do
+  let(:delivery_partner_user) { create(:delivery_partner_user) }
+  let(:organisation) { delivery_partner_user.organisation }
+
+  before do
+    allow(subject).to receive(:current_user).and_return(delivery_partner_user)
+    allow(subject).to receive(:logged_in_using_omniauth?).and_return(true)
+  end
+
   describe "#index" do
-    context "when logged in as a delivery partner" do
-      let(:organisation) { create(:delivery_partner_organisation) }
-      let(:user) { create(:delivery_partner_user, organisation: organisation) }
+    it "redirects to show the user's organisation's reports" do
+      expect(get(:index)).to redirect_to(organisation_reports_path(organisation_id: organisation.id))
+    end
+  end
 
-      before do
-        allow(controller).to receive(:current_user).and_return(user)
-        allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
-      end
+  describe "#show" do
+    it "returns the report file successfully" do
+      report = create(:report, organisation: delivery_partner_user.organisation)
+      export_double = double(Export::Report, filename: "export.csv", headers: [], rows: [])
+      allow(Export::Report).to receive(:new).with(report: report).and_return(export_double)
 
-      it "redirects to show the user's organisation's reports" do
-        expect(get(:index)).to redirect_to(organisation_reports_path(organisation_id: organisation.id))
-      end
+      get :show, params: {id: report.id, format: :csv}
+
+      expect(export_double).to have_received(:filename).once
+      expect(Export::Report).to have_received(:new).once
+      expect(response.header["Content-Disposition"]).to include("filename=export.csv")
+    end
+
+    it "returns the legacy report file successfully" do
+      report = create(:report, organisation: delivery_partner_user.organisation)
+      export_double = double(Report::Export, filename: "legacy_export.csv", headers: [], rows: [])
+      allow(Report::Export).to receive(:new).with(report: report).and_return(export_double)
+
+      get :show, params: {id: report.id, format: :csv, legacy: true}
+
+      expect(export_double).to have_received(:filename).once
+      expect(Report::Export).to have_received(:new).once
+      expect(response.header["Content-Disposition"]).to include("filename=legacy_export.csv")
     end
   end
 end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -158,6 +158,16 @@ RSpec.feature "Users can view reports" do
       expect(page.status_code).to eq 200
     end
 
+    scenario "whilst available, they can download the legacy CSV version of their report" do
+      report = create(:report, :active)
+      visit report_actuals_path(report)
+
+      click_link("Download report as legacy CSV file")
+
+      expect(page.response_headers["Content-Type"]).to include("text/csv")
+      expect(page.status_code).to eq 200
+    end
+
     context "if the report description is empty" do
       scenario "the report csv has a filename made up of the fund name & report financial year & quarter" do
         report = create(:report, :active, description: "", financial_quarter: 4, financial_year: 2019)


### PR DESCRIPTION
## Changes in this PR

Whilst we are introducing the new report csv we want to offer the old
one to reassure users that any workflows will not be broken. Once they
have confidence in the new export, this work can be rollback.
