### PR TITLE
Create CSV report of missing data in activities via validation errors

### DIFF
--- a/doc/utilities.md
+++ b/doc/utilities.md
@@ -9,12 +9,16 @@ each CSV row is:
   - Activity title
   - Activity level
   - Activity URL
+  - Validation Errors, one per column
+
+Each error during validation appears in its own column for ease of manipulation
+in a spreadsheet, and consists of the affected field plus the error message.
 
 The purpose of this task is to be run in production, where the invalid activities
 live at the moment.
 
 ## Running the task
 
-You can run this task on the console by typing `rake invalid_activities`. This
+You can run this task on the console by typing `rake activities:invalid`. This
 command will run the task and, once it's finished, you will find the file
 `invalid_activities.csv` in the `tmp` folder of this project.

--- a/lib/tasks/invalid_activities.rake
+++ b/lib/tasks/invalid_activities.rake
@@ -1,14 +1,28 @@
 require "csv"
+require "set"
 
-desc "Creates a csv file with a list of completed but invalid activities in RODA"
-task invalid_activities: :environment do
-  activities = Activity.where(form_state: "complete")
-  invalid_activities_array = activities.reject { |activity| activity.valid? }
+namespace :activities do
+  desc "Creates a csv file with activities that fail validation and why"
+  task invalid: :environment do
+    def error_strings(errors)
+      errors.errors.map { |x| "#{x.attribute}: #{x.message}" }
+    end
 
-  CSV.open("tmp/invalid_activities.csv", "wb") do |csv|
-    invalid_activities_array.each do |activity|
-      activity_url = Rails.application.routes.url_helpers.organisation_activity_details_url(activity.organisation, activity, host: ENV["DOMAIN"])
-      csv << [activity.organisation.name, activity.roda_identifier, activity.title, activity.level, activity_url]
+    domain = "https://report-official-development-assistance.service.gov.uk/" # ENV["DOMAIN"]
+    error_list = Set[]
+    activities = Activity.all
+    invalid_activities_array = activities.reject(&:valid?)
+    activities.each do |activity|
+      error_list.merge(error_strings(activity))
+    end
+
+    CSV.open("tmp/invalid_activities.csv", "wb") do |csv|
+      invalid_activities_array.each do |activity|
+        activity_url = Rails.application.routes.url_helpers.organisation_activity_details_url(activity.organisation, activity, host: domain)
+        errors = error_strings(activity)
+        matched_errors = error_list.map { |x| errors.include?(x) ? x : "" }
+        csv << [activity.organisation.name, activity.roda_identifier, activity.title, activity.level, activity_url] + matched_errors
+      end
     end
   end
 end

--- a/spec/lib/tasks/invalid_activities_spec.rb
+++ b/spec/lib/tasks/invalid_activities_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 require "csv"
 
-RSpec.describe "rake invalid_activities" do
+RSpec.describe "rake activities:invalid" do
   it "creates a csv file on tmp folder with a list of invalid activities in RODA" do
+    domain = "https://report-official-development-assistance.service.gov.uk/"
     activities = create_list(:project_activity, 5)
 
     first_invalid_activity = activities.first.tap { |a| a.update_columns(gdi: nil, collaboration_type: nil) }
@@ -18,13 +19,13 @@ RSpec.describe "rake invalid_activities" do
       expect(first_invalid_activity_row).to include(first_invalid_activity.title)
       expect(first_invalid_activity_row).to include(first_invalid_activity.organisation.name)
       expect(first_invalid_activity_row).to include(first_invalid_activity.level)
-      expect(first_invalid_activity_row).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(first_invalid_activity.organisation, first_invalid_activity.id, host: ENV["DOMAIN"]))
+      expect(first_invalid_activity_row).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(first_invalid_activity.organisation, first_invalid_activity.id, host: domain))
 
       second_invalid_activity_row = invalid_activities_from_csv.detect { |row| row.include?(second_invalid_activity.roda_identifier) }
       expect(second_invalid_activity_row).to include(second_invalid_activity.title)
       expect(second_invalid_activity_row).to include(second_invalid_activity.organisation.name)
       expect(second_invalid_activity_row).to include(second_invalid_activity.level)
-      expect(second_invalid_activity_row).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(second_invalid_activity.organisation, second_invalid_activity.id, host: ENV["DOMAIN"]))
+      expect(second_invalid_activity_row).to include(Rails.application.routes.url_helpers.organisation_activity_details_url(second_invalid_activity.organisation, second_invalid_activity.id, host: domain))
     end
   end
 end


### PR DESCRIPTION
This adds a 'data_holes' rake task for generating CSV reports to hi. We play about with the errors a bit to get them all their own columns to ensure the data is sortable. 