### PR TITLE
(2334) Fix: Spending breakdown handles no data in activities

### DIFF
--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -7,6 +7,7 @@ class Export::ActivityActualsColumns
 
   def headers
     return [] if @activities.empty?
+    return [] if financial_quarter_range.nil?
 
     financial_quarter_range.map { |financial_quarter|
       if @include_breakdown
@@ -23,12 +24,15 @@ class Export::ActivityActualsColumns
 
   def rows
     return [] if @activities.empty?
+    return activities_with_no_data if financial_quarter_range.nil?
+
     @_rows ||= @activities.map { |activity|
       actual_and_refund_data(activity)
     }.to_h
   end
 
   def last_financial_quarter
+    return nil if financial_quarter_range.nil?
     financial_quarter_range.max
   end
 
@@ -37,6 +41,12 @@ class Export::ActivityActualsColumns
   end
 
   private
+
+  def activities_with_no_data
+    @_rows ||= @activities.map { |activity|
+      [activity.id, []]
+    }.to_h
+  end
 
   def actual_and_refund_data(activity)
     build_columns(all_totals_for_activity(activity), activity)
@@ -98,6 +108,7 @@ class Export::ActivityActualsColumns
   end
 
   def financial_quarter_range
+    return nil if financial_quarters.empty?
     @_financial_quarter_range ||= Range.new(*financial_quarters.minmax)
   end
 end

--- a/app/services/export/spending_breakdown.rb
+++ b/app/services/export/spending_breakdown.rb
@@ -65,6 +65,7 @@ class Export::SpendingBreakdown
 
   def first_forecast_financial_quarter
     return nil if actuals_rows.empty?
+    return nil if @actual_columns.last_financial_quarter.nil?
     @actual_columns.last_financial_quarter.succ
   end
 

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -232,6 +232,26 @@ RSpec.describe Export::ActivityActualsColumns do
     end
   end
 
+  context "when there are activities and NONE have spend, refunds or adjustments" do
+    it "retruns empty arrays for rows and headers" do
+      activity = create(:project_activity)
+      subject = described_class.new(activities: [activity])
+
+      expect(subject.rows.fetch(activity.id)).to eq []
+      expect(subject.rows.count).to eq 1
+      expect(subject.headers).to eq []
+    end
+
+    describe "#last_financial_quarter" do
+      it "returns nil" do
+        activity = create(:project_activity)
+        subject = described_class.new(activities: [activity])
+
+        expect(subject.last_financial_quarter).to be_nil
+      end
+    end
+  end
+
   context "when #rows is called multiple times" do
     let(:breakdown) { false }
     let(:report) { nil }

--- a/spec/services/export/spending_breakdown_spec.rb
+++ b/spec/services/export/spending_breakdown_spec.rb
@@ -221,9 +221,10 @@ RSpec.describe Export::SpendingBreakdown do
       end
     end
 
-    context "when there are no actual spend, refunds and forecasts" do
-      let(:activities) { create_list(:project_activity, 5) }
-      subject { described_class.new(source_fund: activities.first.associated_fund, organisation: activities.first.organisation) }
+    context "when there are no activities" do
+      let(:fund) { create(:fund_activity) }
+      let(:organisation) { create(:delivery_partner_organisation) }
+      subject { described_class.new(source_fund: fund, organisation: organisation) }
 
       it "returns the activity attribute headers only" do
         activity_attribute_headers = [
@@ -235,6 +236,33 @@ RSpec.describe Export::SpendingBreakdown do
         ]
         expect(subject.headers).to match_array(activity_attribute_headers)
         expect(subject.rows).to eq []
+      end
+    end
+
+    context "when there are actvities but NONE have actual spend, refunds and forecasts" do
+      before do
+        @organisation = create(:delivery_partner_organisation)
+        @activities = create_list(:project_activity, 3, organisation: @organisation)
+
+        subject {
+          described_class.new(
+            source_fund: @activities.first.source_fund_code,
+            organisation: @organisation,
+          )
+        }
+      end
+
+      it "returns the activity attribute headers only" do
+        activity_attribute_headers = [
+          "RODA identifier",
+          "Delivery partner identifier",
+          "Activity title",
+          "Activity level",
+          "Activity status",
+          "Delivery partner organisation",
+        ]
+        expect(subject.headers).to match_array(activity_attribute_headers)
+        expect(subject.rows.count).to eq 3
       end
     end
   end


### PR DESCRIPTION
I had noticed the "when there are no actual spend, refunds and
forecasts" failing in CI a couple of times.

I noted down the seeds and ran them locally and was unable to reproduce
the failing.

I think these changes better describe the behaviour which is when there
are activities to render in the spending breakdown and NONE of them have
any spend, refunds or adjustments we cannot handle that and the code
cannot run.

I think that the issue would only arise when there are un-cleared
fixtures in the database AND the activities fixtures happen to meet the
criteria that they appear in the spending breakdown - this is the only
way I can explain the random occurrences.

The chances of ALL activities for a DP having no spend is pretty small
and I think pragmatically could only happen under test, but we should
do something to guard against this case if we can.

I've put together two specs that reproduce the issue at the spending
breakdown level and the underlying `ActivityActualsColumns` level.

There are a couple of parts:

- when there are activities with no spend, refunds or adjustments the
  `financial_quarter_range` now returns nil instead of a useless Range.
- we check for a nil financial_quarter_range and respond accordingly
- I decided the response at the ActivityActualsColumns level is to build
  a row with empty actuals, this is what the `ActivityForecastColumns`
  appears to do
- guard against the last_financial_quarter returning nil in the spending
  breakdown report

