### PR TITLE
(2439) User with confirmed number can request code resend

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,6 +20,11 @@ class Users::SessionsController < Devise::SessionsController
     render "devise/sessions/mobile_number"
   end
 
+  def resend_otp
+    self.resource = find_user
+    send_and_prompt_for_otp
+  end
+
   protected
 
   # Given a login +mfa_phase+, take the appropriate action.
@@ -97,6 +102,13 @@ class Users::SessionsController < Devise::SessionsController
 
   def send_and_prompt_for_otp
     Notify::OTPMessage.new(user.mobile_number, user.current_otp).deliver
+
+    mobile_number_ending = resource.mobile_number.last(4)
+    code_sent_message = action_name == "resend_otp" ?
+      "We've sent a new one-time password to your mobile number ending in #{mobile_number_ending}" :
+      "We've sent a one-time password to your mobile number ending in #{mobile_number_ending}"
+
+    flash.now[:success] = code_sent_message
     prompt_for "otp_attempt"
   end
 

--- a/app/views/devise/sessions/otp_attempt.html.haml
+++ b/app/views/devise/sessions/otp_attempt.html.haml
@@ -15,12 +15,15 @@
                                 pattern: "[0-9]*",
                                 autocomplete: "one-time-code"
 
-  - unless resource.mobile_number_confirmed_at.present?
-    .govuk-grid-row
-      .govuk-grid-column-two-thirds
-        %p.govuk-body
-          Didn't get a message?
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body
+        Didn't get a message?
+
+        - unless resource.mobile_number_confirmed_at.present?
           = link_to "Check your mobile number is correct", edit_mobile_number_path
+        - else
+          = link_to "Resend code", resend_otp_path, method: :post
 
   .govuk-grid-row
     .govuk-grid-column-one-third

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     devise_for :users, controllers: {sessions: "users/sessions"}
     get :edit_mobile_number, to: "users/sessions#edit_mobile_number"
+    post :resend_otp, to: "users/sessions#resend_otp"
   end
 
   # If the DOMAIN env var is present, and the request doesn't come from that


### PR DESCRIPTION
## Changes in this PR
- A user with confirmed mobile number can request the code to be re-sent
- Show the user a message that a code was sent and the last 4 digits of the number

## Screenshots of UI changes

### After

<img width="1181" alt="Screenshot 2022-03-09 at 19 05 31" src="https://user-images.githubusercontent.com/579522/157515049-68e3755d-a380-4f85-a17e-4ff591fb64f5.png">


