### PR TITLE
Lint YAML files

### DIFF
--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -434,7 +434,6 @@ en:
         finance: Finance type
         aid_type: Aid type
         collaboration_type: Collaboration type
-        channel_of_delivery_code: Channel of delivery code
         policy_marker_gender: Gender - policy marker
         policy_marker_climate_change_adaptation: Climate Change - Adaptation policy marker
         policy_marker_climate_change_mitigation: Climate Change - Mitigation policy marker
@@ -449,15 +448,12 @@ en:
         originating_report_id: Originating report identifier
         source_fund_code: Fund code
         call_present: Call present?
-        transparency_identifier: IATI identifier
         parent_id: Parent activity identifier
         parent: Parent activity
         publish_to_iati: Include in IATI XML export?
-        sector_category: Sector category
         previous_identifier: Previous IATI identifier
         geography: Recipient geography
         extending_organisation_id: Extending organisation identifier
-        sector: Sector
         organisation_id: Organisation identifier
         tied_status: Tied status
         organisation: Organisation

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -13,7 +13,6 @@ en:
     header:
       report:
         financial_quarter: Financial quarter
-        state: State
         description: Description
         organisation: Organisation
         fund: Fund (level A)

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -186,14 +186,8 @@ en:
           title: Report activation complete
           body: "%{report_financial_quarter} %{report_description}"
         failure: Report could not be activated
-      submit:
-        failure: Report could not be submitted
       review:
         failure: Report could not be moved to in review
-      request_changes:
-        failure: Report could not be moved to awaiting changes
-      approve:
-        failure: Report could not be approved
       create:
         success: Report successfully created
       update:
@@ -204,6 +198,7 @@ en:
           title: "%{report_financial_quarter} %{report_organisation} report submitted"
         confirm:
           button: Confirm submission
+        failure: Report could not be submitted
       download:
         button: Download report as CSV file
         failure: Reports could not be downloaded
@@ -221,12 +216,14 @@ en:
           button: Confirm
         complete:
           title: "%{report_financial_quarter} %{report_organisation} report is now awaiting changes"
+        failure: Report could not be moved to awaiting changes
       approve:
         complete:
           title: "%{report_financial_quarter} report for %{report_organisation} approved"
         button: Approve
         confirm:
           button: Confirm approval
+        failure: Report could not be approved
   activerecord:
     errors:
       models:


### PR DESCRIPTION
A number of duplicated keys in YAML files were discovered from running the `check-yaml` pre-commit hook (see pre-commit.com)

(further information: https://yaml.readthedocs.io/en/latest/api.html#duplicate-keys )

The following decisions were made whilst correcting them:

* Almost all duplicated keys with string values were identical duplicates; one was removed.
* The only exception is `State`/`Status` for the `state` key; State (the first key) was removed as there's evidence of an attempt to change from State to Status.
* All duplicated keys with hash values had no overlap in the keys of the hashes; the 'failure' subkeys were merged with the other subkeys from the duplicated keys. This *does* change the interpretation of the YAML file (the second, more substantial key with non-`failure` subkeys would have been hidden)

The impact of these changes is unknown but it seemed wise to bring them up for discussion.