### PR TITLE
Use postgres 13 in backing-services-docker-compose.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -928,18 +928,21 @@
 - Update postgres to version 13
 
 ## [release-90] 2021-11-23
+
 - Uploaded actual history must be in past financial quarters
 - Activity summary view uses BEIS approved attribute names
 - Channel of delivery code 90000, 'Other' added to the accepted codes list
 - Fix deployment notification
 
 ## [unreleased]
+
 - Health check endpoint includes basic sidekiq stats
 - Show users a warning about appending data when uploading actuals data
 - Update Readme - Add process to get terraform AWS credentials
 - New reports have a stricter validation to financial period
 - Documentation about logging
 - Fix setup script
+- Use postgres version 13 in backing-services-docker-compose.yml
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90

--- a/backing-services-docker-compose.yml
+++ b/backing-services-docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:11.6
+    image: postgres:13
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Changes in this PR

* The Postgres RDSs have been updated to version 13, so this should be
  the same to ensure the local development environment is the same