### PR TITLE
(2282) Feature: Add basic Sidekiq stats to health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -934,6 +934,7 @@
 - Fix deployment notification
 
 ## [unreleased]
+- Health check endpoint includes basic sidekiq stats
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90

--- a/app/controllers/public/base_controller.rb
+++ b/app/controllers/public/base_controller.rb
@@ -1,9 +1,25 @@
+require "sidekiq/api"
+
 class Public::BaseController < ApplicationController
   def health_check
     render json: {
       rails: "OK",
       git_sha: ENV.fetch("CURRENT_SHA", nil),
       built_at: ENV.fetch("TIME_OF_BUILD", nil),
+      sidekiq: {
+        enqueued: sidekiq_enqueued_size,
+        retry_size: sidekiq_retry_size,
+      },
     }, status: :ok
+  end
+
+  private
+
+  def sidekiq_enqueued_size
+    Sidekiq::Stats.new.enqueued
+  end
+
+  def sidekiq_retry_size
+    Sidekiq::Stats.new.retry_size
   end
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "sidekiq/api"
 
 RSpec.describe "Health Check", type: :request do
   it "returns an ok HTTP status code without requiring authentication" do
@@ -9,7 +10,35 @@ RSpec.describe "Health Check", type: :request do
         "rails" => "OK",
         "git_sha" => "b9c73f88",
         "built_at" => "2020-01-01T00:00:00Z",
+        "sidekiq" => {
+          "enqueued" => 0,
+          "retry_size" => 0,
+        }
       )
+    end
+  end
+
+  context "when enqueued is 20" do
+    it "returns the correct size" do
+      stats_double = double(Sidekiq::Stats, enqueued: 20, retry_size: 0)
+      allow(Sidekiq::Stats).to receive(:new).and_return(stats_double)
+
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).dig("sidekiq", "enqueued")).to eql(20)
+    end
+  end
+
+  context "when retry_size is 20" do
+    it "returns the correct size" do
+      stats_double = double(Sidekiq::Stats, retry_size: 20, enqueued: 0)
+      allow(Sidekiq::Stats).to receive(:new).and_return(stats_double)
+
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).dig("sidekiq", "retry_size")).to eql(20)
     end
   end
 end


### PR DESCRIPTION
We want to know if the Sidekiq worker has failed for any reason and raise
an alert.

We decided it was acceptable to add some very basic stats to the public
`health_check` endpoint for this purpose.

We leverage the Sidekiq API to return the two statistics we want:

- the size of `enqueued`
- the `retry_size`

See:

https://github.com/mperham/sidekiq/wiki/API

and

https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/background-jobs.md