### PR TITLE
Feature: move spending breakdown into async job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,18 @@ NOTIFY_KEY=
 NOTIFY_WELCOME_EMAIL_TEMPLATE=b1282182-887e-4c8a-8a39-649c9215cd41
 NOTIFY_VIEW_TEMPLATE=b541df04-add8-458e-a7d3-2e156386e150
 NOTIFY_OTP_VERIFICATION_TEMPLATE=1a832f2e-b13b-47f0-b32a-9cd6672364d2
+
+VCAP_SERVICES='{
+   "aws-s3-bucket":[
+      {
+         "name":"s3-export-download-bucket",
+         "credentials":{
+            "bucket_name":"paas-s3-broker-prod-lon-id",
+            "aws_access_key_id":"KEY_ID",
+            "aws_secret_access_key":"SECRET",
+            "aws_region":"eu-west-2",
+            "deploy_env":""
+         }
+      }
+   ]
+}'

--- a/.env.test
+++ b/.env.test
@@ -13,3 +13,18 @@ REDIS_URL=redis://localhost:6379
 SECRET_KEY_BASE=abcdefghijklmnopqrstuvwxyz12345678
 NOTIFY_VIEW_TEMPLATE=b541df04-add8-458e-a7d3-2e156386e150
 NOTIFY_OTP_VERIFICATION_TEMPLATE=1a832f2e-b13b-47f0-b32a-9cd6672364d2
+
+VCAP_SERVICES='{
+   "aws-s3-bucket":[
+      {
+         "name":"s3-export-download-bucket",
+         "credentials":{
+            "bucket_name":"paas-s3-broker-prod-lon-id",
+            "aws_access_key_id":"KEY_ID",
+            "aws_secret_access_key":"SECRET",
+            "aws_region":"eu-west-2",
+            "deploy_env":""
+         }
+      }
+   ]
+}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1041,6 +1041,9 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Fix spending breakdown report by running asynchronously and emailing a download link
+  to the requester.
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-107...HEAD
 [release-107]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-106...release-107
 [release-106]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-105...release-106

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.7.3"
 
 gem "acts_as_tree"
 gem "addressable"
+gem "aws-sdk-s3", "~> 1.109"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "govuk_design_system_formbuilder", "~> 3.0.2"
 gem "haml-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,22 @@ GEM
     ast (2.4.2)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.573.0)
+    aws-sdk-core (3.130.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.55.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.113.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.17)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -200,6 +216,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.1)
     json (2.6.1)
     jwt (2.3.0)
     launchy (2.5.0)
@@ -468,6 +485,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_tree
   addressable
+  aws-sdk-s3 (~> 1.109)
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -44,16 +44,12 @@ class Staff::ExportsController < Staff::BaseController
 
   def spending_breakdown
     authorize :export, :show_external_income?
-    fund = Fund.new(params[:fund_id])
 
-    respond_to do |format|
-      format.csv do
-        export = Export::SpendingBreakdown.new(source_fund: fund)
+    SpendingBreakdownJob.perform_later(
+      requester_id: current_user.id,
+      fund_id: params[:fund_id]
+    )
 
-        stream_csv_download(filename: export.filename, headers: export.headers) do |csv|
-          export.rows.each { |row| csv << row }
-        end
-      end
-    end
+    render :export_in_progress
   end
 end

--- a/app/controllers/staff/exports_controller.rb
+++ b/app/controllers/staff/exports_controller.rb
@@ -50,6 +50,11 @@ class Staff::ExportsController < Staff::BaseController
       fund_id: params[:fund_id]
     )
 
+    fund = Fund.new(params[:fund_id])
+    email = current_user.email
+    @message = "The requested spending breakdown for #{fund.name} is being prepared. " \
+               "We will send a download link to #{email} when it is ready."
+
     render :export_in_progress
   end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -2,5 +2,7 @@ class SpendingBreakdownJob < ApplicationJob
   def perform(requester_id:, fund_id:)
     requester = User.find(requester_id)
     fund = Fund.new(fund_id)
+
+    export = Export::SpendingBreakdown.new(source_fund: fund)
   end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -1,0 +1,6 @@
+class SpendingBreakdownJob < ApplicationJob
+  def perform(requester_id:, fund_id:)
+    requester = User.find(requester_id)
+    fund = Fund.new(fund_id)
+  end
+end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -12,6 +12,8 @@ class SpendingBreakdownJob < ApplicationJob
       file_url: upload_csv_to_s3(tempfile),
       file_name: export.filename
     ).deliver
+  rescue => error
+    log_error(error, requester)
   end
 
   def save_tempfile(export)
@@ -27,5 +29,11 @@ class SpendingBreakdownJob < ApplicationJob
 
   def upload_csv_to_s3(file)
     Export::S3Uploader.new(file).upload
+  end
+
+  def log_error(error, requester)
+    message = "#{error.message} for #{requester.email}"
+    Rails.logger.error(message)
+    Rollbar.log(:error, message, error)
   end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -4,10 +4,14 @@ class SpendingBreakdownJob < ApplicationJob
   def perform(requester_id:, fund_id:)
     requester = User.find(requester_id)
     fund = Fund.new(fund_id)
-
     export = Export::SpendingBreakdown.new(source_fund: fund)
     tempfile = save_tempfile(export)
     download_url = upload_csv_to_s3(tempfile)
+    DownloadLinkMailer.send_link(
+      recipient: requester,
+      file_url: download_url,
+      file_name: export.filename
+    ).deliver
   end
 
   def save_tempfile(export)

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -1,8 +1,22 @@
 class SpendingBreakdownJob < ApplicationJob
+  require "csv"
+
   def perform(requester_id:, fund_id:)
     requester = User.find(requester_id)
     fund = Fund.new(fund_id)
 
     export = Export::SpendingBreakdown.new(source_fund: fund)
+    tempfile = save_tempfile(export)
+  end
+
+  def save_tempfile(export)
+    tmpfile = Tempfile.new
+    CSV.open(tmpfile, "wb", {headers: true}) do |csv|
+      csv << export.headers
+      export.rows.each do |row|
+        csv << row
+      end
+    end
+    tmpfile
   end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -7,6 +7,7 @@ class SpendingBreakdownJob < ApplicationJob
 
     export = Export::SpendingBreakdown.new(source_fund: fund)
     tempfile = save_tempfile(export)
+    download_url = upload_csv_to_s3(tempfile)
   end
 
   def save_tempfile(export)
@@ -18,5 +19,11 @@ class SpendingBreakdownJob < ApplicationJob
       end
     end
     tmpfile
+  end
+
+  def upload_csv_to_s3(file)
+    uploader = Export::S3Uploader.new(file)
+    file_url = uploader.upload
+    file_url
   end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -14,6 +14,7 @@ class SpendingBreakdownJob < ApplicationJob
     ).deliver
   rescue => error
     log_error(error, requester)
+    DownloadLinkMailer.send_failure_notification(recipient: requester).deliver
   end
 
   def save_tempfile(export)

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -13,4 +13,7 @@ class DownloadLinkMailer < ApplicationMailer
       )
     )
   end
+
+  def send_failure_notification(recipient:)
+  end
 end

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -1,0 +1,4 @@
+class DownloadLinkMailer < ApplicationMailer
+  def send_link(recipient:, file_url:, file_name:)
+  end
+end

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -1,4 +1,16 @@
 class DownloadLinkMailer < ApplicationMailer
   def send_link(recipient:, file_url:, file_name:)
+    @file_url = file_url
+    @file_name = file_name
+
+    view_mail(
+      ENV["NOTIFY_VIEW_TEMPLATE"],
+      to: recipient.email,
+      subject: t(
+        "mailer.download_link.success.subject",
+        application_name: t("app.title"),
+        file_name: file_name
+      )
+    )
   end
 end

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -15,5 +15,13 @@ class DownloadLinkMailer < ApplicationMailer
   end
 
   def send_failure_notification(recipient:)
+    view_mail(
+      ENV["NOTIFY_VIEW_TEMPLATE"],
+      to: recipient.email,
+      subject: t(
+        "mailer.download_link.failure.subject",
+        application_name: t("app.title")
+      )
+    )
   end
 end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -9,6 +9,7 @@ module Export
 
     def upload
       client.put_object(
+        bucket: S3UploaderConfig.bucket,
         body: file
       )
     end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -1,0 +1,11 @@
+module Export
+  class S3Uploader
+    def initialize(_file)
+      # coming soon
+    end
+
+    def upload
+      # coming soon
+    end
+  end
+end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -3,13 +3,15 @@ module Export
     def initialize(file)
       @client = Aws::S3::Client.new
       @file = file
+      @filename = "export-file-#{Time.current.to_formatted_s(:number)}.csv"
     end
 
-    attr_reader :client, :file
+    attr_reader :client, :file, :filename
 
     def upload
       client.put_object(
         bucket: S3UploaderConfig.bucket,
+        key: filename,
         body: file
       )
     end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -3,7 +3,13 @@ module Export
 
   class S3Uploader
     def initialize(file)
-      @client = Aws::S3::Client.new
+      @client = Aws::S3::Client.new(
+        region: S3UploaderConfig.region,
+        credentials: Aws::Credentials.new(
+          S3UploaderConfig.key_id,
+          S3UploaderConfig.secret_key
+        )
+      )
       @file = file
       @filename = "export-file-#{Time.current.to_formatted_s(:number)}.csv"
     end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -24,7 +24,7 @@ module Export
       )
       raise "Unexpected response." unless response&.etag
 
-      bucket.object(filename).public_url
+      bucket.object(filename).presigned_url(:get, expires_in: 1.day.in_seconds)
     rescue => error
       raise_error(error.message)
     end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -1,4 +1,6 @@
 module Export
+  class S3UploadError < StandardError; end
+
   class S3Uploader
     def initialize(file)
       @client = Aws::S3::Client.new
@@ -14,11 +16,16 @@ module Export
         key: filename,
         body: file
       )
-      if response.etag
-        bucket.object(filename).public_url
-      else
-        false
-      end
+
+      raise_error unless response&.etag
+
+      bucket.object(filename).public_url
+    end
+
+    private
+
+    def raise_error
+      raise S3UploadError, "Error uploading report #{filename}"
     end
 
     def bucket

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -1,11 +1,16 @@
 module Export
   class S3Uploader
-    def initialize(_file)
-      # coming soon
+    def initialize(file)
+      @client = Aws::S3::Client.new
+      @file = file
     end
 
+    attr_reader :client, :file
+
     def upload
-      # coming soon
+      client.put_object(
+        body: file
+      )
     end
   end
 end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -9,11 +9,21 @@ module Export
     attr_reader :client, :file, :filename
 
     def upload
-      client.put_object(
+      response = client.put_object(
         bucket: S3UploaderConfig.bucket,
         key: filename,
         body: file
       )
+      if response.etag
+        bucket.object(filename).public_url
+      else
+        false
+      end
+    end
+
+    def bucket
+      resource = Aws::S3::Resource.new(client: client)
+      resource.bucket(S3UploaderConfig.bucket)
     end
   end
 end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -16,16 +16,17 @@ module Export
         key: filename,
         body: file
       )
-
-      raise_error unless response&.etag
+      raise "Unexpected response." unless response&.etag
 
       bucket.object(filename).public_url
+    rescue => error
+      raise_error(error.message)
     end
 
     private
 
-    def raise_error
-      raise S3UploadError, "Error uploading report #{filename}"
+    def raise_error(original_message = nil)
+      raise S3UploadError, [original_message, "Error uploading report #{filename}"].join(" ")
     end
 
     def bucket

--- a/app/services/export/s3_uploader_config.rb
+++ b/app/services/export/s3_uploader_config.rb
@@ -1,0 +1,28 @@
+module Export
+  class S3UploaderConfig
+    def self.region
+      credentials.fetch("aws_region")
+    end
+
+    def self.bucket
+      credentials.fetch("bucket_name")
+    end
+
+    def self.key_id
+      credentials.fetch("aws_access_key_id")
+    end
+
+    def self.secret_key
+      credentials.fetch("aws_secret_access_key")
+    end
+
+    def self.credentials
+      JSON.parse(ENV.fetch("VCAP_SERVICES"))
+        .fetch("aws-s3-bucket")
+        .find { |config| config.fetch("name").match?(/^s3-export-download-bucket/) }
+        .fetch("credentials")
+    rescue KeyError, NoMethodError => _error
+      raise "AWS S3 credentials not found"
+    end
+  end
+end

--- a/app/views/download_link_mailer/send_failure_notification.text.erb
+++ b/app/views/download_link_mailer/send_failure_notification.text.erb
@@ -1,0 +1,5 @@
+# There has been a problem
+
+There has been a problem preparing your export. The error has been logged and our team will investigate as soon as possible. If you have any additional context to add please create a support request using the link below.
+
+<%= render partial: "report_mailer/footer" %>

--- a/app/views/download_link_mailer/send_link.text.erb
+++ b/app/views/download_link_mailer/send_link.text.erb
@@ -1,0 +1,9 @@
+# Export ready to download
+
+<%= "You may download the requested export ('#{@file_name}') from:" %>
+
+<%= @file_url %>
+
+If you experience any difficulties downloading your export, please let us know. Please include the download link and the export's filename in your report.
+
+<%= render partial: "report_mailer/footer" %>

--- a/app/views/staff/exports/export_in_progress.html.haml
+++ b/app/views/staff/exports/export_in_progress.html.haml
@@ -1,0 +1,7 @@
+=content_for :page_title_prefix, t("document_title.export.export_in_progress")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        Your export is being prepared

--- a/app/views/staff/exports/export_in_progress.html.haml
+++ b/app/views/staff/exports/export_in_progress.html.haml
@@ -5,3 +5,5 @@
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
         Your export is being prepared
+      %p.govuk-body
+        = @message

--- a/app/views/staff/exports/index.html.haml
+++ b/app/views/staff/exports/index.html.haml
@@ -42,7 +42,7 @@
               %td.govuk-table__cell
                 CSV
               %td.govuk-table__cell
-                = a11y_action_link("Download", spending_breakdown_exports_path(fund_id: fund.id, format: "csv"), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+                = a11y_action_link("Download", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
       %h1.govuk-heading-m
         = t("page_content.export.organisations.title")
 

--- a/app/views/staff/exports/index.html.haml
+++ b/app/views/staff/exports/index.html.haml
@@ -42,7 +42,7 @@
               %td.govuk-table__cell
                 CSV
               %td.govuk-table__cell
-                = a11y_action_link("Download", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+                = a11y_action_link("Request", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
       %h1.govuk-heading-m
         = t("page_content.export.organisations.title")
 

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -38,3 +38,7 @@ en:
       index: Exports
       organisation:
         show: Exports for %{name}
+  mailer:
+    download_link:
+      success:
+        subject: "%{application_name} - Your export '%{file_name}' is ready to download"

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -42,3 +42,5 @@ en:
     download_link:
       success:
         subject: "%{application_name} - Your export '%{file_name}' is ready to download"
+      failure:
+        subject: '%{application_name} - Your export failed'

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -3,6 +3,7 @@ en:
   document_title:
     export:
       index: Exports
+      export_in_progress: Export being prepared
   page_title:
     export:
       index: Exports

--- a/spec/controllers/staff/exports_controller_spec.rb
+++ b/spec/controllers/staff/exports_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Staff::ExportsController do
     end
   end
 
-  describe "#spending_breakdown", wip: true do
+  describe "#spending_breakdown" do
     render_views
     let(:user) { create(:beis_user) }
 

--- a/spec/controllers/staff/exports_controller_spec.rb
+++ b/spec/controllers/staff/exports_controller_spec.rb
@@ -70,4 +70,28 @@ RSpec.describe Staff::ExportsController do
       end
     end
   end
+
+  describe "#spending_breakdown", wip: true do
+    render_views
+    let(:user) { create(:beis_user) }
+
+    before do
+      allow(SpendingBreakdownJob).to receive(:perform_later)
+    end
+
+    it "kicks off async job to create the CSV, upload to S3 & email download link" do
+      get "spending_breakdown", params: {fund_id: fund.id}
+
+      expect(SpendingBreakdownJob).to have_received(:perform_later).with(
+        requester_id: user.id,
+        fund_id: fund.id.to_s
+      )
+    end
+
+    it "responds with the 'export_in_progress' template" do
+      get "spending_breakdown", params: {fund_id: fund.id}
+
+      expect(response).to render_template(:export_in_progress)
+    end
+  end
 end

--- a/spec/features/staff/users_can_export_spending_breakdown_spec.rb
+++ b/spec/features/staff/users_can_export_spending_breakdown_spec.rb
@@ -1,17 +1,18 @@
 RSpec.feature "Users can export spending breakdown" do
-  context "as a BEIS user" do
+  context "as a BEIS user", wip: true do
     before do
-      authenticate! user: create(:beis_user)
+      authenticate! user: create(:beis_user, email: "beis@example.com")
     end
 
-    scenario "they can download the spending breakdown export for all organissations" do
+    scenario "they can request a spending breakdown export for all organisations" do
       visit exports_path
-      click_link "Download Spending breakdown for Newton Fund"
+      click_link "Request Spending breakdown for Newton Fund"
 
-      expect(page.status_code).to eq 200
+      export_in_progress_msg =
+        "The requested spending breakdown for Newton Fund is being prepared. " \
+        "We will send a download link to beis@example.com when it is ready."
 
-      headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
-      expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))
+      expect(page).to have_content(export_in_progress_msg)
     end
 
     scenario "they can download the spending breakdown export for a single organisation" do

--- a/spec/features/staff/users_can_export_spending_breakdown_spec.rb
+++ b/spec/features/staff/users_can_export_spending_breakdown_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "Users can export spending breakdown" do
-  context "as a BEIS user", wip: true do
+  context "as a BEIS user" do
     before do
       authenticate! user: create(:beis_user, email: "beis@example.com")
     end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -3,11 +3,13 @@ require "rails_helper"
 RSpec.describe SpendingBreakdownJob, type: :job do
   let(:requester) { double(:user) }
   let(:fund) { double(:fund) }
+  let(:breakdown) { instance_double(Export::SpendingBreakdown, filename: double("filename")) }
 
   describe "#perform" do
     before do
       allow(User).to receive(:find)
-      allow(Fund).to receive(:new)
+      allow(Fund).to receive(:new).and_return(fund)
+      allow(Export::SpendingBreakdown).to receive(:new).and_return(breakdown)
     end
 
     it "asks the user object for the user with a given id" do
@@ -20,6 +22,12 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: "fund123")
 
       expect(Fund).to have_received(:new).with("fund123")
+    end
+
+    it "uses Export::SpendingBreakdown to build the breakdown for the given fund" do
+      SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
+
+      expect(Export::SpendingBreakdown).to have_received(:new).with(source_fund: fund)
     end
   end
 end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SpendingBreakdownJob, type: :job, wip: true do
+RSpec.describe SpendingBreakdownJob, type: :job do
   let(:requester) { double(:user, email: "roger@example.com") }
   let(:fund) { double(:fund) }
   let(:row1) { double("row1") }

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SpendingBreakdownJob, type: :job do
+RSpec.describe SpendingBreakdownJob, type: :job, wip: true do
   let(:requester) { double(:user, email: "roger@example.com") }
   let(:fund) { double(:fund) }
   let(:row1) { double("row1") }

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -97,7 +97,11 @@ RSpec.describe SpendingBreakdownJob, type: :job, wip: true do
         }.not_to raise_error
       end
 
-      it "does not try to send the email with the download link"
+      it "does not try to send the email with the download link" do
+        SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
+
+        expect(DownloadLinkMailer).not_to have_received(:send_link)
+      end
 
       it "sends the email notifying the requester of failure creating the report"
     end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -3,13 +3,27 @@ require "rails_helper"
 RSpec.describe SpendingBreakdownJob, type: :job do
   let(:requester) { double(:user) }
   let(:fund) { double(:fund) }
-  let(:breakdown) { instance_double(Export::SpendingBreakdown, filename: double("filename")) }
+  let(:row1) { double("row1") }
+  let(:row2) { double("row1") }
+
+  let(:breakdown) do
+    instance_double(
+      Export::SpendingBreakdown,
+      filename: double("filename"),
+      headers: %w[col1 col2],
+      rows: [row1, row2]
+    )
+  end
+  let(:tempfile) { double("tempfile") }
+  let(:csv) { double("csv", "<<" => true) }
 
   describe "#perform" do
     before do
       allow(User).to receive(:find)
       allow(Fund).to receive(:new).and_return(fund)
       allow(Export::SpendingBreakdown).to receive(:new).and_return(breakdown)
+      allow(Tempfile).to receive(:new).and_return(tempfile)
+      allow(CSV).to receive(:open).and_yield(csv)
     end
 
     it "asks the user object for the user with a given id" do
@@ -28,6 +42,15 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 
       expect(Export::SpendingBreakdown).to have_received(:new).with(source_fund: fund)
+    end
+
+    it "writes the breakdown to a 'tempfile'" do
+      SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
+
+      expect(CSV).to have_received(:open).with(tempfile, "wb", {headers: true})
+      expect(csv).to have_received(:<<).with(%w[col1 col2])
+      expect(csv).to have_received(:<<).with(row1)
+      expect(csv).to have_received(:<<).with(row2)
     end
   end
 end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SpendingBreakdownJob, type: :job do
+  let(:requester) { double(:user) }
+  let(:fund) { double(:fund) }
+
+  describe "#perform" do
+    before do
+      allow(User).to receive(:find)
+      allow(Fund).to receive(:new)
+    end
+
+    it "asks the user object for the user with a given id" do
+      SpendingBreakdownJob.perform_now(requester_id: "user123", fund_id: double)
+
+      expect(User).to have_received(:find).with("user123")
+    end
+
+    it "asks the fund object for the fund with a given id" do
+      SpendingBreakdownJob.perform_now(requester_id: double, fund_id: "fund123")
+
+      expect(Fund).to have_received(:new).with("fund123")
+    end
+  end
+end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -52,5 +52,9 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       expect(csv).to have_received(:<<).with(row1)
       expect(csv).to have_received(:<<).with(row2)
     end
+
+    it "uploads the file to S3"
+
+    it "emails a download link to the requesting user"
   end
 end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -96,6 +96,10 @@ RSpec.describe SpendingBreakdownJob, type: :job do
           SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
         }.not_to raise_error
       end
+
+      it "does not try to send the email with the download link"
+
+      it "sends the email notifying the requester of failure creating the report"
     end
 
     it "emails a download link to the requesting user" do

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       expect(uploader).to have_received(:upload)
     end
 
+    context "when the uploader raises an error" do
+      it "rescues the error"
+      it "logs the error"
+      it "records the error at Rollbar for exception handling and debugging"
+      it "does not re-raise the error as we don't wish to retry the job"
+    end
+
     it "emails a download link to the requesting user" do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe DownloadLinkMailer, type: :mailer, wip: true do
-  describe "#send_link(recipient:, file_url:, file_name:)" do
-    let(:user) { double("beis user", email: "beis@example.com") }
+  let(:user) { double("beis user", email: "beis@example.com") }
 
+  describe "#send_link(recipient:, file_url:, file_name:)" do
     let(:mail) do
       DownloadLinkMailer.send_link(
         recipient: user,
@@ -38,6 +38,39 @@ RSpec.describe DownloadLinkMailer, type: :mailer, wip: true do
         "If you experience any difficulties downloading your export, " \
         "please let us know. Please include the download link and " \
         "the export's filename in your report."
+      )
+    end
+
+    it "includes contact details for getting in touch" do
+      expect(mail.body).to include("support@beisodahelp.zendesk.com")
+    end
+
+    it "includes a link for requesting support" do
+      expect(mail.body).to include("https://beisodahelp.zendesk.com")
+    end
+  end
+
+  describe "#send_failure_notification(recipient:)" do
+    let(:mail) do
+      DownloadLinkMailer.send_failure_notification(recipient: user)
+    end
+
+    it "sends the email to the given recipient" do
+      expect(mail.to).to include("beis@example.com")
+    end
+
+    it "sets a helpful subject on the email" do
+      expect(mail.subject).to eq(
+        "Report your Official Development Assistance - Your export failed"
+      )
+    end
+
+    it "includes generic message as we can't rely on filename or url being available" do
+      expect(mail.body).to include("There has been a problem")
+      expect(mail.body).to include(
+        "There has been a problem preparing your export. The error has been " \
+        "logged and our team will investigate as soon as possible. If you have any " \
+        "additional context to add please create a support request using the link below."
       )
     end
 

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DownloadLinkMailer, type: :mailer do
+RSpec.describe DownloadLinkMailer, type: :mailer, wip: true do
   describe "#send_link(recipient:, file_url:, file_name:)" do
     let(:user) { double("beis user", email: "beis@example.com") }
 

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe DownloadLinkMailer, type: :mailer do
+  describe "#send_link(recipient:, file_url:, file_name:)" do
+    let(:user) { double("beis user", email: "beis@example.com") }
+
+    let(:mail) do
+      DownloadLinkMailer.send_link(
+        recipient: user,
+        file_url: "https://roda.example.com/abc123",
+        file_name: "spending_breakdown.csv"
+      )
+    end
+
+    it "includes a message with the export's filename" do
+      expect(mail.body).to include(
+        "You may download the requested export ('spending_breakdown.csv') from:"
+      )
+    end
+
+    it "includes the given url as a link to download the export" do
+      expect(mail.body).to include("https://roda.example.com/abc123")
+    end
+
+    it "sends the email to the given recipient" do
+      expect(mail.to).to include("beis@example.com")
+    end
+
+    it "sets a helpful subject on the email" do
+      expect(mail.subject).to eq(
+        "Report your Official Development Assistance - " \
+        "Your export 'spending_breakdown.csv' is ready to download"
+      )
+    end
+
+    it "includes a request for info in the event of a problem" do
+      expect(mail.body).to include(
+        "If you experience any difficulties downloading your export, " \
+        "please let us know. Please include the download link and " \
+        "the export's filename in your report."
+      )
+    end
+
+    it "includes contact details for getting in touch" do
+      expect(mail.body).to include("support@beisodahelp.zendesk.com")
+    end
+
+    it "includes a link for requesting support" do
+      expect(mail.body).to include("https://beisodahelp.zendesk.com")
+    end
+  end
+end

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DownloadLinkMailer, type: :mailer, wip: true do
+RSpec.describe DownloadLinkMailer, type: :mailer do
   let(:user) { double("beis user", email: "beis@example.com") }
 
   describe "#send_link(recipient:, file_url:, file_name:)" do

--- a/spec/mailers/previews/download_link_mailer_preview.rb
+++ b/spec/mailers/previews/download_link_mailer_preview.rb
@@ -8,4 +8,10 @@ class DownloadLinkMailerPreview < ActionMailer::Preview
       file_name: "spending_breakdown.csv"
     )
   end
+
+  def send_failure_notification
+    DownloadLinkMailer.send_failure_notification(
+      recipient: FactoryBot.build(:beis_user, email: "beis@example.com")
+    )
+  end
 end

--- a/spec/mailers/previews/download_link_mailer_preview.rb
+++ b/spec/mailers/previews/download_link_mailer_preview.rb
@@ -1,0 +1,11 @@
+require "factory_bot"
+
+class DownloadLinkMailerPreview < ActionMailer::Preview
+  def send_link
+    DownloadLinkMailer.send_link(
+      recipient: FactoryBot.build(:beis_user, email: "beis@example.com"),
+      file_url: "https://roda.example.com/abc123",
+      file_name: "spending_breakdown.csv"
+    )
+  end
+end

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 module Export
-  RSpec.describe S3UploaderConfig do
+  RSpec.describe S3UploaderConfig, wip: true do
     context "when an expected credential is missing from VCAP_SERVICES" do
       around(:each) do |example|
         vcap_services = <<~JSON

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 module Export
-  RSpec.describe S3UploaderConfig, wip: true do
+  RSpec.describe S3UploaderConfig do
     context "when an expected credential is missing from VCAP_SERVICES" do
       around(:each) do |example|
         vcap_services = <<~JSON

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+module Export
+  RSpec.describe S3UploaderConfig do
+    context "when an expected credential is missing from VCAP_SERVICES" do
+      around(:each) do |example|
+        vcap_services = <<~JSON
+          {
+            "aws-s3-bucket":[
+                {
+                   "name": "s3-export-download-bucket",
+                   "credentials":{
+                      "bucket_name":"exports_bucket",
+                      "aws_access_key_id":"KEY_ID",
+                      "aws_secret_access_key":"SECRET_KEY"
+                   }
+                }
+            ]
+          }
+        JSON
+        ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
+      end
+
+      it "raises a helpful error message" do
+        expect { S3UploaderConfig.region }.to raise_error(KeyError, /key not found: "aws_region"/)
+      end
+    end
+
+    context "when the expected credentials object is missing" do
+      around(:each) do |example|
+        vcap_services = <<~JSON
+          {
+            "aws-s3-bucket":[
+                {
+                   "name": "s3-export-download-bucket",
+                   "incorrect_credentials_key":{
+                      "bucket_name":"exports_bucket",
+                      "aws_access_key_id":"KEY_ID",
+                      "aws_secret_access_key":"SECRET_KEY"
+                   }
+                }
+            ]
+          }
+        JSON
+        ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
+      end
+
+      it "raises a helpful error message" do
+        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+      end
+    end
+
+    context "when the S3 service has an unexpected name" do
+      around(:each) do |example|
+        vcap_services = <<~JSON
+          {
+              "aws-s3-bucket":[
+                  {
+                     "name": "unexpected-s3-service-name",
+                     "credentials":{
+                        "bucket_name":"exports_bucket",
+                        "aws_access_key_id":"KEY_ID",
+                        "aws_secret_access_key":"SECRET_KEY"
+                     }
+                  }
+              ]
+            }
+        JSON
+        ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
+      end
+
+      it "raises a helpful error message" do
+        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+      end
+    end
+
+    context "when the aws object is empty" do
+      around(:each) do |example|
+        vcap_services = <<~JSON
+          {
+            "aws-s3-bucket":[]
+          }
+        JSON
+        ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
+      end
+
+      it "raises a helpful error message" do
+        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+      end
+    end
+
+    context "when the expected credentials within VCAP_SERVICES env var are set" do
+      around(:each) do |example|
+        vcap_services = <<~JSON
+          {
+            "aws-s3-bucket":[
+                {
+                   "name": "s3-export-download-bucket",
+                   "credentials":{
+                      "bucket_name":"exports_bucket",
+                      "aws_access_key_id":"KEY_ID",
+                      "aws_secret_access_key":"SECRET_KEY",
+                      "aws_region":"eu-west-2"
+                   }
+                }
+            ]
+          }
+        JSON
+        ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
+      end
+
+      it "returns the bucket_name" do
+        expect(S3UploaderConfig.bucket).to eq("exports_bucket")
+      end
+
+      it "returns the key_id" do
+        expect(S3UploaderConfig.key_id).to eq("KEY_ID")
+      end
+
+      it "returns the secret_key" do
+        expect(S3UploaderConfig.secret_key).to eq("SECRET_KEY")
+      end
+
+      it "returns the region" do
+        expect(S3UploaderConfig.region).to eq("eu-west-2")
+      end
+    end
+  end
+end

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -18,7 +18,14 @@ RSpec.describe Export::S3Uploader do
       expect(aws_client).to have_received(:put_object).with(hash_including(body: file))
     end
 
-    it "uploads to the bucket defined in by the S3UploaderConfig"
+    it "uploads to the bucket defined by the S3UploaderConfig" do
+      subject.upload
+
+      expect(aws_client).to have_received(:put_object).with(
+        hash_including(bucket: Export::S3UploaderConfig.bucket)
+      )
+    end
+
     it "sets the filename using a timestamp"
 
     context "when the response from S3 has an _etag_" do

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -60,9 +60,12 @@ RSpec.describe Export::S3Uploader do
     end
 
     context "when the response from S3 does not have an _etag_" do
-      it "logs the error"
-      it "logs the error at Rollbar"
-      it "returns _false_"
+      let(:response) { double("response", etag: nil) }
+
+      it "raises an error, including the filename for information" do
+        message = "Error uploading report #{filename}"
+        expect { subject.upload }.to raise_error(Export::S3UploadError, message)
+      end
     end
 
     context "when the attempt to upload the file raises an error" do

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::S3Uploader, wip: true do
+RSpec.describe Export::S3Uploader do
   let(:response) { double("response", etag: double) }
   let(:file) { Tempfile.open("tempfile") { |f| f << "my export here" } }
   let(:aws_credentials) { double("aws credentials") }

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -63,15 +63,20 @@ RSpec.describe Export::S3Uploader do
       let(:response) { double("response", etag: nil) }
 
       it "raises an error, including the filename for information" do
-        message = "Error uploading report #{filename}"
+        message = "Unexpected response. Error uploading report #{filename}"
         expect { subject.upload }.to raise_error(Export::S3UploadError, message)
       end
     end
 
     context "when the attempt to upload the file raises an error" do
-      it "logs the error"
-      it "logs the error at Rollbar"
-      it "returns _false_"
+      before do
+        allow(aws_client).to receive(:put_object).and_raise("There has been a problem!")
+      end
+
+      it "re-raises the error, adding the filename for information" do
+        enriched_message = "There has been a problem! Error uploading report #{filename}"
+        expect { subject.upload }.to raise_error(Export::S3UploadError, enriched_message)
+      end
     end
   end
 end

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::S3Uploader do
+RSpec.describe Export::S3Uploader, wip: true do
   let(:response) { double("response", etag: double) }
   let(:file) { Tempfile.open("tempfile") { |f| f << "my export here" } }
   let(:aws_credentials) { double("aws credentials") }

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -1,8 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Export::S3Uploader do
+  let(:response) { double("response", etag: double) }
+  let(:file) { Tempfile.open("tempfile") { |f| f << "my export here" } }
+  let(:aws_client) { instance_double(Aws::S3::Client, put_object: response) }
+
+  subject { Export::S3Uploader.new(file) }
+
+  before do
+    allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
+  end
+
   describe "#upload" do
-    it "uploads the given file"
+    it "uploads the given file" do
+      subject.upload
+
+      expect(aws_client).to have_received(:put_object).with(hash_including(body: file))
+    end
+
     it "uploads to the bucket defined in by the S3UploaderConfig"
     it "sets the filename using a timestamp"
 

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Export::S3Uploader do
+  describe "#upload" do
+    it "uploads the given file"
+    it "uploads to the bucket defined in by the S3UploaderConfig"
+    it "sets the filename using a timestamp"
+
+    context "when the response from S3 has an _etag_" do
+      it "returns the public_url of the uploaded object"
+    end
+
+    context "when the response from S3 does not have an _etag_" do
+      it "logs the error"
+      it "logs the error at Rollbar"
+      it "returns _false_"
+    end
+
+    context "when the attempt to upload the file raises an error" do
+      it "logs the error"
+      it "logs the error at Rollbar"
+      it "returns _false_"
+    end
+  end
+end

--- a/terraform/s3-export-download-bucket.tf
+++ b/terraform/s3-export-download-bucket.tf
@@ -1,0 +1,13 @@
+data "cloudfoundry_service" "aws-s3-bucket" {
+  name = "aws-s3-bucket"
+}
+
+resource "cloudfoundry_service_instance" "beis-roda-s3-export-download-bucket" {
+  name         = "beis-roda-${var.environment}-s3-export-download-bucket"
+  space        = cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.aws-s3-bucket.service_plans["default"]
+  json_params  = <<EOF
+  {"public_bucket":true}
+EOF
+}
+

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -15,6 +15,12 @@ resource "cloudfoundry_app" "beis-roda-worker" {
   }
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-redis.id }
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-postgres.id }
+  service_binding {
+    service_instance = cloudfoundry_service_instance.beis-roda-s3-export-download-bucket.id
+    params = {
+      "permissions" = "read-write"
+    }
+  }
   service_binding { service_instance = cloudfoundry_user_provided_service.papertrail.id }
   environment = {
     "RAILS_LOG_TO_STDOUT"              = "true"


### PR DESCRIPTION
## Changes in this PR

### Background

The "BEIS" (admin) version of the "spending breakdown" export is a comprehensive output of all spending for all time periods for all organisations -- for a given fund. In recent history this export was considered "broken" because it timed out due to the volume of queries. By contrast, the "Delivery partner" version of the export (which only outputs details for the delivery partner's organisation) has been functional.

From Oct to Nov 2021 we undertook a major refactoring of "exports" (See https://trello.com/c/hbeQLje4/2255-export-improvements). At the end of this process we noted that the spending breakdown export was approx 35% faster. 

However, when the BEIS assurers attempted to run the export in December they experienced 504 (timeout) errors on production. On my (admittedly puny) development machine the exports take more than 10 mins to run so this is not surprising. See:

Zendesk: https://dxw.zendesk.com/agent/tickets/15546

As a first step in improving this area we've decided to hand off the export creation to a background job which is charged with running the report, writing to a CSV, putting the CSV in an S3 bucket and emailing the requester with a download link.

### AWS S3

Some info on using S3 with GPaaS:
 
-  S3 with GPaaS: https://docs.cloud.service.gov.uk/deploying_services/s3/#amazon-s3

- Connecting to a bucket: https://docs.cloud.service.gov.uk/deploying_services/s3/#connect-to-an-s3-bucket-from-your-app

We've initially implemented an `S3UploaderConfig` class to extract the necessary AWS config from Cloudfoundry's rather complex JSON formatted `VCAP_SERVICES` env var. However, we've since become aware of a `VcapParser` class which aleady exists in BEIS, but without S3 config/creds. And of a [RMI version](https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/blob/352b545144653311c9b6a697b985ecbfccc3aa75/lib/vcap_parser.rb) which does include S3. 

### To do

A few things still to do:

- [x] create Terraform for S3 config as at present we only have a manually created test bucket in our staging environment. See [RMI for S3 on GPASS](https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/blob/352b545144653311c9b6a697b985ecbfccc3aa75/terraform/terraform.tf) example. Credentials for the temp experimental bucket are in the RODA vault in 1Password in the "S3 for uploading exports (staging experiments)" secret.

#### To do later
- [ ] reconcile our `S3UploaderConfig` with the `VcapParser` pattern already in play on RODA and RMI. Consider whether there's code which ought be extracted out to a `gem`. We're going to this later as a learning exercise with a more junior team member.
- [ ] make sure temporary CSV file is always removed
- [ ] delete download from S3 -- e.g. after 7 days
- [ ] extract some copy from views and controllers to translation files.

## Screenshots of UI changes

### Exports page now reflects change in action offered

![request_export_cta](https://user-images.githubusercontent.com/20245/150188408-c76b7d95-c3c6-4a55-a2af-4c39379582a4.png)

### Download email sent to requester on success

![Success](https://user-images.githubusercontent.com/20245/150942656-3fc108a3-9d62-4488-b3b2-90feb539f809.png)


### Failure message sent to requester if there's a problem

![failure_email](https://user-images.githubusercontent.com/20245/150188697-5f774eab-8a4b-4827-b8f9-7ddec2257e8e.png)

## Next steps

- [ ] complete "To do" list above
- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [x] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
