### PR TITLE
(2333) Feature: Add a warning to the actual upload page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -935,6 +935,7 @@
 
 ## [unreleased]
 - Health check endpoint includes basic sidekiq stats
+- Show users a warning about appending data when uploading actuals data
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90

--- a/app/views/staff/actual_uploads/new.html.haml
+++ b/app/views/staff/actual_uploads/new.html.haml
@@ -8,6 +8,8 @@
 
       = t("page_content.actuals.upload.copy_html", report_actuals_template_path: report_actual_upload_path(@report_presenter, format: :csv))
 
+      = t("page_content.actuals.upload.warning_html")
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       - if policy(@report_presenter).upload?

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -92,6 +92,8 @@ en:
           <li>Upload and verify the data here</li>
           </ol>
           <p class="govuk-body">For more detailed guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a></p>
+        warning_html:
+          <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Uploading actuals data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.</strong></div>
   page_title:
     actual:
       edit: Edit actual spend

--- a/spec/features/staff/users_can_upload_actuals_spec.rb
+++ b/spec/features/staff/users_can_upload_actuals_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature "users can upload actuals" do
 
     expect(page.html).to include t("page_content.actuals.upload.copy_html",
       report_actuals_template_path: report_actual_upload_path(report, format: :csv))
+
+    expect(page.html).to include t("page_content.actuals.upload.warning_html")
   end
 
   scenario "downloading a CSV template with activities for the current report" do


### PR DESCRIPTION
## Changes in this PR
Some users have duplicated their actual spend data during reporting due
to us not being clear that the upload appends to the data already in the
application as opposed to replacing it.

As a first step towards fixing this issue, we add a strong warning to
users that the upload will append data.

The Linked guidance should be updated along with this change.

## Screenshots of UI changes

![Screenshot 2021-11-24 at 15-57-02 Upload actuals data - Report your Official Development Assistance](https://user-images.githubusercontent.com/480578/143272181-5fa3b4fe-de59-4717-a7b5-dd5aa485217d.png)

