### PR TITLE
Release 97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -967,9 +967,15 @@
 - Ensure that activities validate the presence of `planned_start_date` (or `actual_start_date`) and `planned_end_date` (or `actual_end_date`)
 - Add data migrations for fixing inconsistencies with implementing organisations: add the implementing role to organisations that are missing it; normalise organisation names to uppercase; remove excess spaces from organisation names
 
+## [release-97] 2022-02-15
+
+- Upgrade framework dependencies (gems)
+- Expand the list of channel of delivery codes from 8 to 32 to allow greater precision describing implementing organisations
+
 ## [unreleased]
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-96...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-97...HEAD
+[release-97]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-96...release-97
 [release-96]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-95...release-96
 [release-95]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...release-95
 [release-94]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-93...release-94


### PR DESCRIPTION
- Upgrade framework dependencies (gems)
- Expand the list of channel of delivery codes from 8 to 32 to allow greater precision describing implementing organisations