### PR TITLE
(2246) Refactor: clean up

### DIFF
--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -21,10 +21,6 @@ class ReportPresenter < SimpleDelegator
     "#{financial_quarter_and_year} #{fund.roda_identifier} #{organisation.beis_organisation_reference}"
   end
 
-  def filename_for_report_download
-    filename(purpose: "report")
-  end
-
   def filename_for_activities_template
     filename(purpose: "activities_upload")
   end

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Export::ActivityActualsColumns do
     @q3_report = create(:report, financial_quarter: 3, financial_year: 2020)
     @q4_report = create(:report, financial_quarter: 4, financial_year: 2020)
 
-    create_fixtures(
+    actuals_from_table(
       <<~TABLE
         |transaction|report|financial_period|value|
         | Actual    |q1    | q1             |  100|
@@ -248,37 +248,5 @@ RSpec.describe Export::ActivityActualsColumns do
         .to have_received(:new)
         .exactly(@activities.count).times
     end
-  end
-
-  def value_for_header(header_name)
-    values = subject.rows.fetch(@activity.id)
-    values[subject.headers.index(header_name)]
-  end
-
-  def create_fixtures(table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      case row["transaction"].strip
-      when "Actual"
-        create(:actual, fixture_attrs(row))
-      when "Adj. Act."
-        create(:adjustment, :actual, fixture_attrs(row))
-      when "Adj. Ref."
-        create(:adjustment, :refund, fixture_attrs(row))
-      when "Refund"
-        create(:refund, fixture_attrs(row))
-      else
-        raise "don't know what to do"
-      end
-    end
-  end
-
-  def fixture_attrs(row)
-    {
-      parent_activity: @activity,
-      value: row["value"].strip,
-      financial_quarter: row["financial_period"][/\d/],
-      financial_year: 2020,
-      report: instance_variable_get("@#{row["report"].strip}_report"),
-    }
   end
 end

--- a/spec/models/export/activity_forecast_columns_spec.rb
+++ b/spec/models/export/activity_forecast_columns_spec.rb
@@ -274,20 +274,4 @@ RSpec.describe Export::ActivityForecastColumns do
       end
     end
   end
-
-  def value_for_header(header_name)
-    values = subject.rows.fetch(@activity.id)
-    values[subject.headers.index(header_name)]
-  end
-
-  def forecasts_for_report_from_table(report, table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      ForecastHistory.new(
-        @activity,
-        report: report,
-        financial_quarter: row["financial_quarter"].to_i,
-        financial_year: row["financial_year"].to_i,
-      ).set_value(row["value"].to_i)
-    end
-  end
 end

--- a/spec/models/export/activity_variance_column_spec.rb
+++ b/spec/models/export/activity_variance_column_spec.rb
@@ -68,40 +68,4 @@ RSpec.describe Export::ActivityVarianceColumn do
       expect(variance_for_activity).to eq BigDecimal(20000 - 40000)
     end
   end
-
-  private
-
-  def actuals_from_table(table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      case row["transaction"].strip
-      when "Actual"
-        create(:actual, fixture_attrs(row))
-      when "Refund"
-        create(:refund, fixture_attrs(row))
-      else
-        raise "don't know what to do"
-      end
-    end
-  end
-
-  def forecasts_for_report_from_table(report, table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      ForecastHistory.new(
-        @activity,
-        report: report,
-        financial_quarter: row["financial_quarter"].to_i,
-        financial_year: row["financial_year"].to_i,
-      ).set_value(row["value"].to_i)
-    end
-  end
-
-  def fixture_attrs(row)
-    {
-      parent_activity: @activity,
-      value: row["value"].strip,
-      financial_quarter: row["financial_period"][/\d/],
-      financial_year: 2021,
-      report: instance_variable_get("@#{row["report"].strip}_report"),
-    }
-  end
 end

--- a/spec/models/export/all_activity_totals_spec.rb
+++ b/spec/models/export/all_activity_totals_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Export::AllActivityTotals do
     @q3_report = create(:report, financial_quarter: 3, financial_year: 2020)
     @q4_report = create(:report, financial_quarter: 4, financial_year: 2020)
 
-    create_fixtures(
+    actuals_from_table(
       <<~TABLE
         |transaction|report|financial_period|value|
         | Actual    |q1    | q1             |  100|
@@ -89,32 +89,5 @@ RSpec.describe Export::AllActivityTotals do
       expect(subject.call).not_to include [@activity.id, 1, 2020, "Adjustment", "Refund"] => BigDecimal(400)
       expect(subject.call).not_to include [@activity.id, 1, 2020, "Adjustment", "Actual"] => BigDecimal(500)
     end
-  end
-
-  def create_fixtures(table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      case row["transaction"].strip
-      when "Actual"
-        create(:actual, fixture_attrs(row))
-      when "Adj. Act."
-        create(:adjustment, :actual, fixture_attrs(row))
-      when "Adj. Ref."
-        create(:adjustment, :refund, fixture_attrs(row))
-      when "Refund"
-        create(:refund, fixture_attrs(row))
-      else
-        raise "don't know what to do"
-      end
-    end
-  end
-
-  def fixture_attrs(row)
-    {
-      parent_activity: @activity,
-      value: row["value"].strip,
-      financial_quarter: row["financial_period"][/\d/],
-      financial_year: 2020,
-      report: instance_variable_get("@#{row["report"].strip}_report"),
-    }
   end
 end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -49,14 +49,6 @@ RSpec.describe ReportPresenter do
         description: "My report")
     }
 
-    describe "#filename_for_report_download" do
-      it "returns the URL-encoded filename for the downloadable report" do
-        result = described_class.new(report).filename_for_report_download
-
-        expect(result).to eql "FQ1 2020-2021-GCRF-BOR-report.csv"
-      end
-    end
-
     describe "#filename_for_activities_template" do
       it "returns the URL-encoded filename for the activities template CSV dowload" do
         result = described_class.new(report).filename_for_activities_template

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |config|
   config.include StripAttributes::Matchers
   config.include TimeTravelHelpers
   config.include TransactionHelpers
+  config.include ExportHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/export/spending_breakdown_spec.rb
+++ b/spec/services/export/spending_breakdown_spec.rb
@@ -238,42 +238,4 @@ RSpec.describe Export::SpendingBreakdown do
       end
     end
   end
-
-  def actuals_from_table(table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      case row["transaction"].strip
-      when "Actual"
-        create(:actual, fixture_attrs(row))
-      when "Adj. Act."
-        create(:adjustment, :actual, fixture_attrs(row))
-      when "Adj. Ref."
-        create(:adjustment, :refund, fixture_attrs(row))
-      when "Refund"
-        create(:refund, fixture_attrs(row))
-      else
-        raise "don't know what to do"
-      end
-    end
-  end
-
-  def forecasts_for_report_from_table(report, table)
-    CSV.parse(table, col_sep: "|", headers: true).each do |row|
-      ForecastHistory.new(
-        @activity,
-        report: report,
-        financial_quarter: row["financial_quarter"].to_i,
-        financial_year: row["financial_year"].to_i,
-      ).set_value(row["value"].to_i)
-    end
-  end
-
-  def fixture_attrs(row)
-    {
-      parent_activity: @activity,
-      value: row["value"].strip,
-      financial_quarter: row["financial_period"][/\d/],
-      financial_year: 2020,
-      report: instance_variable_get("@#{row["report"].strip}_report"),
-    }
-  end
 end

--- a/spec/support/export_helpers.rb
+++ b/spec/support/export_helpers.rb
@@ -1,0 +1,44 @@
+module ExportHelpers
+  def value_for_header(header_name)
+    values = subject.rows.fetch(@activity.id)
+    values[subject.headers.index(header_name)]
+  end
+
+  def actuals_from_table(table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      case row["transaction"].strip
+      when "Actual"
+        create(:actual, fixture_attrs(row))
+      when "Adj. Act."
+        create(:adjustment, :actual, fixture_attrs(row))
+      when "Adj. Ref."
+        create(:adjustment, :refund, fixture_attrs(row))
+      when "Refund"
+        create(:refund, fixture_attrs(row))
+      else
+        raise "don't know what to do"
+      end
+    end
+  end
+
+  def forecasts_for_report_from_table(report, table)
+    CSV.parse(table, col_sep: "|", headers: true).each do |row|
+      ForecastHistory.new(
+        @activity,
+        report: report,
+        financial_quarter: row["financial_quarter"].to_i,
+        financial_year: row["financial_year"].to_i,
+      ).set_value(row["value"].to_i)
+    end
+  end
+
+  def fixture_attrs(row)
+    {
+      parent_activity: @activity,
+      value: row["value"].strip,
+      financial_quarter: row["financial_period"][/\d/],
+      financial_year: 2020,
+      report: instance_variable_get("@#{row["report"].strip}_report"),
+    }
+  end
+end


### PR DESCRIPTION
## Changes in this PR
Here we are cleaning up the end of the big Export refactor. We do not remove the old `Report::Export` just yet as we are still offering it incase the new version is missing something that would effect BEIS workflows, see: #1462 