### PR TITLE
(2391) Resetting a user's mobile number for MFA

### DIFF
--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -53,13 +53,14 @@ class Staff::UsersController < Staff::BaseController
     @service_owner = service_owner
     @delivery_partners = delivery_partners
 
-    @user.assign_attributes(user_params)
+    reset_mfa = user_params.delete(:reset_mfa)
+    @user.assign_attributes(user_params.except(:reset_mfa))
 
     if @user.valid?
-      result = UpdateUser.new(user: @user, organisation: organisation).call
+      result = UpdateUser.new(user: @user, organisation: organisation, reset_mfa: reset_mfa).call
 
       if result.success?
-        flash.now[:notice] = t("action.user.update.success")
+        flash[:notice] = t("action.user.update.success")
         redirect_to user_path(@user)
       else
         flash.now[:error] = t("action.user.update.failed")
@@ -71,7 +72,7 @@ class Staff::UsersController < Staff::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :organisation_id, :active)
+    params.require(:user).permit(:name, :email, :organisation_id, :active, :reset_mfa)
   end
 
   def id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,10 @@ class User < ApplicationRecord
     active
   end
 
+  def confirmed_for_mfa?
+    mobile_number.present? && mobile_number_confirmed_at.present?
+  end
+
   private
 
   def ensure_otp_secret!

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,7 +1,7 @@
 class UpdateUser
   attr_accessor :user, :organisation
 
-  def initialize(user:, organisation: [])
+  def initialize(user:, organisation:)
     self.user = user
     self.organisation = organisation
   end
@@ -11,14 +11,6 @@ class UpdateUser
 
     User.transaction do
       user.organisation = organisation
-
-      # begin
-      #   UpdateUserInAuth0.new(user: user).call
-      # rescue Auth0::Exception => e
-      #   result.success = false
-      #   Rails.logger.error("Error updating user #{user.email} to Auth0 during UpdateUser with #{e.message}.")
-      #   raise ActiveRecord::Rollback
-      # end
 
       user.save
     end

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,9 +1,10 @@
 class UpdateUser
-  attr_accessor :user, :organisation
+  attr_accessor :user, :organisation, :reset_mfa
 
-  def initialize(user:, organisation:)
+  def initialize(user:, organisation:, reset_mfa: false)
     self.user = user
     self.organisation = organisation
+    self.reset_mfa = reset_mfa
   end
 
   def call
@@ -11,6 +12,11 @@ class UpdateUser
 
     User.transaction do
       user.organisation = organisation
+
+      if reset_mfa
+        user.mobile_number = nil
+        user.mobile_number_confirmed_at = nil
+      end
 
       user.save
     end

--- a/app/views/staff/users/_form.html.haml
+++ b/app/views/staff/users/_form.html.haml
@@ -4,6 +4,9 @@
   = f.govuk_text_field :name
   = f.govuk_email_field :email, disabled: (action_name == "edit")
 
+  = f.govuk_check_boxes_fieldset :reset_mfa, multiple: false, legend: { text: t("form.legend.user.reset_mfa") }, hint: { text: t("form.hint.user.reset_mfa") } do
+    = f.govuk_check_box :reset_mfa, true, multiple: false, label: { text: t("form.label.user.reset_mfa") }
+
   - if @service_owner.present?
     = f.govuk_radio_buttons_fieldset :organisation, classes: "user-organisations" do
       = f.govuk_radio_button :organisation_id, @service_owner.id, label: { text: @service_owner.name }, link_errors: true

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -35,3 +35,8 @@
             = t("summary.label.user.active")
           %dd.govuk-summary-list__value
             = t("form.user.active.#{@user.active}")
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t("summary.label.user.confirmed_for_mfa.label")
+          %dd.govuk-summary-list__value
+            = t("summary.label.user.confirmed_for_mfa.#{@user.confirmed_for_mfa?}")

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -17,13 +17,16 @@ en:
         email: Email address
         identifier: Auth0 identifier
         name: Full name
+        reset_mfa: Reset the mobile number used for authentication
     legend:
       user:
         active: What is the user's status?
         organisation_id: What organisation does this user belong to?
+        reset_mfa: Reset the user's mobile number?
     hint:
       user:
         active: Deactivated users cannot log in
+        reset_mfa: The user will have to provide their mobile number on their next log in attempt
     user:
       active:
         active: Activate

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -46,6 +46,10 @@ en:
         identifier: Identifier
         organisation: Organisation
         active: Active?
+        confirmed_for_mfa:
+          label: Mobile number confirmed for authentication?
+          "false": "No"
+          "true": "Yes"
   page_content:
     users:
       button:

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -43,6 +43,27 @@ RSpec.feature "BEIS users can edit other users" do
     expect(page).to have_content("New Name")
   end
 
+  scenario "the user's MFA (mobile number and confirmed_at) can be reset" do
+    # When I am logged in as a BEIS user
+    administrator_user = create(:beis_user)
+    authenticate!(user: administrator_user)
+
+    # And a user with a confirmed mobile number exists
+    visit users_path
+    find("tr", text: user.name).click_link("View")
+    expect(page).to have_content("Mobile number confirmed for authentication? Yes")
+
+    # When I reset that user's MFA
+    visit users_path
+    find("tr", text: user.name).click_link("Edit")
+    check "Reset the mobile number used for authentication"
+    click_on t("default.button.submit")
+
+    # Then that user should no longer be confirmed for MFA
+    expect(page).to have_content("User successfully updated")
+    expect(page).to have_content("Mobile number confirmed for authentication? No")
+  end
+
   scenario "an active user can be deactivated" do
     administrator_user = create(:beis_user)
     authenticate!(user: administrator_user)

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -37,6 +37,8 @@ RSpec.feature "BEIS users can can view other users" do
       expect(page).to have_content(t("page_title.users.show"))
       expect(page).to have_content(another_user.name)
       expect(page).to have_content(another_user.email)
+      expect(page).to have_content("Active? Yes")
+      expect(page).to have_content("Mobile number confirmed for authentication? Yes")
     end
 
     scenario "users are grouped by their organisation name in alphabetical order" do
@@ -78,7 +80,7 @@ RSpec.feature "BEIS users can can view other users" do
         find("tr", text: another_user.name).click_link(t("default.link.show"))
       end
 
-      expect(page).to have_content(t("form.user.active.false"))
+      expect(page).to have_content("Active? No")
     end
   end
 end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -26,5 +26,18 @@ RSpec.describe UpdateUser do
         expect(user.reload.organisation).to eql(organisation)
       end
     end
+
+    context "when reset MFA is requested" do
+      it "resets the user's mobile number and its confirmation time" do
+        described_class.new(
+          user: user,
+          organisation: user.organisation,
+          reset_mfa: true
+        ).call
+
+        expect(user.reload.mobile_number).to be_nil
+        expect(user.mobile_number_confirmed_at).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -1,19 +1,13 @@
 require "rails_helper"
 
-RSpec.describe UpdateUser, pending: "To be finished as part of the user edit card" do
-  let(:user) { create(:administrator, identifier: "auth0|1234") }
+RSpec.describe UpdateUser do
+  let(:user) { create(:administrator) }
 
   let(:updated_email) { "new@example.com" }
   let(:updated_name) { "New Name" }
 
-  before(:each) do
-    stub_auth0_token_request
-  end
-
   describe "#call" do
     it "returns a successful result" do
-      stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
-
       result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
 
       expect(result.success?).to eq(true)
@@ -22,8 +16,6 @@ RSpec.describe UpdateUser, pending: "To be finished as part of the user edit car
 
     context "when an organisation is provided" do
       it "associates the user to it" do
-        stub_auth0_update_user_request(auth0_identifier: "auth0|1234", email: user.email, name: user.name)
-
         organisation = create(:delivery_partner_organisation)
 
         described_class.new(
@@ -32,31 +24,6 @@ RSpec.describe UpdateUser, pending: "To be finished as part of the user edit car
         ).call
 
         expect(user.reload.organisation).to eql(organisation)
-      end
-    end
-
-    context "when Auth0 errors" do
-      before(:each) do
-        stub_auth0_update_user_request_failure(auth0_identifier: "auth0|1234")
-        user.email = updated_email
-      end
-
-      it "returns a failed result" do
-        result = described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
-        expect(result.failure?).to eq(true)
-      end
-
-      it "does not save the user" do
-        expect {
-          described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
-        }.to_not change { user.reload }
-      end
-
-      it "logs a failure message" do
-        expect(Rails.logger).to receive(:error)
-          .with("Error updating user #{user.email} to Auth0 during UpdateUser with .")
-
-        described_class.new(user: user, organisation: build_stubbed(:delivery_partner_organisation)).call
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
- Allow BEIS users to reset any user's mobile number used for MFA, by using the edit user flow 

## Screenshots of UI changes

### After
<img width="794" alt="Screenshot 2022-03-02 at 14 31 06" src="https://user-images.githubusercontent.com/579522/156381959-c77f192a-059a-4515-9d11-0336cedb5337.png">

<img width="780" alt="Screenshot 2022-03-02 at 14 30 52" src="https://user-images.githubusercontent.com/579522/156382503-d447ac32-3278-4f56-aff4-565fdff763d8.png">
