### PR TITLE
Filter unwanted budgets for deletion

### DIFF
--- a/db/data/20211207144100_delete_unwanted_budgets.rb
+++ b/db/data/20211207144100_delete_unwanted_budgets.rb
@@ -1,0 +1,50 @@
+# Run me with `rails runner db/data/20211207144100_delete_unwanted_budgets.rb`
+
+def find(organisation_name:, fund:, level:)
+  organisation = Organisation.find_by(beis_organisation_reference: organisation_name)
+  activities = Activity.where(organisation_id: organisation.id, level: level)
+
+  if fund == "Newton"
+    activities.filter do |activity|
+      activity.is_newton_funded?
+    end
+  else
+    activities.filter do |activity|
+      activity.is_gcrf_funded?
+    end
+  end.filter do |activity|
+    activity.budgets.any?
+  end
+end
+
+targets = [
+  {organisation_name: "AMS", fund: "Newton", level: "project"},
+  {organisation_name: "RS", fund: "Newton", level: "project"},
+  {organisation_name: "UKSA", fund: "GCRF", level: "third_party_project"},
+]
+
+targets.each do |target|
+  results = find(target)
+  puts
+  puts "Finding activities matching #{target}"
+  puts "#{results.count} number of activities"
+
+  budgets_count = results.sum { |activity|
+    activity.budgets.count
+  }
+
+  puts "#{budgets_count} number of budgets"
+  puts
+
+  results.each do |activity|
+    puts "#{activity.roda_identifier} | #{activity.title} | #{activity.budgets.count}"
+    activity.budgets.each do |budget|
+      puts "#{budget.financial_year} fiancial year and #{budget.value} value"
+      if budget.delete
+        puts "budget deleted"
+      else
+        raise "could not delete"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Filter unwanted budgets for deletion

Budget figures were entered (est. July/August 2020) for the first onboarded delivery partners UKSA, AMS and RS in order to meet IATI publishing requirements using RODA for the first time.
- Some of the activities have multiple budgets across years that are fixed on 2020-2021.
- When originally added to RODA you couldn't delete a budget once entered. Some data entry errors were made and these were edited to 0.01.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
