### PR TITLE
2410: Make forecast and activity CSV upload look like actuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -976,6 +976,7 @@
 
 - No longer hide all the organisations when creating a user if one wasn't picked to start with
 - Correctly highlight the absence of an organisation when creating a user if one wasn't picked to start with
+- Make activities and forecasts CSV upload buttons consistent with actuals
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-97...HEAD
 [release-97]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-96...release-97

--- a/app/views/staff/actual_uploads/update.html.haml
+++ b/app/views/staff/actual_uploads/update.html.haml
@@ -18,4 +18,4 @@
           = t("page_title.actual.upload_success")
 
         = render partial: "shared/actuals/actuals_by_activity"
-        = link_to t("importer.success.actual.back_link"), report_actuals_path(@report_presenter), class: "govuk-button govuk-button"
+        = link_to t("importer.success.actual.back_link"), report_actuals_path(@report_presenter), class: "govuk-button"

--- a/app/views/staff/forecast_uploads/update.html.haml
+++ b/app/views/staff/forecast_uploads/update.html.haml
@@ -7,7 +7,7 @@
         %h1.govuk-heading-xl
           = t("importer.success.heading")
         = render partial: "shared/forecasts/forecasts_by_activity"
-        = link_to t("importer.success.back_link"), report_forecasts_path(@report_presenter), class: "govuk-button govuk-button"
+        = link_to t("importer.success.back_link"), report_forecasts_path(@report_presenter), class: "govuk-button"
 
     - else
       .govuk-grid-column-two-thirds
@@ -18,4 +18,3 @@
     - if @errors.any?
       .govuk-grid-column-full
         = render partial: "error_table"
-

--- a/app/views/staff/reports/_activities_upload.html.haml
+++ b/app/views/staff/reports/_activities_upload.html.haml
@@ -1,0 +1,17 @@
+%h3.govuk-heading-m
+  = t("tabs.activities.providing.heading")
+
+%p.govuk-body
+  = t("tabs.activities.providing.copy")
+
+%h3.govuk-heading-s
+  = t("tabs.activities.upload.heading")
+
+= t("tabs.activities.upload.copy_html")
+
+.govuk-inset-text
+  = t("tabs.activities.upload.warning")
+
+.govuk-button-group
+  = link_to t("page_content.activities.button.download_template"), report_activity_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+  = link_to t("page_content.activities.button.upload"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button"

--- a/app/views/staff/reports/_activities_upload.html.haml
+++ b/app/views/staff/reports/_activities_upload.html.haml
@@ -14,4 +14,4 @@
 
 .govuk-button-group
   = link_to t("page_content.activities.button.download_template"), report_activity_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
-  = link_to t("page_content.activities.button.upload"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button"
+  = link_to t("page_content.activities.button.upload"), new_report_activity_upload_path(@report_presenter), class: "govuk-button"

--- a/app/views/staff/reports/_actuals_upload.html.haml
+++ b/app/views/staff/reports/_actuals_upload.html.haml
@@ -14,4 +14,4 @@
 
 .govuk-button-group
   = link_to t("page_content.actuals.button.download_template"), report_actual_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
-  = link_to t("page_content.actuals.button.upload"), new_report_actual_upload_path(@report_presenter), class: "govuk-button govuk-button"
+  = link_to t("page_content.actuals.button.upload"), new_report_actual_upload_path(@report_presenter), class: "govuk-button"

--- a/app/views/staff/reports/_actuals_upload_history.html.haml
+++ b/app/views/staff/reports/_actuals_upload_history.html.haml
@@ -6,5 +6,4 @@
     = t("page_content.uploads.actual_histories.actuals_tab.body_html")
 
     .govuk-button-group
-      = link_to t("actions.uploads.actual_histories.new_upload"), new_report_uploads_actual_history_path(@report_presenter), class: "govuk-button govuk-button"
-
+      = link_to t("actions.uploads.actual_histories.new_upload"), new_report_uploads_actual_history_path(@report_presenter), class: "govuk-button"

--- a/app/views/staff/reports/_forecasts_upload.html.haml
+++ b/app/views/staff/reports/_forecasts_upload.html.haml
@@ -14,4 +14,4 @@
 
 .govuk-button-group
   = link_to t("page_content.forecasts.button.download_template"), report_forecast_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
-  = link_to t("page_content.forecasts.button.upload"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button"
+  = link_to t("page_content.forecasts.button.upload"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button"

--- a/app/views/staff/reports/_forecasts_upload.html.haml
+++ b/app/views/staff/reports/_forecasts_upload.html.haml
@@ -1,0 +1,17 @@
+%h3.govuk-heading-m
+  = t("tabs.forecasts.providing.heading")
+
+%p.govuk-body
+  = t("tabs.forecasts.providing.copy")
+
+%h3.govuk-heading-s
+  = t("tabs.forecasts.upload.heading")
+
+= t("tabs.forecasts.upload.copy_html")
+
+.govuk-inset-text
+  = t("tabs.forecasts.upload.warning")
+
+.govuk-button-group
+  = link_to t("page_content.forecasts.button.download_template"), report_forecast_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+  = link_to t("page_content.forecasts.button.upload"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button"

--- a/app/views/staff/reports/activities.html.haml
+++ b/app/views/staff/reports/activities.html.haml
@@ -15,18 +15,8 @@
         .govuk-tabs__panel
           %h2.govuk-heading-l
             = t("tabs.report.activities.heading")
-
           - if policy(@report_presenter).upload?
-            %h3.govuk-heading-m
-              Upload new or changed activity data
-            %p.govuk-body
-              Large numbers of activities can be added or updated via the activities upload.
-
-            %p.govuk-body
-              For guidance on adding or updating activities, see the
-              = link_to_new_tab "guidance in the help centre", "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data"
-            %p.govuk-body
-              = link_to t("action.activity.upload.link"), new_report_activity_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
+            = render partial: "staff/reports/activities_upload"
 
           = render partial: "staff/activity_uploads/activities_table", locals: { table_caption: t("table.caption.activity.new_activities_report"), activities: @new_activities }
 

--- a/app/views/staff/reports/forecasts.html.haml
+++ b/app/views/staff/reports/forecasts.html.haml
@@ -19,11 +19,9 @@
           = t("page_content.tab_content.forecasts.guidance_html")
 
           - if policy(@report_presenter).upload?
-            = link_to t("action.forecast.upload.link"), new_report_forecast_upload_path(@report_presenter), class: "govuk-button govuk-button--secondary"
+            = render partial: "staff/reports/forecasts_upload"
 
           %h3.govuk-heading-m
             = t("page_content.tab_content.forecasts.per_activity_heading")
 
           = render partial: "shared/forecasts/forecasts_by_activity"
-
-

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -282,6 +282,8 @@ en:
     activities:
       button:
         create: Add activity
+        download_template: Download activity data template
+        upload: Upload activity data
       cta:
         html: To create a new Activity, first choose the %{organisations_link} you wish to create the Activity under
       organisation: Organisation
@@ -335,6 +337,14 @@ en:
     activities:
       current: Current
       historic: Historic
+      providing:
+        heading: Providing Activities Data
+        copy: Activities data can be added by using the application interface or by uploading data.
+      upload:
+        heading: Upload data
+        copy_html: <p class="govuk-body">Large numbers of activities can be added via the activities upload.</p>
+          <p class="govuk-body">For guidance on uploading activities data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data">guidance in the help centre (opens in new tab)</a>.</p>
+        warning: Ensure you use the correct template (available below) when uploading activities data.
   page_title:
     activity:
       index: Activities

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -45,9 +45,9 @@ en:
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
         disbursement_channel: The channel through which the funds will flow for this actual.
         providing_organisation: The organisation where this actual is coming from.
-        providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
         receiving_organisation: The organisation receiving the money from this actual spend.
-        receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
   table:
     caption:
       actual:

--- a/config/locales/models/forecast.en.yml
+++ b/config/locales/models/forecast.en.yml
@@ -41,10 +41,22 @@ en:
           original: Original
           revised: Revised
         edit_noun: forecast
+  tabs:
+    forecasts:
+      providing:
+        heading: Providing Forecast Data
+        copy: Forecast data can be added by using the application interface or by uploading data.
+      upload:
+        heading: Upload data
+        copy_html: <p class="govuk-body">Large numbers of forecasts can be added via the forecast upload.</p>
+          <p class="govuk-body">For guidance on uploading forecasts data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data">guidance in the help centre (opens in new tab)</a>.</p>
+        warning: Ensure you use the correct template (available below) when uploading forecast data.
   page_content:
     forecasts:
       button:
         create: Add forecasted spend
+        download_template: Download forecast data template
+        upload: Upload forecast data
   page_title:
     forecast:
       edit: Edit forecasted spend for %{quarter}

--- a/config/locales/models/forecast.en.yml
+++ b/config/locales/models/forecast.en.yml
@@ -29,7 +29,7 @@ en:
         csv_file: Upload a spreadsheet containing forecast information in CSV format.
         csv_file_recover_from_error_html: Upload a spreadsheet containing forecast information in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
         receiving_organisation: The organisation receiving the money from this transaction.
-        receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more infomation see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
+        receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>
   table:
     header:
       forecast:

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "users can upload activities" do
   before do
     authenticate!(user: user)
     visit report_activities_path(report)
-    click_link t("action.activity.upload.link")
+    click_link t("page_content.activities.button.upload")
   end
 
   scenario "downloading the CSV template" do

--- a/spec/features/staff/users_can_upload_actuals_spec.rb
+++ b/spec/features/staff/users_can_upload_actuals_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "users can upload actuals" do
   before do
     authenticate!(user: user)
     visit report_actuals_path(report)
-    click_link t("action.actual.upload.link")
+    click_link t("page_content.actuals.button.upload")
   end
 
   def expect_to_see_successful_upload_summary_with(count:, total:)

--- a/spec/features/staff/users_can_upload_forecasts_spec.rb
+++ b/spec/features/staff/users_can_upload_forecasts_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "users can upload forecasts" do
   before do
     authenticate!(user: user)
     visit report_forecasts_path(report)
-    click_link t("action.forecast.upload.link")
+    click_link t("page_content.forecasts.button.upload")
   end
 
   def expect_to_see_successful_upload_summary_with(count:, total:)

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Users can view forecasts in tab within a report" do
       click_link "Forecasts"
 
       expect(page).to have_content(t("page_content.tab_content.forecasts.heading"))
-      expect(page).to have_link(t("action.forecast.upload.link"))
+      expect(page).to have_link(t("page_content.forecasts.button.upload"))
 
       # guidance with 2 links
       expect(page).to have_content("This page shows all the new or updated forecasts")


### PR DESCRIPTION
## Changes in this PR

## Screenshots of UI changes

Forecasts: Before
![image](https://user-images.githubusercontent.com/85497046/155122101-e7dbf6af-9b87-4d34-85ad-be4fcab096e2.png)

Forecasts: After
![image](https://user-images.githubusercontent.com/85497046/155121978-bae43c88-8107-4ff3-a7af-92d70c44c028.png)

-----

Activities: Before
![image](https://user-images.githubusercontent.com/85497046/155122067-aae5f37e-b916-494b-acae-8c95152ef3a3.png)
Activities: After
![image](https://user-images.githubusercontent.com/85497046/155122014-834d9ceb-89fc-4b3a-892c-db1487179222.png)

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Remove unused translations
