### PR TITLE
(2286) Check delete activity rake task is recursive

### DIFF
--- a/spec/lib/tasks/delete_activity_spec.rb
+++ b/spec/lib/tasks/delete_activity_spec.rb
@@ -145,5 +145,13 @@ RSpec.describe "rake activities:delete", type: :task do
 
       expect { delete_activity(activity_id: activity.id) }.to change { Activity.count }.by(-2)
     end
+
+    it "deletes the descendant activities" do
+      programme = create(:programme_activity)
+      activity = create(:project_activity, parent: programme)
+      create(:third_party_project_activity, parent: activity)
+
+      expect { delete_activity(activity_id: programme.id) }.to change { Activity.count }.by(-3)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
When I wrote the delete activity task, I thought afterwards that it
would not delete descendent activities. Looking at it here though, it is
recursive and deletes right down the hierarchy.

Here is a spec to confirm that behaviour.

https://trello.com/c/WJwzZHXX
