### PR TITLE
Add IF EXISTS to DROP commands for databases/extensions

### DIFF
--- a/script/db-restore
+++ b/script/db-restore
@@ -72,13 +72,13 @@ if [ "$delete_data" == "y" ]; then
             --exclude-table="spatial_ref_sys"
 
     echo "==> Dropping and recreating the roda-development database..."
-    psql -c '\set AUTOCOMMIT on\n DROP DATABASE "roda-development"; CREATE DATABASE "roda-development";' -d postgres
+    psql -c '\set AUTOCOMMIT on\n DROP DATABASE IF EXISTS "roda-development"; CREATE DATABASE "roda-development";' -d postgres
 
     echo "==> Restoring the data from the backup..."
     pg_restore -d roda-development --no-owner --clean "$filename" || true
 
     echo "==> Removing extraneous Postgres extensions..."
-    psql -d roda-development -c 'DROP extension citext; DROP extension postgis; DROP extension "uuid-ossp";'
+    psql -d roda-development -c 'DROP EXTENSION IF EXISTS citext; DROP EXTENSION IF EXISTS postgis; DROP EXTENSION IF EXISTS "uuid-ossp";'
 
     echo "==> Setting database environment..."
     bundle exec rails db:environment:set RAILS_ENV=development


### PR DESCRIPTION
If a database or extension does not exist, attempting to DROP it
fails and halts the restore process. Specifically, `postgis` did
not exist as an extension when installing a local development
environment for me.

```
==> Removing extraneous Postgres extensions...
NOTICE:  extension "postgis" does not exist, skipping
DROP EXTENSION
```

## Next steps

None.