### PR TITLE
Fix deploy notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -931,6 +931,8 @@
 - Uploaded actual history must be in past financial quarters
 - Activity summary view uses BEIS approved attribute names
 - Channel of delivery code 90000, 'Other' added to the accepted codes list
+- Fix deployment notification
+
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...HEAD
 [release-89]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-88...release-89

--- a/script/deploy-notification
+++ b/script/deploy-notification
@@ -15,5 +15,5 @@ done
 
 echo "Sending Slack notification!"
 
-curl -s -X POST --data-urlencode "payload={\"text\": \"@here :badgerbadger: The latest release of RODA has been deployed to production :badgerbadger:\"}" "$SLACK_WEBHOOK_URL"
+curl -s -X POST --data-urlencode "payload={\"text\": \"<!here> :badgerbadger: The latest release of RODA has been deployed to production :badgerbadger:\"}" "$SLACK_WEBHOOK_URL"
 


### PR DESCRIPTION
* When using the Slack API, `<!here>` is used in place of `@here`, otherwise the message just shows '@here' in plain text rather than notifying user.