### PR TITLE
2431: Add Other ODA fund into RODA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -996,7 +996,9 @@
 - Use Devise case-insensitive method when retrieving users for authentication
 - Add functionality to search for activities by IATI identifier
 
-## [unreleased]
+## [unreleased] ...
+
+- Add 'Other ODA' fund
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-100...HEAD
 [release-100]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-99...release-100

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -86,7 +86,7 @@ class Activity < ApplicationRecord
   validates :total_awards, presence: true, on: :total_applications_and_awards_step, if: :call_present?
   validates :programme_status, presence: true, on: :programme_status_step
   validates :country_delivery_partners, presence: true, on: :country_delivery_partners_step, if: :requires_country_delivery_partners?
-  validates :gdi, presence: true, on: :gdi_step
+  validates :gdi, presence: true, on: :gdi_step, unless: proc { |activity| activity.fund? }
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :covid19_related, presence: true, on: :covid19_related_step
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?

--- a/db/data/20220308163700_add_ooda_fund_activity.rb
+++ b/db/data/20220308163700_add_ooda_fund_activity.rb
@@ -1,0 +1,26 @@
+# Add the top level (A) Other ODA Activity (i.e. a fund-tier activity)
+
+beis = Organisation.service_owner
+
+description = <<~TXT.squish
+  Other ODA represents spending from ‘other non ODA budgets from BEIS’ which may be
+  classed as ‘ODA spend’ i.e. is ODA-eligible in the same way as spend from the
+  Newton Fund and GCRF.
+TXT
+
+Activity.create!(
+  source_fund_code: 3,
+  roda_identifier: "OODA",
+  title: "Other ODA",
+  organisation: beis,
+  level: "fund",
+  form_state: "complete", # wizard progress
+  fstc_applies: false, # free_standing_technical_cooperation: false,
+  delivery_partner_identifier: "OODA",
+  description: description,
+  sector_category: "998", # 510, 998 for NF/GCRF (based on GCRF)
+  sector: "99810", # focus area, # 51010, 99810 for NF/GCRF (based on GCRF)
+  programme_status: "spend_in_progress", # as NF/GCRF
+  actual_start_date: Date.new(2015, 4, 1),
+  aid_type: "C01" # same as NF/GCRF
+)

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -14,6 +14,13 @@ newton_fund_params = FactoryBot.build(:fund_activity,
 
 _newton_fund = Activity.find_or_create_by(newton_fund_params)
 
+ooda_fund_params = FactoryBot.build(:fund_activity,
+  roda_identifier: "OODA",
+  title: "Other ODA",
+  organisation: beis).attributes
+
+_ooda_fund = Activity.find_or_create_by(ooda_fund_params)
+
 delivery_partner = User.all.find(&:delivery_partner?).organisation
 
 first_programme_params = FactoryBot.build(:programme_activity,

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -73,6 +73,16 @@ FactoryBot.define do
           Activity.find_or_initialize_by(roda_identifier: "NF")
         end
       end
+
+      trait :ooda do
+        roda_identifier { "OODA" }
+        title { "Other ODA" }
+        source_fund_code { Fund.by_short_name("OODA").id }
+
+        initialize_with do
+          Activity.find_or_initialize_by(roda_identifier: "OODA")
+        end
+      end
     end
 
     factory :programme_activity do
@@ -96,6 +106,13 @@ FactoryBot.define do
         source_fund_code { Fund.by_short_name("GCRF").id }
         parent do
           Activity.fund.find_by(source_fund_code: Fund.by_short_name("GCRF").id) || create(:fund_activity, :gcrf)
+        end
+      end
+
+      trait :ooda_funded do
+        source_fund_code { Fund.by_short_name("OODA").id }
+        parent do
+          Activity.fund.find_by(source_fund_code: Fund.by_short_name("OODA").id) || create(:fund_activity, :ooda)
         end
       end
 

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -119,6 +119,54 @@ RSpec.feature "BEIS users can create a programme level activity" do
     end
   end
 
+  context "when the source fund is OODA" do
+    let(:identifier) { "a-fund-has-an-accountable-organisation" }
+    let!(:activity) do
+      build(:programme_activity, :ooda_funded,
+        delivery_partner_identifier: identifier,
+        benefitting_countries: ["AG", "HT"],
+        sdgs_apply: true,
+        sdg_1: 5)
+    end
+
+    scenario "an activity can be created" do
+      visit organisation_activities_path(delivery_partner)
+      click_on t("form.button.activity.new_child", name: activity.associated_fund.title)
+
+      form = ActivityForm.new(activity: activity, level: "programme", fund: "ooda")
+      form.complete!
+
+      expect(page).to have_content(t("action.programme.create.success"))
+
+      created_activity = form.created_activity
+
+      expect(created_activity.title).to eq(activity.title)
+      expect(created_activity.description).to eq(activity.description)
+      expect(created_activity.objectives).to eq(activity.objectives)
+      expect(created_activity.sector_category).to eq(activity.sector_category)
+      expect(created_activity.sector).to eq(activity.sector)
+      expect(created_activity.programme_status).to eq(activity.programme_status)
+      expect(created_activity.planned_start_date).to eq(activity.planned_start_date)
+      expect(created_activity.planned_end_date).to eq(activity.planned_end_date)
+      expect(created_activity.actual_start_date).to eq(activity.actual_start_date)
+      expect(created_activity.actual_end_date).to eq(activity.actual_end_date)
+      expect(created_activity.benefitting_countries).to match_array(activity.benefitting_countries)
+      expect(created_activity.gdi).to eq(activity.gdi)
+      expect(created_activity.aid_type).to eq(activity.aid_type)
+      expect(created_activity.collaboration_type).to eq(activity.collaboration_type)
+      expect(created_activity.sdgs_apply).to eq(activity.sdgs_apply)
+      expect(created_activity.sdg_1).to eq(activity.sdg_1)
+      expect(created_activity.covid19_related).to eq(activity.covid19_related)
+      expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
+
+      expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_type).to eq("10")
+
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+    end
+  end
+
   def expect_implementing_organisation_to_be_the_delivery_partner(
     activity:,
     organisation:

--- a/spec/models/iati/xml_download_spec.rb
+++ b/spec/models/iati/xml_download_spec.rb
@@ -43,14 +43,23 @@ RSpec.describe Iati::XmlDownload do
         allow(third_party_project_relation).to receive(:where).and_return(build_list(:project_activity, 5))
       end
 
-      it "returns all XML download paths for all levels and funds in the correct order" do
-        paths = described_class.all_for_organisation(organisation)
+      it "returns all XML downloads ordered by levels, then funds" do
+        downloads = described_class.all_for_organisation(organisation)
 
-        expect(paths.count).to eq(6)
+        expect(downloads.count).to eq(9)
 
-        expect(paths.map { |p| p.fund.short_name }).to eq(["NF", "GCRF", "NF", "GCRF", "NF", "GCRF"])
-        expect(paths.map(&:level)).to eq(["programme", "programme", "project", "project", "third_party_project", "third_party_project"])
-        expect(paths.map(&:organisation).uniq).to eq([organisation])
+        expect(downloads.map { |p| p.fund.short_name }).to eq(%w[
+          NF GCRF OODA
+          NF GCRF OODA
+          NF GCRF OODA
+        ])
+
+        expect(downloads.map(&:level)).to eq(%w[
+          programme programme programme
+          project project project
+          third_party_project third_party_project third_party_project
+        ])
+        expect(downloads.map(&:organisation).uniq).to eq([organisation])
       end
     end
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -59,6 +59,23 @@ class ActivityForm
     fill_in_oda_eligibility
   end
 
+  def fill_in_ooda_programme_activity_form
+    fill_in_identifier_step
+    fill_in_purpose_step
+    fill_in_objectives_step
+    fill_in_sector_category_step
+    fill_in_sector_step
+    fill_in_programme_status
+    fill_in_dates
+    fill_in_benefitting_countries
+    fill_in_gdi
+    fill_in_aid_type
+    fill_in_collaboration_type
+    fill_in_sdgs_apply
+    fill_in_covid19_related
+    fill_in_oda_eligibility
+  end
+
   def fill_in_gcrf_project_activity_form
     fill_in_identifier_step
     fill_in_purpose_step

--- a/vendor/data/codelists/BEIS/fund_types.yml
+++ b/vendor/data/codelists/BEIS/fund_types.yml
@@ -5,3 +5,6 @@ data:
   - code: 2
     name: Global Challenges Research Fund
     short_name: GCRF
+  - code: 3
+    name: Other ODA
+    short_name: OODA


### PR DESCRIPTION
## Changes in this PR

We add the Other ODA (OODA) fund, both as a Fund in the codelist and as an Activity with level: 'fund'

For the Activity, we generated the values in the data migration by: 

Sector and Sector Category are identical to GCRF (after discussion from BEIS)
Description and start date are directly from BEIS
Other values generally there to pass validation 
We removed GDI validation from Activities at Fund Level since it's nil for both GCRF/NF

We've done some testing that if we swap the :newton_funded traits in the activities factories to reference OODA activities, any failing tests are understood not to be due to OODA.

- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Data Migration has occurred after deployment
