### PR TITLE
2098 Use unique list of implementing organisations

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -126,6 +126,13 @@ class Activity < ApplicationRecord
   belongs_to :extending_organisation, foreign_key: "extending_organisation_id", class_name: "Organisation", optional: true
   has_many :implementing_organisations, dependent: :destroy
   validates_associated :implementing_organisations
+  has_many :implementing_org_participations,
+    -> { where("org_participations.role = 'Implementing'") },
+    class_name: "OrgParticipation"
+  has_many :unique_implementing_organisations,
+    -> { distinct },
+    through: :implementing_org_participations,
+    source: :organisation
 
   has_many :budgets, foreign_key: "parent_activity_id"
   has_many :actuals, foreign_key: "parent_activity_id"

--- a/app/models/org_participation.rb
+++ b/app/models/org_participation.rb
@@ -1,0 +1,35 @@
+class OrgParticipation < ApplicationRecord
+  belongs_to :activity
+  belongs_to :organisation, class_name: "UniqueImplementingOrganisation"
+
+  attribute :role, :string, default: "Implementing"
+
+  # At present this join model is only linking "Implementing org" and "Activity"
+  # but we plan to use this for all type of Organisation, e.g.
+  #
+  #  Activity#has_one
+  #    :delivery_partner
+  #    through: :extending_org_participation
+  #
+  # Activity#has_one
+  #   :extending_org_participations,
+  #   -> { where("org_participations.role = 'Extending'") },
+  #   class_name: "OrgParticipation"
+  #
+  # In this way there will be one table of Organisations and one table of
+  # OrgParticipations, with OrParticipation#role distinguishing the types
+  # of particpation defined by IATI:
+  #
+  # 1. *Funding*: The government or organisation which
+  #    provides funds to the activity.
+  #
+  # 2. *Accountable*: An organisation responsible for
+  #     oversight of the activity and its outcomes
+  #
+  # 3. *Extending*: An organisation that manages the budget
+  #    and direction of an activity on behalf of the funding
+  #    organisation
+  #
+  # 4. *Implementing*: The organisation that physically carries
+  #    out the activity or intervention.
+end

--- a/app/models/unique_implementing_organisation.rb
+++ b/app/models/unique_implementing_organisation.rb
@@ -6,6 +6,18 @@ class UniqueImplementingOrganisation < ApplicationRecord
 
   strip_attributes only: [:name, :reference]
 
+  def self.find_matching(name)
+    where(name: name.strip)
+      .or(where(
+        UniqueImplementingOrganisation
+        .arel_table[:legacy_names]
+        .contains([name])
+      ))
+      .first
+  end
+
+  private
+
   class << self
     private def valid_organisation_types
       organisations = Codelist.new(type: "organisation_type")

--- a/app/models/unique_implementing_organisation.rb
+++ b/app/models/unique_implementing_organisation.rb
@@ -6,6 +6,12 @@ class UniqueImplementingOrganisation < ApplicationRecord
 
   strip_attributes only: [:name, :reference]
 
+  has_many :org_participations,
+    -> { where(role: "Implementing").distinct },
+    foreign_key: :organisation_id,
+    inverse_of: :organisation
+  has_many :activities, through: :org_participations
+
   scope :with_legacy_name, ->(name) do
     where(
       UniqueImplementingOrganisation

--- a/app/models/unique_implementing_organisation.rb
+++ b/app/models/unique_implementing_organisation.rb
@@ -1,0 +1,15 @@
+class UniqueImplementingOrganisation < ApplicationRecord
+  validates :name, presence: true
+  validates :organisation_type,
+    presence: true,
+    inclusion: {in: ->(_) { valid_organisation_types }, allow_blank: true}
+
+  strip_attributes only: [:name, :reference]
+
+  class << self
+    private def valid_organisation_types
+      organisations = Codelist.new(type: "organisation_type")
+      organisations.map { |d| d["code"] }
+    end
+  end
+end

--- a/app/models/unique_implementing_organisation.rb
+++ b/app/models/unique_implementing_organisation.rb
@@ -6,13 +6,17 @@ class UniqueImplementingOrganisation < ApplicationRecord
 
   strip_attributes only: [:name, :reference]
 
+  scope :with_legacy_name, ->(name) do
+    where(
+      UniqueImplementingOrganisation
+      .arel_table[:legacy_names]
+      .contains([name])
+    )
+  end
+
   def self.find_matching(name)
     where(name: name.strip)
-      .or(where(
-        UniqueImplementingOrganisation
-        .arel_table[:legacy_names]
-        .contains([name])
-      ))
+      .or(merge(with_legacy_name(name)))
       .first
   end
 

--- a/db/data/20211116_seed_unique_implementing_organisations.rb
+++ b/db/data/20211116_seed_unique_implementing_organisations.rb
@@ -1,0 +1,27 @@
+# Run me with `rails runner db/data/20211116_seed_unique_implementing_organisations.rb`
+
+if UniqueImplementingOrganisation.any?
+  abort "We have already seeded the Unique Implementing Organisations"
+end
+
+require "csv"
+path = "db/seeds/unique_implementing_orgs.csv"
+
+CSV.readlines(path, encoding: "bom|utf-8", headers: true).each do |row|
+  name = row["NAME"]
+  legacy_names = row["LEGACY_NAMES"]
+  organisation_type = row["ORG_TYPE"]
+  iati_reference = row["IATI_REF"]
+
+  puts "seeding: #{name} with legacy names: #{legacy_names}"
+
+  UniqueImplementingOrganisation.create!(
+    name: name,
+    legacy_names: legacy_names,
+    organisation_type: organisation_type,
+    reference: iati_reference
+  )
+end
+
+puts
+puts "#{UniqueImplementingOrganisation.count} Unique Implementing Orgs created."

--- a/db/data/20211117_create_implementing_organisation_participations.rb
+++ b/db/data/20211117_create_implementing_organisation_participations.rb
@@ -1,0 +1,17 @@
+# Run me with `rails runner db/data/20211117_create_implementing_organisation_participations.rb`
+
+ImplementingOrganisation.where.not(name: "0").each do |org|
+  next unless org.activity
+
+  unique_org = UniqueImplementingOrganisation.find_matching(org.name)
+  if unique_org
+    puts "#{org.name} maps to Unique IO named #{unique_org.name}"
+    begin
+      org.activity.unique_implementing_organisations << unique_org
+    rescue ActiveRecord::RecordNotUnique => _error
+      puts "  the 'Implementing' OrgParticipation already exists..."
+    end
+  else
+    abort "There is no Unique Implementing Org matching #{org.name}"
+  end
+end

--- a/db/migrate/20211116105817_create_unique_implementing_organisations.rb
+++ b/db/migrate/20211116105817_create_unique_implementing_organisations.rb
@@ -1,0 +1,11 @@
+class CreateUniqueImplementingOrganisations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :unique_implementing_organisations, id: :uuid do |t|
+      t.string :name
+      t.string :legacy_names, array: true
+      t.string :reference
+      t.string :organisation_type
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211118114612_create_org_participations.rb
+++ b/db/migrate/20211118114612_create_org_participations.rb
@@ -1,0 +1,16 @@
+class CreateOrgParticipations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :org_participations, id: :uuid do |t|
+      t.uuid :organisation_id
+      t.uuid :activity_id
+      t.string :role, null: false
+
+      t.timestamps
+    end
+    add_index :org_participations, :organisation_id
+    add_index :org_participations, :activity_id
+    add_index :org_participations, :role
+    add_index :org_participations, [:organisation_id, :activity_id, :role],
+      unique: true, name: "idx_org_participations_on_org_and_act_and_role"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_105817) do
+ActiveRecord::Schema.define(version: 2021_11_18_114612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -238,6 +238,18 @@ ActiveRecord::Schema.define(version: 2021_11_16_105817) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["activity_id"], name: "index_matched_efforts_on_activity_id"
     t.index ["organisation_id"], name: "index_matched_efforts_on_organisation_id"
+  end
+
+  create_table "org_participations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organisation_id"
+    t.uuid "activity_id"
+    t.string "role", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_org_participations_on_activity_id"
+    t.index ["organisation_id", "activity_id", "role"], name: "idx_org_participations_on_org_and_act_and_role", unique: true
+    t.index ["organisation_id"], name: "index_org_participations_on_organisation_id"
+    t.index ["role"], name: "index_org_participations_on_role"
   end
 
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_18_171800) do
+ActiveRecord::Schema.define(version: 2021_11_16_105817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -308,6 +308,15 @@ ActiveRecord::Schema.define(version: 2021_10_18_171800) do
     t.index ["parent_activity_id"], name: "index_transactions_on_parent_activity_id"
     t.index ["report_id"], name: "index_transactions_on_report_id"
     t.index ["type"], name: "index_transactions_on_type"
+  end
+
+  create_table "unique_implementing_organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "legacy_names", array: true
+    t.string "reference"
+    t.string "organisation_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds/unique_implementing_orgs.csv
+++ b/db/seeds/unique_implementing_orgs.csv
@@ -1,0 +1,503 @@
+NAME,LEGACY_NAMES,IATI_REF,ORG_TYPE
+3B ADVISORY LIMITED,"",,71
+AB5 CONSULTING LTD,"",,71
+ADAS,"",,71
+ADVANCED MICROWAVE TECHNOLOGIES LTD,"",,71
+ADVANCED NANOSTRUCTURED MATERIALS DESIGN AND CONSULTANCY (ANAMAD) LIMITED,"",,71
+AGRI-EPI CENTRE LIMITED,"",,71
+AGROPY UK LIMITED,"",,71
+AGSENZE LIMITED,{AGSENZE LTD},,71
+AIR PUREX LTD,"",,71
+ARCH - KWTRP,"",,71
+AUTONOMOUS DEVICES LIMITED,"",,71
+AUTSERA LTD,"",,71
+AbacusBio International Limited,"",,71
+Abertay University,"",,80
+Aberystwyth University,"",,80
+Academy of Medical Science,"{Academy of Medical Sciences,Academy of Medical Sciencwes}",,80
+Addis Ababa University,"",,80
+African Ctr for Economic Transformation,"",,24
+African Origins UK Limited,"",,71
+African Population and Health Res Centre,"",,24
+Aga Khan University,"",,80
+Agricompas,"",,71
+Airbus,{Airbus },,71
+Airponix Ltd,"",,71
+American University of Beirut,"",,80
+Anglia Ruskin University,"",,80
+Another Way Learning and Development Ltd,"",,71
+Aquaffirm,"",,71
+Arts and Humanities Research Council,"",,80
+Assimila Ltd,{Assimila},,71
+Aston University,"",,80
+Astrosat,"",,71
+Avanti Communications,{Avanti Communications },,71
+BEIS Finance,"{""Department for Business, Energy and Industrial Strategy""}",,80
+BIG SOLAR LTD / Power Roll Ltd,"",,71
+BRAC Centre,"",,80
+BRITS ENERGY LIMITED,"",,71
+BUFFALOGRID LTD,"",,71
+Bangor University,"",,80
+Bath Spa University,"",,80
+Beyond Water Ltd,"",,90
+Biopolymer Solutions Limited,"",,80
+Biotechnology & Biological Sciences Research Council,"",,80
+Bioversity International,"",,80
+Birkbeck College,"",,80
+"Birkbeck, University of London",{Birkbeck College},,80
+Birmingham City University,"",,80
+Bournemouth University,"",,80
+British Academy,"",,80
+British Antarctic Survey,"",,80
+British Council,"",,80
+British Geological Survey,"",,80
+British Institute at Ankara,"",,80
+British Institute in Eastern Africa,"",,80
+British Library,"",,15
+Brown University,"",,80
+Brunel University London,"",,80
+C.A.B. INTERNATIONAL LIMITED,"{CAB International,CAB International (CABI)}",,71
+C3 BIO-TECHNOLOGIES LIMITED,"",,71
+CABI,"",,21
+CAMNEXUS LTD,"",,71
+CAPILLARY FILM TECHNOLOGY LTD,"",,71
+CARNOT LTD,"",,71
+CBCI Society for Medical Education,"",,80
+CDL,"",,90
+CGI IT UK,{CGI IT UK },,90
+CHARM IMPACT LTD,"",,71
+CIRAD,"",,90
+CLIMATE EDGE LIMITED,"",,71
+CNRS - Delegation Midi-Pyrenees,"",,90
+COGNITANT GROUP LIMITED,"",,71
+CONDESAN,"",,90
+CONNECTED ENERGY TECHNOLOGIES LTD,"",,71
+CREATIVENERGIE,"",,90
+CSIRO,"",,90
+Cambivac Ltd,"",,71
+Carbon Foundation of East Africa,"",,80
+Carbon trust,"",,21
+Cardiff Metropolitan University,"",,80
+Cardiff University,"",,80
+Caribou Space,"",,71
+Centre for Chronic Disease Control,"",,80
+Centre for Environment Fisheries and Aquaculture Science,"",,80
+Chelsea & Westminster Hosp NHS Fdn Trust,"",,80
+Chelsea Technologies Group Ltd.,"",,71
+Christian Aid,"",,80
+"City, University of London","",,80
+Clean Water Designs,"",,90
+Cloudsense Consulting,"",,90
+ClydeSpace,"",,90
+Columbia University,"",,80
+Conservation International Foundation,"",,80
+Council for Sci and Industrial Res,"",,90
+Coventry University,"",,80
+Cranfield University,"",,80
+Crop Health and Protection,"",,90
+Ctr for Nat Health Dev Ethiopia (CNHDE),"",,90
+Ctr for Res & Advan Studies (CINVESTAV),"",,90
+Ctr for Study Equity & Gov (Health Sys),"",,90
+Curatio International Foundation,"",,80
+DIGILAND HOLDING LTD,"",,71
+DWR OFFSHORE LIMITED,"",,71
+De Montfort University,"",,80
+Dem DX,"",,90
+Desolenator,"",,90
+Diamond Light Source,"",,90
+Duckduck Ltd,"",,71
+Duke Kunshan University,"",,80
+Durham University,"",,80
+EDUCATION INTELLIGENCE LIMITED,"",,71
+EMBL - European Bioinformatics Institute,"",,80
+ENERGY SRS LTD,"",,71
+ENTRUST MICROGRID LLP,"",,90
+ENTRUST SMART HOME MICROGRID LTD,"",,71
+ENVIRONMENTAL PROCESS SYSTEMS LTD.,"",,71
+EXCEED SOCIAL ENTERPRISES LTD,"",,71
+Earlham Institute,"",,80
+Earth Observation,"",,90
+Earth-i,"",,90
+Ecometrica,{Ecometrica },,90
+Economic & Social Research Council,"",,80
+Edge Hill University,"",,80
+Edinburgh Napier University,"",,80
+EnSo Impact,"",,90
+Engineering & Physical Sciences Research Council,"",,80
+Environment Systems,{Environment Systems },,90
+Environmental Monitoring Solutions Ltd,"",,71
+Exactearth Europe Ltd,{ExactEarth Europe},,71
+FERA SCIENCE LIMITED,"",,71
+FOCALSUN LTD,"",,71
+FRONTIER TECHNICAL LTD,"",,71
+Fair Business Alliance,"",,90
+Fauna and Flora International,"",,21
+Federal University of Bahia (UFBA),"",,80
+Fiocruz (Oswaldo Cruz Foundation),"",,80
+Flinders University of South Australia,"",,80
+Forest Research,"",,80
+Foundation for Research in HealthSystems,"",,80
+Free (VU) University of Amsterdam,"",,80
+GAMOS LIMITED,"",,71
+Gambia Unit,"",,80
+Geocento,"",,90
+George Inst for Global Health Australia,"",,80
+Geosas,"",,90
+Geospatial,"",,90
+Ghana College of Physicians and Surgeons,"",,80
+Glasgow Caledonian University,"",,80
+Global MapAid,"",,21
+Glyconics,"",,90
+Gokhale Inst of Politics and Economics,"",,80
+"Goldsmiths, University of London","{Goldsmith's College,Goldsmiths College}",,80
+Green Fuels Research Ltd,"",,80
+H R Wallingford Ltd,{HR Wallingford },,71
+HR Wallingford,"",,90
+Hanoi University of Public Health,"",,80
+Harper Adams University,"",,80
+Harvard University,"",,80
+Hawassa University,"",,80
+Health and Safety Executive,"",,80
+Heriot-Watt University,"",,80
+Human Sciences Research Council,"",,80
+I-RENEWABLE ENERGY LTD,"",,71
+ICDDRB,"",,90
+ICLEI - Local Govts for Sustainability,"",,90
+IHE Delft Foundation,"",,80
+IPEC LIMITED,"",,71
+Ifakara Health Institute (IHI),"",,80
+Imperial College London,{Imperial College},GB-COH-04465125,80
+Indian Council for Medical Res (ICMR),"",,80
+Indian Institute of Technology Madras,"",,80
+Infectious Diseases Institute (IDI),"",,80
+Inmarsat,{Inmarsat },,90
+Innovate UK,"",,80
+Innovation Consultancy & Entrepreneurship Ltd,"",,71
+Innovations for Poverty Action,"",,21
+Innvotek Limited,"",,71
+"Institute for Environmental Analytics, University of Reading","{Instute for Environmental Analytics ,International Institute for Env and Dev}",,80
+Institute for Financial Management & Res,"",,80
+Institute for Fiscal Studies,"",,80
+Institute for Peace and Security Studies,"",,80
+Institute of Business Administration,"",,80
+Institute of Development Studies,"",GB-COH-877338,80
+Institute of Occupational Medicine,"",,80
+Institute of Research for Dev (IRD),"",,80
+Instute for Environmental Analytics,"",,80
+Int Centre for Tropical Agriculture,"",,80
+Int Livestock Research Institute,"",,80
+International Food Policy Research Inst,"",,80
+International Institute for Environment and Development,"",,80
+International Rice Research Institute,"",,80
+International Water Management Institute,"",,80
+JESMOND ENGINEERING LIMITED,"",,71
+JLU Gliessen (Tech support),"",,80
+John Innes Centre,"",,80
+Johns Hopkins University,"",,80
+KERACOL LIMITED,"",,71
+KISPE Ltd,"",,71
+KOALAA LIMITED,"",,71
+KOOLMILL SYSTEMS LIMITED,"",,71
+KTN,"",,90
+Keele University,"",,80
+King's College London,"",GB-COH-RC000297,80
+Kingston University,"",,80
+Knowledge Transfer Network Ltd,"",,71
+Kulima Integrated Development Solutions,"",,90
+LEGUME TECHNOLOGY LIMITED,"",,71
+LUDGER LIMITED,"",,71
+Lagos State Univ Coll of Med LAUSCOM,"",,80
+Lambda Energy Ltd,"",,71
+Lancaster Inst for the Contemporary Arts,"",,80
+Lancaster University,"",,80
+Leeds Beckett University,"",,80
+Leonard Cheshire Disability,"",,90
+Lilongwe Uni of Agri and Nat Resources,"",,80
+Liverpool Hope University,"",,80
+Liverpool John Moores University,"",,80
+Liverpool School of Tropical Medicine,"",GB-CHC-222655,80
+London Business School,"",,80
+London Chamber of Commerce,"",,90
+London School of Economics and Political Science,{London School of Economics & Pol Sci},,80
+London School of Hygiene and Tropical Medicine,"{London Sch of Hygiene and Trop Medicine,The London School of Hygiene and Tropical Medicine}",,80
+London South Bank University,"",,80
+Loughborough University,"",GB-HESA-10004113,80
+Lund University,"",,80
+M-SOLV UK,{M-SOLV LTD},,90
+MANROCHEM LIMITED,"",,71
+MARLAN MARITIME TECHNOLOGIES LTD,"",,71
+MITT WEARABLES LIMITED,"",,71
+MOBILE POWER LTD,"",,71
+MODULARITY GRID LTD,"",,71
+MRC Unit The Gambia,"{""MRC Unit, The Gambia""}",,80
+MU-JHU Care Ltd,"",,71
+MYWAY DIGITAL HEALTH LIMITED,"",,71
+Madras Diabetes Research Foundation,"",,80
+Makerere University,"",,80
+Manchester Metropolitan University,"",,80
+Marylebone Consultants,"",,90
+Mbale Clinical Research Institute,"",,80
+McMaster University,"",,80
+Medical Research Council,"",,80
+Met Office,"",,10
+Middlesex University,"",,80
+Monash University,"",,80
+Moorfields Eye Hospital NHS Foundation Trust,{Moorfields Eye Hosp NHS Foundation Trust},,80
+Moredun Research Institute,"",,80
+Muhimbili Uni of Health & Allied Sciences,"",,80
+Mwanza Intervention Trials Unit,"",,80
+Mzumbe University,"",,80
+NATURAL SYNERGIES LTD,{NATURAL SYNERGIES LIMITED},,71
+NATURE METRICS LTD,"",,71
+NERC British Antarctic Survey,"",,80
+NERC British Geological Survey,"",,80
+NERC Centre for Ecology and Hydrology,{NERC CEH (Up to 30.11.2019)},,80
+NEUDRIVE LIMITED,"",,71
+NIAB,"",,90
+NLA International,"",,21
+NOREUS,"",,90
+NORTECH MANAGEMENT LIMITED,"",,71
+NOVA PANGAEA TECHNOLOGIES (UK) LIMITED,"",,71
+NQUIRINGMINDS LIMITED,"",,71
+Nanoshift Ltd,"",,71
+National Crops Resources Res Institute,"",,80
+National Institute for Medical Research,"",,80
+National Institute of Agricultural Botany,{National Inst of Agricultural Botany},,80
+National Oceanography Centre,"{NOC (Up to 31.10.2019),National Oceanography Centre (Tech support),National Oceanographic Centre}",,80
+National University of Singapore,"",,80
+Natural Environment Research Council,"",,80
+Nature Conservation Research Centre,"",,80
+New York University,"",,80
+Newcastle University,"",,80
+North Carolina State University,"",,80
+Northumbria University,"",,80
+Nottingham Trent University,"",,80
+OAKTEC LIMITED,"",,71
+OPEN ENERGY LABS LTD,"",,71
+ORXA GRID LTD,"",,71
+OXTO LTD,"",,71
+Obafemi Awolowo University,"",,80
+Omanos Analytics,{Omanos Analytics },,90
+Overseas Development Institute,{Overseas Development Institute ODI},GB-CHC-228248,80
+Oxford Brookes University,"",,80
+P.A.K. ENGINEERING LIMITED,"",,71
+P.E.S. Technologies Limited,"",,71
+PCI TECHNOLOGY INVESTMENTS LTD,"",,71
+PSECC - Portsmouth Sustainable Energy & Climate Change Centre,"",,80
+PST Sensors Europe Ltd,"",,71
+PYROGENESYS LTD,"",,71
+Papua New Guinea Institute of Medical Research,{Papua New Guinea Inst of Med Research},,80
+Paris School of Economics,"",,80
+Percheron Ltd,"",,71
+Peruvian University Cayetano Heredia,"",,80
+Phase Change Material Products Ltd,"",,71
+Pixalytics Ltd,{Pixalytics Ltd },,71
+Plymouth Marine Laboratory,"",,80
+Pontifical Catholic University Rio de Janeiro,"",,80
+Pontifical Catholic University of Ecuador,"",,80
+Proctor and Gamble Technical Centres,"",,80
+Provenance Partners Ltd,"",,71
+Public Health Foundation of India (PHFI),"",,80
+QUBE RENEWABLES LIMITED,"",,71
+Quadram Institute Bioscience,"",,80
+Queen Margaret University Edinburgh,"",,80
+Queen Mary University of London,{Queen Mary University},,80
+Queen's University Belfast,{Queen's University of Belfast},,80
+REFGAS LIMITED,"",,71
+RENES-CARTES ENERGY AND MANAGEMENT CONSULTING LTD,"",,71
+RESOURCE FUTURES LIMITED,"",,71
+ROBOSCIENTIFIC LIMITED,"",,71
+RSPB,"",,21
+RTC North,"",,90
+Rail Vision Europe Limited,"",,71
+Rawalpindi Medical University,"",,80
+Razbio Ltd,"",,71
+Reach 52 / Allied World Healthcare,"",,90
+Red Cross Red Crescent Climate Centre,"",,21
+Regents of the Univ California Berkeley,"",,80
+Remote Sensing Applications Consultants Limited,"{Remote Sensing Applications Consultant,Remote Sensing Applications Consultants Limited }",,71
+Rezatec,"",,90
+Rhea Group,"",,90
+Rhodes University,"",,80
+Roehampton University,"",,80
+Rothamsted Research,{Rothamstead Research },,80
+Royal Academy of Engineering,"",,80
+Royal Botanic Garden Edinburgh,"",,80
+Royal Botanic Gardens Kew,"",,80
+Royal Central School of Speech and Drama,{Royal Central Sch of Speech and Drama},,80
+Royal College of Art,"",,80
+"Royal Holloway, University of London","{""Royal Holloway, Univ of London""}",,80
+Royal Society,"",,80
+Royal Veterinary College,"",,80
+SAFETYNET TECHNOLOGIES LIMITED,"",,71
+SAHFOS,"",,90
+SATELLITE APPLICATIONS CATAPULT LIMITED,"",,71
+SCENE CONNECT LTD,"",,71
+SEI Oxford Office Ltd,"",,71
+SEIP 7 TECHNOLOGY AND RESEARCH LTD,"",,80
+SH24 C.I.C.,"",,90
+SMART VILLAGES RESEARCH GROUP LTD,"",,80
+SOAS University of London,"",,80
+SOLAPAK DEVELOPMENT LIMITED,"",,71
+SOLAPAK SYSTEMS LIMITED,"",,71
+SOLAR POLAR LIMITED,"",,71
+SOLARISKIT LTD,"",,71
+SPARK AFRICA CIC,"",,71
+SRUC,"",,80
+START International Inc,"",,21
+STEPHEN BUDD MUSIC LIMITED,"",,71
+STFC - Laboratories,"",,80
+STRAW INNOVATIONS LTD,"",,71
+Sangath,"",,90
+Satellite Applications Catapult,"",,71
+Satellite Oceanographic Consultants,{Satellite Oceanographic Consultants },,71
+"School of Advanced Study, University of London","",,80
+School of Oriental and African Studies,"",,80
+Science Museum Group,"",,80
+Science Technology and Innovation for Development Ltd,{SCIENCE TECHNOLOGY AND INNOVATION FOR DEVELOPMENT LTD},,71
+Science and Technology Facilities Council,"",,80
+Scottish Association For Marine Science,"",,80
+Scottish Universities Env Research Cen,"",,80
+Seawater Solutions,"",,80
+Shandong University,"",,80
+Sheffield Hallam University,"",,80
+Sightsavers,"",,21
+Sokoine University of Agriculture,"",,80
+South African Medical Research Council,"",,80
+SpaceTimeAI Ltd,"",,71
+St George's University of London,"",,80
+Steama Company Ltd,"",,71
+Stellenbosch University,"",,80
+Stockholm University,"",,80
+Stony Brook University,"",,80
+Strathmore University,"",,80
+Sun Yat-Sen University,"",,80
+Swansea University,"",,80
+Swedish Meteorological & Hydro Institute,"",,80
+Swiss Tropical & Public Health Institute,"",,80
+THE BIOFACTORY LTD,"",,71
+THERMOFLUIDICS LTD.,"",,71
+THIN METAL FILMS LIMITED,"",,71
+TIWAKIKI CONSULTING LIMITED,"",,71
+Teesside University,"",,80
+"The Aga Khan University, Pakistan","",,80
+The British Geological Survey,"",,15
+The British Museum,"",,15
+The Francis Crick Institute,"",,80
+The James Hutton Institute,"",,80
+The Natural History Museum,"",,15
+The Open University,{Open University},GB-CHC-000391,80
+The Pirbright Institute,"",,80
+The Robert Gordon University,"",,80
+Tufts University,"",,80
+UBIPOS UK LIMITED,"",,71
+UK Centre for Ecology and Hydrology,"{UK CEH,UK Centre for Ecology & Hydrology}",,80
+UK Research and Innovation,{UKRI},,80
+UK Space Agency,"",,15
+UKA CONSULTANCY LTD,"",,71
+Uganda Unit,"",,80
+Ulster University,"",,80
+Umea University,"",,80
+Uni of Illinois at Urbana Champaign,"",,80
+United Nations Development Programme,"",,80
+United States International University,"",,80
+Universitat Bern,"",,80
+University College London,"",,80
+University for Development Studies,"",,80
+University of Aberdeen,"",,80
+University of Bath,"",,80
+University of Bedfordshire,"",,80
+University of Birmingham,"",GB-EDU-133784,80
+University of Bolton,"",,80
+University of Bradford,"",,80
+University of Brighton,"",,80
+University of Bristol,"",,80
+"University of California, Santa Cruz","",,80
+University of Cambridge,"",,80
+University of Cape Town,"",,80
+University of Cape Town Lung Institute,"",,80
+University of Central Asia,"",,80
+University of Central Lancashire,"",GB-UKPRN-10007141,80
+University of Chester,"",,80
+University of Chile,"",,80
+University of Copenhagen,"",,80
+University of Dar es Salaam,"",,80
+University of Derby,"",,80
+University of Dundee,"",GB-SC-015096,80
+University of East Anglia,"",,80
+University of East London,"",,80
+University of Edinburgh,"",GB-UKPRN-10007790,80
+University of Essex,"",,80
+University of Exeter,"",,80
+University of Geneva,"",,80
+University of Ghana,"",,80
+University of Glasgow,"",,80
+University of Greenwich,"",,80
+University of Hertfordshire,"",,80
+University of Huddersfield,"",,80
+University of Hull,"",,80
+University of Ibadan,"",,80
+University of Johannesburg,"",,80
+University of Kent,"",,80
+University of KwaZulu-Natal,"",,80
+University of Lagos,"",,80
+University of Leeds,"",GB-COH-RC000658,80
+University of Leicester,"",,80
+University of Lincoln,"",,80
+University of Liverpool,"",GB-COH-RC000660,80
+University of London,"",GB-COH-RC000631,80
+University of Malawi,"",,80
+University of Manchester,{The University of Manchester},GB-COH-RC000797,80
+University of Medicine Pham Ngoc Thach,"",,80
+University of Michigan,"",,80
+University of Nairobi,"",,80
+University of Nottingham,{University of Nottingham },GB-COH-RC000664,80
+University of Oxford,"",GB-UKPRN-10007774,80
+University of Plymouth,"",,80
+University of Portsmouth,"",,80
+University of Pretoria,"",,80
+University of Reading,"",,80
+University of Rwanda,"",,80
+University of Salford,"",,80
+University of Sheffield,"",,80
+University of South Wales,"",,80
+University of Southampton,"",,80
+University of St Andrews,"",,80
+University of Stirling,"",,80
+University of Strathclyde,"",,80
+University of Surrey,"",,80
+University of Sussex,"",,80
+University of Ulm,"",,80
+University of Ulster,"",,80
+University of Warwick,"",,80
+University of West of Scotland (UWS),"",,80
+University of Westminster,"",,80
+University of Wolverhampton,"",,80
+University of York,"",GB-COH-RC000679,80
+University of the Andes (Colombia),"",,80
+University of the Arts London,"",,80
+University of the Free State,"",,80
+University of the West Indies,"",,80
+University of the West of England,"",GB-UKPRN-10007164,80
+University of the West of Scotland,{University of the West of Scotland (UWS)},,80
+University of the Western Cape,"",,80
+University of the Witwatersrand,"",,80
+UtterBerry,{Utter Berry},,71
+VIGMR,"",,90
+Vivid Economics,{Vivid Economics },,71
+WATERSCOPE LIMITED,"",,71
+WATERWHELM LTD,"",,71
+WATT SOLUTIONS LTD,"",,71
+WELLS PLASTICS LTD,{WELLS PLASTICS LIMITED},,71
+Wageningen University,"",,80
+Washington University in St Louis,"",,80
+WaterAid UK,"",,21
+Weber State University,"",,80
+Wellcome  Sanger Institute,{Wellcome Trust Sanger Institute},,80
+Wildlife Conservation Society,"",,21
+Wits Health Consortium,{Wits Health Consortium (Pty) Ltd},,80
+World Agroforestry Centre,"",,80
+World Conservation Monitoring Centre( WCMC),{World Conservation Monitoring Cen WCMC},,80
+Zoological Society London Institute  of Zoology,"",GB-COH-RC000749,80
+Zutari,"",,71
+eOsphere Limited,"{eOsphere,eOsphere Limited }",,71

--- a/spec/factories/org_participation.rb
+++ b/spec/factories/org_participation.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :org_participation do
+    association :organisation, factory: :unique_implementing_organisation
+    association :activity, factory: :programme_activity
+    role { "Implementing" }
+  end
+end

--- a/spec/factories/unique_implementing_organisation.rb
+++ b/spec/factories/unique_implementing_organisation.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :unique_implementing_org, class: "UniqueImplementingOrganisation" do
+    name { "UKRI" }
+    reference
+    organisation_type { "10" }
+    legacy_names { ["UK Research and Innovation", "UK Research & Innovation"] }
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -626,6 +626,8 @@ RSpec.describe Activity, type: :model do
     it { should have_many(:child_activities).with_foreign_key("parent_id") }
     it { should belong_to(:extending_organisation).with_foreign_key("extending_organisation_id").optional }
     it { should have_many(:implementing_organisations) }
+    it { should have_many(:implementing_org_participations) }
+    it { should have_many(:unique_implementing_organisations) }
     it { should have_many(:budgets) }
     it { should have_many(:actuals) }
     it { should have_many(:refunds) }

--- a/spec/models/org_participation_spec.rb
+++ b/spec/models/org_participation_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe OrgParticipation, type: :model do
+  it { should belong_to(:activity) }
+  it { should belong_to(:organisation).class_name("UniqueImplementingOrganisation") }
+end

--- a/spec/models/unique_implementing_organisation_spec.rb
+++ b/spec/models/unique_implementing_organisation_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe UniqueImplementingOrganisation, type: :model do
+  describe "::find_matching" do
+    let!(:canonical) do
+      create(
+        :unique_implementing_org,
+        name: "canonical",
+        legacy_names: ["uncanonical", "non_canonical"]
+      )
+    end
+
+    it "finds the canonical record when the search term matches the name" do
+      expect(UniqueImplementingOrganisation.find_matching("canonical"))
+        .to eq(canonical)
+    end
+
+    it "finds the canonical record when the search term matches any legacy name" do
+      aggregate_failures do
+        expect(UniqueImplementingOrganisation.find_matching("uncanonical"))
+          .to eq(canonical)
+
+        expect(UniqueImplementingOrganisation.find_matching("non_canonical"))
+          .to eq(canonical)
+      end
+    end
+  end
+end

--- a/spec/models/unique_implementing_organisation_spec.rb
+++ b/spec/models/unique_implementing_organisation_spec.rb
@@ -1,6 +1,39 @@
 require "rails_helper"
 
 RSpec.describe UniqueImplementingOrganisation, type: :model do
+  describe "associations" do
+    let(:organisation) { create(:unique_implementing_org) }
+
+    let(:implemented_activity) { create(:programme_activity) }
+    let(:other_activity) { create(:programme_activity) }
+
+    let!(:implementing_participation) do
+      OrgParticipation.create(
+        activity: implemented_activity,
+        organisation: organisation,
+        role: "Implementing"
+      )
+    end
+
+    let!(:other_participation) do
+      OrgParticipation.create(
+        activity: other_activity,
+        organisation: organisation,
+        role: "Other"
+      )
+    end
+
+    it "associates with org_participations with the 'Implementing' role only" do
+      expect(organisation.org_participations).to include(implementing_participation)
+      expect(organisation.org_participations).not_to include(other_participation)
+    end
+
+    it "associates with activities through the 'Implementing' role only" do
+      expect(organisation.activities).to include(implemented_activity)
+      expect(organisation.activities).not_to include(other_activity)
+    end
+  end
+
   describe "::find_matching" do
     let!(:canonical) do
       create(

--- a/spec/models/unique_implementing_organisation_spec.rb
+++ b/spec/models/unique_implementing_organisation_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe UniqueImplementingOrganisation, type: :model do
       end
     end
   end
+
+  describe "::with_legacy_name scope" do
+    let!(:canonical) do
+      create(
+        :unique_implementing_org,
+        name: "canonical",
+        legacy_names: ["uncanonical", "non_canonical"]
+      )
+    end
+
+    it "finds the cananonical record when the search matches any legacy name" do
+      aggregate_failures do
+        expect(UniqueImplementingOrganisation.with_legacy_name("uncanonical"))
+          .to include(canonical)
+
+        expect(UniqueImplementingOrganisation.with_legacy_name("non_canonical"))
+          .to include(canonical)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### The problem

Organisations are not well modelled in RODA. 

Organisations can play multiple roles. Are per [IATI](https://iatistandard.org/en/iati-standard/203/codelists/organisationrole/) participation can be described as follows:

> 1. *Funding*: The government or organisation which  
   provides funds to the activity.  
>  
> 2. *Accountable*: An organisation responsible for  
    oversight of the activity and its outcomes  
>  
> 3. *Extending*: An organisation that manages the budget  
   and direction of an activity on behalf of the funding  
   organisation  
>  
> 4. *Implementing*: The organisation that physically carries out the activity or intervention.

At present RODA uses 2 db tables:

1. `organisations` for "extending organisations", aka "delivery partners"
2. `implementing_organisations` for "implementing organisations"

There are two duplication issues:

- i. Due to the uncontrolled way they are managed, there are currently an ever increasing number of duplicate implementing organisations, created with slightly different names.

- ii. Many of the extending organisations (delivery partners) also have entries in the implementing organisation table



### The solution

Introduce a new canonical table of unique organisations and a table of "organisations participations" to allow an organisation to play multiple roles in a particular activity:

#### 1. Activity's implementing organisations

Allow an `Activity` to have many implementing organisations through "organisation participations", e.g.

```rb
  has_many :implementing_org_participations,
    -> { where("org_participations.role = 'Implementing'") },
    class_name: "OrgParticipation"
```

#### 2. Activity's delivery partner
Move from `Activity#extending_organisation` to `Activity#delivery partner`.

As per Meyrics and Leeky's proposed rfactoring to [Replace 'organisation' and 'extending_organisation' with a 'delivery_partner' attribute](https://trello.com/c/kJG0qMT3/1647) to use an `Activity#delivery_partner_id` foreign key to link to the new `unique_organisations` table.


### Steps to get there

1. [x] introduce implementing organisations
2. [x] migrate existing implementing orgs to new membership system
3. [ ] allow DPs to set new implementing orgs
4. [ ] allow BEIS to manage unique organisations
5. [ ] refactor extending organisation to use unique organisations
6. [ ] rename `Activity#extending_organisation` to `Activity#delivery_partner`

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
