### PR TITLE
Replace ImplementingOrganisation with OrgParticipation in delete activity task

### DIFF
--- a/lib/tasks/delete_activity.rake
+++ b/lib/tasks/delete_activity.rake
@@ -18,7 +18,7 @@ namespace :activities do
     external_income = ExternalIncome.where(activity_id: activity.id)
     history = HistoricalEvent.where(activity_id: activity.id)
     adjustments = Adjustment.where(parent_activity_id: activity.id)
-    implementing_organisations = ImplementingOrganisation.where(activity_id: activity.id)
+    implementing_organisations = OrgParticipation.where(activity_id: activity.id)
     incomming_transfers_count = IncomingTransfer.where(destination_id: activity.id).count
     outgoing_transfers_count = OutgoingTransfer.where(source_id: activity.id).count
 


### PR DESCRIPTION
https://trello.com/c/ElWiw4K1/26-beis-roda-delete-activity-rake-task-is-broken

ImplementingOrganisation has been replaced with the OrgParticipation model. This
was updated everywhere except for the delete activity task, and as a result
the task was not functioning correctly.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
