### PR TITLE
(2386) Update password policy to align with BEIS policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "breadcrumbs_on_rails"
 # Authentication
 gem "devise"
 gem "devise-two-factor"
+gem "devise-security"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-security (0.17.0)
+      devise (>= 4.3.0)
     devise-two-factor (4.0.1)
       activesupport (< 6.2)
       attr_encrypted (>= 1.3, < 4, != 2)
@@ -466,6 +468,7 @@ DEPENDENCIES
   coveralls
   database_cleaner
   devise
+  devise-security
   devise-two-factor
   dotenv-rails
   factory_bot_rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,10 @@
 class User < ApplicationRecord
-  devise :two_factor_authenticatable, :rememberable, :validatable, :recoverable,
+  devise :two_factor_authenticatable, :rememberable, :secure_validatable, :recoverable,
     otp_secret_encryption_key: ENV["SECRET_KEY_BASE"]
 
   belongs_to :organisation
   has_many :historical_events
   validates_presence_of :name, :email
-  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :email, with: :email_cannot_be_changed_after_create, on: :update
 
   before_save :ensure_otp_secret!, if: -> { otp_required_for_login && otp_secret.nil? }

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -10,7 +10,10 @@ class CreateUser
     result = Result.new(true)
 
     user.organisation = organisation
-    user.password = SecureRandom.uuid
+    # This password will never be used: the user must set a new password upon first login
+    # but it must fulfill the password_complexity requirements we set in
+    # config/initializers/devise_security
+    user.password = "Ab3!#{SecureRandom.uuid}"
     result.success = user.save
 
     SendWelcomeEmail.new(user: user).call if user.persisted?

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,7 @@
+class EmailValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.email.blank? || record.email.match?(URI::MailTo::EMAIL_REGEXP)
+
+    record.errors.add(:email, :invalid)
+  end
+end

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -3,13 +3,12 @@
 %h1.govuk-heading-l Change your password
 
 .govuk-grid-row
-  .govuk-grid-column-one-third
+  .govuk-grid-column-two-thirds
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-      = render "devise/shared/error_messages", resource: resource
-
+      = f.govuk_error_summary
       = f.hidden_field :reset_password_token
 
-      = f.govuk_password_field :password, autofocus: true, autocomplete: "new-password", label: {text: "New password"}, hint: {text: "(#{@minimum_password_length} characters minimum)"}
+      = f.govuk_password_field :password, autofocus: true, autocomplete: "new-password", label: {text: "New password"}, hint: {text: t("form.hint.user.new_password")}
 
       = f.govuk_password_field :password_confirmation, label: {text: "Confirm new password"}, autocomplete: "new-password"
 

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -5,7 +5,7 @@
 .govuk-grid-row
   .govuk-grid-column-one-third
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-      = render "devise/shared/error_messages", resource: resource
+      = f.govuk_error_summary
 
       = f.govuk_email_field :email, autofocus: true, autocomplete: "email"
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/initializers/devise_security.rb
+++ b/config/initializers/devise_security.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Devise.setup do |config|
+  # ==> Security Extension
+  # Configure security extension for devise
+
+  # Should the password expire (e.g 3.months)
+  # config.expire_password_after = false
+
+  # Need 1 char each of: A-Z, a-z, 0-9, and a punctuation mark or symbol
+  # You may use "digits" in place of "digit" and "symbols" in place of
+  # "symbol" based on your preference
+  # config.password_complexity = { digit: 1, lower: 1, symbol: 1, upper: 1 }
+
+  # How many passwords to keep in archive
+  # config.password_archiving_count = 5
+
+  # Deny old passwords (true, false, number_of_old_passwords_to_check)
+  # Examples:
+  # config.deny_old_passwords = false # allow old passwords
+  # config.deny_old_passwords = true # will deny all the old passwords
+  # config.deny_old_passwords = 3 # will deny new passwords that matches with the last 3 passwords
+  # config.deny_old_passwords = true
+
+  # enable email validation for :secure_validatable. (true, false, validation_options)
+  # dependency: see https://github.com/devise-security/devise-security/blob/master/README.md#e-mail-validation
+  # config.email_validation = true
+
+  # captcha integration for recover form
+  # config.captcha_for_recover = true
+
+  # captcha integration for sign up form
+  # config.captcha_for_sign_up = true
+
+  # captcha integration for sign in form
+  # config.captcha_for_sign_in = true
+
+  # captcha integration for unlock form
+  # config.captcha_for_unlock = true
+
+  # captcha integration for confirmation form
+  # config.captcha_for_confirmation = true
+
+  # Time period for account expiry from last_activity_at
+  # config.expire_after = 90.days
+
+  # Allow password to equal the email
+  # config.allow_passwords_equal_to_email = false
+end

--- a/config/initializers/devise_security.rb
+++ b/config/initializers/devise_security.rb
@@ -10,7 +10,8 @@ Devise.setup do |config|
   # Need 1 char each of: A-Z, a-z, 0-9, and a punctuation mark or symbol
   # You may use "digits" in place of "digit" and "symbols" in place of
   # "symbol" based on your preference
-  # config.password_complexity = { digit: 1, lower: 1, symbol: 1, upper: 1 }
+  config.password_complexity = {digit: 1, lower: 1, symbol: 1, upper: 1}
+  config.password_length = 15..1024
 
   # How many passwords to keep in archive
   # config.password_archiving_count = 5

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -45,7 +45,7 @@ en:
       messages:
         accepted: "%{attribute} must be accepted"
         blank: "%{attribute} can't be blank"
-        confirmation: doesn't match %{attribute}
+        confirmation: "%{attribute} confirmation doesn't match %{attribute}"
         empty: "%{attribute} can't be empty"
         equal_to: "%{attribute} must be equal to %{count}"
         even: "%{attribute} must be even"

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,0 +1,42 @@
+en:
+  errors:
+    messages:
+      taken_in_past: 'was used previously.'
+      equal_to_current_password: 'must be different than the current password.'
+      equal_to_email: 'must be different than the email.'
+      password_complexity:
+        digit:
+          one: must contain at least one digit
+          other: must contain at least %{count} digits
+        lower:
+          one: must contain at least one lower-case letter
+          other: must contain at least %{count} lower-case letters
+        symbol:
+          one: must contain at least one punctuation mark or symbol
+          other: must contain at least %{count} punctuation marks or symbols
+        upper:
+          one: must contain at least one upper-case letter
+          other: must contain at least %{count} upper-case letters
+  devise:
+    invalid_captcha: 'The captcha input was invalid.'
+    invalid_security_question: 'The security question answer was invalid.'
+    paranoid_verify:
+      code_required: 'Please enter the code our support team provided'
+    paranoid_verification_code:
+      updated: Verification code accepted
+      show:
+        submit_verification_code: Submit verification code
+        verification_code: Verification code
+        submit: Submit
+    password_expired:
+      updated: 'Your new password is saved.'
+      change_required: 'Your password is expired. Please renew your password.'
+      show:
+        renew_your_password: Renew your password
+        current_password: Current password
+        new_password: New password
+        new_password_confirmation: Confirm new password
+        change_my_password: Change my password
+    failure:
+      session_limited: 'Your login credentials were used in another browser. Please sign in again to continue in this browser.'
+      expired: 'Your account has expired due to inactivity. Please contact the site administrator.'

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,9 +1,9 @@
 en:
   errors:
     messages:
-      taken_in_past: 'was used previously.'
-      equal_to_current_password: 'must be different than the current password.'
-      equal_to_email: 'must be different than the email.'
+      taken_in_past: "was used previously."
+      equal_to_current_password: "must be different than the current password."
+      equal_to_email: "must be different than the email."
       password_complexity:
         digit:
           one: Password must contain at least one digit
@@ -17,11 +17,12 @@ en:
         upper:
           one: Password must contain at least one upper-case letter
           other: Password must contain at least %{count} upper-case letters
+      password_confirmation: Password confirmation doesn't match password
   devise:
-    invalid_captcha: 'The captcha input was invalid.'
-    invalid_security_question: 'The security question answer was invalid.'
+    invalid_captcha: "The captcha input was invalid."
+    invalid_security_question: "The security question answer was invalid."
     paranoid_verify:
-      code_required: 'Please enter the code our support team provided'
+      code_required: "Please enter the code our support team provided"
     paranoid_verification_code:
       updated: Verification code accepted
       show:
@@ -29,8 +30,8 @@ en:
         verification_code: Verification code
         submit: Submit
     password_expired:
-      updated: 'Your new password is saved.'
-      change_required: 'Your password is expired. Please renew your password.'
+      updated: "Your new password is saved."
+      change_required: "Your password is expired. Please renew your password."
       show:
         renew_your_password: Renew your password
         current_password: Current password
@@ -38,5 +39,5 @@ en:
         new_password_confirmation: Confirm new password
         change_my_password: Change my password
     failure:
-      session_limited: 'Your login credentials were used in another browser. Please sign in again to continue in this browser.'
-      expired: 'Your account has expired due to inactivity. Please contact the site administrator.'
+      session_limited: "Your login credentials were used in another browser. Please sign in again to continue in this browser."
+      expired: "Your account has expired due to inactivity. Please contact the site administrator."

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -6,17 +6,17 @@ en:
       equal_to_email: 'must be different than the email.'
       password_complexity:
         digit:
-          one: must contain at least one digit
-          other: must contain at least %{count} digits
+          one: Password must contain at least one digit
+          other: Password must contain at least %{count} digits
         lower:
-          one: must contain at least one lower-case letter
-          other: must contain at least %{count} lower-case letters
+          one: Password must contain at least one lower-case letter
+          other: Password must contain at least %{count} lower-case letters
         symbol:
-          one: must contain at least one punctuation mark or symbol
-          other: must contain at least %{count} punctuation marks or symbols
+          one: Password must contain at least one punctuation mark or symbol
+          other: Password must contain at least %{count} punctuation marks or symbols
         upper:
-          one: must contain at least one upper-case letter
-          other: must contain at least %{count} upper-case letters
+          one: Password must contain at least one upper-case letter
+          other: Password must contain at least %{count} upper-case letters
   devise:
     invalid_captcha: 'The captcha input was invalid.'
     invalid_security_question: 'The security question answer was invalid.'

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -87,4 +87,5 @@ en:
               blank: Enter a full name
             email:
               blank: Enter an email address
+              invalid: is not a valid email
               cannot_be_changed: "cannot be changed once a user has been created"

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -26,6 +26,7 @@ en:
     hint:
       user:
         active: Deactivated users cannot log in
+        new_password: Minimum 15 characters; must contain at least one digit, one lowercase letter, one uppercase letter, and one punctuation mark or symbol
         reset_mfa: The user will have to provide their mobile number on their next log in attempt
     user:
       active:

--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -9,8 +9,8 @@ delivery_partner = User.find_or_initialize_by(
   identifier: "auth0|5e5e1ee731555a0cb0ab5a75"
 )
 
-administrator.password = "letmein"
-delivery_partner.password = "letmein"
+administrator.password = "LlEeTtMmEeIiNn!1"
+delivery_partner.password = "LlEeTtMmEeIiNn!1"
 
 beis = Organisation.service_owner
 administrator.organisation = beis

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     active { true }
-    password { SecureRandom.uuid }
+    password { "Ab1!#{SecureRandom.uuid}" }
     mobile_number { Faker::PhoneNumber.phone_number }
     mobile_number_confirmed_at { 1.day.ago }
     otp_required_for_login { false }

--- a/spec/features/staff/users_can_reset_password_spec.rb
+++ b/spec/features/staff/users_can_reset_password_spec.rb
@@ -9,6 +9,16 @@ RSpec.feature "Users can reset their password" do
     visit root_path
     click_link "Sign in"
     click_link "Forgot password?"
+
+    # When I fill in a valid email address that is not registered
+    fill_in "Email address", with: "notregistered@example.org"
+    click_on "Submit"
+
+    # Then I should see a generic message that doesn't disclose that the email is not registered
+    expect(page).to have_content("If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.")
+
+    # When I fill in my email address
+    click_link "Forgot password?"
     fill_in "Email address", with: user.email
     click_on "Submit"
 

--- a/spec/features/staff/users_can_reset_password_spec.rb
+++ b/spec/features/staff/users_can_reset_password_spec.rb
@@ -21,8 +21,8 @@ RSpec.feature "Users can reset their password" do
     visit reset_password_link
 
     # And I set a new password
-    fill_in "New password", with: "letmein!"
-    fill_in "Confirm new password", with: "letmein!"
+    fill_in "New password", with: "LlEeTtMmEeIin1!"
+    fill_in "Confirm new password", with: "LlEeTtMmEeIin1!"
     click_on "Change my password"
 
     # Then my password should be changed and I should be logged in

--- a/spec/features/staff/users_can_reset_password_spec.rb
+++ b/spec/features/staff/users_can_reset_password_spec.rb
@@ -20,7 +20,19 @@ RSpec.feature "Users can reset their password" do
     reset_password_link = email.body.raw_source.match(/(https?:\/\/\S+)/)
     visit reset_password_link
 
-    # And I set a new password
+    # Then I should see a password hint with the full requirements
+    expect(page).to have_content("Minimum 15 characters; must contain at least one digit, one lowercase letter, one uppercase letter, and one punctuation mark or symbol")
+
+    # When I try to set a password that doesn't fulfill the requirements
+    fill_in "New password", with: "LlEeTtMmEeIinnn"
+    fill_in "Confirm new password", with: "LlEeTtMmEeIinnn"
+    click_on "Change my password"
+
+    # Then I should see an error message complying with GOV.UK guidelines
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Password must contain at least one digit")
+
+    # When I set a password that fulfills the requirements
     fill_in "New password", with: "LlEeTtMmEeIin1!"
     fill_in "Confirm new password", with: "LlEeTtMmEeIin1!"
     click_on "Change my password"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,4 +25,31 @@ RSpec.describe User, type: :model do
     it { is_expected.to delegate_method(:service_owner?).to(:organisation) }
     it { is_expected.to delegate_method(:delivery_partner?).to(:organisation) }
   end
+
+  it "validates the email format" do
+    user = build(:administrator, email: "bogus")
+
+    expect(user).to be_invalid
+    expect(user.errors[:email]).to eq(["is not a valid email"])
+  end
+
+  describe "password requirements" do
+    it "should have a minimum length" do
+      user = build(:administrator, password: "Ab3$")
+
+      expect(user.valid?).to be_falsey
+      expect(user.errors.messages[:password]).to include("Password is too short (minimum is 15 characters)")
+    end
+
+    it "should contain the required characters" do
+      user = build(:administrator, password: "AaBbCc123456789")
+
+      expect(user.valid?).to be_falsey
+      expect(user.errors.messages[:password]).to include("Password must contain at least one punctuation mark or symbol")
+
+      user.password = "AaBbCc123456789!"
+
+      expect(user.valid?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- Enforce password requirements as close to BEIS requirements and GOV.UK guidelines as possible
- Turn devise's `paranoid` mode on, to avoid email enumeration attacks

## Screenshots of UI changes

### After

<img width="1163" alt="Screenshot 2022-03-08 at 14 18 29" src="https://user-images.githubusercontent.com/579522/157256800-73d179dd-06d3-498c-971a-247bdc648482.png">
<img width="790" alt="Screenshot 2022-03-08 at 14 19 11" src="https://user-images.githubusercontent.com/579522/157256808-196f0896-8b67-415b-b08c-a80815f9dff8.png">
<img width="767" alt="Screenshot 2022-03-08 at 14 19 25" src="https://user-images.githubusercontent.com/579522/157256810-3b63c09e-5dde-48f3-b385-317b35939f28.png">
<img width="780" alt="Screenshot 2022-03-08 at 14 20 01" src="https://user-images.githubusercontent.com/579522/157256812-df9a4be6-4457-469f-9c8d-b7497dcc1f63.png">
