### PR TITLE
Fix: Don't use file extensions in partial names

### DIFF
--- a/app/views/staff/uploads/actual_histories/update.html.haml
+++ b/app/views/staff/uploads/actual_histories/update.html.haml
@@ -4,6 +4,6 @@
   = t("page_title.uploads.actual_histories")
 
 - if @errors.any?
-  = render partial: "errors_table.html.haml"
+  = render partial: "errors_table"
 - if @total_actuals.present?
   = render partial: "shared/actuals/actuals_by_activity"


### PR DESCRIPTION
It raises a deprecation warning.
