### PR TITLE
(2252) Feature: actual history must be in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -928,6 +928,7 @@
 - Update postgres to version 13
 
 ## [unreleased]
+- Uploaded actual history must be in past financial quarters
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...HEAD
 [release-89]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-88...release-89

--- a/app/models/import/actual_history.rb
+++ b/app/models/import/actual_history.rb
@@ -102,6 +102,11 @@ class Import::ActualHistory
         return false
       end
 
+      unless financial_quarter_valid?
+        @errors << financial_quarter_error
+        return false
+      end
+
       create_actual
     end
 
@@ -170,6 +175,27 @@ class Import::ActualHistory
         row_number: row_number,
         value: roda_identifier,
         message: "No activity with this RODA identifier could be found"
+      )
+    end
+
+    def financial_quarter_valid?
+      row_financial_quarter < latest_valid_financial_quarter
+    end
+
+    def latest_valid_financial_quarter
+      FinancialQuarter.for_date(Date.today).pred
+    end
+
+    def row_financial_quarter
+      FinancialQuarter.new(FinancialYear.new(financial_year.to_i), financial_quarter.to_i)
+    end
+
+    def financial_quarter_error
+      Import::RowError.new(
+        column: VALID_HEADERS[:roda_identifier],
+        row_number: row_number,
+        value: roda_identifier,
+        message: "The actual spend must be in or before #{latest_valid_financial_quarter}"
       )
     end
 

--- a/app/views/staff/reports/_actuals_upload_history.html.haml
+++ b/app/views/staff/reports/_actuals_upload_history.html.haml
@@ -1,8 +1,10 @@
-%h3.govuk-heading-m
-  = t("page_title.uploads.actual_histories")
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h3.govuk-heading-m
+      = t("page_title.uploads.actual_histories")
 
-= t("page_content.uploads.actual_histories.actuals_tab.body_html")
+    = t("page_content.uploads.actual_histories.actuals_tab.body_html")
 
-.govuk-button-group
-  = link_to t("actions.uploads.actual_histories.new_upload"), new_report_uploads_actual_history_path(@report_presenter), class: "govuk-button govuk-button"
+    .govuk-button-group
+      = link_to t("actions.uploads.actual_histories.new_upload"), new_report_uploads_actual_history_path(@report_presenter), class: "govuk-button govuk-button"
 

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -14,9 +14,9 @@ en:
           body_html:
             <p class="govuk-body">Actual data history differs from regular reporting data in the following ways:</p>
             <ul class="govuk-list govuk-list--bullet">
+              <li>Historic actuals must be in a past financial quarter</li>
               <li>Historic actuals can be negative</li>
-              <li>Historic actuals can be from the current or any past financial quarter</li>
-              </ul>
+            </ul>
           warning_html:
             <div class="govuk-inset-text">
               Uploading actual history data will append to any values already provided in this report.

--- a/config/locales/views/uploads/actual_histories.en.yml
+++ b/config/locales/views/uploads/actual_histories.en.yml
@@ -9,7 +9,7 @@ en:
         actuals_tab:
           body_html:
             <p class="govuk-body">Historic actuals can be uploaded into this report.</p>
-            <div class="govuk-inset-text">It is recommended that the actual data history is the only data uploaded in this report.</div>
+            <div class="govuk-inset-text">When uploading actual data history, it is recommended to use a new, empty report that contains only the actual data history</div>
         new:
           body_html:
             <p class="govuk-body">Actual data history differs from regular reporting data in the following ways:</p>


### PR DESCRIPTION
## Changes in this PR
In #1478 we decided the actual history importer should onlt allow values from past financial quarters. Here we change the `Import::ActualHistory` to enforce this. See the commit message for details on what 'the past' means in this context.

I've had a go at making the help on the initial upload content a little clearer? 🧑‍⚖️ 
