### PR TITLE
Add recent MacOS platforms to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     launchy (2.5.0)
       addressable (~> 2.7)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -254,6 +255,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
@@ -492,6 +495,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Since [upgrading Bundler to 2.3.5 and Rubygems to 3.3.5](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1542), `bundle install`
will now compile gems with native components rather than auto-selecting
a precompiled version. In some cases those compilations take so long to
be indistinguishable from a hang.

When we add MacOS variants with

```
bundle lock --add-platform x86_64-darwin
```

then precompiled versions are selected and used in dev, preventing hangs
on `bundle install` when compiling nokogiri, sassc et al

Note that I've not been able to find the behaviour change that causes
this; the bundler gem release notes stop at 2.1.4, after which bundler
started shipping with ruby. We were on 2.1.4 before we leapt to 2.3.5
apropos of the mini_racer issues in #1542.