### PR TITLE
Doc: Add support runbook for adding a channel of delivery code to accepted list

### DIFF
--- a/doc/0_index_of_contents.md
+++ b/doc/0_index_of_contents.md
@@ -92,3 +92,7 @@
 
 - **[Change a report's financial period (support_tasks/change_financial_period.md)](./support_tasks/change_financial_period.md)**:
   If a report is created with the wrong financial period it is a little fiddly to change.
+
+- **[Add "channel of delivery" code to the accepted list (support_tasks/add_accepted_channel_of_delivery_code.md)](./support_tasks/add_accepted_channel_of_delivery_code.md)**:
+  From time to time an additional IATI "channel of delivery" code needs to be
+  added to RODA's list of accepted codes.

--- a/doc/support_tasks/add_accepted_channel_of_delivery_code.md
+++ b/doc/support_tasks/add_accepted_channel_of_delivery_code.md
@@ -1,0 +1,21 @@
+# Add a channel of delivery code to the "accepted" list
+
+From time to time, usually following the assurance of a reporting period, BEIS
+will take the view that an additional IATI "channel of delivery" code should be
+added to RODA's list of accepted codes. The process for doing this is:
+
+- verify that the candidate code exists in the [list of valid "channel of
+  delivery"
+  codes](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/master/vendor/data/codelists/IATI/2_03/activity/channel_of_delivery_code.yml)
+
+- add the new "accepted" code to the [list of accepted
+  codes](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/master/vendor/data/codelists/BEIS/accepted_channel_of_delivery_codes.yml)
+
+- tweak the `spec/helpers/codelist_helper_spec.rb` to reflect the new quantity
+  of accepted codes
+
+- note the detail of the additional code in the `./CHANGELOG.md`
+
+Refer to [commit
+6189f90502e20aa9c8200e2b60b8b68e47cf1e40](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/commit/6189f90502e20aa9c8200e2b60b8b68e47cf1e40)
+for an example.


### PR DESCRIPTION
We currently have the need to do this (see https://trello.com/c/3DPKYfLg/2321-channel-delivery-code).

As we are also currently working on both BEIS' "Operating manual" and the "Developer docs" stored here in `doc/`, we'll take the opportunity to follow the support process:

- BEIS raise a support ticket on Zendesk
- dxw follow the support runbook entry

