### PR TITLE
Remove control characters from Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -960,6 +960,7 @@
 ## [unreleased]
 
 - Moved deactivated users to the bottom of the users list
+- Remove control characters from input before validation
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...HEAD
 [release-94]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-93...release-94

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     launchy (2.5.0)
       addressable (~> 2.7)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -254,6 +255,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
@@ -492,6 +495,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/db/data/20220127155800_invalid_activities_viewer.rb
+++ b/db/data/20220127155800_invalid_activities_viewer.rb
@@ -1,0 +1,18 @@
+invalid_activities = []
+
+Activity.find_each do |a|
+  # a.touch
+  # a.validate
+  # warn "#{a} changed" if a.dirty?
+  unless a.valid?
+    warn "#{a.id}: #{a.title} invalid, #{a.errors.full_messages}"
+    a.errors.each do |error|
+      warn "#{error.attribute}, #{error.type}"
+    end
+    invalid_activities << a
+  end
+
+  # a.save(validate: false)
+end
+
+puts "#{invalid_activities.count} invalid_activities"

--- a/db/data/20220127173100_correct_control_code_activity.rb
+++ b/db/data/20220127173100_correct_control_code_activity.rb
@@ -1,0 +1,10 @@
+ACTIVITY_WITH_CONTROL_CODE = "d7d98613-ed06-49ae-bb4f-8f6b5c28bcae"
+
+# Activity.joins(:organisation).includes(:organisation).each do |a|
+# Activity.find_each do |a|
+a = Activity.find(ACTIVITY_WITH_CONTROL_CODE)
+a.valid? #  this will call the before_validation hook which removes control codes
+if a.changed?
+  warn "#{a.id}: '#{a.title}' was changed: #{a.changed}"
+  a.save(validate: false)
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  describe "#strip_control_characters_from_fields!" do
+    context "for text fields" do
+      it "removes control characters and preserves text" do
+        activity = Activity.new
+        activity.objectives = "kit\x02t\x00en ✓"
+        activity.valid?
+        expect(activity.objectives).to eq "kitten ✓"
+      end
+    end
+
+    context "for string fields" do
+      it "removes control characters and preserves text" do
+        activity = Activity.new
+        activity.title = "kit\x02t\x00en ✓"
+        activity.valid?
+        expect(activity.title).to eq "kitten ✓"
+      end
+    end
+  end
+
   describe "#finance" do
     it "always returns Standard Grant, code '110'" do
       activity = Activity.new


### PR DESCRIPTION
For fields which are of type 'string' or 'text' (and not an array
of those), before we validate we delete almost all control characters to
avoid XML documents we generate being malformed due to containing
unescaped control characters.

(We don't remove tab, carriage return or line-feed as they're
commonly found within normal text, and are permitted as-is within XML
documents. https://www.w3.org/International/questions/qa-controls#support )

## Next steps

- ❌ Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- ❌  Do any environment variables need amending or adding?
- [X] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)

(The XML doesn't pass, due to a schema validation error, which we'll look into next)

- [ ] Perform database migration on live by running `
❯ bundle exec rails runner db/data/20220127173100_correct_control_code_activity.rb`