### PR TITLE
(2324) Fix: show unknown country codes and data migration to remove those in production 

### DIFF
--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -274,15 +274,15 @@ class ActivityPresenter < SimpleDelegator
 
   private
 
-  def translate(reference)
-    I18n.t(reference)
+  def translate(*args)
+    I18n.t(*args)
   end
 
   def sentence_of_benefitting_countries(country_code_list)
     return nil unless country_code_list.present?
     benefitting_country_names = country_code_list.map { |country_code|
       benefitting_country = BenefittingCountry.find_by_code(country_code)
-      benefitting_country.nil? ? translate("page_content.activity.unknown_country") : benefitting_country.name
+      benefitting_country.nil? ? translate("page_content.activity.unknown_country", code: country_code) : benefitting_country.name
     }
     benefitting_country_names.to_sentence
   end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -332,7 +332,7 @@ en:
         html: To create a new Activity, first choose the %{organisations_link} you wish to create the Activity under
       organisation: Organisation
     activity:
-      unknown_country: Unknown country code
+      unknown_country: Unknown country code (%{code})
       benefitting_region_check_box: Select or deselect all countries in %{region}
       budgets: Budgets
       button:

--- a/db/data/20211118113311_remove_incompatible_country_codes.rb
+++ b/db/data/20211118113311_remove_incompatible_country_codes.rb
@@ -1,0 +1,18 @@
+# Run me with `rails runner db/data/20211118113311_remove_incompatible_country_codes.rb`
+#
+INCOMPATIBLE_COUNTRY_CODES = ["CH", "A region on IATI code 88"]
+
+def get_all_affected_activities(code)
+  Activity.where("? = ANY(benefitting_countries)", code)
+end
+
+def remove_incompatible_country_codes(affected_activities, code)
+  affected_activities.each do |activity|
+    puts "Removing code #{code} from activity #{activity.id}"
+    benefitting_countries = activity.benefitting_countries.reject { |country_code| country_code == code }
+    activity.benefitting_countries = benefitting_countries
+    activity.save!(validate: false)
+  end
+end
+
+INCOMPATIBLE_COUNTRY_CODES.each { |code| remove_incompatible_country_codes(get_all_affected_activities(code), code) }

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe ActivityPresenter do
       it "handles unexpected country codes" do
         activity = build(:project_activity, benefitting_countries: ["UK"])
         result = described_class.new(activity).benefitting_countries
-        expect(result).to eql t("page_content.activity.unknown_country")
+        expect(result).to eql t("page_content.activity.unknown_country", code: "UK")
       end
     end
   end
@@ -333,7 +333,7 @@ RSpec.describe ActivityPresenter do
       it "handles unexpected country codes" do
         activity = build(:project_activity, benefitting_countries: ["UK"])
         result = described_class.new(activity).benefitting_countries
-        expect(result).to eql t("page_content.activity.unknown_country")
+        expect(result).to eql t("page_content.activity.unknown_country", code: "UK")
       end
     end
 
@@ -359,7 +359,7 @@ RSpec.describe ActivityPresenter do
       it "handles unexpected country codes" do
         activity = build(:project_activity, benefitting_countries: ["UK"])
         result = described_class.new(activity).benefitting_countries
-        expect(result).to eql t("page_content.activity.unknown_country")
+        expect(result).to eql t("page_content.activity.unknown_country", code: "UK")
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
We discovered we has some 'unknown country codes' - interestingly this is exactly why we put 'unknown country codes' in. to discover any in the data set!

I've done two things:

1. We now show the unknown code along with the text, this will help users (and us) 'debug' the data
2. A data migration to remove the codes from the activities that have them now.

###Data migrattion to run in this PR
`rails runner db/data/20211118113311_remove_incompatible_country_codes.r`

https://trello.com/c/tHbVco0U
