### PR TITLE
Upgrade bundler & rubygems for terraform/dependabot issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
 COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
-RUN gem update --system 3.2.16
+RUN gem update --system 3.3.5
 RUN gem update rake 13.0.1
-RUN gem install bundler -v 2.1.4
+RUN gem install bundler -v 2.3.5
 
 RUN bundle config set frozen 'true'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,4 +555,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.1.4
+   2.3.5


### PR DESCRIPTION
We have a dependabot/terraform PR problem: all the dependabot-triggered
builds fail. A propos of

rubyjs/mini_racer#220 (comment)

...update the rubygems and bundler that Docker (and hence CI) uses.

Try this on its own first due to rubygems [patch](https://github.com/rubygems/rubygems/pull/4082) (check build runs, merge, maybe see new dependabot PR builds work?), then try

`bundle lock --add-platform x86_64-linux` as per the comment in the link above if still no joy

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
