### PR TITLE
Feature (2325) New reports have a valid financial period.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,7 +893,7 @@
 
 ## [release-85] 2021-11-09
 
-- Fix "Total forecasted" (in Activity financial summary) to exclude periods 
+- Fix "Total forecasted" (in Activity financial summary) to exclude periods
   already reported
 - Fix spending breakdown report
 
@@ -937,6 +937,7 @@
 - Health check endpoint includes basic sidekiq stats
 - Show users a warning about appending data when uploading actuals data
 - Update Readme - Add process to get terraform AWS credentials
+- New reports have a stricter validation to financial period
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,7 @@ class Organisation < ApplicationRecord
   strip_attributes only: [:iati_reference]
   has_many :users
   has_many :funds
+  has_many :reports
   has_many :org_participations, -> { where(role: "implementing").distinct }
   has_many :activities, through: :org_participations
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -19,6 +19,7 @@ class Report < ApplicationRecord
   has_many :comments
 
   validate :activity_must_be_a_fund
+  validate :financial_quarter_is_not_in_the_future?, on: :new
   validate :no_unapproved_reports_per_series, on: :new
   validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit
 
@@ -113,5 +114,14 @@ class Report < ApplicationRecord
 
   def summed_forecasts_for_reportable_activities
     forecasts_for_reportable_activities.sum(&:value)
+  end
+
+  def financial_quarter_is_not_in_the_future?
+    return false unless financial_quarter && financial_year
+
+    current_period = FinancialQuarter.for_date(Date.current)
+    unless financial_period.last <= current_period.end_date
+      errors.add(:financial_period, "Financial period must be no later than the current period.")
+    end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,6 +20,7 @@ class Report < ApplicationRecord
 
   validate :activity_must_be_a_fund
   validate :financial_quarter_is_not_in_the_future?, on: :new
+  validate :no_prexisting_later_report?, on: :new
   validate :no_unapproved_reports_per_series, on: :new
   validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit
 
@@ -122,6 +123,15 @@ class Report < ApplicationRecord
     current_period = FinancialQuarter.for_date(Date.current)
     unless financial_period.last <= current_period.end_date
       errors.add(:financial_period, "Financial period must be no later than the current period.")
+    end
+  end
+
+  def no_prexisting_later_report?
+    return false unless financial_quarter && financial_year
+
+    latest_report = organisation.reports.in_historical_order.where(fund_id: fund_id).first
+    if latest_report && latest_report.financial_period.last > financial_period.last
+      errors.add(:financial_period, "A report already exists for a later period.")
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe Report, type: :model do
         expect(new_report.valid?(:new)).to eql(false)
         expect(new_report.valid?).to eql(true)
       end
+
+      context "validates that the financial quarter is previous to the current quarter" do
+        it "when creating a report for the next finanical quarter in the same financial year" do
+          travel_to(Date.parse("01-04-2020")) do
+            new_report = build(:report, financial_quarter: 2, financial_year: 2020)
+            expect(new_report.valid?(:new)).to eql(false)
+          end
+        end
+        it "when creating a report for the next finanical quarter in the next financial year" do
+          travel_to(Date.parse("01-02-2020")) do
+            new_report = build(:report, financial_quarter: 1, financial_year: 2020)
+            expect(new_report.valid?(:new)).to eql(false)
+          end
+        end
+        it "when creating a report for the previous financial quarter in the same financial year" do
+          travel_to(Date.parse("01-08-2020")) do
+            new_report = build(:report, financial_quarter: 1, financial_year: 2020)
+            expect(new_report.valid?(:new)).to eql(true)
+          end
+        end
+        it "when creating a report for the previous financial quarter in the previous financial year" do
+          travel_to(Date.parse("01-04-2020")) do
+            new_report = build(:report, financial_quarter: 4, financial_year: 2019)
+            expect(new_report.valid?(:new)).to eql(true)
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -57,6 +57,30 @@ RSpec.describe Report, type: :model do
           end
         end
       end
+
+      describe "Ensuring that a new report does not attempt to rewrite history" do
+        let(:organisation) { create(:delivery_partner_organisation) }
+        let(:fund) { create(:fund_activity) }
+        context "where a report already exists for a period later than that of the new report" do
+          it "is not valid" do
+            create(:report, :approved, organisation: organisation, fund: fund, financial_quarter: 4, financial_year: 2018)
+            travel_to(Date.parse("01-04-2020")) do
+              new_report = build(:report, organisation: organisation, fund: fund, financial_quarter: 3, financial_year: 2018)
+              expect(new_report.valid?(:new)).to eql(false)
+            end
+          end
+        end
+        context "where a report does not exist for a period later than that of the new report" do
+          it "is valid" do
+            create(:report, :approved, organisation: organisation, fund: fund, financial_quarter: 4, financial_year: 2018)
+            travel_to(Date.parse("01-04-2020")) do
+              new_report = build(:report, organisation: organisation, fund: fund, financial_quarter: 4, financial_year: 2018)
+
+              expect(new_report.valid?(:new)).to eql(true)
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

- Ensure new reports have a financial period no later than the period of their creation
-  Add has_many reports association to Organisation
- Ensure new report does not rewrite history. A new report will be invalid if there is a pre-existing report for a later period.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
