### PR TITLE
(2252) Feature: BEIS users can upload actuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -921,6 +921,8 @@
 ## [unreleased]
 - Actual spend values can no longer be negative, use Adjustments or Refunds to
   document funding flowing back
+- BEIS users can upload 'actual history' – historic actual spend, this is a
+  short term feature to facilitate migration to the application
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-88...HEAD
 [release-88]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-87...release-88

--- a/app/controllers/staff/uploads/actual_histories_controller.rb
+++ b/app/controllers/staff/uploads/actual_histories_controller.rb
@@ -14,17 +14,28 @@ class Staff::Uploads::ActualHistoriesController < Staff::BaseController
 
     set_breadcrumb
 
+    return handle_missing_file unless file_supplied?
+
     upload = CsvFileUpload.new(params[:report], :actual_csv_file)
 
     if upload.valid?
-      flash.now[:notice] = t("actions.uploads.actual_histories.success")
+      flash[:notice] = t("actions.uploads.actual_histories.success")
     else
-      flash.now[:error] = t("actions.uploads.actual_histories.missing_or_invalid")
+      flash[:error] = t("actions.uploads.actual_histories.invalid")
     end
     render :new
   end
 
   private
+
+  def handle_missing_file
+    flash[:error] = t("actions.uploads.actual_histories.missing")
+    render :new
+  end
+
+  def file_supplied?
+    params.dig(:report, :actual_csv_file).present?
+  end
 
   def set_breadcrumb
     prepare_default_report_trail(@report)

--- a/app/controllers/staff/uploads/actual_histories_controller.rb
+++ b/app/controllers/staff/uploads/actual_histories_controller.rb
@@ -5,6 +5,28 @@ class Staff::Uploads::ActualHistoriesController < Staff::BaseController
     @report = Report.find(params[:report_id])
     authorize @report, :upload_history?
 
+    set_breadcrumb
+  end
+
+  def update
+    @report = Report.find(params[:report_id])
+    authorize @report, :upload_history?
+
+    set_breadcrumb
+
+    upload = CsvFileUpload.new(params[:report], :actual_csv_file)
+
+    if upload.valid?
+      flash.now[:notice] = t("actions.uploads.actual_histories.success")
+    else
+      flash.now[:error] = t("actions.uploads.actual_histories.missing_or_invalid")
+    end
+    render :new
+  end
+
+  private
+
+  def set_breadcrumb
     prepare_default_report_trail(@report)
     add_breadcrumb t("breadcrumb.uploads.actual_histories"), new_report_uploads_actual_history_path(@report)
   end

--- a/app/controllers/staff/uploads/actual_histories_controller.rb
+++ b/app/controllers/staff/uploads/actual_histories_controller.rb
@@ -1,0 +1,11 @@
+class Staff::Uploads::ActualHistoriesController < Staff::BaseController
+  include Reports::Breadcrumbed
+
+  def new
+    @report = Report.find(params[:report_id])
+    authorize @report, :upload_history?
+
+    prepare_default_report_trail(@report)
+    add_breadcrumb t("breadcrumb.uploads.actual_histories"), new_report_uploads_actual_history_path(@report)
+  end
+end

--- a/app/controllers/staff/uploads/actual_histories_controller.rb
+++ b/app/controllers/staff/uploads/actual_histories_controller.rb
@@ -24,7 +24,7 @@ class Staff::Uploads::ActualHistoriesController < Staff::BaseController
     @errors = importer.errors
     @imported_actuals = importer.imported
 
-    if importer.call
+    if importer.imported?
       render_uploaded_actual_history
     else
       render_uploaded_actual_history_errors

--- a/app/models/csv_file_upload.rb
+++ b/app/models/csv_file_upload.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 class CsvFileUpload
   BYTE_ORDER_MARK = "\uFEFF".encode(Encoding::UTF_8)
 

--- a/app/models/import/actual_history.rb
+++ b/app/models/import/actual_history.rb
@@ -1,13 +1,4 @@
 class Import::ActualHistory
-  class RowError < StandardError
-    attr_reader :row_number
-
-    def initialize(message, row_number)
-      @row_number = row_number
-      super(message)
-    end
-  end
-
   VALID_HEADERS = {
     roda_identifier: "RODA identifier",
     financial_quarter: "Financial quarter",
@@ -64,7 +55,12 @@ class Import::ActualHistory
   end
 
   def headers_error
-    RowError.new("Invalid headers, must be #{VALID_HEADERS.values.to_sentence}", 1)
+    Import::RowError.new(
+      column: nil,
+      row_number: 1,
+      value: nil,
+      message: "Invalid headers, must be #{VALID_HEADERS.values.to_sentence}"
+    )
   end
 
   def record_import_history
@@ -149,10 +145,12 @@ class Import::ActualHistory
     end
 
     def report_error
-      RowError
+      Import::RowError
         .new(
-          "Activity with RODA ID #{activity.roda_identifier} does not match the fund and organisation of this report",
-          row_number
+          column: VALID_HEADERS[:roda_identifier],
+          row_number: row_number,
+          value: activity.roda_identifier,
+          message: "Activity does not match the fund and organisation of this report"
         )
     end
 
@@ -165,11 +163,23 @@ class Import::ActualHistory
     end
 
     def roda_identifier_error
-      RowError.new("Unknown RODA identifier #{roda_identifier}", row_number)
+      Import::RowError.new(
+        column: VALID_HEADERS[:roda_identifier],
+        row_number: row_number,
+        value: roda_identifier,
+        message: "No activity with this RODA identifier could be found"
+      )
     end
 
     def active_model_to_import_errors_for_row(errors)
-      errors.map { |error| RowError.new(error.message, row_number) }
+      errors.map do |error|
+        Import::RowError.new(
+          column: VALID_HEADERS[error.attribute],
+          row_number: row_number,
+          value: error.options[:value],
+          message: error.message
+        )
+      end
     end
   end
 end

--- a/app/models/import/actual_history.rb
+++ b/app/models/import/actual_history.rb
@@ -21,6 +21,8 @@ class Import::ActualHistory
     import_actual_history(@csv)
   end
 
+  alias imported? call
+
   private
 
   def import_actual_history(csv)

--- a/app/models/import/actual_history.rb
+++ b/app/models/import/actual_history.rb
@@ -1,9 +1,9 @@
 class Import::ActualHistory
   VALID_HEADERS = {
-    roda_identifier: "RODA identifier",
-    financial_quarter: "Financial quarter",
-    financial_year: "Financial year",
-    value: "Value",
+    roda_identifier: I18n.t("activerecord.attributes.activity.roda_identifier"),
+    financial_quarter: I18n.t("activerecord.attributes.default.financial_quarter"),
+    financial_year: I18n.t("activerecord.attributes.default.financial_year"),
+    value: I18n.t("activerecord.attributes.default.value"),
   }
 
   attr_reader :errors, :imported

--- a/app/models/import/row_error.rb
+++ b/app/models/import/row_error.rb
@@ -1,0 +1,10 @@
+class Import::RowError < StandardError
+  attr_reader :row_number, :column, :value
+
+  def initialize(column:, row_number:, value:, message:)
+    @row_number = row_number
+    @column = column
+    @value = value
+    super(message)
+  end
+end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -46,6 +46,11 @@ class ReportPolicy < ApplicationPolicy
     record.editable? && record.organisation == user.organisation
   end
 
+  def upload_history?
+    return true if beis_user? && record.editable?
+    false
+  end
+
   def download?
     show?
   end

--- a/app/views/staff/reports/_actuals_upload.html.haml
+++ b/app/views/staff/reports/_actuals_upload.html.haml
@@ -1,0 +1,17 @@
+%h3.govuk-heading-m
+  = t("tabs.actuals.providing.heading")
+
+%p.govuk-body
+  = t("tabs.actuals.providing.copy")
+
+%h3.govuk-heading-s
+  = t("tabs.actuals.upload.heading")
+
+= t("tabs.actuals.upload.copy_html")
+
+.govuk-inset-text
+  = t("tabs.actuals.upload.warning")
+
+.govuk-button-group
+  = link_to t("page_content.actuals.button.download_template"), report_actual_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+  = link_to t("page_content.actuals.button.upload"), new_report_actual_upload_path(@report_presenter), class: "govuk-button govuk-button"

--- a/app/views/staff/reports/_actuals_upload_history.html.haml
+++ b/app/views/staff/reports/_actuals_upload_history.html.haml
@@ -1,0 +1,8 @@
+%h3.govuk-heading-m
+  = t("page_title.uploads.actual_histories")
+
+= t("page_content.uploads.actual_histories.actuals_tab.body_html")
+
+.govuk-button-group
+  = link_to t("actions.uploads.actual_histories.new_upload"), new_report_uploads_actual_history_path(@report_presenter), class: "govuk-button govuk-button"
+

--- a/app/views/staff/reports/actuals.html.haml
+++ b/app/views/staff/reports/actuals.html.haml
@@ -20,23 +20,10 @@
             = t("tabs.actuals.copy")
 
           - if policy(@report_presenter).upload?
-            %h3.govuk-heading-m
-              = t("tabs.actuals.providing.heading")
+            = render partial: "staff/reports/actuals_upload"
 
-            %p.govuk-body
-              = t("tabs.actuals.providing.copy")
-
-            %h3.govuk-heading-s
-              = t("tabs.actuals.upload.heading")
-
-            = t("tabs.actuals.upload.copy_html")
-
-            .govuk-inset-text
-              = t("tabs.actuals.upload.warning")
-
-            .govuk-button-group
-              = link_to t("page_content.actuals.button.download_template"), report_actual_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
-              = link_to t("page_content.actuals.button.upload"), new_report_actual_upload_path(@report_presenter), class: "govuk-button govuk-button"
+          - if policy(@report_presenter).upload_history?
+            = render partial: "staff/reports/actuals_upload_history"
 
             %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 

--- a/app/views/staff/uploads/actual_histories/_errors_table.html.haml
+++ b/app/views/staff/uploads/actual_histories/_errors_table.html.haml
@@ -1,0 +1,20 @@
+%p.govuk-body
+  Below are the errors in your actual data upload, fix the errors listed
+  and try again.
+.govuk-inset-text
+  No data has been uploaded.
+%table.govuk-table
+  %caption.govuk-table__caption.govuk-table__caption--m Upload errors
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Column
+      %th.govuk-table__header{scope: "col"} Row
+      %th.govuk-table__header{scope: "col"} Current Value
+      %th.govuk-table__header{scope: "col"} Error description
+  %tbody.govuk-table__body
+    - @errors.each do |error|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= error.column
+        %td.govuk-table__cell= error.row_number
+        %td.govuk-table__cell= error.value
+        %td.govuk-table__cell= error.message

--- a/app/views/staff/uploads/actual_histories/new.html.haml
+++ b/app/views/staff/uploads/actual_histories/new.html.haml
@@ -1,0 +1,14 @@
+= content_for :page_title_prefix, t("page_title.uploads.actual_histories")
+
+%h1.govuk-heading-xl
+  = t("page_title.uploads.actual_histories")
+
+= t("page_content.uploads.actual_histories.new.body_html")
+
+= t("page_content.uploads.actual_histories.new.warning_html")
+
+= form_for @report, url: report_uploads_actual_history_path(@report), method: :put do |f|
+  = f.govuk_file_field "actual_csv_file",
+    label: { text: t("form.label.uploads.actual_histories.csv_file") },
+    hint: { text: t("form.hint.uploads.actual_histories.csv_file") }
+  = f.govuk_submit t("actions.uploads.actual_histories.upload.button")

--- a/app/views/staff/uploads/actual_histories/update.html.haml
+++ b/app/views/staff/uploads/actual_histories/update.html.haml
@@ -1,0 +1,9 @@
+= content_for :page_title_prefix, t("page_title.uploads.actual_histories")
+
+%h1.govuk-heading-xl
+  = t("page_title.uploads.actual_histories")
+
+- if @errors.any?
+  = render partial: "errors_table.html.haml"
+- if @total_actuals.present?
+  = render partial: "shared/actuals/actuals_by_activity"

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -35,6 +35,11 @@ en:
         action: Action
         actions: Actions
   activerecord:
+    attributes:
+      default:
+        financial_quarter: Financial quarter
+        financial_year: Financial year
+        value: Value
     errors:
       format: "%{attribute} %{message}"
       messages:

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -25,6 +25,19 @@ en:
     uploads:
       actual_histories:
         new_upload: Upload actual history data
+        upload:
+          button: Upload and continue
+        success: Success
+        missing_or_invalid: Actual history data file is missing or invalid
   breadcrumb:
     uploads:
       actual_histories: Upload actual history
+  form:
+    label:
+      uploads:
+        actual_histories:
+          csv_file: Provide actual history data file
+    hint:
+      uploads:
+        actual_histories:
+          csv_file: Select the file that contains the actual history data for this report.

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -1,0 +1,30 @@
+---
+en:
+  page_title:
+    uploads:
+      actual_histories: Upload actual data history
+  page_content:
+    uploads:
+      actual_histories:
+        actuals_tab:
+          body_html:
+            <p class="govuk-body">Historic actuals can be uploaded into this report.</p>
+            <div class="govuk-inset-text">It is recommended that the actual data history is the only data uploaded in this report.</div>
+        new:
+          body_html:
+            <p class="govuk-body">Actual data history differs from regular reporting data in the following ways:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Historic actuals can be negative</li>
+              <li>Historic actuals can be from the current or any past financial quarter</li>
+              </ul>
+          warning_html:
+            <div class="govuk-inset-text">
+              Uploading actual history data will append to any values already provided in this report.
+            </div>
+  actions:
+    uploads:
+      actual_histories:
+        new_upload: Upload actual history data
+  breadcrumb:
+    uploads:
+      actual_histories: Upload actual history

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -28,6 +28,7 @@ en:
         upload:
           button: Upload and continue
         success: Actual history uploaded successfully
+        failed: Actual history upload failed
         invalid: Actual history data file is invalid
         missing: You must provide an actual history data file
   breadcrumb:

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -27,8 +27,9 @@ en:
         new_upload: Upload actual history data
         upload:
           button: Upload and continue
-        success: Success
-        missing_or_invalid: Actual history data file is missing or invalid
+        success: Actual history uploaded successfully
+        invalid: Actual history data file is invalid
+        missing: You must provide an actual history data file
   breadcrumb:
     uploads:
       actual_histories: Upload actual history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
       get "activities" => "report_activities#show"
       get "comments" => "report_comments#show"
       namespace :uploads do
-        resource :actual_history, only: [:new]
+        resource :actual_history, only: [:new, :update]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,9 @@ Rails.application.routes.draw do
       get "budgets" => "report_budgets#show"
       get "activities" => "report_activities#show"
       get "comments" => "report_comments#show"
+      namespace :uploads do
+        resource :actual_history, only: [:new]
+      end
     end
 
     concern :transactionable do

--- a/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
+++ b/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
@@ -18,10 +18,29 @@ RSpec.describe Staff::Uploads::ActualHistoriesController do
     end
 
     describe "#update" do
-      it "renders the view" do
+      it "renders the new view" do
+        put :update, params: {report_id: report.id, actual_csv_file: {}}
+
+        expect(response).to render_template(:new)
+      end
+
+      it "handles a missing file with an error" do
         put :update, params: {report_id: report.id}
 
         expect(response).to render_template(:new)
+        expect(flash[:error]).to eq(t("actions.uploads.actual_histories.missing"))
+      end
+
+      it "handles an invalid file with an error" do
+        upload = double(CsvFileUpload, valid?: false)
+        allow(CsvFileUpload).to receive(:new).and_return(upload)
+        allow(controller).to receive(:file_supplied?).and_return(true)
+
+        put :update, params: {report_id: report.id}
+
+        expect(response).to render_template(:new)
+
+        expect(flash[:error]).to eq(t("actions.uploads.actual_histories.invalid"))
       end
     end
   end

--- a/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
+++ b/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Staff::Uploads::ActualHistoriesController do
+  let(:report) { create(:report, organisation: user.organisation) }
+
+  context "as a BEIS partner user" do
+    let(:user) { create(:beis_user) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+    end
+
+    describe "#new" do
+      it "renders the view" do
+        get :new, params: {report_id: report.id}
+
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  context "as a delivery partner user" do
+    let(:user) { create(:delivery_partner_user) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:logged_in_using_omniauth?).and_return(true)
+    end
+
+    describe "#new" do
+      it "returns unauthorized (401)" do
+        get :new, params: {report_id: report.id}
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
+++ b/spec/controllers/staff/uploads/actual_histories_controller_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Staff::Uploads::ActualHistoriesController do
         expect(response).to render_template(:new)
       end
     end
+
+    describe "#update" do
+      it "renders the view" do
+        put :update, params: {report_id: report.id}
+
+        expect(response).to render_template(:new)
+      end
+    end
   end
 
   context "as a delivery partner user" do
@@ -29,6 +37,14 @@ RSpec.describe Staff::Uploads::ActualHistoriesController do
     describe "#new" do
       it "returns unauthorized (401)" do
         get :new, params: {report_id: report.id}
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe "#update" do
+      it "returns unauthorized (401)" do
+        put :update, params: {report_id: report.id}
 
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
@@ -1,0 +1,29 @@
+RSpec.feature "BEIS users upload actual history" do
+  context "as a BEIS user" do
+    let(:beis_user) { create(:beis_user) }
+    let(:report) { create(:report) }
+
+    before { authenticate!(user: beis_user) }
+
+    scenario "they can see the actuals history upload interface" do
+      visit report_actuals_path(report)
+
+      expect(page).to have_content(t("actions.uploads.actual_histories.new_upload"))
+    end
+  end
+
+  context "as a delvivery partner user" do
+    let(:delivery_partner_user) { create(:delivery_partner_user) }
+    let(:report) { create(:report, organisation: beis_user.organisation) }
+
+    before { authenticate!(user: delivery_partner_user) }
+
+    scenario "they cannot see the actuals history upload interface" do
+      report = create(:report)
+
+      visit report_actuals_path(report)
+
+      expect(page).not_to have_content(t("actions.uploads.actual_histories.new_upload"))
+    end
+  end
+end

--- a/spec/models/import/actual_history_spec.rb
+++ b/spec/models/import/actual_history_spec.rb
@@ -3,13 +3,9 @@ RSpec.describe Import::ActualHistory do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
 
-    @activity = create(:project_activity)
-    @report = create(
-      :report,
-      organisation: @activity.organisation,
-      fund: @activity.associated_fund
-    )
     @user = create(:beis_user)
+    @activity = create(:project_activity)
+    @report = create(:report, organisation: @activity.organisation, fund: @activity.associated_fund)
 
     valid_data = <<~CSV
       RODA identifier,Financial quarter,Financial year,Value
@@ -236,7 +232,10 @@ RSpec.describe Import::ActualHistory do
 
       it "has a helpful error message" do
         subject.call
-        expect(subject.errors.first.message).to include("Unknown RODA identifier")
+        expect(subject.errors.first.message).to include("No activity with this RODA identifier could be found")
+        expect(subject.errors.first.column).to eq("RODA identifier")
+        expect(subject.errors.first.row_number).to eq(2)
+        expect(subject.errors.first.value).to eq("NOT-A-RODA-ID")
       end
     end
 

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ReportPolicy do
 
       it "controls actions as expected" do
         is_expected.to permit_action(:create)
+        is_expected.to permit_action(:upload_history)
 
         is_expected.to forbid_action(:change_state)
         is_expected.to forbid_action(:activate)
@@ -43,6 +44,7 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:request_changes)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
+        is_expected.to forbid_action(:upload_history)
       end
     end
 
@@ -58,6 +60,7 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:submit)
         is_expected.to forbid_action(:review)
         is_expected.to forbid_action(:upload)
+        is_expected.to forbid_action(:upload_history)
       end
     end
 
@@ -72,6 +75,8 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:review)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
+
+        is_expected.to permit_action(:upload_history)
       end
     end
 
@@ -86,6 +91,7 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:review)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
+        is_expected.to forbid_action(:upload_history)
       end
     end
   end
@@ -115,6 +121,7 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:request_changes)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
+        is_expected.to forbid_action(:upload_history)
 
         is_expected.to permit_action(:index)
       end
@@ -139,6 +146,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
           is_expected.to forbid_action(:approve)
+          is_expected.to forbid_action(:upload_history)
         end
       end
 
@@ -156,6 +164,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:request_changes)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
+          is_expected.to forbid_action(:upload_history)
         end
       end
 
@@ -173,6 +182,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:request_changes)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
+          is_expected.to forbid_action(:upload_history)
         end
       end
 
@@ -190,6 +200,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
           is_expected.to forbid_action(:approve)
+          is_expected.to forbid_action(:upload_history)
         end
       end
 
@@ -207,6 +218,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
+          is_expected.to forbid_action(:upload_history)
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR
This is the BEIS users actual spend history upload. I decided to utiltise the exisiting report UI to house this, as we decided that these backfilling imports would still use a Report to encapsulate them it make sense to use the existing paths to a single report to guide users.

The importer itself was added in #1472 

https://trello.com/c/IKyiv8kX

## Screenshots of UI changes
![Screenshot 2021-11-19 at 10-42-19 FQ3 2021-2022 Q3 Report - IATI Transparency data audit actuals - Report your Official Dev](https://user-images.githubusercontent.com/480578/142609991-a8b382ea-407d-4604-bfa6-dfda5d08c11a.png)
![Screenshot 2021-11-19 at 10-42-26 Upload actual data history - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/142609995-883d99ff-1884-4f96-a704-e2b238b63bc2.png)
![Screenshot 2021-11-19 at 10-43-43 Upload actual data history - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/142609997-1ec4c7a7-3f20-451e-afe3-4e7189f629c9.png)
![Screenshot 2021-11-19 at 10-43-59 Upload actual data history - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/142609999-157dc186-a6fa-40e6-a6bf-9ccf47291f53.png)

