### PR TITLE
2387 remember my login for 30 days

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,7 +164,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 30.days
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
 
-def log_in_via_form(user)
+def log_in_via_form(user, remember_me: false)
   click_on t("header.link.sign_in")
   # type in username and password
   fill_in "Email", with: user.email
   fill_in "Password", with: user.password
+
+  check "Remember me" if remember_me
+
   click_on "Log in"
 end
 
@@ -58,6 +61,24 @@ RSpec.feature "Users can sign in" do
 
     log_in_via_form(user)
     expect(page.current_path).to eql home_path
+  end
+
+  scenario "Logins can be remembered for 30 days" do
+    user = create(:beis_user)
+
+    visit root_path
+    expect(page).to have_content(t("start_page.title"))
+
+    log_in_via_form(user, remember_me: true)
+
+    travel 29.days do
+      visit reports_path
+      expect(page).to have_content("Create a new report")
+    end
+    travel 31.days do
+      visit reports_path
+      expect(page).to have_content("Sign in")
+    end
   end
 
   scenario "protected pages cannot be visited unless signed in" do


### PR DESCRIPTION
## Changes in this PR

Devise is configured to remember logins for 30 days.

As an aside, note that we haven't been updating the CHANGELOG.md for `devise-authentication`. Add a card to remember to do this before merging to `develop`.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
