### PR TITLE
Fix Pundit deprecation warnings

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   include Auth
-  include Pundit
+  include Pundit::Authorization
 
   def not_found
     render "pages/errors/not_found",

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
 class PagesController < ApplicationController
   include HighVoltage::StaticPage
-  include Pundit
+  include Pundit::Authorization
 end

--- a/app/controllers/staff/base_controller.rb
+++ b/app/controllers/staff/base_controller.rb
@@ -1,7 +1,7 @@
 class Staff::BaseController < ApplicationController
   include Secured
   include Auth
-  include Pundit
+  include Pundit::Authorization
 
   # Ensure that Pundit 'authorize' and scopes are used
   after_action :verify_authorized, except: :index

--- a/app/services/activity/tab.rb
+++ b/app/services/activity/tab.rb
@@ -1,6 +1,6 @@
 class Activity
   class Tab
-    include Pundit
+    include Pundit::Authorization
 
     VALID_TAB_NAMES = [
       "financials",

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -1,5 +1,5 @@
 class FindProgrammeActivities
-  include Pundit
+  include Pundit::Authorization
 
   attr_accessor :organisation, :user, :fund_code
 

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -1,5 +1,5 @@
 class FindProjectActivities
-  include Pundit
+  include Pundit::Authorization
 
   attr_accessor :organisation, :user, :fund_code
 

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -1,5 +1,5 @@
 class FindThirdPartyProjectActivities
-  include Pundit
+  include Pundit::Authorization
 
   attr_accessor :organisation, :user, :fund_code
 


### PR DESCRIPTION
`include Pundit` -> `include Pundit::Authorization` following dependabot
upgrade to 2.2.0

See
https://github.com/varvet/pundit/blob/main/CHANGELOG.md#220-2022-02-11

## Changes in this PR

Deprecation warnings go away

## Screenshots of UI changes

### Before

<img width="865" alt="image" src="https://user-images.githubusercontent.com/194511/154543504-34935295-6c90-4ce2-8b7e-39f20946019e.png">

### After

<img width="250" alt="image" src="https://user-images.githubusercontent.com/194511/154543534-9f0f4f0d-7984-4bee-bd50-73aa3b9f78e1.png">


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
