### PR TITLE
Add binding_of_caller to allow REPL in local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "binding_of_caller"
   gem "better_errors"
   gem "html2haml"
   gem "listen", ">= 3.0.5", "< 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     brakeman (5.2.1)
@@ -115,6 +117,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    debug_inspector (1.1.0)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -502,6 +505,7 @@ DEPENDENCIES
   acts_as_tree
   auth0 (~> 5.6)
   better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   brakeman
   breadcrumbs_on_rails


### PR DESCRIPTION
Adds a REPL to Rails in local development in the context of the exception

![image](https://user-images.githubusercontent.com/85497046/155171912-3903aee6-283a-4f57-874f-1c5c2c415fd8.png)
