### PR TITLE
Support: Delete all "actuals" associated with a given list of activities

### DIFF
--- a/db/data/20220106163037_remove_actuals_from_given_activities.rb
+++ b/db/data/20220106163037_remove_actuals_from_given_activities.rb
@@ -1,0 +1,93 @@
+# Run me with `rails runner db/data/20220106163037_remove_actuals_from_given_activities.rb`
+
+require "csv"
+timestamp = Time.current.to_formatted_s(:number)
+input_path = "tmp/activities_whose_actuals_are_to_be_deleted.csv"
+summary_output_path = "tmp/activities_and_their_actuals_#{timestamp}.csv"
+detail_output_path = "tmp/actuals_for_deletion_#{timestamp}.csv"
+
+summary_output_headers = %w[
+  roda_id
+  activity_id
+  actual_count
+  pre_2022_actual_count
+  earliest_period
+  latest_period
+  refunds_count
+  adjustments_count
+]
+
+summary_output_rows = []
+
+detail_output_headers = %w[
+  roda_id
+  activity_id
+  actual_id
+  actual_value
+  actual_date
+  actual_financial_quarter_and_year
+]
+
+detail_output_rows = []
+
+CSV.readlines(input_path, encoding: "bom|utf-8", headers: true).each do |row|
+  roda_id = row.fetch("RODA_ID")
+  activity = Activity.find_by!(roda_identifier: roda_id)
+  all_actuals = activity.actuals
+  actuals_for_deletion = all_actuals.reject { |a| ["FQ2 2021-2022", "FQ1 2021-2022"].include?(a.financial_quarter_and_year) }
+
+  earliest_actual = if all_actuals.any?
+    all_actuals
+      .min_by { |a| [a.financial_year, a.financial_quarter] }
+      .financial_quarter_and_year
+  else
+    "-"
+  end
+
+  latest_actual = if all_actuals.any?
+    all_actuals
+      .max_by { |a| [a.financial_year, a.financial_quarter] }
+      .financial_quarter_and_year
+  else
+    "-"
+  end
+
+  refunds = activity.refunds
+  adjustments = activity.adjustments
+
+  summary_output_rows << [
+    roda_id,
+    activity.id,
+    all_actuals.count,
+    actuals_for_deletion.count,
+    earliest_actual,
+    latest_actual,
+    refunds.count,
+    adjustments.count,
+  ]
+
+  actuals_for_deletion.each do |actual|
+    detail_output_rows << [
+      roda_id,
+      activity.id,
+      actual.id,
+      actual.value.to_s,
+      actual.date.to_s,
+      actual.financial_quarter_and_year,
+    ]
+    puts "deleting actual #{actual.id}"
+    actual.destroy!
+  end
+rescue => error
+  puts error
+end
+
+CSV.open(summary_output_path, "w", headers: true) do |csv|
+  csv << summary_output_headers
+  summary_output_rows.each { |row| csv << row }
+end
+
+CSV.open(detail_output_path, "w", headers: true) do |csv|
+  csv << detail_output_headers
+  detail_output_rows.each { |row| csv << row }
+end

--- a/db/data/20220106163037_remove_actuals_from_given_activities.rb
+++ b/db/data/20220106163037_remove_actuals_from_given_activities.rb
@@ -30,7 +30,7 @@ detail_output_headers = %w[
 
 detail_output_rows = []
 
-ActiveRecord::Base.transaction do 
+ActiveRecord::Base.transaction do
   CSV.readlines(input_path, encoding: "bom|utf-8", headers: true).each do |row|
     roda_id = row.fetch("RODA_ID")
     activity = Activity.find_by!(roda_identifier: roda_id)


### PR DESCRIPTION
## Changes in this PR

Script for deleting (only pre-2022) historic actuals associated with a list of activities. See https://dxw.zendesk.com/agent/tickets/15615 for details.

The process: 

1. Upload the CSV provided by BEIS listing the target activities to GPaaS and locate it as `tmp/activities_whose_actuals_are_to_be_deleted.csv`

2. Run this script with the command `bin/rails runner db/data/20220106163037_remove_actuals_from_given_activities.rb`

3.  Download the output files `tmp/activities_and_their_actuals.csv` and `tmp/actuals_for_deletion.csv` for a record of what was deleted.



## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
