### PR TITLE
Release 98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -972,13 +972,16 @@
 - Upgrade framework dependencies (gems)
 - Expand the list of channel of delivery codes from 8 to 32 to allow greater precision describing implementing organisations
 
-## [unreleased]
+## [release-98] 2022-02-24
 
 - No longer hide all the organisations when creating a user if one wasn't picked to start with
 - Correctly highlight the absence of an organisation when creating a user if one wasn't picked to start with
 - Make activities and forecasts CSV upload buttons consistent with actuals
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-97...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-98...HEAD
+[release-98]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-97...release-98
 [release-97]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-96...release-97
 [release-96]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-95...release-96
 [release-95]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-94...release-95


### PR DESCRIPTION
- No longer hide all the organisations when creating a user if one
  wasn't picked to start with
- Correctly highlight the absence of an organisation when creating a
  user if one wasn't picked to start with
- Make activities and forecasts CSV upload buttons consistent with
  actuals