### PR TITLE
(2348) Refactor policy specs to minimise setup costs

### DIFF
--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      it "controls actions as expected" do
+      it "only permits show and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
         is_expected.to forbid_action(:create_refund)
@@ -75,7 +75,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      it "controls actions as expected" do
+      it "only permits show and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
 
@@ -98,7 +98,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity) }
 
-      it "controls actions as expected" do
+      it "forbids all actions" do
         is_expected.to forbid_action(:show)
         is_expected.to forbid_action(:create)
         is_expected.to forbid_action(:edit)
@@ -117,7 +117,7 @@ RSpec.describe ActivityPolicy do
       let(:activity) { create(:programme_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it "controls actions as expected" do
+        it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
           is_expected.to forbid_action(:edit)
@@ -137,7 +137,7 @@ RSpec.describe ActivityPolicy do
           activity.update(extending_organisation: user.organisation)
         end
 
-        it "controls actions as expected" do
+        it "only permits show" do
           is_expected.to permit_action(:show)
 
           is_expected.to forbid_action(:create)
@@ -157,7 +157,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "controls actions as expected" do
+          it "only permits create_child" do
             is_expected.to permit_action(:create_child)
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
@@ -171,7 +171,7 @@ RSpec.describe ActivityPolicy do
       let(:activity) { create(:project_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it "controls actions as expected" do
+        it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
           is_expected.to forbid_action(:edit)
@@ -196,7 +196,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :approved)
           end
 
-          it "controls actions as expected" do
+          it "only permits show" do
             is_expected.to permit_action(:show)
 
             is_expected.to forbid_action(:create)
@@ -217,7 +217,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "controls actions as expected" do
+          it "only forbids destroy and redact_from_iati" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -239,7 +239,7 @@ RSpec.describe ActivityPolicy do
       let(:activity) { create(:third_party_project_activity) }
 
       context "and the users organisation is not the extending organisation" do
-        it "controls actions as expected" do
+        it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
           is_expected.to forbid_action(:edit)
@@ -260,7 +260,7 @@ RSpec.describe ActivityPolicy do
         end
 
         context "and there is no editable report for the users organisation" do
-          it "controls actions as expected" do
+          it "only permits show" do
             is_expected.to permit_action(:show)
 
             is_expected.to forbid_action(:create)
@@ -280,7 +280,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "controls actions as expected" do
+          it "only forbids destroy, redact_from_iati, and create_child" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)

--- a/spec/policies/actual_policy_spec.rb
+++ b/spec/policies/actual_policy_spec.rb
@@ -11,44 +11,52 @@ RSpec.describe ActualPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
+      it "only permits show" do
+        is_expected.to permit_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
 
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
-      it { is_expected.to permit_action(:destroy) }
+      it "permits all actions" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:edit)
+        is_expected.to permit_action(:update)
+        is_expected.to permit_action(:destroy)
+      end
     end
 
     context "when the activity is a project" do
       let(:activity) { create(:project_activity, organisation: create(:delivery_partner_organisation)) }
 
-      it { is_expected.to permit_action(:show) }
+      it "only permits show" do
+        is_expected.to permit_action(:show)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a third party project" do
       let(:activity) { create(:third_party_project_activity, organisation: create(:delivery_partner_organisation)) }
 
-      it { is_expected.to permit_action(:show) }
+      it "only permits show" do
+        is_expected.to permit_action(:show)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
   end
 
@@ -58,32 +66,38 @@ RSpec.describe ActualPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity) }
 
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
       context "and the activity does not belong to the users organisation" do
-        it { is_expected.to forbid_action(:show) }
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
 
       context "and the activity does belong to the users organisation" do
@@ -94,24 +108,28 @@ RSpec.describe ActualPolicy do
         context "when there is no editable report" do
           let(:report) { create(:report, :approved) }
 
-          it { is_expected.to permit_action(:show) }
+          it "only permits show" do
+            is_expected.to permit_action(:show)
 
-          it { is_expected.to forbid_action(:create) }
-          it { is_expected.to forbid_action(:edit) }
-          it { is_expected.to forbid_action(:update) }
-          it { is_expected.to forbid_action(:destroy) }
+            is_expected.to forbid_action(:create)
+            is_expected.to forbid_action(:edit)
+            is_expected.to forbid_action(:update)
+            is_expected.to forbid_action(:destroy)
+          end
         end
 
         context "when there is an editable report" do
           let(:report) { create(:report, :active) }
 
           context "and the report is not for the organisation or fund of the activity" do
-            it { is_expected.to permit_action(:show) }
+            it "only permits show" do
+              is_expected.to permit_action(:show)
 
-            it { is_expected.to forbid_action(:create) }
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
+              is_expected.to forbid_action(:create)
+              is_expected.to forbid_action(:edit)
+              is_expected.to forbid_action(:update)
+              is_expected.to forbid_action(:destroy)
+            end
           end
 
           context "and the report is for the organisation but not the fund of the activity" do
@@ -119,12 +137,14 @@ RSpec.describe ActualPolicy do
               report.update(organisation: activity.organisation)
             end
 
-            it { is_expected.to permit_action(:show) }
+            it "only permits show" do
+              is_expected.to permit_action(:show)
 
-            it { is_expected.to forbid_action(:create) }
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
+              is_expected.to forbid_action(:create)
+              is_expected.to forbid_action(:edit)
+              is_expected.to forbid_action(:update)
+              is_expected.to forbid_action(:destroy)
+            end
           end
 
           context "and the report is for the organisation and fund of the activity" do
@@ -133,12 +153,14 @@ RSpec.describe ActualPolicy do
             end
 
             context "when the report is not the one in which the actual was created" do
-              it { is_expected.to permit_action(:show) }
-              it { is_expected.to permit_action(:create) }
+              it "only permits show and create" do
+                is_expected.to permit_action(:show)
+                is_expected.to permit_action(:create)
 
-              it { is_expected.to forbid_action(:edit) }
-              it { is_expected.to forbid_action(:update) }
-              it { is_expected.to forbid_action(:destroy) }
+                is_expected.to forbid_action(:edit)
+                is_expected.to forbid_action(:update)
+                is_expected.to forbid_action(:destroy)
+              end
             end
 
             context "when the report is the one in which the actual was created" do
@@ -146,11 +168,13 @@ RSpec.describe ActualPolicy do
                 actual.update(report: report)
               end
 
-              it { is_expected.to permit_action(:show) }
-              it { is_expected.to permit_action(:create) }
-              it { is_expected.to permit_action(:edit) }
-              it { is_expected.to permit_action(:update) }
-              it { is_expected.to permit_action(:destroy) }
+              it "permits all actions" do
+                is_expected.to permit_action(:show)
+                is_expected.to permit_action(:create)
+                is_expected.to permit_action(:edit)
+                is_expected.to permit_action(:update)
+                is_expected.to permit_action(:destroy)
+              end
             end
           end
         end

--- a/spec/policies/budget_policy_spec.rb
+++ b/spec/policies/budget_policy_spec.rb
@@ -11,43 +11,51 @@ RSpec.describe BudgetPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
-      it { is_expected.to permit_action(:destroy) }
+      it "permits all actions" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:edit)
+        is_expected.to permit_action(:update)
+        is_expected.to permit_action(:destroy)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
-      it { is_expected.to permit_action(:destroy) }
+      it "permits all actions" do
+        is_expected.to permit_action(:show)
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:edit)
+        is_expected.to permit_action(:update)
+        is_expected.to permit_action(:destroy)
+      end
     end
 
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      it { is_expected.to permit_action(:show) }
+      it "only permits show" do
+        is_expected.to permit_action(:show)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a third party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      it { is_expected.to permit_action(:show) }
+      it "only permits show" do
+        is_expected.to permit_action(:show)
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
   end
 
@@ -57,32 +65,38 @@ RSpec.describe BudgetPolicy do
     context "when the activity is a fund" do
       let(:activity) { create(:fund_activity) }
 
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity) }
 
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:edit) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:edit)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
 
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
       context "and the activity does not belong to the users organisation" do
-        it { is_expected.to forbid_action(:show) }
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:edit) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:edit)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
 
       context "and the activity does belong to the users organisation" do
@@ -93,24 +107,28 @@ RSpec.describe BudgetPolicy do
         context "when there is no editable report" do
           let(:report) { create(:report, :approved) }
 
-          it { is_expected.to permit_action(:show) }
+          it "only permits show" do
+            is_expected.to permit_action(:show)
 
-          it { is_expected.to forbid_action(:create) }
-          it { is_expected.to forbid_action(:edit) }
-          it { is_expected.to forbid_action(:update) }
-          it { is_expected.to forbid_action(:destroy) }
+            is_expected.to forbid_action(:create)
+            is_expected.to forbid_action(:edit)
+            is_expected.to forbid_action(:update)
+            is_expected.to forbid_action(:destroy)
+          end
         end
 
         context "when there is an editable report" do
           let(:report) { create(:report, :active) }
 
           context "and the report is not for the organisation or fund of the activity" do
-            it { is_expected.to permit_action(:show) }
+            it "only permits show" do
+              is_expected.to permit_action(:show)
 
-            it { is_expected.to forbid_action(:create) }
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
+              is_expected.to forbid_action(:create)
+              is_expected.to forbid_action(:edit)
+              is_expected.to forbid_action(:update)
+              is_expected.to forbid_action(:destroy)
+            end
           end
 
           context "and the report is for the organisation but not the fund of the activity" do
@@ -118,12 +136,14 @@ RSpec.describe BudgetPolicy do
               report.update(organisation: activity.organisation)
             end
 
-            it { is_expected.to permit_action(:show) }
+            it "only permits show" do
+              is_expected.to permit_action(:show)
 
-            it { is_expected.to forbid_action(:create) }
-            it { is_expected.to forbid_action(:edit) }
-            it { is_expected.to forbid_action(:update) }
-            it { is_expected.to forbid_action(:destroy) }
+              is_expected.to forbid_action(:create)
+              is_expected.to forbid_action(:edit)
+              is_expected.to forbid_action(:update)
+              is_expected.to forbid_action(:destroy)
+            end
           end
 
           context "and the report is for the organisation and fund of the activity" do
@@ -132,12 +152,14 @@ RSpec.describe BudgetPolicy do
             end
 
             context "when the report is not the one in which the budget was created" do
-              it { is_expected.to permit_action(:show) }
-              it { is_expected.to permit_action(:create) }
+              it "only permits show and create" do
+                is_expected.to permit_action(:show)
+                is_expected.to permit_action(:create)
 
-              it { is_expected.to forbid_action(:edit) }
-              it { is_expected.to forbid_action(:update) }
-              it { is_expected.to forbid_action(:destroy) }
+                is_expected.to forbid_action(:edit)
+                is_expected.to forbid_action(:update)
+                is_expected.to forbid_action(:destroy)
+              end
             end
 
             context "when the report is the one in which the budget was created" do
@@ -145,11 +167,13 @@ RSpec.describe BudgetPolicy do
                 budget.update(report: report)
               end
 
-              it { is_expected.to permit_action(:show) }
-              it { is_expected.to permit_action(:create) }
-              it { is_expected.to permit_action(:edit) }
-              it { is_expected.to permit_action(:update) }
-              it { is_expected.to permit_action(:destroy) }
+              it "permits all actions" do
+                is_expected.to permit_action(:show)
+                is_expected.to permit_action(:create)
+                is_expected.to permit_action(:edit)
+                is_expected.to permit_action(:update)
+                is_expected.to permit_action(:destroy)
+              end
             end
           end
         end

--- a/spec/policies/external_income_policy_spec.rb
+++ b/spec/policies/external_income_policy_spec.rb
@@ -12,17 +12,21 @@ RSpec.describe ExternalIncomePolicy do
     context "when the activity is a programme activity owned by the organisation" do
       let(:activity) { build_stubbed(:programme_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:update) }
-      it { is_expected.to permit_action(:destroy) }
+      it "permits all actions" do
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:update)
+        is_expected.to permit_action(:destroy)
+      end
     end
 
     context "when the activity is a project activity" do
       let(:activity) { build_stubbed(:project_activity) }
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
   end
 
@@ -37,15 +41,19 @@ RSpec.describe ExternalIncomePolicy do
           report.update(state: :active)
         end
 
-        it { is_expected.to permit_action(:create) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it "permits all actions" do
+          is_expected.to permit_action(:create)
+          is_expected.to permit_action(:update)
+          is_expected.to permit_action(:destroy)
+        end
       end
 
       context "when there is no editable report for the organisation" do
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
     end
 
@@ -57,15 +65,19 @@ RSpec.describe ExternalIncomePolicy do
           report.update(state: :active)
         end
 
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
 
       context "when there is no editable report for the organisation" do
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
     end
   end

--- a/spec/policies/fund_policy_spec.rb
+++ b/spec/policies/fund_policy_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe FundPolicy do
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to permit_action(:destroy) }
+    it "permits all actions" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to permit_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to permit_action(:destroy)
+    end
 
     it "includes activity in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.all).resolve
@@ -23,11 +25,13 @@ RSpec.describe FundPolicy do
   context "as a user that does NOT belong to BEIS" do
     let(:user) { build_stubbed(:delivery_partner_user) }
 
-    it { is_expected.to forbid_action(:index) }
-    it { is_expected.to forbid_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
+    it "forbids all actions" do
+      is_expected.to forbid_action(:index)
+      is_expected.to forbid_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to forbid_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+    end
 
     it "includes activity in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.all).resolve

--- a/spec/policies/matched_effort_policy_spec.rb
+++ b/spec/policies/matched_effort_policy_spec.rb
@@ -12,17 +12,21 @@ RSpec.describe MatchedEffortPolicy do
     context "when the activity is a programme activity owned by the organisation" do
       let(:activity) { build_stubbed(:programme_activity, organisation: user.organisation) }
 
-      it { is_expected.to permit_action(:create) }
-      it { is_expected.to permit_action(:update) }
-      it { is_expected.to permit_action(:destroy) }
+      it "permits all actions" do
+        is_expected.to permit_action(:create)
+        is_expected.to permit_action(:update)
+        is_expected.to permit_action(:destroy)
+      end
     end
 
     context "when the activity is a project activity" do
       let(:activity) { build_stubbed(:project_activity) }
 
-      it { is_expected.to forbid_action(:create) }
-      it { is_expected.to forbid_action(:update) }
-      it { is_expected.to forbid_action(:destroy) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:create)
+        is_expected.to forbid_action(:update)
+        is_expected.to forbid_action(:destroy)
+      end
     end
   end
 
@@ -37,15 +41,19 @@ RSpec.describe MatchedEffortPolicy do
           report.update(state: :active)
         end
 
-        it { is_expected.to permit_action(:create) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it "permits all actions" do
+          is_expected.to permit_action(:create)
+          is_expected.to permit_action(:update)
+          is_expected.to permit_action(:destroy)
+        end
       end
 
       context "when there is ano editable report for the organisation" do
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
     end
 
@@ -57,15 +65,19 @@ RSpec.describe MatchedEffortPolicy do
           report.update(state: :active)
         end
 
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
 
-      context "when there is ano editable report for the organisation" do
-        it { is_expected.to forbid_action(:create) }
-        it { is_expected.to forbid_action(:update) }
-        it { is_expected.to forbid_action(:destroy) }
+      context "when there is no editable report for the organisation" do
+        it "forbids all actions" do
+          is_expected.to forbid_action(:create)
+          is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:destroy)
+        end
       end
     end
   end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -8,35 +8,41 @@ RSpec.describe OrganisationPolicy do
   context "as user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to permit_action(:destroy) }
-    it { is_expected.to permit_action(:download) }
+    it "permits all actions" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to permit_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to permit_action(:destroy)
+      is_expected.to permit_action(:download)
+    end
   end
 
   context "as user that does NOT belong to BEIS" do
     context "when the user belongs to that organisation" do
       let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
 
-      it { is_expected.to forbid_action(:index) }
-      it { is_expected.to permit_action(:show) }
-      it { is_expected.to forbid_new_and_create_actions }
-      it { is_expected.to permit_edit_and_update_actions }
-      it { is_expected.to forbid_action(:destroy) }
-      it { is_expected.to forbid_action(:download) }
+      it "controls actions as expected" do
+        is_expected.to forbid_action(:index)
+        is_expected.to permit_action(:show)
+        is_expected.to forbid_new_and_create_actions
+        is_expected.to permit_edit_and_update_actions
+        is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:download)
+      end
     end
 
     context "when the user does NOT belong to that organisation" do
       let(:user) { build_stubbed(:delivery_partner_user, organisation: create(:delivery_partner_organisation)) }
 
-      it { is_expected.to forbid_action(:index) }
-      it { is_expected.to forbid_action(:show) }
-      it { is_expected.to forbid_new_and_create_actions }
-      it { is_expected.to forbid_edit_and_update_actions }
-      it { is_expected.to forbid_action(:destroy) }
-      it { is_expected.to forbid_action(:download) }
+      it "forbids all actions" do
+        is_expected.to forbid_action(:index)
+        is_expected.to forbid_action(:show)
+        is_expected.to forbid_new_and_create_actions
+        is_expected.to forbid_edit_and_update_actions
+        is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:download)
+      end
     end
   end
 end

--- a/spec/policies/programme_policy_spec.rb
+++ b/spec/policies/programme_policy_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe ProgrammePolicy do
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to permit_action(:destroy) }
+    it "permits all actions" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to permit_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to permit_action(:destroy)
+    end
 
     it "includes all programmes in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.programme).resolve
@@ -25,11 +27,13 @@ RSpec.describe ProgrammePolicy do
   context "as a user that does NOT belong to BEIS" do
     let(:user) { create(:delivery_partner_user, organisation: organisation) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
+    it "only permits index and show" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to forbid_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+    end
 
     it "includes only programmes that the users organisation is the extending organisation for in resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.programme).resolve

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe ProjectPolicy do
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
-    it { is_expected.to permit_action(:download) }
-    it { is_expected.to permit_action(:redact_from_iati) }
+    it "controls actions as expected" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to forbid_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+      is_expected.to permit_action(:download)
+      is_expected.to permit_action(:redact_from_iati)
+    end
 
     it "includes all projects in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.project).resolve
@@ -27,13 +29,15 @@ RSpec.describe ProjectPolicy do
   context "as a user that does NOT belong to BEIS" do
     let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
-    it { is_expected.to forbid_action(:download) }
-    it { is_expected.to forbid_action(:redact_from_iati) }
+    it "controls actions as expected" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to permit_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+      is_expected.to forbid_action(:download)
+      is_expected.to forbid_action(:redact_from_iati)
+    end
 
     it "includes only projects that the users organisation is reporting the project in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.project).resolve

--- a/spec/policies/third_party_project_policy_spec.rb
+++ b/spec/policies/third_party_project_policy_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe ThirdPartyProjectPolicy do
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
-    it { is_expected.to permit_action(:download) }
-    it { is_expected.to permit_action(:redact_from_iati) }
+    it "controls actions as expected" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to forbid_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+      is_expected.to permit_action(:download)
+      is_expected.to permit_action(:redact_from_iati)
+    end
 
     it "includes all third party projects in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.third_party_project).resolve
@@ -27,13 +29,15 @@ RSpec.describe ThirdPartyProjectPolicy do
   context "as a user that does NOT belong to BEIS" do
     let(:user) { build_stubbed(:delivery_partner_user, organisation: organisation) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
-    it { is_expected.to forbid_action(:download) }
-    it { is_expected.to forbid_action(:redact_from_iati) }
+    it "controls actions as expected" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+      is_expected.to forbid_action(:download)
+      is_expected.to forbid_action(:redact_from_iati)
+    end
 
     context "with an editable report" do
       let(:third_party_project) { create(:third_party_project_activity, :with_report, organisation: organisation) }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -8,20 +8,24 @@ RSpec.describe UserPolicy do
   context "as user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_new_and_create_actions }
-    it { is_expected.to permit_edit_and_update_actions }
-    it { is_expected.to permit_action(:destroy) }
+    it "permits all actions" do
+      is_expected.to permit_action(:index)
+      is_expected.to permit_action(:show)
+      is_expected.to permit_new_and_create_actions
+      is_expected.to permit_edit_and_update_actions
+      is_expected.to permit_action(:destroy)
+    end
   end
 
   context "as user that does NOT belong to BEIS" do
     let(:user) { build_stubbed(:delivery_partner_user) }
 
-    it { is_expected.to forbid_action(:index) }
-    it { is_expected.to forbid_action(:show) }
-    it { is_expected.to forbid_new_and_create_actions }
-    it { is_expected.to forbid_edit_and_update_actions }
-    it { is_expected.to forbid_action(:destroy) }
+    it "forbids all actions" do
+      is_expected.to forbid_action(:index)
+      is_expected.to forbid_action(:show)
+      is_expected.to forbid_new_and_create_actions
+      is_expected.to forbid_edit_and_update_actions
+      is_expected.to forbid_action(:destroy)
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Refactor policy specs to decrease the setup costs of individual examples

On my machine, the comparative gains when running all policy specs are as such:
Initial:
```
Finished in 1 minute 48.85 seconds (files took 10.44 seconds to load)
446 examples, 0 failures
```

After refactoring:
```
Finished in 1 minute 6.61 seconds (files took 4.49 seconds to load)
263 examples, 0 failures
```

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
