### PR TITLE
(2360) Include date validation step when importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -964,6 +964,8 @@
 
 ## [unreleased]
 
+- Ensure that activities validate the presence of `planned_start_date` (or `actual_start_date`) and `planned_end_date` (or `actual_end_date`)
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-95...HEAD
 [release-95]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...release-95
 [release-94]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-93...release-94

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -47,6 +47,7 @@ class Activity < ApplicationRecord
     :sector_step,
     :call_present_step,
     :call_dates_step,
+    :dates_step,
     :total_applications_and_awards_step,
     :programme_status_step,
     :country_delivery_partners_step,

--- a/app/views/staff/shared/xml/_activity.xml.haml
+++ b/app/views/staff/shared/xml/_activity.xml.haml
@@ -24,10 +24,12 @@
   - if activity.previous_identifier?
     %other-identifier{"ref" => activity.transparency_identifier, type: "A1"}
   %activity-status{"code" => activity.iati_status}/
-  %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
+  - if activity.planned_start_date?
+    %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/
   - if activity.actual_start_date?
     %activity-date{"iso-date" => activity.actual_start_date, type: "2"}/
-  %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
+  - if activity.planned_end_date?
+    %activity-date{"iso-date" => activity.planned_end_date, type: "3"}/
   - if activity.actual_end_date?
     %activity-date{"iso-date" => activity.actual_end_date, type: "4"}/
   %contact-info{"type" => "1"}

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -712,6 +712,23 @@ RSpec.describe Activities::ImportFromCsv do
       end
     end
 
+    it "has an error if it fails dates_step validation" do
+      new_activity_attributes["Planned start date"] = nil
+      new_activity_attributes["Actual start date"] = nil
+
+      expect { subject.import([new_activity_attributes]) }.to_not change { Activity.count }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(2)
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column).to eq("Planned start date")
+      expect(subject.errors.first.column).to eq(:planned_start_date)
+      expect(subject.errors.first.value).to be_nil
+      expect(subject.errors.first.message).to eq(I18n.t("activerecord.errors.models.activity.attributes.dates"))
+    end
+
     it "has an error if the parent activity cannot be found" do
       new_activity_attributes["Parent RODA ID"] = "111111"
 


### PR DESCRIPTION
## Changes in this PR
- Ensure that activities validate the presence of `planned_start_date` (or `actual_start_date`) and `planned_end_date` (or `actual_end_date`)

Previously, imported activities were validated in a context that was missing the `:dates_step` validation step.

This has allowed a few activities to be imported without any of `planned_start_date`, `actual_start_date`, `planned_end_date`, `actual_end_date`. These activities go on to generate an invalid IATI XML, which is missing the `iso-date` attribute from the `activity-date` field.

This fix ensures that both imported activities and activities created via the UI form will be validated against the `:dates_step`.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
