### PR TITLE
Strip control characters from some Activity fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -960,6 +960,7 @@
 ## [unreleased]
 
 - Moved deactivated users to the bottom of the users list
+- Remove control characters from input before validation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...HEAD
 [release-94]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-93...release-94

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  describe "#strip_control_characters_from_fields!" do
+    context "for text fields" do
+      it "removes control characters and preserves text" do
+        activity = Activity.new
+        activity.objectives = "kit\x02t\x00en ✓"
+        activity.valid?
+        expect(activity.objectives).to eq "kitten ✓"
+      end
+    end
+
+    context "for string fields" do
+      it "removes control characters and preserves text" do
+        activity = Activity.new
+        activity.title = "kit\x02t\x00en ✓"
+        activity.valid?
+        expect(activity.title).to eq "kitten ✓"
+      end
+    end
+  end
+
   describe "#finance" do
     it "always returns Standard Grant, code '110'" do
       activity = Activity.new


### PR DESCRIPTION
For fields which are of type 'string' or 'text' (and not an array
of those), before we validate we delete almost all control characters to
avoid XML documents we generate being malformed due to containing
unescaped control characters.

(We don't remove tab, carriage return or line-feed as they're
commonly found within normal text, and are permitted as-is within XML
documents. https://www.w3.org/International/questions/qa-controls#support )

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- ❌  Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
