### PR TITLE
Update Readme - Add process to get terraform AWS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -936,6 +936,7 @@
 ## [unreleased]
 - Health check endpoint includes basic sidekiq stats
 - Show users a warning about appending data when uploading actuals data
+- Update Readme - Add process to get terraform AWS credentials
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90

--- a/doc/terraform-deployment.md
+++ b/doc/terraform-deployment.md
@@ -45,6 +45,25 @@ training environment (pentest).
   in the item "terraform state S3 bucket credentials". The CF credentials should
   be your username and password for GPaaS. Once set, load these variables into
   your shell by running `source deploy-credentials.sh`
+
+  If you can't find the AWS credentials within 1Password (or they are incorrect), you can
+  find them within the `terraform` space in GPaaS:
+
+  1. Login to GPaaS
+  ```
+  cf login
+  ```
+
+  1. When promted, select the `terraform` space. If you are already logged in, switch to the
+  `terraform space:
+  ```
+  cf target -s terraform
+  ```
+
+  1. Then to output the AWS credentials, run:
+  ```
+  cf service-key terraform-state terraform-state-key
+  ```
 - download a copy of the Terraform variables from the RODA 1Password vault;
   they're in the item "pentest.tfvars" -- save them to a file named
   `pentest.tfvars` in the current directory


### PR DESCRIPTION
## Changes in this PR

Adds process to readme for retrieving the AWS credentials via GPaaS
