### PR TITLE
Move deactivated users to the bottom of the list of users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -959,6 +959,8 @@
 
 ## [unreleased]
 
+- Moved deactivated users to the bottom of the users list
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...HEAD
 [release-94]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-93...release-94
 [release-93]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-92...release-93

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -3,7 +3,7 @@ class Staff::UsersController < Staff::BaseController
 
   def index
     authorize :user, :index?
-    @users = policy_scope(User).includes(:organisation).order("organisations.name ASC, users.name ASC")
+    @users = policy_scope(User).includes(:organisation).joins(:organisation).order("users.active DESC, organisations.name ASC, users.name ASC")
   end
 
   def show


### PR DESCRIPTION
`includes` doesn't like it if you try to sort on the users table first, so we `joins` as well.
`joins` on its own raises an error saying to add includes:
```
     Bullet::Notification::UnoptimizedQueryError:
       user: dragon
       GET /users
       USE eager loading detected
         User => [:organisation]
         Add to your query: .includes([:organisation])
```


### Before
Mikey Middleton would appear in the middle.

### After
<img width="772" alt="image" src="https://user-images.githubusercontent.com/85497046/151154445-ba538c1d-887f-414a-a9d3-c1a8939b74f9.png">


## Next steps

- ❌ Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- ❌ Do any environment variables need amending or adding?
- ❌ Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
- [ ] Update the "how to use this website" guidance for Sam
