### PR TITLE
2412: Bulk upload Refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1002,6 +1002,7 @@
 - Change the HTML title tag of the Users page to be Users, not Home
 - Prevent server errors when a mobile number is invalid
 - Fix bug where comments on actuals were not being included in activity comments
+- Add bulk uploading to Refunds via the Actual importer
 
 ## [release-102] 2022-03-23
 

--- a/app/services/create_actual.rb
+++ b/app/services/create_actual.rb
@@ -1,14 +1,19 @@
 class CreateActual
-  attr_accessor :activity, :report, :actual
+  attr_accessor :activity, :report, :actual, :user
 
-  def initialize(activity:, report: nil, actual_class: Actual)
+  def initialize(activity:, report: nil, user: nil)
     self.activity = activity
     self.report = report || Report.editable_for_activity(activity)
-    self.actual = actual_class.new
+    self.actual = Actual.new
+    self.user = user
   end
 
   def call(attributes: {})
     actual.parent_activity = activity
+
+    body = attributes.delete(:comment)
+    actual.build_comment(body: body, commentable: actual, report: @report) if body.present?
+
     actual.assign_attributes(attributes)
 
     convert_and_assign_value(actual, attributes[:value])
@@ -21,11 +26,6 @@ class CreateActual
 
     unless activity.organisation.service_owner?
       actual.report = report
-    end
-
-    if actual.comment
-      actual.comment.report = @report
-      actual.comment.commentable = actual
     end
 
     Result.new(actual.save, actual)

--- a/app/services/create_actual.rb
+++ b/app/services/create_actual.rb
@@ -1,10 +1,10 @@
 class CreateActual
   attr_accessor :activity, :report, :actual
 
-  def initialize(activity:, report: nil)
+  def initialize(activity:, report: nil, actual_class: Actual)
     self.activity = activity
     self.report = report || Report.editable_for_activity(activity)
-    self.actual = Actual.new
+    self.actual = actual_class.new
   end
 
   def call(attributes: {})

--- a/app/services/create_refund.rb
+++ b/app/services/create_refund.rb
@@ -13,11 +13,8 @@ class CreateRefund
     refund.parent_activity = activity
     refund.report = editable_report_for(activity)
     assign_refund_and_comment(attributes)
-    save_value = refund.save
-
-    raise Error, validation_error_message(refund) if refund.errors.any?
-
-    record_historical_event(refund)
+    save_successful = refund.save
+    record_historical_event(refund) if save_successful
 
     Result.new(save_successful, refund)
   end

--- a/app/services/create_refund.rb
+++ b/app/services/create_refund.rb
@@ -3,7 +3,7 @@ class CreateRefund
 
   attr_accessor :activity, :report, :refund, :user
 
-  def initialize(activity:, user:)
+  def initialize(activity:, user:, report: nil)
     self.activity = activity
     self.user = user
     self.refund = Refund.new
@@ -13,13 +13,13 @@ class CreateRefund
     refund.parent_activity = activity
     refund.report = editable_report_for(activity)
     assign_refund_and_comment(attributes)
-    refund.save
+    save_value = refund.save
 
     raise Error, validation_error_message(refund) if refund.errors.any?
 
     record_historical_event(refund)
 
-    refund
+    Result.new(save_successful, refund)
   end
 
   private

--- a/app/services/import_actuals.rb
+++ b/app/services/import_actuals.rb
@@ -1,3 +1,4 @@
+# This originally handled only Actuals, but now also handles Refunds as well.
 class ImportActuals
   Error = Struct.new(:row, :column, :value, :message) {
     def csv_row
@@ -137,7 +138,7 @@ class ImportActuals
     def actual_type
       return Actual if @row["Refund Value"].nil?
       return Refund if @row["Actual Value"].nil?
-      # TODO: make this nicer, actually return value that's bad
+      # TODO: for some reason I can't use t("importer.errors.actual.non_numeric_value") here.
       @errors[:value] = [@row["Actual Value"], "One of Actual Value and Refund Value must be numeric and the other must be blank"]
       @errors[:refund_value] = [@row["Refund Value"], "One of Actual Value and Refund Value must be numeric and the other must be blank"]
     end

--- a/app/services/import_actuals.rb
+++ b/app/services/import_actuals.rb
@@ -55,7 +55,7 @@ class ImportActuals
 
     def import_row
       @converter = Converter.new(@row)
-      return if @converter.zero_value_actual?
+      return if @converter.zero_value?
 
       @errors.update(@converter.errors)
 
@@ -223,7 +223,7 @@ class ImportActuals
       code
     end
 
-    def zero_value_actual?
+    def zero_value?
       @attributes[:value].present? && @attributes[:value].zero?
     end
   end

--- a/app/services/import_actuals.rb
+++ b/app/services/import_actuals.rb
@@ -137,7 +137,7 @@ class ImportActuals
     # the other is empty when we validate the value it contains
     def actual_type
       return Actual if @row["Refund Value"].nil?
-      return Refund if @row["Actual Value"].nil?
+      return Refund if @row["Actual Value"].nil? || @row["Actual Value"] == "0.00"
       # TODO: for some reason I can't use t("importer.errors.actual.non_numeric_value") here.
       @errors[:value] = [@row["Actual Value"], "One of Actual Value and Refund Value must be numeric and the other must be blank"]
       @errors[:refund_value] = [@row["Refund Value"], "One of Actual Value and Refund Value must be numeric and the other must be blank"]

--- a/app/services/refund/grouped_refund_fetcher.rb
+++ b/app/services/refund/grouped_refund_fetcher.rb
@@ -6,7 +6,7 @@ class Refund
 
     def call
       report.refunds
-        .includes([:parent_activity])
+        .includes([:parent_activity, :comment])
         .map { |refund| RefundPresenter.new(refund) }
         .group_by { |refund| ActivityPresenter.new(refund.parent_activity) }
     end

--- a/app/views/shared/refunds/_refunds_by_activity.html.haml
+++ b/app/views/shared/refunds/_refunds_by_activity.html.haml
@@ -24,6 +24,10 @@
                     = refund.financial_quarter_and_year
                   %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
                     = refund.value
+                  - if refund.comment
+                    %tr.govuk-table__row
+                      %td.govuk-table__cell--numeric{class: "govuk-!-width-full", scope: "col", colspan: 2}
+                        = refund.comment.body
 
       %tr.govuk-table__row.totals
         %td.govuk-table__cell Total

--- a/app/views/staff/reports/_actuals_upload.html.haml
+++ b/app/views/staff/reports/_actuals_upload.html.haml
@@ -2,7 +2,7 @@
   = t("tabs.actuals.providing.heading")
 
 %p.govuk-body
-  = t("tabs.actuals.providing.copy")
+  = t("tabs.actuals.providing.copy_html")
 
 %h3.govuk-heading-s
   = t("tabs.actuals.upload.heading")

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -19,7 +19,7 @@ en:
   form:
     label:
       actual:
-        csv_file: Provide actuals data to upload
+        csv_file: Provide actuals and refunds data to upload
         csv_file_recover_from_error: Re-upload CSV spreadsheet
         currency: Currency
         description: Describe the actual
@@ -39,7 +39,7 @@ en:
         receiving_organisation: Receiving organisation (optional)
     hint:
       actual:
-        csv_file: Select the file that contains the actuals data for this report.
+        csv_file: Select the UTF-8 CSV file that contains the actuals and refunds data for this report.
         csv_file_recover_from_error_html: Upload a spreadsheet containing actual spend information in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
         date: If you're reporting quarterly data, select the last day of the quarter. For example, 31 12 2020
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
@@ -60,10 +60,16 @@ en:
   tabs:
     actuals:
       heading: Actuals / Refunds
-      copy: Listed below are the actuals and refunds that have been added to this report.
+      copy: Actuals and refunds that have already been added to this report are listed below.
       providing:
-        heading: Providing actuals and refunds data
-        copy: Actuals and refunds data can be added by using the application interface or by uploading data.
+        heading: Adding more actuals and refunds data
+        copy_html: |
+          To add more actuals on this page:
+          <ul class="govuk-list govuk-list--bullet">
+          <li>Download the actuals data template</li>
+          <li>Complete the template with your additional actuals data</li>
+          <li>Upload the template</li>
+          </ul>
       upload:
         heading: Upload data
         copy_html:
@@ -83,22 +89,22 @@ en:
           receiving_organisation: Receiver
       upload:
         copy_html:
-          <p class="govuk-body">Large numbers of actuals and refunds can be added to the report by uploading them here.</p>
-          <p class="govuk-body">The basic steps are:</p>
+          <p class="govuk-body">You can add large numbers of actuals and refunds to this report at once.</p>
+
+          <p class="govuk-body">To add actuals and refunds data:</p>
           <ol class="govuk-list govuk-list--number">
-          <li>Prepare the actuals and refunds data</li>
-          <li>Use the <a class="govuk-link" href="%{report_actuals_template_path}">actuals and refunds data template</a> as is or as a guide if required</li>
-          <li>Ensure the file is saved as UTF-8 CSV, <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005515621-Uploading-your-Activity-Actuals-or-Forecasts-data-via-the-Templates-to-RODA">see guidance in the help centre (opens in new tab)</a></li>
-          <li>Upload and verify the data here</li>
+            <li>Download the <a class="govuk-link" href="%{report_actuals_template_path}">actuals and refunds template</a> as is or as a guide if required</li>
+            <li>Complete the template with your additional actuals and refunds</li>
+            <li>Save the file in the CSV format with the UTF-8 encoding</li>
+            <li>Click the Browse button below and find the file you want to upload, then click Upload and continue.</li>
           </ol>
-          <p class="govuk-body">For more detailed guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a></p>
         warning_html:
           <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.</strong></div>
   page_title:
     actual:
       edit: Edit actual spend
       new: Add an actual
-      upload: Upload actuals and refunds data
+      upload: Upload actuals and refunds
       upload_success: Successful uploads
   breadcrumb:
     actual:

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -139,7 +139,7 @@ en:
         invalid_date: Date must be a valid date
         invalid_iati_disbursement_channel: The disbursement channel must be a valid IATI Disbursement Channel code
         invalid_iati_organisation_type: The receiving organisation type must be a valid IATI Organisation Type code
-        non_numeric_value: The value must be numeric
+        non_numeric_value: One of Actual Value and Refund Value must be numeric and the other must be blank
         unauthorised: You are not authorised to report against this activity
         unknown_identifier: Identifier is not recognised
         invalid_characters: This cell contains invalid characters

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -59,23 +59,23 @@ en:
         receiving_organisation: Receiver
   tabs:
     actuals:
-      heading: Actuals
-      copy: Listed below are the actuals that have been added to this report.
+      heading: Actuals / Refunds
+      copy: Listed below are the actuals and refunds that have been added to this report.
       providing:
-        heading: Providing actuals data
-        copy: Actuals data can be added by using the application interface or by uploading data.
+        heading: Providing actuals and refunds data
+        copy: Actuals and refunds data can be added by using the application interface or by uploading data.
       upload:
         heading: Upload data
         copy_html:
-          <p class="govuk-body">Large numbers of actuals can be added via the actuals upload.</p>
-          <p class="govuk-body">For guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.</p>
-        warning: Ensure you use the correct template (available below) when uploading actuals data.
+          <p class="govuk-body">Large numbers of actuals and refunds can be added via the actuals upload.</p>
+          <p class="govuk-body">For guidance on uploading actuals and refunds, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.</p>
+        warning: Ensure you use the correct template (available below) when uploading the actuals and refunds.
   page_content:
     actuals:
       button:
         create: Add an actual
-        upload: Upload actuals data
-        download_template: Download actuals data template
+        upload: Upload actuals and refunds data
+        download_template: Download actuals and refunds data template
       edit_noun: actual spend
       table:
         headers:
@@ -83,22 +83,22 @@ en:
           receiving_organisation: Receiver
       upload:
         copy_html:
-          <p class="govuk-body">Large numbers of actuals can be added to the report by uploading them here.</p>
+          <p class="govuk-body">Large numbers of actuals and refunds can be added to the report by uploading them here.</p>
           <p class="govuk-body">The basic steps are:</p>
           <ol class="govuk-list govuk-list--number">
-          <li>Prepare the actuals data</li>
-          <li>Use the <a class="govuk-link" href="%{report_actuals_template_path}">actuals data template</a> as is or as a guide if required</li>
+          <li>Prepare the actuals and refunds data</li>
+          <li>Use the <a class="govuk-link" href="%{report_actuals_template_path}">actuals and refunds data template</a> as is or as a guide if required</li>
           <li>Ensure the file is saved as UTF-8 CSV, <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005515621-Uploading-your-Activity-Actuals-or-Forecasts-data-via-the-Templates-to-RODA">see guidance in the help centre (opens in new tab)</a></li>
           <li>Upload and verify the data here</li>
           </ol>
           <p class="govuk-body">For more detailed guidance on uploading actuals data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a></p>
         warning_html:
-          <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Uploading actuals data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.</strong></div>
+          <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.</strong></div>
   page_title:
     actual:
       edit: Edit actual spend
       new: Add an actual
-      upload: Upload actuals data
+      upload: Upload actuals and refunds data
       upload_success: Successful uploads
   breadcrumb:
     actual:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -40,7 +40,7 @@ en:
       forecasts:
         heading: Forecasts
       actuals:
-        heading: Actuals
+        heading: Actuals / Refunds
       variance:
         heading: Variance
         body: This tab shows the variance between forecasted and actual spend, including any adjustments, in this reporting cycle.
@@ -151,7 +151,7 @@ en:
         complete: This report is approved
       variance: "%{report_financial_quarter} %{report_description} variance"
       forecasts: "%{report_financial_quarter} %{report_description} forecasts"
-      actuals: "%{report_financial_quarter} %{report_description} actuals"
+      actuals: "%{report_financial_quarter} %{report_description} actuals and refunds"
       budgets: "%{report_financial_quarter} %{report_description} budgets"
       activities: "%{report_financial_quarter} %{report_description} activities"
       comments: "%{report_financial_quarter} %{report_description} comments"
@@ -159,7 +159,7 @@ en:
     report:
       upload_activities: Upload bulk activity data
       upload_forecasts: Upload forecast data
-      upload_actuals:  Upload actuals data
+      upload_actuals:  Upload actuals and refunds data
   mailer:
     report:
       activated:

--- a/spec/controllers/staff/actual_uploads_controller_spec.rb
+++ b/spec/controllers/staff/actual_uploads_controller_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Staff::ActualUploadsController do
     allow(controller).to receive(:current_user).and_return(user)
   end
 
+  RSpec::Matchers.define :have_upload_button do
+    match do |actual|
+      RSpec::Matchers::BuiltIn::Match.new("#{t("action.actual.upload.button")}</button>").matches?(actual)
+    end
+  end
+
   describe "#new" do
     render_views
 
@@ -19,7 +25,7 @@ RSpec.describe Staff::ActualUploadsController do
       it "shows the upload button" do
         get :new, params: {report_id: report.id}
 
-        expect(response.body).to include(t("action.actual.upload.button"))
+        expect(response.body).to have_upload_button
       end
     end
 
@@ -29,17 +35,15 @@ RSpec.describe Staff::ActualUploadsController do
       it "shows the upload button" do
         get :new, params: {report_id: report.id}
 
-        expect(response.body).to include(t("action.actual.upload.button"))
+        expect(response.body).to have_upload_button
       end
     end
 
     context "with a report in review" do
       let(:state) { :in_review }
-
       it "doesn't show the upload button" do
         get :new, params: {report_id: report.id}
-
-        expect(response.body).to_not include(t("action.actual.upload.button"))
+        expect(response.body).to_not have_upload_button
       end
     end
 
@@ -52,7 +56,7 @@ RSpec.describe Staff::ActualUploadsController do
         it "doesn't show the upload button" do
           get :new, params: {report_id: report.id}
 
-          expect(response.body).to_not include(t("action.actual.upload.button"))
+          expect(response.body).to_not have_upload_button
         end
       end
 
@@ -62,7 +66,7 @@ RSpec.describe Staff::ActualUploadsController do
         it "doesn't show the upload button" do
           get :new, params: {report_id: report.id}
 
-          expect(response.body).to_not include(t("action.actual.upload.button"))
+          expect(response.body).to_not have_upload_button
         end
       end
     end

--- a/spec/features/staff/users_can_upload_actuals_spec.rb
+++ b/spec/features/staff/users_can_upload_actuals_spec.rb
@@ -53,7 +53,8 @@ RSpec.feature "users can upload actuals" do
         "Activity RODA Identifier" => project.roda_identifier,
         "Financial Quarter" => report.financial_quarter.to_s,
         "Financial Year" => report.financial_year.to_s,
-        "Value" => "0.00",
+        "Actual Value" => "0.00",
+        "Refund Value" => nil,
         "Receiving Organisation Name" => nil,
         "Receiving Organisation Type" => nil,
         "Receiving Organisation IATI Reference" => nil,
@@ -65,7 +66,8 @@ RSpec.feature "users can upload actuals" do
         "Activity RODA Identifier" => sibling_project.roda_identifier,
         "Financial Quarter" => report.financial_quarter.to_s,
         "Financial Year" => report.financial_year.to_s,
-        "Value" => "0.00",
+        "Actual Value" => "0.00",
+        "Refund Value" => nil,
         "Receiving Organisation Name" => nil,
         "Receiving Organisation Type" => nil,
         "Receiving Organisation IATI Reference" => nil,
@@ -88,9 +90,9 @@ RSpec.feature "users can upload actuals" do
 
     # When I upload some actuals with comments
     upload_csv <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
-      #{ids[0]}                | 1                 | 2020           | 20    | Example University          | 80                          |                                       | A unique comment
-      #{ids[1]}                | 1                 | 2020           | 30    | Example Foundation          | 60                          |                                       |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{ids[0]}                | 1                 | 2020           | 20           | Example University          | 80                          |                                       | A unique comment
+      #{ids[1]}                | 1                 | 2020           | 30           | Example Foundation          | 60                          |                                       |
     CSV
 
     # Then I should see a summary of my upload
@@ -116,9 +118,9 @@ RSpec.feature "users can upload actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1                 | 2020           | 20    |                             |                             |
-      #{ids[1]}                | 1                 | 2020           | 30    |                             |                             |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 20           |                             |                             |
+      #{ids[1]}                | 1                 | 2020           | 30           |                             |                             |
     CSV
 
     expect(Actual.count).to eq(2)
@@ -131,9 +133,9 @@ RSpec.feature "users can upload actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1                 | 2020           | 0.00  | Example University          | 80                          |
-      #{ids[1]}                | 1                 | 2020           | 30    | Example Foundation          | 60                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 0.00         | Example University          | 80                          |
+      #{ids[1]}                | 1                 | 2020           | 30           | Example Foundation          | 60                          |
     CSV
 
     expect(Actual.count).to eq(1)
@@ -146,16 +148,16 @@ RSpec.feature "users can upload actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1                 | 2020           | fish  | Example University          | 80                          |
-      #{ids[1]}                | 1                 | 2020           | 30    | Example Foundation          | 61                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | fish         | Example University          | 80                          |
+      #{ids[1]}                | 1                 | 2020           | 30           | Example Foundation          | 61                          |
     CSV
 
     expect(Actual.count).to eq(0)
     expect(page).not_to have_text(t("action.actual.upload.success"))
 
     within "//tbody/tr[1]" do
-      expect(page).to have_xpath("td[1]", text: "Value")
+      expect(page).to have_xpath("td[1]", text: "Actual Value")
       expect(page).to have_xpath("td[2]", text: "2")
       expect(page).to have_xpath("td[3]", text: "fish")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.non_numeric_value"))
@@ -173,7 +175,7 @@ RSpec.feature "users can upload actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     csv = <<~CSV
-      Activity RODA Identifier,Financial Quarter,Financial Year,,Value,Receiving Organisation Name,Receiving Organisation Type,Receiving Organisation IATI Reference
+      Activity RODA Identifier,Financial Quarter,Financial Year,,Actual Value,Receiving Organisation Name,Receiving Organisation Type,Receiving Organisation IATI Reference
       #{ids[0]},1,2020,\xA320,Example University,80
       #{ids[1]},1,2020,\xA330,Example Foundation,60
     CSV
@@ -197,9 +199,9 @@ RSpec.feature "users can upload actuals" do
     bom = "\uFEFF"
 
     upload_csv bom + <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1                 | 2020           | 20    | Example University          | 80                          |
-      #{ids[1]}                | 2                 | 2020           | 30    | Example Foundation          | 60                          |
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
+      #{ids[0]}                | 1                 | 2020           | 20           | Example University          | 80                          |
+      #{ids[1]}                | 2                 | 2020           | 30           | Example Foundation          | 60                          |
     CSV
 
     expect(Actual.count).to eq(2)

--- a/spec/features/staff/users_can_upload_refunds_spec.rb
+++ b/spec/features/staff/users_can_upload_refunds_spec.rb
@@ -1,3 +1,8 @@
+# NOTE:
+# This spec primarily interacts with import_actuals and create_actual,
+# rather than the non-existant import_actuals or the actually
+# existing create_refund
+
 RSpec.feature "users can upload refunds" do
   # Given that I am logged in as a Delivery Partner,
   # And a report exists that is waiting for refunds to be uploaded
@@ -62,6 +67,21 @@ RSpec.feature "users can upload refunds" do
     click_on("Actuals")
 
     # Then I should see my Refund amount and comment are there
+    expect(page).to have_text("-£1,234.56")
+    expect(page).to have_text("Ocelot")
+  end
+
+  scenario "Upload a valid refund with a zero actual" do
+    click_link t("page_content.actuals.button.upload")
+    id = project.roda_identifier
+
+    # When I upload some refunds with comments
+    upload_csv <<~CSV
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{id}                    | 1                 | 2020           | 0.00         | 1234.56      | Example University          | 80                          |                                       | Ocelot
+    CSV
+
+    # Then I see my refund amount and comment in the Refund section
     expect(page).to have_text("-£1,234.56")
     expect(page).to have_text("Ocelot")
   end

--- a/spec/features/staff/users_can_upload_refunds_spec.rb
+++ b/spec/features/staff/users_can_upload_refunds_spec.rb
@@ -1,0 +1,71 @@
+RSpec.feature "users can upload refunds" do
+  # Given that I am logged in as a Delivery Partner,
+  # And a report exists that is waiting for refunds to be uploaded
+  let(:organisation) { create(:delivery_partner_organisation) }
+  let(:user) { create(:delivery_partner_user, organisation: organisation) }
+  #  only used for fund so far from project
+  let(:project) { create(:project_activity, :newton_funded, organisation: organisation) } # was bang
+
+  let :report do # was bang
+    create(:report,
+      :active,
+      fund: project.associated_fund,
+      organisation: organisation)
+  end
+
+  before do
+    authenticate!(user: user)
+    visit report_actuals_path(report)
+  end
+
+  def upload_csv(content)
+    file = Tempfile.new("actuals.csv")
+    file.write(content.gsub(/ *\| */, ","))
+    file.close
+
+    attach_file "report[actual_csv]", file.path
+    click_button t("action.actual.upload.button")
+
+    file.unlink
+  end
+
+  scenario "Download a template CSV" do
+    # When I download the Actuals & Refunds template CSV
+    click_link t("page_content.actuals.button.download_template")
+    # Then I see an Actual Value then a Refund Value column
+    expect(page).to have_text(",Actual Value,Refund Value,")
+  end
+
+  scenario "Upload a refund" do
+    click_link t("page_content.actuals.button.upload")
+    id = project.roda_identifier
+
+    # When I upload some refunds with comments
+    upload_csv <<~CSV
+      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{id}                    | 1                 | 2020           |              | 1234.56      | Example University          | 80                          |                                       | Refund 1234
+    CSV
+
+    # Then I see my refunds in the Refund section
+    expect(page).to have_text("1,234.56")
+    expect(page).to have_text("Refund 1234")
+  end
+
+  # When I upload an Actuals & Refunds CSV with a refund and comments,
+  # Then I should see a summary of my refund with comments,
+
+  # When I go back to the Report,
+  # And I open the Comments tab,
+  # Then I should see my Refunds comment is there.
+  # When I open the Actuals tab
+  # Then I should see my Refunds in there.
+
+  # When I download the Actuals & Refunds template CSV
+  # Then I see an Actual Value and Refund Value column
+
+  # When I upload an Actuals & Refunds row which has a row with an Actual Value and Refund Value
+  # Then it shows an error for that row in the list of validation errors
+
+  # When I upload an Actuals & Refunds row which has a Refund Value and a Comment
+  # We can see the refund exists
+end

--- a/spec/services/create_actual_spec.rb
+++ b/spec/services/create_actual_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe CreateActual do
       expect(result.success?).to be true
     end
 
-    context "when passed Refund" do
-      it "returns a refund" do
-        result = described_class.new(activity: activity, actual_class: Refund).call(attributes: ActionController::Parameters.new(value: "1234").permit!)
-        expect(result.object).to be_a(Refund)
-      end
-    end
-
     context "when passed Actual" do
       it "returns an actual" do
         result = described_class.new(activity: activity).call(attributes: ActionController::Parameters.new(value: "1234").permit!)

--- a/spec/services/create_actual_spec.rb
+++ b/spec/services/create_actual_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe CreateActual do
       expect(result.success?).to be true
     end
 
+    context "when passed Refund" do
+      it "returns a refund" do
+        result = described_class.new(activity: activity, actual_class: Refund).call(attributes: ActionController::Parameters.new(value: "1234").permit!)
+        expect(result.object).to be_a(Refund)
+      end
+    end
+
+    context "when passed Actual" do
+      it "returns an actual" do
+        result = described_class.new(activity: activity).call(attributes: ActionController::Parameters.new(value: "1234").permit!)
+        expect(result.object).to be_an(Actual)
+      end
+    end
+
     context "when the actual isn't valid" do
       it "returns a failed result" do
         allow_any_instance_of(Actual).to receive(:valid?).and_return(false)

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe CreateRefund do
         end
       end
 
+      context "when there isn't a comment" do
+        let(:attributes) do
+          {
+            value: 100.10,
+            financial_quarter: 1,
+            financial_year: 2020
+          }
+        end
+
+        it "has an error" do
+          expect(subject.object.errors.messages.values.to_s).to include("Enter a comment describing the need for the refund")
+        end
+      end
+
       context "when the atrributes are invalid" do
         let(:attributes) do
           {
@@ -79,7 +93,7 @@ RSpec.describe CreateRefund do
         end
 
         it "raises an error with the validation errors" do
-          expect { subject }.to raise_error(CreateRefund::Error, /Select a financial year/)
+          expect(subject.object.errors.messages.values.to_s).to include("Select a financial year")
         end
 
         it "does not create a historical event" do

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CreateRefund do
         it "creates a refund" do
           expect(refund).to receive(:save).at_least(:once)
 
-          created_refund = subject
+          created_refund = subject.object
 
           expect(created_refund).to be_a(Refund)
 
@@ -45,7 +45,7 @@ RSpec.describe CreateRefund do
           expect(created_refund.financial_quarter).to eq(1)
           expect(created_refund.financial_year).to eq(2020)
           expect(created_refund.comment.body).to eq("Some words")
-          expect(subject.comment.report).to eq(report)
+          expect(created_refund.comment.report).to eq(report)
         end
 
         it "creates historical events" do

--- a/spec/services/import_actuals_spec.rb
+++ b/spec/services/import_actuals_spec.rb
@@ -19,13 +19,38 @@ RSpec.describe ImportActuals do
     ImportActuals.new(report: report, uploader: reporter)
   end
 
+  describe "importing a single refund" do
+    let :actual_row do
+      {
+        "Activity RODA Identifier" => project.roda_identifier,
+        "Financial Quarter" => "4",
+        "Financial Year" => "2019",
+        "Actual Value" => nil,
+        "Refund Value" => "12.00",
+        "Receiving Organisation Name" => "Example University",
+        "Receiving Organisation Type" => "80",
+        "Receiving Organisation IATI Reference" => "",
+        "Comment" => "Refund"
+      }
+    end
+
+    before do
+      importer.import([actual_row])
+    end
+
+    it "imports a single refund" do
+      expect(report.refunds.count).to eq(1)
+      expect(report.refunds.first.comment.body).to eq("Refund")
+    end
+  end
+
   describe "importing a single actual" do
     let :actual_row do
       {
         "Activity RODA Identifier" => project.roda_identifier,
         "Financial Quarter" => "4",
         "Financial Year" => "2019",
-        "Value" => "50.00",
+        "Actual Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
         "Receiving Organisation IATI Reference" => "",
@@ -175,7 +200,7 @@ RSpec.describe ImportActuals do
 
     context "with additional formatting in the Value field" do
       let :actual_row do
-        super().merge("Value" => "£ 12,345.67")
+        super().merge("Actual Value" => "£ 12,345.67")
       end
 
       it "imports the actual" do
@@ -188,9 +213,14 @@ RSpec.describe ImportActuals do
       end
     end
 
-    context "when the Value is blank" do
+    # Note: the higher-level behaviour is that CSV rows with a blank value
+    # are skipped entirely. But here it's an error for there to be no data.
+    context "when the Actual Value and the Refund Value are blank" do
       let :actual_row do
-        super().merge("Value" => "")
+        super().merge(
+          "Actual Value" => "",
+          "Refund Value" => ""
+        )
       end
 
       it "does not import any actuals" do
@@ -199,14 +229,15 @@ RSpec.describe ImportActuals do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportActuals::Error.new(0, "Value", "", t("importer.errors.actual.non_numeric_value"))
+          ImportActuals::Error.new(0, "Actual Value", "", t("importer.errors.actual.non_numeric_value")),
+          ImportActuals::Error.new(0, "Refund Value", "", t("importer.errors.actual.non_numeric_value"))
         ])
       end
     end
 
     context "when the Value is zero" do
       let :actual_row do
-        super().merge("Value" => "0")
+        super().merge("Actual Value" => "0")
       end
 
       it "does not import any actuals" do
@@ -220,7 +251,7 @@ RSpec.describe ImportActuals do
 
     context "when the Value is not numeric" do
       let :actual_row do
-        super().merge("Value" => "This is not a number")
+        super().merge("Actual Value" => "This is not a number")
       end
 
       it "does not import any actuals" do
@@ -229,14 +260,14 @@ RSpec.describe ImportActuals do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportActuals::Error.new(0, "Value", "This is not a number", t("importer.errors.actual.non_numeric_value"))
+          ImportActuals::Error.new(0, "Actual Value", "This is not a number", t("importer.errors.actual.non_numeric_value"))
         ])
       end
     end
 
     context "when the Value is partially numeric" do
       let :actual_row do
-        super().merge("Value" => "3a4b5.c67")
+        super().merge("Actual Value" => "3a4b5.c67")
       end
 
       it "does not import any actuals" do
@@ -245,7 +276,7 @@ RSpec.describe ImportActuals do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportActuals::Error.new(0, "Value", "3a4b5.c67", t("importer.errors.actual.non_numeric_value"))
+          ImportActuals::Error.new(0, "Actual Value", "3a4b5.c67", t("importer.errors.actual.non_numeric_value"))
         ])
       end
     end
@@ -337,7 +368,7 @@ RSpec.describe ImportActuals do
         "Activity RODA Identifier" => sibling_project.roda_identifier,
         "Financial Quarter" => "3",
         "Financial Year" => "2020",
-        "Value" => "50.00",
+        "Actual Value" => "50.00",
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
         "Comment" => "A comment!"
@@ -349,7 +380,7 @@ RSpec.describe ImportActuals do
         "Activity RODA Identifier" => project.roda_identifier,
         "Financial Quarter" => "3",
         "Financial Year" => "2020",
-        "Value" => "150.00",
+        "Actual Value" => "150.00",
         "Receiving Organisation Name" => "Example Corporation",
         "Receiving Organisation Type" => "70",
         "Comment" => ""
@@ -361,7 +392,7 @@ RSpec.describe ImportActuals do
         "Activity RODA Identifier" => sibling_project.roda_identifier,
         "Financial Quarter" => "3",
         "Financial Year" => "2019",
-        "Value" => "£5,000",
+        "Actual Value" => "£5,000",
         "Receiving Organisation Name" => "Example Foundation",
         "Receiving Organisation Type" => "60",
         "Comment" => "Not blank"
@@ -404,7 +435,7 @@ RSpec.describe ImportActuals do
 
     context "when any row is not valid" do
       let :third_actual_row do
-        super().merge("Value" => "fish")
+        super().merge("Actual Value" => "fish")
       end
 
       it "does not import any actuals" do
@@ -414,14 +445,14 @@ RSpec.describe ImportActuals do
 
       it "returns an error" do
         expect(importer.errors).to eq([
-          ImportActuals::Error.new(2, "Value", "fish", t("importer.errors.actual.non_numeric_value"))
+          ImportActuals::Error.new(2, "Actual Value", "fish", t("importer.errors.actual.non_numeric_value"))
         ])
       end
     end
 
     context "when there are multiple errors" do
       let :first_actual_row do
-        super().merge("Receiving Organisation Type" => "81", "Value" => "fish")
+        super().merge("Receiving Organisation Type" => "81", "Actual Value" => "fish")
       end
 
       let :third_actual_row do
@@ -437,8 +468,8 @@ RSpec.describe ImportActuals do
 
         expect(errors.size).to eq(3)
         expect(errors).to eq([
+          ImportActuals::Error.new(0, "Actual Value", "fish", t("importer.errors.actual.non_numeric_value")),
           ImportActuals::Error.new(0, "Receiving Organisation Type", "81", t("importer.errors.actual.invalid_iati_organisation_type")),
-          ImportActuals::Error.new(0, "Value", "fish", t("importer.errors.actual.non_numeric_value")),
           ImportActuals::Error.new(2, "Financial Quarter", third_actual_row["Financial Quarter"], t("activerecord.errors.models.actual.attributes.financial_quarter.inclusion"))
         ])
       end

--- a/spec/services/import_actuals_spec.rb
+++ b/spec/services/import_actuals_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ImportActuals do
         "Receiving Organisation Name" => "Example University",
         "Receiving Organisation Type" => "80",
         "Receiving Organisation IATI Reference" => "",
-        "Comment" => "Refund"
+        "Comment" => "This is a Refund"
       }
     end
 
@@ -40,7 +40,7 @@ RSpec.describe ImportActuals do
 
     it "imports a single refund" do
       expect(report.refunds.count).to eq(1)
-      expect(report.refunds.first.comment.body).to eq("Refund")
+      expect(report.refunds.first.comment.body).to eq("This is a Refund")
     end
   end
 

--- a/spec/services/refund/grouped_refund_fetcher_spec.rb
+++ b/spec/services/refund/grouped_refund_fetcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Refund::GroupedRefundFetcher do
 
     before do
       allow(report).to receive(:refunds).and_return(refunds_stub)
-      allow(refunds_stub).to receive(:includes).with([:parent_activity]).and_return(refunds)
+      allow(refunds_stub).to receive(:includes).with([:parent_activity, :comment]).and_return(refunds)
     end
 
     it "returns refunds grouped by activity" do


### PR DESCRIPTION
## Changes in this PR

    The chosen method is to bolt this functionality onto the existing Actuals
    upload, renaming the Value column to Actual Value and adding a new Refund Value
    column.
    
    Exactly one of these values must be filled in for an upload to occur.
    
    Create Actual now takes an optional parameter which allows it to generate a
    Refund instead, but is otherwise unchanged.
    
    Import Actual contains logic for determining whether a row is a Refund or
    Actual, based on the presence of the two types of value.
    
   
We also make comments visible on 'refunds by activity'
 
## Screenshots of UI changes

### Actuals copy: before
![image](https://user-images.githubusercontent.com/85497046/158653161-f2baf72f-cf02-41b1-b6b4-f64b89d1254e.png)

### Actuals copy: after
<img width="757" alt="image" src="https://user-images.githubusercontent.com/85497046/159910676-1591c66a-0c46-4fa6-bbca-72719a745d98.png">

### Upload page: before
![image](https://user-images.githubusercontent.com/85497046/159336829-b60ec3e3-1151-4687-b698-8053586d09bf.png)

### Upload page: after
![image](https://user-images.githubusercontent.com/85497046/159910776-b271d2df-b549-4bde-9023-d0b4723aa9b8.png)


### After

CSV upload has Actual Value and Refund Value
<img width="939" alt="image" src="https://user-images.githubusercontent.com/85497046/157883900-59ea0dbd-478e-4065-85d0-37cbfb1cb5c6.png">

Refunds have comments (still messy)
![image](https://user-images.githubusercontent.com/85497046/157884136-7c2e24cf-4216-4524-a840-7d01a36c4991.png)


## Next steps
- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
