### PR TITLE
Feature (2281) Set implementing organisation for new programmes (level b)

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -219,7 +219,15 @@ class Activity < ApplicationRecord
       delivery_partner_organisation: delivery_partner_organisation
     ).call
 
-    new(attributes, &block)
+    new(attributes, &block).tap do |new_activity|
+      if new_activity.programme?
+        new_activity.implementing_organisations << ImplementingOrganisation.new(
+          name: delivery_partner_organisation.name,
+          reference: delivery_partner_organisation.iati_reference,
+          organisation_type: delivery_partner_organisation.organisation_type
+        )
+      end
+    end
   end
 
   def self.by_roda_identifier(identifier)

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -61,6 +61,11 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.accountable_organisation_type).to eq("10")
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+
+      expect_implementing_organisation_to_be_the_delivery_partner(
+        activity: created_activity,
+        organisation: delivery_partner
+      )
     end
   end
 
@@ -112,5 +117,17 @@ RSpec.feature "BEIS users can create a programme level activity" do
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
     end
+  end
+
+  def expect_implementing_organisation_to_be_the_delivery_partner(
+    activity:,
+    organisation:
+  )
+    expect(activity.implementing_organisations.first)
+      .to have_attributes(
+        "name" => organisation.name,
+        "reference" => organisation.iati_reference,
+        "organisation_type" => organisation.organisation_type
+      )
   end
 end

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -73,6 +73,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
         expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
         expect(created_activity.uk_dp_named_contact).to eq(activity.uk_dp_named_contact)
+        expect(created_activity.implementing_organisations).to be_none
       end
 
       scenario "can create a new child activity for a given programme" do


### PR DESCRIPTION
Trello https://trello.com/c/5jyIqHIi/2281

During the recent submission of data to IATI we recognised the need to supply "implement organisation" data for Level B activities (Programmes).

i.e. the XML submitted should include a `<participating-org>` element with a `role` attribute of `4` to signify "implementing organisation", e.g.:

```
<participating-org ref="GB-CHC-293074" role="4" type="80">
  <narrative>Royal Academy of Engineering</narrative>
</participating-org>
```

See https://iatistandard.org/en/iati-standard/203/codelists/organisationrole/

We recently ran a data migration to backfill these implementing organisations for pre-existing programmes. See:

`20211027111140_copy_extending_organisation_to_implementing_organisation_at_level_b.rb`

This commit changes the `Activity::new_child` to set an implementing organisation when a new programme is created.

### TO FOLLOW

We intend to offset this slight increase in complexity in the already sprawling handling of "organisation" concept with an improvement in the **quality** of the data. As per [Change how we collect and store implementing organisation](https://trello.com/c/8teLzwsh/2098), we plan to introduce a list of approved implementing organisations and require that implementing organisation memberships use this list. 

This will require:

-   [ ] migrating existing implementing organisations to these memberships
-   [ ] changing the "new implemention organisation form" to use the list of available implementing organisations
-   [ ] instituting a workable mechanism or workflow for i) DPs to create new implementing organisations and ii) for BEIS to review new orgs and tweak as necessary (merging into existing ones in the case of duplicates or editing e.g. to add a missing IATI reference)


