### PR TITLE
2388 registering mfa number for the first time

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -82,8 +82,9 @@ class Users::SessionsController < Devise::SessionsController
       session.delete(:otp_user_id)
 
       remember_me(user) if user_params[:remember_me] == "1"
-      user.mobile_number_confirmed_at = Time.zone.now
+      user.mobile_number_confirmed_at ||= Time.zone.now
       user.save!
+
       sign_in(user, event: :authentication)
     else
       flash.now[:alert] = t("devise.failure.invalid_two_factor")

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,12 @@ class Users::SessionsController < Devise::SessionsController
 
   protect_from_forgery with: :exception, prepend: true, except: :destroy
 
+  def edit_mobile_number
+    @user = self.resource = find_user
+
+    render "devise/sessions/mobile_number"
+  end
+
   protected
 
   # we also need to completely override Devise's require_no_authentication such that
@@ -76,6 +82,7 @@ class Users::SessionsController < Devise::SessionsController
       session.delete(:otp_user_id)
 
       remember_me(user) if user_params[:remember_me] == "1"
+      user.mobile_number_confirmed_at = Time.zone.now
       user.save!
       sign_in(user, event: :authentication)
     else

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,7 +13,7 @@ require "notify/otp_message"
 class Users::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: :create
 
-  prepend_before_action :authenticate_with_otp_two_factor,
+  prepend_before_action :handle_otp_flow,
     if: -> { action_name == "create" && otp_two_factor_enabled? }
 
   protect_from_forgery with: :exception, prepend: true, except: :destroy
@@ -57,7 +57,7 @@ class Users::SessionsController < Devise::SessionsController
     user.validate_and_consume_otp!(user_params[:otp_attempt])
   end
 
-  def authenticate_with_otp_two_factor
+  def handle_otp_flow
     user = self.resource = find_user
 
     if user_params[:otp_attempt].present? && session[:otp_user_id]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -65,13 +65,13 @@ class Users::SessionsController < Devise::SessionsController
     elsif user_params[:mobile_number].present? && session[:otp_user_id]
       user.update!(mobile_number: user_params[:mobile_number])
       send_otp(user)
-      prompt_for_otp_two_factor(user)
+      prompt_for(user, "otp_attempt")
     elsif user&.valid_password?(user_params[:password])
       if user.mobile_number.nil?
-        prompt_for_mobile_number(user)
+        prompt_for(user, "mobile_number")
       else
         send_otp(user)
-        prompt_for_otp_two_factor(user)
+        prompt_for(user, "otp_attempt")
       end
     end
   end
@@ -87,7 +87,7 @@ class Users::SessionsController < Devise::SessionsController
       sign_in(user, event: :authentication)
     else
       flash.now[:alert] = t("devise.failure.invalid_two_factor")
-      prompt_for_otp_two_factor(user)
+      prompt_for(user, "otp_attempt")
     end
   end
 
@@ -108,18 +108,11 @@ class Users::SessionsController < Devise::SessionsController
     find_user&.otp_required_for_login
   end
 
-  def prompt_for_otp_two_factor(user)
+  def prompt_for(user, template)
     @user = user
 
     session[:otp_user_id] = user.id
-    render "devise/sessions/two_factor"
-  end
-
-  def prompt_for_mobile_number(user)
-    @user = user
-
-    session[:otp_user_id] = user.id
-    render "devise/sessions/mobile_number"
+    render "devise/sessions/#{template}"
   end
 
   def send_otp(user)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,20 +11,94 @@ require "notify/otp_message"
 # Much of this is taken from step 4 of
 # https://www.jamesridgway.co.uk/implementing-a-two-step-otp-u2f-login-workflow-with-rails-and-devise/
 class Users::SessionsController < Devise::SessionsController
-  before_action :configure_sign_in_params, only: :create
-
-  prepend_before_action :handle_otp_flow,
-    if: -> { action_name == "create" && otp_two_factor_enabled? }
+  prepend_before_action :handle_mfa_flow, if: -> { action_name == "create" && otp_two_factor_enabled? }
 
   protect_from_forgery with: :exception, prepend: true, except: :destroy
 
   def edit_mobile_number
-    @user = self.resource = find_user
-
+    self.resource = find_user
     render "devise/sessions/mobile_number"
   end
 
   protected
+
+  # Given a login +mfa_phase+, take the appropriate action.
+  def handle_mfa_flow
+    case mfa_phase
+    when :needs_mobile_number then prompt_for "mobile_number"
+    when :has_mobile_number then send_and_prompt_for_otp
+    when :updating_mobile_number
+      user.update!(mobile_number: user_params[:mobile_number])
+      send_and_prompt_for_otp
+    when :validating_otp then complete_sign_in_with_otp? || prompt_for("otp_attempt")
+    end
+  end
+
+  def mfa_phase
+    if user_params[:otp_attempt] && session[:otp_user_id]
+      :validating_otp
+    elsif user_params[:mobile_number] && session[:otp_user_id]
+      :updating_mobile_number
+    elsif user&.valid_password?(user_params[:password])
+      user.mobile_number.nil? ? :needs_mobile_number : :has_mobile_number
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :password, :remember_me, :otp_attempt, :mobile_number)
+  end
+
+  def valid_otp_attempt?
+    user.validate_and_consume_otp!(user_params[:otp_attempt])
+  end
+
+  # Attempt to verify and consume the current sign-in OTP to prevent reuse.
+  # @return true if successful, false otherwise
+  def complete_sign_in_with_otp?
+    if valid_otp_attempt?
+      # Remove any lingering user data from login
+      session.delete(:otp_user_id)
+
+      remember_me(user) if user_params[:remember_me] == "1"
+      user.mobile_number_confirmed_at ||= Time.zone.now
+      user.save!
+
+      sign_in(user, event: :authentication)
+      true
+    else
+      flash.now[:alert] = t("devise.failure.invalid_two_factor")
+      false
+    end
+  end
+
+  def user
+    @user ||= (self.resource = find_user)
+  end
+
+  # First time through on login, we find on email. Thereafter, we have the otp_user_id
+  # in session. When we successfully auth via +complete_sign_in_with_otp?+ we remove that otp_user_id.
+  def find_user
+    if session[:otp_user_id]
+      User.find(session[:otp_user_id])
+    elsif user_params[:email]
+      User.find_by(email: user_params[:email]).tap do |user|
+        session[:otp_user_id] = user&.id
+      end
+    end
+  end
+
+  def otp_two_factor_enabled?
+    user&.otp_required_for_login
+  end
+
+  def prompt_for(template)
+    render "devise/sessions/#{template}"
+  end
+
+  def send_and_prompt_for_otp
+    Notify::OTPMessage.new(user.mobile_number, user.current_otp).deliver
+    prompt_for "otp_attempt"
+  end
 
   # we also need to completely override Devise's require_no_authentication such that
   # we don't display an "already signed in" message instead of "signed in successfully".
@@ -47,76 +121,5 @@ class Users::SessionsController < Devise::SessionsController
       set_flash_message(:alert, "already_authenticated", scope: "devise.failure")
       redirect_to after_sign_in_path_for(resource)
     end
-  end
-
-  def user_params
-    params.require(:user).permit(:email, :password, :remember_me, :otp_attempt, :mobile_number)
-  end
-
-  def valid_otp_attempt?(user)
-    user.validate_and_consume_otp!(user_params[:otp_attempt])
-  end
-
-  def handle_otp_flow
-    user = self.resource = find_user
-
-    if user_params[:otp_attempt].present? && session[:otp_user_id]
-      authenticate_user_with_otp_two_factor(user)
-    elsif user_params[:mobile_number].present? && session[:otp_user_id]
-      user.update!(mobile_number: user_params[:mobile_number])
-      send_otp(user)
-      prompt_for(user, "otp_attempt")
-    elsif user&.valid_password?(user_params[:password])
-      if user.mobile_number.nil?
-        prompt_for(user, "mobile_number")
-      else
-        send_otp(user)
-        prompt_for(user, "otp_attempt")
-      end
-    end
-  end
-
-  def authenticate_user_with_otp_two_factor(user)
-    if valid_otp_attempt?(user)
-      # Remove any lingering user data from login
-      session.delete(:otp_user_id)
-
-      remember_me(user) if user_params[:remember_me] == "1"
-      user.mobile_number_confirmed_at ||= Time.zone.now
-      user.save!
-
-      sign_in(user, event: :authentication)
-    else
-      flash.now[:alert] = t("devise.failure.invalid_two_factor")
-      prompt_for(user, "otp_attempt")
-    end
-  end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:otp_attempt, :mobile_number])
-  end
-
-  def find_user
-    if session[:otp_user_id]
-      User.find(session[:otp_user_id])
-    elsif user_params[:email]
-      User.find_by(email: user_params[:email])
-    end
-  end
-
-  def otp_two_factor_enabled?
-    find_user&.otp_required_for_login
-  end
-
-  def prompt_for(user, template)
-    @user = user
-
-    session[:otp_user_id] = user.id
-    render "devise/sessions/#{template}"
-  end
-
-  def send_otp(user)
-    Notify::OTPMessage.new(user.mobile_number, user.current_otp).deliver
   end
 end

--- a/app/views/devise/sessions/mobile_number.html.haml
+++ b/app/views/devise/sessions/mobile_number.html.haml
@@ -1,0 +1,15 @@
+= content_for :page_title_prefix, "Enter your mobile number"
+
+.govuk-grid-row
+  .govuk-grid-column-one-third
+    = form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
+      .govuk-form-group
+        %fieldset.govuk-fieldset
+          %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+            %h1.govuk-fieldset__heading
+              Enter your mobile number
+
+          = f.govuk_text_field :mobile_number, label: { text: "Enter your mobile number" }
+
+      .actions
+        = f.govuk_submit "Continue"

--- a/app/views/devise/sessions/otp_attempt.html.haml
+++ b/app/views/devise/sessions/otp_attempt.html.haml
@@ -15,7 +15,7 @@
                                 pattern: "[0-9]*",
                                 autocomplete: "one-time-code"
 
-  - unless resource.mobile_number_confirmed_at
+  - unless resource.mobile_number_confirmed_at.present?
     .govuk-grid-row
       .govuk-grid-column-two-thirds
         %p.govuk-body

--- a/app/views/devise/sessions/two_factor.html.haml
+++ b/app/views/devise/sessions/two_factor.html.haml
@@ -1,15 +1,28 @@
 = content_for :page_title_prefix, "Log in"
 
-.govuk-grid-row
-  .govuk-grid-column-one-third
-    = form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
+= form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
+  .govuk-grid-row
+    .govuk-grid-column-one-third
       .govuk-form-group
         %fieldset.govuk-fieldset
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
             %h1.govuk-fieldset__heading
               Verify your login
 
-          = f.govuk_text_field :otp_attempt, label: { text: "Please enter your six-digit verification code" }
+          = f.govuk_text_field :otp_attempt,
+                                label: { text: "Please enter your six-digit verification code" },
+                                inputmode: "numeric",
+                                pattern: "[0-9]*",
+                                autocomplete: "one-time-code"
 
+  - unless resource.mobile_number_confirmed_at
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        %p.govuk-body
+          Didn't get a message?
+          = link_to "Check your mobile number is correct", edit_mobile_number_path
+
+  .govuk-grid-row
+    .govuk-grid-column-one-third
       .actions
         = f.govuk_submit "Continue"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: {
-    sessions: "users/sessions"
-  }
+  devise_scope :user do
+    devise_for :users, controllers: {sessions: "users/sessions"}
+    get :edit_mobile_number, to: "users/sessions#edit_mobile_number"
+  end
 
   # If the DOMAIN env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present

--- a/db/migrate/20220224151206_add_mobile_number_confirmed_at.rb
+++ b/db/migrate/20220224151206_add_mobile_number_confirmed_at.rb
@@ -1,0 +1,5 @@
+class AddMobileNumberConfirmedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :mobile_number_confirmed_at, :datetime
+  end
+end

--- a/db/migrate/20220301145502_default_user_otp_required_for_login_to_true.rb
+++ b/db/migrate/20220301145502_default_user_otp_required_for_login_to_true.rb
@@ -1,0 +1,14 @@
+class DefaultUserOtpRequiredForLoginToTrue < ActiveRecord::Migration[6.1]
+  def up
+    change_column :users, :otp_required_for_login, :boolean, default: true
+    sql = <<~SQL
+      UPDATE users SET otp_required_for_login = 't'
+    SQL
+
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    change_column :users, :otp_required_for_login, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_24_151206) do
+ActiveRecord::Schema.define(version: 2022_03_01_145502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -329,10 +329,10 @@ ActiveRecord::Schema.define(version: 2022_02_24_151206) do
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
-    t.boolean "otp_required_for_login"
     t.string "mobile_number"
     t.datetime "mobile_number_confirmed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.boolean "otp_required_for_login", default: true
     t.index ["identifier"], name: "index_users_on_identifier"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_21_171133) do
+ActiveRecord::Schema.define(version: 2022_02_24_151206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 2022_02_21_171133) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "mobile_number"
+    t.datetime "mobile_number_confirmed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["identifier"], name: "index_users_on_identifier"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     password { SecureRandom.uuid }
     mobile_number { Faker::PhoneNumber.phone_number }
     mobile_number_confirmed_at { 1.day.ago }
+    otp_required_for_login { false }
 
     organisation factory: :beis_organisation
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     active { true }
     password { SecureRandom.uuid }
     mobile_number { Faker::PhoneNumber.phone_number }
+    mobile_number_confirmed_at { 1.day.ago }
 
     organisation factory: :beis_organisation
 
@@ -27,6 +28,11 @@ FactoryBot.define do
 
     trait :mfa_enabled do
       otp_required_for_login { true }
+    end
+
+    trait :no_mobile_number do
+      mobile_number              { nil }
+      mobile_number_confirmed_at { nil }
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     end
 
     trait :no_mobile_number do
-      mobile_number              { nil }
+      mobile_number { nil }
       mobile_number_confirmed_at { nil }
     end
   end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -75,6 +75,25 @@ RSpec.feature "Users can sign in" do
         # And I should be at the home page
         expect(page).to have_content("You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title")
       end
+
+      scenario "unsuccessful OTP attempt" do
+        # Given a user with 2FA enabled and a confirmed mobile number exists
+        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.now)
+
+        # When I log in with that user's email and password
+        visit root_path
+        log_in_via_form(user)
+
+        # And I enter an incorrect OTP
+        fill_in "Please enter your six-digit verification code", with: "000000"
+        click_on "Continue"
+
+        # Then I should not be logged in
+        expect(page).to have_content("Invalid two-factor verification code")
+        expect(page).not_to have_link(t("header.link.sign_out"))
+        visit root_path
+        expect(page).to have_content("Sign in")
+      end
     end
 
     context "user initially entered an incorrect mobile number" do


### PR DESCRIPTION
## Changes in this PR

Collect mobile numbers for accounts that require OTP for login. Note that we aren't mandating that yet and it's `users.otp_required_for_login`.

## Screenshots of UI changes

### After

The link to check shows only until the mobile number is confirmed for the first time:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/194511/156007864-aa853828-1bf8-4e68-86f2-99d6d6b288e9.png">

<img width="425" alt="image" src="https://user-images.githubusercontent.com/194511/156012288-001320c1-aff0-4aad-8bf6-0c56ea2249b1.png">


## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [x] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
