### PR TITLE
Release 91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -934,7 +934,7 @@
 - Channel of delivery code 90000, 'Other' added to the accepted codes list
 - Fix deployment notification
 
-## [unreleased]
+## [release-91] 2021-12-07
 
 - Health check endpoint includes basic sidekiq stats
 - Show users a warning about appending data when uploading actuals data
@@ -944,7 +944,10 @@
 - Fix setup script
 - Use postgres version 13 in backing-services-docker-compose.yml
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-91...HEAD
+[release-91]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-90...release-91
 [release-90]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-89...release-90
 [release-89]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-88...release-89
 [release-88]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-87...release-88


### PR DESCRIPTION
- Health check endpoint includes basic sidekiq stats
- Show users a warning about appending data when uploading actuals data
- Update Readme - Add process to get terraform AWS credentials
- New reports have a stricter validation to financial period
- Documentation about logging
- Fix setup script
- Use postgres version 13 in backing-services-docker-compose.yml

## Next steps

### Data migrations

- [ ] `rails runner db/data/20211123_add_uniq_implementing_orgs_to_orgs.rb`
- [ ] `rails runner db/data/20211124_create_implementing_organisation_participations.rb`
