### PR TITLE
Standardise Org names -- all caps, no surplus spaces

### DIFF
--- a/db/data/20220202135400-all-caps-orgs.rb
+++ b/db/data/20220202135400-all-caps-orgs.rb
@@ -1,0 +1,8 @@
+Organisation.find_each do |org|
+  old_name = org.name.dup # we need this otherwise it *is* org.name, which we change, and hence changes
+  org.name.upcase!
+  org.name.squish!
+
+  puts "[#{old_name}] became [#{org.name}]" if old_name != org.name
+  org.save(validate: false)
+end


### PR DESCRIPTION
Needed for data quality and sorting on drop-down for choosing
an Implementing Organisation.

<img width="568" alt="image" src="https://user-images.githubusercontent.com/85497046/152170478-bb95b80a-0c7e-4e0a-9462-def7119084c1.png">
