### PR TITLE
Feature (2098 pt3) BEIS manage Implementing organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -951,6 +951,8 @@
 
 ## [unreleased]
 
+- BEIS users can add and edit implementing organisations
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-92...HEAD
 [release-92]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-91...release-92
 [release-91]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...release-91

--- a/app/controllers/staff/implementing_organisations_controller.rb
+++ b/app/controllers/staff/implementing_organisations_controller.rb
@@ -2,7 +2,7 @@ class Staff::ImplementingOrganisationsController < Staff::BaseController
   def new
     @activity = Activity.find(params[:activity_id])
     authorize @activity
-    @implementing_organisations = Organisation.implementing
+    @implementing_organisations = Organisation.sorted_by_name
     @implementing_organisation = Organisation.new
   end
 

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -3,7 +3,7 @@
 class Staff::OrganisationsController < Staff::BaseController
   def index
     @role = params[:role]
-    @organisations = policy_scope(Organisation).where(role: @role.singularize).sorted_by_name
+    @organisations = organisations
     authorize @organisations
 
     add_breadcrumb I18n.t("breadcrumbs.organisation.index"), organisations_path(role: @role)
@@ -65,6 +65,12 @@ class Staff::OrganisationsController < Staff::BaseController
 
   private def id
     params[:id]
+  end
+
+  private def organisations
+    return policy_scope(Organisation).implementing.sorted_by_name if @role == "implementing_organisations"
+
+    policy_scope(Organisation).where(role: @role.singularize).sorted_by_name
   end
 
   private def organisation_params

--- a/app/controllers/staff/organisations_controller.rb
+++ b/app/controllers/staff/organisations_controller.rb
@@ -6,14 +6,14 @@ class Staff::OrganisationsController < Staff::BaseController
     @organisations = organisations
     authorize @organisations
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.index"), organisations_path(role: @role)
+    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@role.singularize}.index"), organisations_path(role: @role)
   end
 
   def show
     organisation = Organisation.find(id)
     authorize organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.index"), organisations_path(role: organisation.role.pluralize)
+    add_breadcrumb I18n.t("breadcrumbs.organisation.#{organisation.role}.index"), organisations_path(role: organisation.role.pluralize)
     add_breadcrumb organisation.name, :organisation_path
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
@@ -23,7 +23,7 @@ class Staff::OrganisationsController < Staff::BaseController
     @organisation = Organisation.new(role: params[:role].singularize)
     authorize @organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.index"), organisations_path(role: @organisation.role.pluralize)
+    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
     add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: params[:role])
   end
 
@@ -44,7 +44,7 @@ class Staff::OrganisationsController < Staff::BaseController
     @organisation = Organisation.find(id)
     authorize @organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.index"), organisations_path(role: @organisation.role.pluralize)
+    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
     add_breadcrumb t("breadcrumbs.organisation.edit", name: @organisation.name), :edit_organisation_path
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -19,6 +19,7 @@ class Organisation < ApplicationRecord
     delivery_partner: 0,
     matched_effort_provider: 1,
     external_income_provider: 2,
+    implementing_organisation: 3,
     service_owner: 99,
   }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -42,7 +42,7 @@ class Organisation < ApplicationRecord
   scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
   scope :matched_effort_providers, -> { sorted_by_name.where(role: "matched_effort_provider") }
   scope :external_income_providers, -> { sorted_by_name.where(role: "external_income_provider") }
-  scope :implementing, -> { sorted_by_name.where(organisation_type: %w[15 21 24 71 80 90]) }
+  scope :implementing, -> { joins(:org_participations).distinct(:id).sorted_by_name }
   scope :reporters, -> { sorted_by_name.where(role: ["delivery_partner", "service_owner"]) }
   scope :active, -> { where(active: true) }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -57,6 +57,13 @@ class Organisation < ApplicationRecord
       .first
   end
 
+  def role
+    # temp hack whilst we figure out how to handle moving role from Org to OrgParticipation
+    return "implementing_organisation" unless read_attribute(:role)
+
+    super
+  end
+
   def ensure_beis_organisation_reference_is_uppercase
     return unless beis_organisation_reference
 

--- a/app/presenters/organisation_presenter.rb
+++ b/app/presenters/organisation_presenter.rb
@@ -2,10 +2,18 @@
 
 class OrganisationPresenter < SimpleDelegator
   def language_code
-    super.downcase
+    return I18n.t("organisation.language_code.#{super.downcase}") if super
+
+    super
   end
 
   def default_currency
-    super.downcase
+    return I18n.t("generic.default_currency.#{super.downcase}") if super
+
+    super
+  end
+
+  def organisation_type
+    I18n.t("organisation.organisation_type.#{super}")
   end
 end

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -235,7 +235,7 @@ module Activities
       end
 
       def organisation
-        @organisation = Organisation.implementing.find_matching(row["Implementing organisation name"])
+        @organisation = Organisation.find_matching(row["Implementing organisation name"])
       end
 
       def participations

--- a/app/views/staff/organisations/_form.html.haml
+++ b/app/views/staff/organisations/_form.html.haml
@@ -7,7 +7,7 @@
                      organisation_type_options,
                      :code,
                      :name
-- if f.object.is_reporter?
+- if f.object.is_reporter? || f.object.implementing_organisation?
   = f.govuk_text_field :iati_reference,
                         hint: { text: t("form.hint.organisation.iati_reference_html", link: link_to_new_tab("See International Aid Transparency Initiative (IATI) for detailed documentation", "https://reference.iatistandard.org/organisation-identifiers/")) }
 = f.govuk_collection_select :language_code,

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -5,7 +5,7 @@
         Organisations
 
       %ul.govuk-tabs__list
-        - ["delivery_partners", "matched_effort_providers", "external_income_providers"].each do |role|
+        - ["delivery_partners", "matched_effort_providers", "external_income_providers", "implementing_organisations"].each do |role|
           %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
             = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: (role == @role) } }
 
@@ -30,7 +30,7 @@
 
             %tbody.govuk-table__body
               - organisations.each do |organisation|
-                %tr.govuk-table__row{id: organisation.id}
+                %tr.govuk-table__row.organisation{id: organisation.id}
                   %td.govuk-table__cell= organisation.name
                   %td.govuk-table__cell= organisation.beis_organisation_reference
                   %td.govuk-table__cell

--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -21,17 +21,17 @@
           %dt.govuk-summary-list__key
             = t("summary.label.organisation.organisation_type")
           %dd.govuk-summary-list__value
-            = t("organisation.organisation_type.#{@organisation_presenter.organisation_type}")
+            = @organisation_presenter.organisation_type
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("summary.label.organisation.language_code")
           %dd.govuk-summary-list__value
-            = t("organisation.language_code.#{@organisation_presenter.language_code}")
+            = @organisation_presenter.language_code
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("summary.label.organisation.default_currency")
           %dd.govuk-summary-list__value
-            = t("generic.default_currency.#{@organisation_presenter.default_currency}")
+            = @organisation_presenter.default_currency
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("summary.label.organisation.beis_organisation_reference")

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -106,12 +106,16 @@ en:
       edit: Edit %{name}
       implementing_organisation:
         new: Create a new implementing organisation
+        index: Implementing organisations
       delivery_partner:
         new: Create a new delivery partner organisation
+        index: Delivery partners
       matched_effort_provider:
         new: Create a new matched effort provider organisation
+        index: Matched effort providers
       external_income_provider:
         new: Create a new external income provider organisation
+        index: External income providers
   activerecord:
     errors:
       models:

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -87,6 +87,8 @@ en:
       edit: Edit organisation
       index: Organisations
       show: Organisation %{name}
+      implementing_organisation:
+        new: Create a new implementing organisation
       delivery_partner:
         new: Create a new delivery partner organisation
       matched_effort_provider:
@@ -102,6 +104,8 @@ en:
     organisation:
       index: Organisations
       edit: Edit %{name}
+      implementing_organisation:
+        new: Create a new implementing organisation
       delivery_partner:
         new: Create a new delivery partner organisation
       matched_effort_provider:

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -34,6 +34,7 @@ en:
         beis_organisation_reference: Short name
   tabs:
     organisations:
+      implementing_organisations: Implementing organisations
       delivery_partners: Delivery partners
       matched_effort_providers: Matched effort providers
       external_income_providers: External income providers
@@ -48,6 +49,9 @@ en:
   page_content:
     organisation_details: Organisation details
     organisations:
+      implementing_organisations:
+        button:
+          create: Add implementing organisation
       delivery_partners:
         button:
           create: Add delivery partner organisation
@@ -90,6 +94,7 @@ en:
       external_income_provider:
         new: Create a new external income provider organisation
     organisations:
+      implementing_organisations: Implementing organisations
       delivery_partners: Delivery partners
       matched_effort_providers: Matched effort providers
       external_income_providers: External income providers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
     resources :users
     resources :activities, only: [:index]
 
-    constraints role: /delivery_partners|matched_effort_providers|external_income_providers/ do
+    roles = %w[implementing_organisations delivery_partners matched_effort_providers external_income_providers]
+    constraints role: /#{roles.join("|")}/ do
       get "organisations/(:role)", to: "organisations#index", defaults: {role: "delivery_partners"}, as: :organisations
       get "organisations/(:role)/new", to: "organisations#new", as: :new_organisation
     end

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -100,6 +100,57 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.active).to eq(true)
     end
 
+    scenario "successfully creating an implementing organisation" do
+      def given_i_am_on_the_new_implementing_organisation_page
+        click_link t("tabs.organisations.implementing_organisations")
+        click_link t("page_content.organisations.implementing_organisations.button.create")
+        expect(page).to have_content(t("page_title.organisation.implementing_organisation.new"))
+      end
+
+      def and_i_submit_the_new_implementing_organisation_form
+        click_button t("default.button.submit")
+      end
+
+      def then_i_expect_to_see_that_an_implementing_organisation_has_mandatory_fields
+        within ".govuk-error-summary" do
+          expect(page).to have_content("Enter an organisation type")
+          expect(page).to have_content("Enter a language code")
+          expect(page).to have_content("Enter a default currency")
+          expect(page).to have_content("Enter an organisation name")
+        end
+      end
+
+      def when_i_fill_in_the_implementing_organisation_form_correctly
+        fill_in "organisation[name]", with: "A New Implementing Organisation"
+        fill_in "organisation[beis_organisation_reference]", with: "ANIO"
+        fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
+        select "Other", from: "organisation[organisation_type]"
+        select "English", from: "organisation[language_code]"
+        select "Pound Sterling", from: "organisation[default_currency]"
+      end
+
+      def then_i_expect_to_see_the_created_implementing_organisation(organisation)
+        presented_org = OrganisationPresenter.new(organisation)
+
+        expect(page).to have_content(t("action.organisation.create.success"))
+        expect(page).to have_content(presented_org.name)
+        expect(page).to have_content(presented_org.iati_reference)
+        expect(page).to have_content(presented_org.language_code)
+        expect(page).to have_content(presented_org.default_currency)
+        expect(page).to have_content(presented_org.organisation_type)
+      end
+
+      given_i_am_on_the_new_implementing_organisation_page
+      and_i_submit_the_new_implementing_organisation_form
+      then_i_expect_to_see_that_an_implementing_organisation_has_mandatory_fields
+
+      when_i_fill_in_the_implementing_organisation_form_correctly
+      and_i_submit_the_new_implementing_organisation_form
+      then_i_expect_to_see_the_created_implementing_organisation(
+        Organisation.order("created_at ASC").last
+      )
+    end
+
     scenario "presence validation works as expected" do
       click_link t("page_content.organisations.delivery_partners.button.create")
 

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -17,8 +17,23 @@ RSpec.feature "BEIS users can create organisations" do
       end
     end
 
+    def then_breadcrumb_shows_type_of_organisation(name:, link: nil)
+      within ".govuk-breadcrumbs" do
+        if link
+          expect(page).to have_link(name, href: link)
+        else
+          expect(page).to have_content(name)
+        end
+      end
+    end
+
     scenario "successfully creating a delivery partner organisation" do
       click_link t("page_content.organisations.delivery_partners.button.create")
+
+      then_breadcrumb_shows_type_of_organisation(
+        name: "Delivery partners",
+        link: organisations_path(role: "delivery_partners")
+      )
 
       expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
       fill_in "organisation[name]", with: "My New Organisation"
@@ -49,6 +64,11 @@ RSpec.feature "BEIS users can create organisations" do
 
       click_link t("page_content.organisations.matched_effort_providers.button.create")
 
+      then_breadcrumb_shows_type_of_organisation(
+        name: "Matched effort providers",
+        link: organisations_path(role: "matched_effort_providers")
+      )
+
       expect(page).to have_content(t("page_title.organisation.matched_effort_provider.new"))
       expect(page).to have_field("organisation[active]", type: "radio")
 
@@ -76,6 +96,10 @@ RSpec.feature "BEIS users can create organisations" do
       click_link t("tabs.organisations.external_income_providers")
 
       click_link t("page_content.organisations.external_income_providers.button.create")
+      then_breadcrumb_shows_type_of_organisation(
+        name: "External income provider",
+        link: organisations_path(role: "external_income_providers")
+      )
 
       expect(page).to have_content(t("page_title.organisation.external_income_provider.new"))
       expect(page).to have_field("organisation[active]", type: "radio")
@@ -105,6 +129,10 @@ RSpec.feature "BEIS users can create organisations" do
         click_link t("tabs.organisations.implementing_organisations")
         click_link t("page_content.organisations.implementing_organisations.button.create")
         expect(page).to have_content(t("page_title.organisation.implementing_organisation.new"))
+        then_breadcrumb_shows_type_of_organisation(
+          name: "Implementing organisations",
+          link: organisations_path(role: "implementing_organisations")
+        )
       end
 
       def and_i_submit_the_new_implementing_organisation_form

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -66,7 +66,17 @@ RSpec.feature "BEIS users can view other organisations" do
     let!(:delivery_partner_organisations) { create_list(:delivery_partner_organisation, 3) }
     let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
     let!(:external_income_provider_organisations) { create_list(:external_income_provider, 2) }
-    let!(:implementing_organisations) { create_list(:implementing_organisation, 2) }
+    let!(:implementing_organisations) do
+      2.times {
+        create(:implementing_organisation).tap do |org|
+          OrgParticipation.create(
+            organisation: org,
+            activity: create(:project_activity),
+            role: "implementing"
+          )
+        end
+      }
+    end
 
     before do
       authenticate!(user: user)
@@ -80,7 +90,7 @@ RSpec.feature "BEIS users can view other organisations" do
       context "the role is 'implementing_organisations'" do
         let(:role) { "implementing_organisations" }
 
-        scenario "lists only implementing organisations" do
+        scenario "lists all organisations which have an implementing 'participation'" do
           within ".organisations" do
             Organisation.implementing.each do |org|
               expect(page).to have_content(org.name)

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -87,6 +87,7 @@ RSpec.feature "BEIS users can view other organisations" do
             end
           end
           expect(page).to have_css(".organisation", count: Organisation.implementing.count)
+          then_breadcrumb_shows_type_of_organisation(name: "Implementing organisations")
         end
       end
 
@@ -100,12 +101,20 @@ RSpec.feature "BEIS users can view other organisations" do
             click_on t("tabs.organisations.matched_effort_providers")
           end
 
+          it "includes type of organisation in breadcrumb" do
+            then_breadcrumb_shows_type_of_organisation(name: "Matched effort providers")
+          end
+
           include_examples "lists matched effort provider organisations"
         end
 
         context "when viewing the external income providers tab" do
           before do
             click_on t("tabs.organisations.external_income_providers")
+          end
+
+          it "includes type of organisation in breadcrumb" do
+            then_breadcrumb_shows_type_of_organisation(name: "External income providers")
           end
 
           include_examples "lists external income provider organisations"
@@ -163,6 +172,12 @@ RSpec.feature "BEIS users can view other organisations" do
       end
 
       include_examples "lists delivery partner organisations"
+    end
+
+    def then_breadcrumb_shows_type_of_organisation(name:)
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content(name)
+      end
     end
   end
 end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -90,7 +90,9 @@ RSpec.feature "BEIS users can view other organisations" do
       context "the role is 'implementing_organisations'" do
         let(:role) { "implementing_organisations" }
 
-        scenario "lists all organisations which have an implementing 'participation'" do
+        scenario "lists all organisations in the 'implementing' scope" do
+          expect(Organisation.implementing.count).to be >= 2
+
           within ".organisations" do
             Organisation.implementing.each do |org|
               expect(page).to have_content(org.name)

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -66,6 +66,7 @@ RSpec.feature "BEIS users can view other organisations" do
     let!(:delivery_partner_organisations) { create_list(:delivery_partner_organisation, 3) }
     let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
     let!(:external_income_provider_organisations) { create_list(:external_income_provider, 2) }
+    let!(:implementing_organisations) { create_list(:implementing_organisation, 2) }
 
     before do
       authenticate!(user: user)
@@ -74,6 +75,19 @@ RSpec.feature "BEIS users can view other organisations" do
     context "when a role is provided" do
       before do
         visit organisations_path(role: role)
+      end
+
+      context "the role is 'implementing_organisations'" do
+        let(:role) { "implementing_organisations" }
+
+        scenario "lists only implementing organisations" do
+          within ".organisations" do
+            Organisation.implementing.each do |org|
+              expect(page).to have_content(org.name)
+            end
+          end
+          expect(page).to have_css(".organisation", count: Organisation.implementing.count)
+        end
       end
 
       context "the role is 'delivery_partners'" do

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -9,7 +9,13 @@ RSpec.feature "Users can manage the implementing organisations" do
         :implementing_organisation,
         name: "Implementing org",
         iati_reference: "GB-COH-123456"
-      )
+      ).tap do |org|
+        OrgParticipation.create(
+          organisation: org,
+          activity: create(:project_activity),
+          role: "implementing"
+        )
+      end
     end
 
     let!(:other_implementing_org) do
@@ -17,7 +23,13 @@ RSpec.feature "Users can manage the implementing organisations" do
         :implementing_organisation,
         name: "Another implementing org",
         iati_reference: "GB-COH-654321"
-      )
+      ).tap do |org|
+        OrgParticipation.create(
+          organisation: org,
+          activity: create(:project_activity),
+          role: "implementing"
+        )
+      end
     end
 
     before do
@@ -27,11 +39,11 @@ RSpec.feature "Users can manage the implementing organisations" do
       create(:delivery_partner_organisation, name: "Another delivery partner")
     end
 
-    scenario "they can add an implementing org from a list of qualifying organisation" do
-      def then_i_see_a_list_containing_only_implementing_organisations
+    scenario "they can add an implementing org from a list of all organisations" do
+      def then_i_see_a_list_containing_all_organisations
         expect(page).to have_select(
           t("form.label.implementing_organisation"),
-          options: ["Another implementing org", "Implementing org"]
+          options: Organisation.sorted_by_name.pluck(:name)
         )
       end
 
@@ -58,7 +70,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       expect(page).to have_content t("page_content.activity.implementing_organisation.button.new")
       click_on t("page_content.activity.implementing_organisation.button.new")
 
-      then_i_see_a_list_containing_only_implementing_organisations
+      then_i_see_a_list_containing_all_organisations
       then_i_see_guidance_about_adding_to_this_list
       when_i_select_the_implementing_organisation("Implementing org")
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -245,12 +245,14 @@ RSpec.describe Organisation, type: :model do
       delivery_partner_organisation = create(:delivery_partner_organisation)
       matched_effort_provider = create(:matched_effort_provider)
       external_income_provider = create(:external_income_provider)
+      implementing_organisation = create(:implementing_organisation)
       reporters = Organisation.reporters
 
       expect(reporters).to include(delivery_partner_organisation)
       expect(reporters).to include(beis_organisation)
       expect(reporters).not_to include(matched_effort_provider)
       expect(reporters).not_to include(external_income_provider)
+      expect(reporters).not_to include(implementing_organisation)
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -274,6 +274,30 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
+  describe ".implementing" do
+    let!(:delivery_partner) { create(:delivery_partner_organisation) }
+    let!(:matched_effort_provider) { create(:matched_effort_provider) }
+    let!(:implementing_org) { create(:implementing_organisation) }
+    let!(:unused_implementing_org) { create(:implementing_organisation) }
+
+    before do
+      OrgParticipation.create!(
+        organisation: implementing_org,
+        activity: create(:project_activity),
+        role: "implementing"
+      )
+    end
+
+    it "includes only organisations with an 'implementing' participation" do
+      aggregate_failures do
+        expect(Organisation.implementing).to include(implementing_org)
+        expect(Organisation.implementing).not_to include(unused_implementing_org)
+        expect(Organisation.implementing).not_to include(delivery_partner)
+        expect(Organisation.implementing).not_to include(matched_effort_provider)
+      end
+    end
+  end
+
   describe ".active" do
     it "should contain only active organisations" do
       create_list(:delivery_partner_organisation, 3, active: false)

--- a/spec/presenters/organisation_presenter_spec.rb
+++ b/spec/presenters/organisation_presenter_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe OrganisationPresenter do
   let(:organisation) { FactoryBot.build(:delivery_partner_organisation, language_code: "EN", default_currency: "GBP") }
 
   describe "#language_code" do
-    it "downcases the language_code" do
-      expect(described_class.new(organisation).language_code).to eq("en")
+    it "converts to readable form" do
+      expect(described_class.new(organisation).language_code).to eq("English")
     end
   end
 
   describe "#default_currency" do
-    it "downcases the default_currency" do
-      expect(described_class.new(organisation).default_currency).to eq("gbp")
+    it "converts to readable form" do
+      expect(described_class.new(organisation).default_currency).to eq("Pound Sterling")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

BEIS users can now and edit implementing organisations. Often this
will be in response to the needs of delivery partners.

## List of implementing organisations

All organisations which can be considered "implementing":

  i) legacy organisations such as BEIS which have a role
  other than `implementing_organisation` but have an
  OrgParticipation of the role `implementing`

  ii) organisations which were migrated over from
  `implementing_organisations`. They don't have any
  `Organisation#role` as this is a deprecated concept. They do
  have an OrgParticipation of the role `implementing`

  iii) an Organisation newly created by BEIS which has the
  role `implementing_organisation` and as yet has no
  OrgParticipation. This is because it has not yet been
  associated with an activity by a delivery partner --
  presumably this will shortly be done, as we expect new
  implementing organisations to be made by BEIS in response
  to requests (Zendesk tickets) received by BEIS

<img width="1139" alt="implementing_orgs" src="https://user-images.githubusercontent.com/20245/145091003-3fe354f0-00ee-4e89-b6e0-792314eee9f6.png">


## Creating a new implementing organisation

Typically in response to a request from a delivery partner. IATI reference is optional.

<img width="801" alt="new_org" src="https://user-images.githubusercontent.com/20245/145091131-f065c658-1ec1-4e88-a561-887ac3c44faa.png">

## Editing an implementing organisation

Here we see a record recently migrated from the old `implementing_organisations` table being edited. It will be necessary to supply missing fields (short name, default currency and language code)

<img width="814" alt="edit_migrated_org" src="https://user-images.githubusercontent.com/20245/145091476-3314be6a-e2a2-4f6b-8c63-3d30dbb9ba24.png">



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
