### PR TITLE
(2252) Feature: new actual history importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -919,6 +919,8 @@
 - Add support runbook for adding a channel of delivery code to accepted list
 
 ## [unreleased]
+- Actual spend values can no longer be negative, use Adjustments or Refunds to
+  document funding flowing back
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-88...HEAD
 [release-88]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-87...release-88

--- a/app/models/actual.rb
+++ b/app/models/actual.rb
@@ -1,2 +1,5 @@
 class Actual < Transaction
+  validates :value,
+    numericality: {greater_than: 0},
+    unless: proc { |actual| actual.validation_context == :history }
 end

--- a/app/models/import/actual_history.rb
+++ b/app/models/import/actual_history.rb
@@ -1,0 +1,159 @@
+class Import::ActualHistory
+  class RowError < StandardError
+    attr_reader :row_number
+
+    def initialize(message, row_number)
+      @row_number = row_number
+      super(message)
+    end
+  end
+
+  VALID_HEADERS = {
+    roda_identifier: "RODA identifier",
+    financial_quarter: "Financial quarter",
+    financial_year: "Financial year",
+    value: "Value",
+  }
+
+  attr_reader :errors, :imported
+
+  def initialize(report:, csv:)
+    @report = report
+    @headers = csv.headers
+    @csv = csv
+    @imported = []
+    @errors = []
+  end
+
+  def call
+    import_actual_history(@csv)
+  end
+
+  private
+
+  def import_actual_history(csv)
+    unless headers_valid?
+      @errors << headers_error
+      return false
+    end
+
+    ActiveRecord::Base.transaction do
+      csv.each.with_index(2) do |row, row_number|
+        row_import = RowImport.new(row_number: row_number, row: row, report: @report)
+
+        if row_import.call
+          @imported.append(row_import.actual)
+        else
+          @errors.concat(row_import.errors)
+        end
+      end
+
+      if @errors.any?
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    return false if @errors.any?
+
+    true
+  end
+
+  def headers_valid?
+    @headers == VALID_HEADERS.values
+  end
+
+  def headers_error
+    RowError.new("Invalid headers, must be #{VALID_HEADERS.values.to_sentence}", 1)
+  end
+
+  class RowImport
+    attr_reader :errors, :actual, :row_number, :row
+
+    def initialize(row_number:, row:, report:)
+      @report = report
+      @errors = []
+      @row = row
+      @row_number = row_number
+      @actual = nil
+    end
+
+    def call
+      unless roda_identifier_valid?
+        @errors << roda_identifier_error
+        return false
+      end
+
+      unless report_valid?
+        @errors << report_error
+        return false
+      end
+
+      create_actual
+    end
+
+    private
+
+    def create_actual
+      actual = Actual.new(
+        parent_activity_id: activity.id,
+        report_id: @report.id,
+        financial_quarter: financial_quarter,
+        financial_year: financial_year,
+        value: value
+      )
+      if actual.valid?(:history)
+        actual.save(context: :history)
+        @actual = actual
+        true
+      else
+        @errors = active_model_to_import_errors_for_row(actual.errors)
+        false
+      end
+    end
+
+    def activity
+      @_activity ||= Activity.by_roda_identifier(roda_identifier)
+    end
+
+    def financial_quarter
+      @row.field("Financial quarter").strip
+    end
+
+    def financial_year
+      @row.field("Financial year").strip
+    end
+
+    def value
+      @row.field("Value").strip
+    end
+
+    def report_valid?
+      @report.fund.source_fund_code == activity.source_fund_code &&
+        @report.organisation == activity.organisation
+    end
+
+    def report_error
+      RowError
+        .new(
+          "Activity with RODA ID #{activity.roda_identifier} does not match the fund and organisation of this report",
+          row_number
+        )
+    end
+
+    def roda_identifier
+      @row.field("RODA identifier").strip
+    end
+
+    def roda_identifier_valid?
+      activity.present? ? true : false
+    end
+
+    def roda_identifier_error
+      RowError.new("Unknown RODA identifier #{roda_identifier}", row_number)
+    end
+
+    def active_model_to_import_errors_for_row(errors)
+      errors.map { |error| RowError.new(error.message, row_number) }
+    end
+  end
+end

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -122,6 +122,7 @@ en:
               other_than: Value must not be zero
               blank: Enter an actual spend amount
               not_a_number: Value must be a valid number
+              greater_than: Value cannot be negative
             transaction_type:
               blank: Select a transaction type
             description:

--- a/spec/features/staff/users_can_create_an_actual_spec.rb
+++ b/spec/features/staff/users_can_create_an_actual_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Users can create an actual" do
         expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.other_than")
       end
 
-      scenario "Value can be negative" do
+      scenario "Value cannot be negative" do
         activity = create(:programme_activity, :with_report, organisation: user.organisation)
 
         visit organisation_activity_path(activity.organisation, activity)
@@ -101,7 +101,7 @@ RSpec.feature "Users can create an actual" do
         select "Government", from: "actual[receiving_organisation_type]"
         click_on(t("default.button.submit"))
 
-        expect(page).to have_content t("action.actual.create.success")
+        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.greater_than")
       end
 
       scenario "When the value includes a pound sign" do

--- a/spec/models/actual_spec.rb
+++ b/spec/models/actual_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Actual do
+  describe "validations" do
+    context "with no validation context" do
+      it "allows positive values" do
+        actual = build(:actual, value: 10_000)
+        expect(actual.valid?).to be true
+      end
+
+      it "does not allow negative values" do
+        actual = build(:actual, value: -10_000)
+        expect(actual.valid?).to be false
+      end
+    end
+
+    context "with the `:history` validation context" do
+      it "allows positive values" do
+        actual = build(:actual, value: 10_000)
+        expect(actual.valid?(:history)).to be true
+      end
+
+      it "allows negative values" do
+        actual = build(:actual, value: -10_000)
+        expect(actual.valid?(:history)).to be true
+      end
+    end
+  end
+end

--- a/spec/models/import/actual_history_spec.rb
+++ b/spec/models/import/actual_history_spec.rb
@@ -1,0 +1,256 @@
+RSpec.describe Import::ActualHistory do
+  before(:all) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.start
+
+    @activity = create(:project_activity)
+    @report = create(
+      :report,
+      organisation: @activity.organisation,
+      fund: @activity.associated_fund
+    )
+    @user = create(:beis_user)
+
+    valid_data = <<~CSV
+      RODA identifier,Financial quarter,Financial year,Value
+      #{@activity.roda_identifier},1,2021,10000
+      #{@activity.roda_identifier},2,2021,20000
+      #{@activity.roda_identifier},3,2021,30000
+    CSV
+
+    invalid_data = <<~CSV
+      RODA identifier,Financial quarter,Financial year,Value
+      NOT-A-RODA-ID,1,2021,10000
+      #{@activity.roda_identifier},Quarter 1,2021,10000
+      #{@activity.roda_identifier},1,the year of 2021,10000
+      #{@activity.roda_identifier},1,2021,0
+      #{@activity.roda_identifier},1,2021,10000
+    CSV
+
+    invalid_headers = <<~CSV
+      Not,Valid,Headers
+    CSV
+
+    @valid_csv = CSV.parse(valid_data, headers: true)
+    @invalid_csv = CSV.parse(invalid_data, headers: true)
+    @invalid_headers_csv = CSV.parse(invalid_headers, headers: true)
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+  end
+
+  context "with valid data" do
+    subject { described_class.new(report: @report, csv: @valid_csv) }
+
+    it "returns true" do
+      expect(subject.call).to be true
+    end
+
+    it "creates the actuals" do
+      expect { subject.call }.to change { Actual.count }.by(3)
+    end
+
+    it "returns the imported actuals" do
+      subject.call
+      expect(subject.imported.count).to eq 3
+    end
+  end
+
+  context "with invalid headers" do
+    subject { described_class.new(report: @report, csv: @invalid_headers_csv) }
+
+    it "returns false" do
+      expect(subject.call).to be false
+    end
+
+    it "returns the correct number of errors" do
+      subject.call
+      expect(subject.errors.count).to eq 1
+    end
+
+    it "returns the errros" do
+      subject.call
+      expect(subject.errors.first.message).to include "Invalid headers,"
+    end
+
+    it "does not create any actuals" do
+      expect { subject.call }.not_to change { Actual.count }
+    end
+  end
+
+  context "with invalid data" do
+    subject { described_class.new(report: @report, csv: @invalid_csv) }
+
+    it "returns false" do
+      expect(subject.call).to be false
+    end
+
+    it "returns all of the errors" do
+      subject.call
+      expect(subject.errors.count).to eq 4
+    end
+
+    describe "the errors" do
+      it "returns the error for the first row" do
+        subject.call
+        error = subject.errors.first
+        expect(error.row_number).to eq 2
+        expect(error.message).to include("RODA identifier")
+      end
+
+      it "returns the error for the second row" do
+        subject.call
+        error = subject.errors.second
+        expect(error.row_number).to eq 3
+        expect(error.message).to include("Enter a financial quarter between 1 and 4")
+      end
+
+      it "returns the error for the third row" do
+        subject.call
+        error = subject.errors.third
+        expect(error.row_number).to eq 4
+        expect(error.message).to include("Date must be between")
+      end
+
+      it "returns the error for the fourth row" do
+        subject.call
+        error = subject.errors.fourth
+        expect(error.row_number).to eq 5
+        expect(error.message).to include("Value must not be zero")
+      end
+    end
+  end
+
+  describe Import::ActualHistory::RowImport do
+    context "with valid row data" do
+      let(:row) {
+        CSV::Row.new(
+          ["RODA identifier", "Financial quarter", "Financial year", "Value"],
+          [@activity.roda_identifier, "1", "2021", "10000"]
+        )
+      }
+
+      subject { described_class.new(report: @report, row_number: 2, row: row) }
+
+      it "returns true" do
+        expect(subject.call).to be true
+      end
+
+      it "returns no errors" do
+        subject.call
+        expect(subject.errors.count).to eq 0
+      end
+
+      it "creates the actual" do
+        expect { subject.call }.to change { Actual.count }.by(1)
+      end
+
+      describe "the new actual" do
+        subject { described_class.new(report: @report, row_number: 2, row: row) }
+
+        it "has the correct parent activity" do
+          subject.call
+          expect(subject.actual.parent_activity).to eq @activity
+        end
+
+        it "has the correct financial quarter" do
+          subject.call
+          expect(subject.actual.financial_quarter).to eq 1
+        end
+        it "has the correct financial year" do
+          subject.call
+          expect(subject.actual.financial_year).to eq 2021
+        end
+
+        it "has the correct value" do
+          subject.call
+          expect(subject.actual.value).to eq BigDecimal(10_000)
+        end
+
+        it "has the correct report" do
+          subject.call
+          expect(subject.actual.report).to eq @report
+        end
+
+        it "validates the actual in the history context" do
+          actual = double(Actual, valid?: true, save: true)
+          allow(Actual).to receive(:new).and_return(actual)
+
+          subject.call
+
+          expect(actual).to have_received(:valid?).with(:history)
+        end
+
+        it "saves the actual in the history context" do
+          actual = double(Actual, valid?: true, save: true)
+          allow(Actual).to receive(:new).and_return(actual)
+
+          subject.call
+
+          expect(actual).to have_received(:save).with(context: :history)
+        end
+      end
+    end
+
+    context "with invalid row data" do
+      let(:row) {
+        CSV::Row.new(
+          ["RODA identifier", "Financial quarter", "Financial year", "Value"],
+          ["NOT-A-RODA-ID", "Quarter One", "the year 2021", "0"]
+        )
+      }
+
+      subject { described_class.new(report: @report, row_number: 2, row: row) }
+
+      it "returns false" do
+        expect(subject.call).to be false
+      end
+
+      it "returns errors" do
+        subject.call
+        expect(subject.errors.count).to eq 1
+      end
+
+      it "does not create the actual" do
+        expect(subject.actual).to be_nil
+      end
+
+      it "has a helpful error message" do
+        subject.call
+        expect(subject.errors.first.message).to include("Unknown RODA identifier")
+      end
+    end
+
+    context "when the row data has and incorrect but valid activity" do
+      let(:other_activity) { create(:project_activity) }
+      let(:row) {
+        CSV::Row.new(
+          ["RODA identifier", "Financial quarter", "Financial year", "Value"],
+          [other_activity.roda_identifier, "1", "2021", "100000"]
+        )
+      }
+
+      subject { described_class.new(report: @report, row_number: 2, row: row) }
+
+      it "returns false" do
+        expect(subject.call).to be false
+      end
+
+      it "returns errors" do
+        subject.call
+        expect(subject.errors.count).to eq 1
+      end
+
+      it "does not create the actual" do
+        expect(subject.actual).to be_nil
+      end
+
+      it "has a helpful error message" do
+        subject.call
+        expect(subject.errors.first.message)
+          .to include("does not match the fund and organisation of this report")
+      end
+    end
+  end
+end

--- a/spec/models/import/actual_history_spec.rb
+++ b/spec/models/import/actual_history_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Import::ActualHistory do
   end
 
   context "with valid data" do
-    subject { described_class.new(report: @report, csv: @valid_csv) }
+    subject { described_class.new(report: @report, csv: @valid_csv, user: @user) }
 
     it "returns true" do
       expect(subject.call).to be true
@@ -55,10 +55,19 @@ RSpec.describe Import::ActualHistory do
       subject.call
       expect(subject.imported.count).to eq 3
     end
+
+    it "records the actuals in the history" do
+      history_recorder = double(HistoryRecorder, call: nil)
+      allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
+
+      subject.call
+
+      expect(history_recorder).to have_received(:call).exactly(3).times
+    end
   end
 
   context "with invalid headers" do
-    subject { described_class.new(report: @report, csv: @invalid_headers_csv) }
+    subject { described_class.new(report: @report, csv: @invalid_headers_csv, user: @user) }
 
     it "returns false" do
       expect(subject.call).to be false
@@ -80,7 +89,7 @@ RSpec.describe Import::ActualHistory do
   end
 
   context "with invalid data" do
-    subject { described_class.new(report: @report, csv: @invalid_csv) }
+    subject { described_class.new(report: @report, csv: @invalid_csv, user: @user) }
 
     it "returns false" do
       expect(subject.call).to be false
@@ -89,6 +98,15 @@ RSpec.describe Import::ActualHistory do
     it "returns all of the errors" do
       subject.call
       expect(subject.errors.count).to eq 4
+    end
+
+    it "does not record the actuals in the history" do
+      history_recorder = double(HistoryRecorder, call: nil)
+      allow(HistoryRecorder).to receive(:new).and_return(history_recorder)
+
+      subject.call
+
+      expect(history_recorder).not_to have_received(:call)
     end
 
     describe "the errors" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -215,9 +215,9 @@ RSpec.describe Transaction, type: :model do
         expect(actual.valid?).to be true
       end
 
-      it "allows a negative value" do
+      it "does not allow a negative value" do
         actual = build(:actual, parent_activity: activity, value: -500_000.00)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be false
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
This is the new importer for historic actual spend that ony BEIS users can use, it is not currently available that will follow.

Historic actual spend is treated differently to regular actual spend in that we expect negative values and we expect financial quarters in the past, as already mentioned, we only expect BEIS users to perform this upload and we don't expect it to be something long term, it is only fir use during migration to the service.

The import follows the `Import::Commitments` in that it returns `true` or `false` and builds arrays of `errors` and `imported` actuals - I like this interface.

Here I start out by preventing negative values in 'regular' actuals and allowing them when the validation context is `:history`. The importer then creates it's actuals in this context and is therefore allowed to add negative values.

In the early commits I decided that I wouldn't worry about validating the report that is used to import against - I come to a better conculsion in the final commit.

Big thank you to @pezholio who spiked this work out and made it simpler for me to follow up.