### PR TITLE
Admin can deactivate a user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,10 @@ class User < ApplicationRecord
 
   delegate :service_owner?, :delivery_partner?, to: :organisation
 
+  def active_for_authentication?
+    active
+  end
+
   private
 
   def email_cannot_be_changed_after_create

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,7 +8,9 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
+      inactive: |
+        Your account is not active. If you believe this to be in error,
+        please contact the person who invited you to the service.
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."

--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -23,14 +23,4 @@ RSpec.feature "Home page" do
       expect(page.current_path).to eq home_path
     end
   end
-
-  context "when signed in as a user who is not active" do
-    let(:user) { create(:delivery_partner_user, active: false) }
-    before { authenticate!(user: user) }
-
-    scenario "they are shown the start page" do
-      visit root_path
-      expect(page).to have_link(t("header.link.sign_in"))
-    end
-  end
 end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -101,28 +101,19 @@ RSpec.feature "Users can sign in" do
 
   context "when the user has been deactivated" do
     scenario "the user cannot log in and sees an informative message" do
-      pending "a viable Devise hook to use with User#active"
       user = create(:delivery_partner_user, active: false, identifier: "deactivated-user")
 
       visit root_path
-
-      expect(page).to have_content(t("header.link.sign_in"))
       log_in_via_form(user)
 
-      expect(page).to have_content(t("page_title.errors.not_authorised"))
-      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content("Your account is not active. If you believe this to be in error, please contact the person who invited you to the service.")
     end
 
     scenario "a user who is logged in and then deactivated sees an error message" do
-      pending "a viable Devise hook to use with User#active"
       user = create(:delivery_partner_user)
 
-      mock_successful_authentication(
-        uid: user.identifier, name: user.name, email: user.email
-      )
-
       visit root_path
-      click_on t("header.link.sign_in")
+      log_in_via_form(user)
 
       expect(page.current_path).to eql home_path
 
@@ -131,8 +122,7 @@ RSpec.feature "Users can sign in" do
 
       visit home_path
 
-      expect(page).to have_content(t("page_title.errors.not_authorised"))
-      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content("Your account is not active. If you believe this to be in error, please contact the person who invited you to the service.")
     end
   end
 end


### PR DESCRIPTION
A deactivated user does not get signed in, so we have removed the old
text and only slightly modified the default devise message.

We are not deleting unused translations at this stage. That has been
planned as a larger “mop-up” operation for later.

We also handle the user editing specs, because this seemed like the best
place to reinstate them.

Co-authored-by: rgarner <rgarner@zephyros-systems.co.uk>

## Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="703" alt="image" src="https://user-images.githubusercontent.com/194511/154698851-47f62c1d-02f1-4805-9a6a-9ce40de88e4a.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
