### PR TITLE
Fix/2393 missing orgs on user create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -974,6 +974,9 @@
 
 ## [unreleased]
 
+- No longer hide all the organisations when creating a user if one wasn't picked to start with
+- Correctly highlight the absence of an organisation when creating a user if one wasn't picked to start with
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-97...HEAD
 [release-97]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-96...release-97
 [release-96]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-95...release-96

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -26,7 +26,8 @@ class Staff::UsersController < Staff::BaseController
     @user = User.new(user_params)
     @user.active = params[:user][:active]
     authorize @user
-    @organisations = policy_scope(Organisation)
+    @service_owner = service_owner
+    @delivery_partners = delivery_partners
 
     if @user.valid?
       result = CreateUser.new(user: @user, organisation: organisation).call

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -5,7 +5,7 @@
   = f.govuk_email_field :email, disabled: (action_name == "edit")
 
   - if @service_owner.present?
-    = f.govuk_radio_buttons_fieldset :organisation_id, classes: "user-organisations" do
+    = f.govuk_radio_buttons_fieldset :organisation, classes: "user-organisations" do
       = f.govuk_radio_button :organisation_id, @service_owner.id, label: { text: @service_owner.name }, link_errors: true
       - if @delivery_partners.any?
         = f.govuk_radio_divider

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -11,9 +11,6 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
     before do
       authenticate!(user: user)
-    end
-
-    before do
       stub_auth0_token_request
     end
 
@@ -68,7 +65,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       context "when there was an error creating the user in auth0" do
         context "when there was a generic error" do
-          it "does not create the user and displays an error message" do
+          it "doesn't create the user, displays an error and displays organisations" do
             stub_auth0_token_request
             new_email = "email@example.com"
             organisation = create(:delivery_partner_organisation)
@@ -86,11 +83,12 @@ RSpec.feature "BEIS users can invite new users to the service" do
             }.not_to change { User.count }
 
             expect(page).to have_content(t("action.user.create.failed", error: "The user already exists."))
+            expect(page).to have_content(organisation.name)
           end
         end
 
         context "when the email was invalid" do
-          it "does not create the user and displays an invalid email message" do
+          it "doesn't create user, displays 'email invalid' but still displays organisations" do
             new_email = "tom"
             organisation = create(:delivery_partner_organisation)
             stub_auth0_create_user_request_failure(email: new_email)
@@ -104,6 +102,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
             expect(page).to have_content("Email is invalid")
             expect(page).not_to have_content(t("action.user.create.failed"))
+            expect(page).to have_content(organisation.name)
           end
         end
       end


### PR DESCRIPTION
## Changes in this PR

We ensure User#create has access to the BEIS/DP organisations to display them after an error.
We ensure the error message for those organisations renders correctly, highlighting the erroneous field and allowing the user to click the link to travel there.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/85497046/154541590-9f716e83-9f33-47a0-bf5f-bee83161552e.png)

### After first commit
![image](https://user-images.githubusercontent.com/85497046/154541023-746f3ebd-c0d8-4f8d-b783-6c28e6b6a442.png)

### After
![image](https://user-images.githubusercontent.com/85497046/154541137-e96699d7-7a26-4540-9f31-afdc526876aa.png)

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.