### PR TITLE
Fix rows_for_first_financial_quarter

### DIFF
--- a/app/models/export/activity_forecast_columns.rb
+++ b/app/models/export/activity_forecast_columns.rb
@@ -26,7 +26,7 @@ class Export::ActivityForecastColumns
   end
 
   def rows_for_first_financial_quarter
-    rows.each_with_object({}) { |(key, values), rows| rows[key] = values.first }
+    rows.each_with_object({}) { |(key, values), rows| rows[key] = values.first || 0 }
   end
 
   private

--- a/spec/models/export/activity_forecast_columns_spec.rb
+++ b/spec/models/export/activity_forecast_columns_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe Export::ActivityForecastColumns do
           expect(activity_value).to eq BigDecimal(10_000)
           expect(first_column_of_forecasts.count).to eq 5
         end
+
+        context "when there is no value for that report quarter" do
+          let(:report) { create(:report, financial_quarter: 1, financial_year: 2022) }
+
+          it "returns zero and not nil" do
+            first_column_of_forecasts = subject.rows_for_first_financial_quarter
+            activity_value = first_column_of_forecasts.fetch(@activity.id)
+
+            expect(activity_value).to eq 0
+            expect(activity_value).not_to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
Whilst the last column of actuals will always have values, there is a
high chance that the first column of forecasts will have none, when this
happens the value pulled out when rendering data will be `nil` and when
the variance column tries to calculate, the nil causes an error.

As a general rule, where we have no data we have to assume zero, so here
we replace nil with zero if there is no value.
