### PR TITLE
Replace i18n references with actual text

### DIFF
--- a/spec/features/public/visitors/home_page_spec.rb
+++ b/spec/features/public/visitors/home_page_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Home page" do
   scenario "visit the home page" do
     visit root_path
-    expect(page).to have_content(t("app.title"))
+    expect(page).to have_content("Report your Official Development Assistance")
   end
 
   context "when signed in as a BEIS user" do
@@ -30,7 +30,7 @@ RSpec.feature "Home page" do
 
     scenario "they are shown the start page" do
       visit root_path
-      expect(page).to have_button(t("header.link.sign_in"))
+      expect(page).to have_button("Sign in")
     end
   end
 end

--- a/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/staff/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       form = ActivityForm.new(activity: activity, level: "programme", fund: "gcrf")
       form.complete!
 
-      expect(page).to have_content(t("action.programme.create.success"))
+      expect(page).to have_content("Programme (level B) successfully created")
 
       created_activity = form.created_activity
 
@@ -86,7 +86,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       form = ActivityForm.new(activity: activity, level: "programme", fund: "newton")
       form.complete!
 
-      expect(page).to have_content(t("action.programme.create.success"))
+      expect(page).to have_content("Programme (level B) successfully created")
 
       created_activity = form.created_activity
 

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "BEIS users can create organisations" do
       visit organisation_path(user.organisation)
 
       within ".govuk-header__navigation" do
-        click_link t("page_title.organisation.index")
+        click_link "Organisations"
       end
     end
 
@@ -28,23 +28,23 @@ RSpec.feature "BEIS users can create organisations" do
     end
 
     scenario "successfully creating a delivery partner organisation" do
-      click_link t("page_content.organisations.delivery_partners.button.create")
+      click_link "Add delivery partner organisation"
 
       then_breadcrumb_shows_type_of_organisation(
         name: "Delivery partners",
         link: organisations_path(role: "delivery_partners")
       )
 
-      expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
+      expect(page).to have_content("Create a new delivery partner organisation")
       fill_in "organisation[name]", with: "My New Organisation"
       fill_in "organisation[beis_organisation_reference]", with: "MNO"
       fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
-      click_button t("default.button.submit")
+      click_button "Submit"
 
-      expect(page).to have_content(t("action.organisation.create.success"))
+      expect(page).to have_content("Organisation successfully created")
       expect(page).to_not have_field("organisation[active]", type: "radio")
 
       organisation = Organisation.order("created_at ASC").last
@@ -60,29 +60,29 @@ RSpec.feature "BEIS users can create organisations" do
     end
 
     scenario "successfully creating a matched effort provider organisation" do
-      click_link t("tabs.organisations.matched_effort_providers")
+      click_link "Matched effort providers"
 
-      click_link t("page_content.organisations.matched_effort_providers.button.create")
+      click_link "Add matched effort provider organisation"
 
       then_breadcrumb_shows_type_of_organisation(
         name: "Matched effort providers",
         link: organisations_path(role: "matched_effort_providers")
       )
 
-      expect(page).to have_content(t("page_title.organisation.matched_effort_provider.new"))
+      expect(page).to have_content("Create a new matched effort provider organisation")
       expect(page).to have_field("organisation[active]", type: "radio")
 
       fill_in "organisation[name]", with: "My New Organisation"
       select "Government", from: "organisation[organisation_type]"
       select "Czech", from: "organisation[language_code]"
       select "Zloty", from: "organisation[default_currency]"
-      choose t("form.label.organisation.active.true"), name: "organisation[active]"
+      choose "Active", name: "organisation[active]"
 
-      click_button t("default.button.submit")
+      click_button "Submit"
 
       organisation = Organisation.order("created_at ASC").last
 
-      expect(page).to have_content(t("action.organisation.create.success"))
+      expect(page).to have_content("Organisation successfully created")
 
       expect(organisation.name).to eq("My New Organisation")
       expect(organisation.organisation_type).to eq("10")
@@ -93,28 +93,28 @@ RSpec.feature "BEIS users can create organisations" do
     end
 
     scenario "successfully creating a external income provider organisation" do
-      click_link t("tabs.organisations.external_income_providers")
+      click_link "External income providers"
 
-      click_link t("page_content.organisations.external_income_providers.button.create")
+      click_link "Add external income provider organisation"
       then_breadcrumb_shows_type_of_organisation(
         name: "External income provider",
         link: organisations_path(role: "external_income_providers")
       )
 
-      expect(page).to have_content(t("page_title.organisation.external_income_provider.new"))
+      expect(page).to have_content("Create a new external income provider organisation")
       expect(page).to have_field("organisation[active]", type: "radio")
 
       fill_in "organisation[name]", with: "My New External Income Provider"
       select "Other", from: "organisation[organisation_type]"
       select "Russian", from: "organisation[language_code]"
       select "Russian Ruble", from: "organisation[default_currency]"
-      choose t("form.label.organisation.active.true"), name: "organisation[active]"
+      choose "Active", name: "organisation[active]"
 
-      click_button t("default.button.submit")
+      click_button "Submit"
 
       organisation = Organisation.order("created_at ASC").last
 
-      expect(page).to have_content(t("action.organisation.create.success"))
+      expect(page).to have_content("Organisation successfully created")
 
       expect(organisation.name).to eq("My New External Income Provider")
       expect(organisation.organisation_type).to eq("90")
@@ -126,9 +126,9 @@ RSpec.feature "BEIS users can create organisations" do
 
     scenario "successfully creating an implementing organisation" do
       def given_i_am_on_the_new_implementing_organisation_page
-        click_link t("tabs.organisations.implementing_organisations")
-        click_link t("page_content.organisations.implementing_organisations.button.create")
-        expect(page).to have_content(t("page_title.organisation.implementing_organisation.new"))
+        click_link "Implementing organisations"
+        click_link "Add implementing organisation"
+        expect(page).to have_content("Create a new implementing organisation")
         then_breadcrumb_shows_type_of_organisation(
           name: "Implementing organisations",
           link: organisations_path(role: "implementing_organisations")
@@ -136,7 +136,7 @@ RSpec.feature "BEIS users can create organisations" do
       end
 
       def and_i_submit_the_new_implementing_organisation_form
-        click_button t("default.button.submit")
+        click_button "Submit"
       end
 
       def then_i_expect_to_see_that_an_implementing_organisation_has_mandatory_fields
@@ -160,7 +160,7 @@ RSpec.feature "BEIS users can create organisations" do
       def then_i_expect_to_see_the_created_implementing_organisation(organisation)
         presented_org = OrganisationPresenter.new(organisation)
 
-        expect(page).to have_content(t("action.organisation.create.success"))
+        expect(page).to have_content("Organisation successfully created")
         expect(page).to have_content(presented_org.name)
         expect(page).to have_content(presented_org.iati_reference)
         expect(page).to have_content(presented_org.language_code)
@@ -180,14 +180,14 @@ RSpec.feature "BEIS users can create organisations" do
     end
 
     scenario "presence validation works as expected" do
-      click_link t("page_content.organisations.delivery_partners.button.create")
+      click_link "Add delivery partner organisation"
 
-      expect(page).to have_content(t("page_title.organisation.delivery_partner.new"))
+      expect(page).to have_content("Create a new delivery partner organisation")
       fill_in "organisation[name]", with: "My New Organisation"
 
-      click_button t("default.button.submit")
-      expect(page).to_not have_content t("action.organisation.create.success")
-      expect(page).to have_content t("activerecord.errors.models.organisation.attributes.organisation_type.blank")
+      click_button "Submit"
+      expect(page).to_not have_content "Organisation successfully created"
+      expect(page).to have_content "Enter an organisation type"
     end
   end
 
@@ -196,7 +196,7 @@ RSpec.feature "BEIS users can create organisations" do
 
     it "does not show them the manage user button" do
       visit organisation_path(user.organisation)
-      expect(page).not_to have_link(t("page_title.organisation.index"))
+      expect(page).not_to have_link("Organisations")
     end
   end
 end

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -14,19 +14,19 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "2021"
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to have_content t("action.report.update.success")
+      expect(page).to have_content "Report successfully updated"
       within "##{report.id}" do
         expect(page).to have_content("31 Jan 2021")
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
       expect(page).to have_field("report[deadline(1i)]", with: "2021")
       expect(page).to have_field("report[deadline(2i)]", with: "1")
@@ -40,17 +40,17 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "2001"
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to_not have_content t("action.report.update.success")
-      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.not_in_past")
+      expect(page).to_not have_content "Report successfully updated"
+      expect(page).to have_content "The deadline must be a date in the future"
     end
 
     scenario "the deadline cannot be very far in the future" do
@@ -60,16 +60,16 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
 
       fill_in "report[deadline(3i)]", with: "31"
       fill_in "report[deadline(2i)]", with: "1"
       fill_in "report[deadline(1i)]", with: "200020"
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to_not have_content t("action.report.update.success")
+      expect(page).to_not have_content "Report successfully updated"
       expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 10, max: 25)
     end
 
@@ -80,14 +80,14 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
 
       fill_in "report[description]", with: "Quarter 4 2020"
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to have_content t("action.report.update.success")
+      expect(page).to have_content "Report successfully updated"
 
       within "##{report.id}" do
         expect(page).to have_content("Quarter 4 2020")
@@ -118,7 +118,7 @@ RSpec.feature "BEIS users can edit a report" do
       visit reports_path
 
       within "##{report.id}" do
-        expect(page).to_not have_content(t("default.link.edit"))
+        expect(page).to_not have_content("Edit")
       end
     end
   end

--- a/spec/features/staff/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_user_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "BEIS users can editing other users" do
     target_user = create(:delivery_partner_user, name: "Old Name", email: "old@example.com")
 
     visit organisation_path(user.organisation)
-    click_on(t("page_title.users.index"))
+    click_on("Users")
 
     find("tr", text: target_user.name).click_link("Edit")
 
@@ -39,10 +39,10 @@ RSpec.feature "BEIS users can editing other users" do
     # Navigate from the landing page
     visit organisation_path(user.organisation)
 
-    click_on(t("page_title.users.index"))
+    click_on("Users")
 
     # Navigate to the users page
-    expect(page).to have_content(t("page_title.users.index"))
+    expect(page).to have_content("Users")
 
     # Find the target user and click on edit button
 
@@ -52,7 +52,7 @@ RSpec.feature "BEIS users can editing other users" do
     fill_in "user[name]", with: updated_name
 
     # Submit the form
-    click_button t("form.button.user.submit")
+    click_button "Submit"
 
     # Verify the user was updated
     expect(page).to have_content(updated_name)
@@ -63,11 +63,11 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on t("page_title.users.index")
+    click_on "Users"
     find("tr", text: user.name).click_link("Edit")
 
-    choose t("form.user.active.inactive")
-    click_on t("default.button.submit")
+    choose "Deactivate"
+    click_on "Submit"
 
     expect(user.reload.active).to be false
   end
@@ -78,11 +78,11 @@ RSpec.feature "BEIS users can editing other users" do
     authenticate!(user: administrator_user)
 
     visit organisation_path(administrator_user.organisation)
-    click_on t("page_title.users.index")
+    click_on "Users"
     find("tr", text: user.name).click_link("Edit")
 
-    choose t("form.user.active.active")
-    click_on t("default.button.submit")
+    choose "Activate"
+    click_on "Submit"
 
     expect(user.reload.active).to be true
   end

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -52,14 +52,14 @@ RSpec.feature "BEIS users can invite new users to the service" do
         it "shows the user validation errors instead" do
           visit new_user_path
 
-          expect(page).to have_content(t("page_title.users.new"))
+          expect(page).to have_content("Create user")
           fill_in "user[name]", with: "" # deliberately omit a value
           fill_in "user[email]", with: "" # deliberately omit a value
 
-          click_button t("default.button.submit")
+          click_button "Submit"
 
-          expect(page).to have_content(t("activerecord.errors.models.user.attributes.name.blank"))
-          expect(page).to have_content(t("activerecord.errors.models.user.attributes.email.blank"))
+          expect(page).to have_content("Enter a full name")
+          expect(page).to have_content("Enter an email address")
         end
       end
 
@@ -73,13 +73,13 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
             visit new_user_path
 
-            expect(page).to have_content(t("page_title.users.new"))
+            expect(page).to have_content("Create user")
             fill_in "user[name]", with: "foo"
             fill_in "user[email]", with: new_email
             choose organisation.name
 
             expect {
-              click_button t("default.button.submit")
+              click_button "Submit"
             }.not_to change { User.count }
 
             expect(page).to have_content(t("action.user.create.failed", error: "The user already exists."))
@@ -98,10 +98,10 @@ RSpec.feature "BEIS users can invite new users to the service" do
             fill_in "user[email]", with: "tom"
             choose organisation.name
 
-            click_button t("default.button.submit")
+            click_button "Submit"
 
             expect(page).to have_content("Email is invalid")
-            expect(page).not_to have_content(t("action.user.create.failed"))
+            expect(page).not_to have_content("The service failed to create the new user. The error received was: %{error}")
             expect(page).to have_content(organisation.name)
           end
         end
@@ -113,7 +113,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
       it "does not show them the manage user button" do
         visit organisation_path(user.organisation)
-        expect(page).not_to have_content(t("page_title.users.index"))
+        expect(page).not_to have_content("Users")
       end
     end
   end
@@ -121,13 +121,13 @@ RSpec.feature "BEIS users can invite new users to the service" do
   def create_user(organisation, new_user_name, new_user_email)
     # Navigate from the landing page
     visit organisation_path(organisation)
-    click_on(t("page_title.users.index"))
+    click_on("Users")
 
     # Navigate to the users page
-    expect(page).to have_content(t("page_title.users.index"))
+    expect(page).to have_content("Users")
 
     # Create a new user
-    click_on(t("page_content.users.button.create"))
+    click_on("Add user")
 
     # We expect to see BEIS separately on this page
     within(".user-organisations") do
@@ -137,12 +137,12 @@ RSpec.feature "BEIS users can invite new users to the service" do
     end
 
     # Fill out the form
-    expect(page).to have_content(t("page_title.users.new"))
+    expect(page).to have_content("Create user")
     fill_in "user[name]", with: new_user_name
     fill_in "user[email]", with: new_user_email
     choose organisation.name
 
     # Submit the form
-    click_button t("default.button.submit")
+    click_button "Submit"
   end
 end

--- a/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "BEIS users upload actual history" do
     scenario "they can see the actuals history upload interface" do
       visit report_actuals_path(report)
 
-      expect(page).to have_content(t("actions.uploads.actual_histories.new_upload"))
+      expect(page).to have_content("Upload actual history data")
     end
 
     scenario "they can successfully upload a file" do
@@ -22,7 +22,7 @@ RSpec.feature "BEIS users upload actual history" do
       visit new_report_uploads_actual_history_path(report)
       upload_fixture(file_content)
 
-      expect(page).to have_content(t("actions.uploads.actual_histories.success"))
+      expect(page).to have_content("Actual history uploaded successfully")
       expect(page).to have_content(activity.title)
       expect(page).to have_content(activity.roda_identifier)
       expect(page).to have_content("10,000")
@@ -31,9 +31,9 @@ RSpec.feature "BEIS users upload actual history" do
 
     scenario "when the file is missing" do
       visit new_report_uploads_actual_history_path(report)
-      click_button t("actions.uploads.actual_histories.upload.button")
+      click_button "Upload and continue"
 
-      expect(page).to have_content(t("actions.uploads.actual_histories.missing"))
+      expect(page).to have_content("You must provide an actual history data file")
     end
 
     scenario "when the file cannot be parsed" do
@@ -45,7 +45,7 @@ RSpec.feature "BEIS users upload actual history" do
       visit new_report_uploads_actual_history_path(report)
       upload_fixture(file_content)
 
-      expect(page).to have_content(t("actions.uploads.actual_histories.invalid"))
+      expect(page).to have_content("Actual history data file is invalid")
     end
 
     scenario "when the contents of the upload has errors" do
@@ -58,7 +58,7 @@ RSpec.feature "BEIS users upload actual history" do
       visit new_report_uploads_actual_history_path(report)
       upload_fixture(file_content)
 
-      expect(page).to have_content(t("actions.uploads.actual_histories.failed"))
+      expect(page).to have_content("Actual history upload failed")
       expect(page).to have_content("Value")
       expect(page).to have_content("1")
       expect(page).to have_content("Ten thousand pounds")
@@ -77,7 +77,7 @@ RSpec.feature "BEIS users upload actual history" do
 
       visit report_actuals_path(report)
 
-      expect(page).not_to have_content(t("actions.uploads.actual_histories.new_upload"))
+      expect(page).not_to have_content("Upload actual history data")
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.feature "BEIS users upload actual history" do
     file.close
 
     attach_file "report[actual_csv_file]", file.path
-    click_button t("actions.uploads.actual_histories.upload.button")
+    click_button "Upload and continue"
 
     file.unlink
   end

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -8,10 +8,10 @@ RSpec.feature "BEIS users can view other organisations" do
 
   RSpec.shared_examples "lists delivery partner organisations" do
     scenario "it lists delivery partner organisations" do
-      expect(page).to have_content(t("page_title.organisation.index"))
-      expect(page).to have_content(t("page_title.organisations.delivery_partners"))
+      expect(page).to have_content("Organisations")
+      expect(page).to have_content("Delivery partners")
 
-      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.delivery_partners"))
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text("Delivery partners")
 
       delivery_partner_organisations.each do |organisation|
         expect(page).to have_content(organisation.beis_organisation_reference)
@@ -26,9 +26,9 @@ RSpec.feature "BEIS users can view other organisations" do
 
   RSpec.shared_examples "lists matched effort provider organisations" do
     scenario "it lists matched effort provider organisations" do
-      expect(page).to have_content(t("page_title.organisation.index"))
-      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.matched_effort_providers"))
-      expect(page).to have_content(t("page_title.organisations.matched_effort_providers"))
+      expect(page).to have_content("Organisations")
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text("Matched effort providers")
+      expect(page).to have_content("Matched effort providers")
 
       matched_effort_provider_organisations.each do |organisation|
         expect(page).to have_content(organisation.name)
@@ -42,9 +42,9 @@ RSpec.feature "BEIS users can view other organisations" do
 
   RSpec.shared_examples "lists external income provider organisations" do
     scenario "it lists external income provider organisations" do
-      expect(page).to have_content(t("page_title.organisation.index"))
-      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text(t("tabs.organisations.external_income_providers"))
-      expect(page).to have_content(t("page_title.organisations.external_income_providers"))
+      expect(page).to have_content("Organisations")
+      expect(page.find("li.govuk-tabs__list-item--selected a.govuk-tabs__tab")).to have_text("External income providers")
+      expect(page).to have_content("External income providers")
 
       matched_effort_provider_organisations.each do |organisation|
         expect(page).to_not have_content(organisation.name)
@@ -110,7 +110,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the matched effort providers tab" do
           before do
-            click_on t("tabs.organisations.matched_effort_providers")
+            click_on "Matched effort providers"
           end
 
           it "includes type of organisation in breadcrumb" do
@@ -122,7 +122,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the external income providers tab" do
           before do
-            click_on t("tabs.organisations.external_income_providers")
+            click_on "External income providers"
           end
 
           it "includes type of organisation in breadcrumb" do
@@ -140,7 +140,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the delivery partner organisations tab" do
           before do
-            click_on t("tabs.organisations.delivery_partners")
+            click_on "Delivery partners"
           end
 
           include_examples "lists delivery partner organisations"
@@ -148,7 +148,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the external income providers tab" do
           before do
-            click_on t("tabs.organisations.external_income_providers")
+            click_on "External income providers"
           end
 
           include_examples "lists external income provider organisations"
@@ -162,7 +162,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the delivery partner organisations tab" do
           before do
-            click_on t("tabs.organisations.delivery_partners")
+            click_on "Delivery partners"
           end
 
           include_examples "lists delivery partner organisations"
@@ -170,7 +170,7 @@ RSpec.feature "BEIS users can view other organisations" do
 
         context "when viewing the matched effort providers tab" do
           before do
-            click_on t("tabs.organisations.matched_effort_providers")
+            click_on "Matched effort providers"
           end
 
           include_examples "lists matched effort provider organisations"

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -20,21 +20,21 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(t("page_title.users.index"))
+      click_on("Users")
 
       # Navigate to the users page
-      expect(page).to have_content(t("page_title.users.index"))
+      expect(page).to have_content("Users")
       expect(page).to have_content(another_user.name)
       expect(page).to have_content(another_user.email)
       expect(page).to have_content(another_user.organisation.name)
-      expect(page).to have_content(t("form.user.active.true"))
+      expect(page).to have_content("Yes")
 
       # Navigate to the individual user page
       within(".users") do
-        find("tr", text: another_user.name).click_link(t("default.link.show"))
+        find("tr", text: another_user.name).click_link("View")
       end
 
-      expect(page).to have_content(t("page_title.users.show"))
+      expect(page).to have_content("User")
       expect(page).to have_content(another_user.name)
       expect(page).to have_content(another_user.email)
     end
@@ -50,7 +50,7 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(t("page_title.users.index"))
+      click_on("Users")
 
       expected_array = [
         a1_user.organisation.name,
@@ -68,17 +68,17 @@ RSpec.feature "BEIS users can can view other users" do
 
       # Navigate from the landing page
       visit organisation_path(user.organisation)
-      click_on(t("page_title.users.index"))
+      click_on("Users")
 
       # The details include whether the user is active
-      expect(page).to have_content(t("form.user.active.false"))
+      expect(page).to have_content("No")
 
       # Navigate to the individual user page
       within(".users") do
-        find("tr", text: another_user.name).click_link(t("default.link.show"))
+        find("tr", text: another_user.name).click_link("View")
       end
 
-      expect(page).to have_content(t("form.user.active.false"))
+      expect(page).to have_content("No")
     end
   end
 end

--- a/spec/features/staff/organisation_show_page_spec.rb
+++ b/spec/features/staff/organisation_show_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Organisation show page" do
       scenario "they see a edit details button" do
         visit organisation_path(beis_user.organisation)
 
-        expect(page).to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
+        expect(page).to have_link "Edit details", href: edit_organisation_path(beis_user.organisation)
       end
     end
   end
@@ -31,7 +31,7 @@ RSpec.feature "Organisation show page" do
     scenario "they do not see the edit details button" do
       visit organisation_path(delivery_partner_user.organisation)
 
-      expect(page).not_to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(delivery_partner_user.organisation)
+      expect(page).not_to have_link "Edit details", href: edit_organisation_path(delivery_partner_user.organisation)
     end
   end
 end

--- a/spec/features/staff/users_can_add_benefitting_countries_in_one_step_spec.rb
+++ b/spec/features/staff/users_can_add_benefitting_countries_in_one_step_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "users can add benefitting countries" do
 
       visit activity_step_path(activity, :benefitting_countries)
 
-      expect(page).to have_content t("form.legend.activity.benefitting_countries")
+      expect(page).to have_content "What countries will benefit from this activity?"
       expect(page).to have_content("Afghanistan")
       expect(page).to have_content("Zimbabwe")
       expect(page).to have_selector(".country-checkbox", count: all_non_graduated_benefitting_countires.count)
@@ -18,7 +18,7 @@ RSpec.feature "users can add benefitting countries" do
       check "Gambia"
       check "Pakistan"
       check "Egypt"
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
       activity.reload
       expect(activity.benefitting_countries).to match_array(["GM", "PK", "EG"])
@@ -32,10 +32,10 @@ RSpec.feature "users can add benefitting countries" do
 
       visit activity_step_path(activity, :benefitting_countries)
 
-      expect(page).to have_content t("form.legend.activity.benefitting_countries")
+      expect(page).to have_content "What countries will benefit from this activity?"
 
       check t("page_content.activity.benefitting_region_check_box", region: caribbean_region.name)
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
       activity.reload
       expect(activity.benefitting_countries).to match_array(country_codes)

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -12,8 +12,8 @@ RSpec.feature "Users can approve reports" do
 
       perform_enqueued_jobs do
         visit report_path(report)
-        click_link t("action.report.approve.button")
-        click_button t("action.report.approve.confirm.button")
+        click_link "Approve"
+        click_button "Confirm approval"
       end
 
       expect(page).to have_content "approved"
@@ -21,10 +21,10 @@ RSpec.feature "Users can approve reports" do
 
       expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count + 1)
 
-      expect(beis_user).to have_received_email.with_subject(t("mailer.report.approved.service_owner.subject", application_name: t("app.title")))
+      expect(beis_user).to have_received_email.with_subject(t("mailer.report.approved.service_owner.subject", application_name: "Report your Official Development Assistance"))
 
       organisation.users.each do |user|
-        expect(user).to have_received_email.with_subject(t("mailer.report.approved.delivery_partner.subject", application_name: t("app.title")))
+        expect(user).to have_received_email.with_subject(t("mailer.report.approved.delivery_partner.subject", application_name: "Report your Official Development Assistance"))
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.feature "Users can approve reports" do
         visit report_path(report)
 
         within("#main-content") do
-          expect(page).not_to have_link t("action.report.approve.button")
+          expect(page).not_to have_link "Approve"
         end
       end
     end
@@ -53,7 +53,7 @@ RSpec.feature "Users can approve reports" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link t("action.report.approve.button")
+      expect(page).not_to have_link "Approve"
 
       visit edit_report_state_path(report)
 

--- a/spec/features/staff/users_can_create_a_budget_spec.rb
+++ b/spec/features/staff/users_can_create_a_budget_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(fund_activity.organisation, fund_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(t("action.budget.create.success"))
+        expect(page).to have_content("Budget successfully created")
       end
     end
 
@@ -26,11 +26,11 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(t("action.budget.create.success"))
+        expect(page).to have_content("Budget successfully created")
       end
 
       scenario "successfully creates a budget in the past" do
@@ -39,14 +39,14 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         expect(page).to have_checked_field("budget[budget_type]", with: "direct", visible: false)
         select "2010-2011", from: "budget[financial_year]"
         fill_in "budget[value]", with: "1000.00"
-        click_button t("default.button.submit")
+        click_button "Submit"
 
-        expect(page).to have_content(t("action.budget.create.success"))
+        expect(page).to have_content("Budget successfully created")
       end
 
       scenario "sees validation errors for missing attributes" do
@@ -55,13 +55,13 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
-        click_button t("default.button.submit")
+        click_button "Submit"
 
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content(t("activerecord.errors.models.budget.attributes.financial_year.blank"))
-        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.blank")
+        expect(page).to have_content("Select a financial year")
+        expect(page).to have_content "Enter a budget amount"
       end
 
       scenario "sees validation error when the value is more than allowed" do
@@ -70,14 +70,14 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
         choose("budget[budget_type]", option: "direct")
         fill_in "budget[value]", with: "10000000000000.00"
-        click_button t("default.button.submit")
+        click_button "Submit"
 
-        expect(page).to have_content t("activerecord.errors.models.budget.attributes.value.less_than_or_equal_to")
+        expect(page).to have_content "Value must not be more than 99,999,999,999.00"
       end
     end
   end
@@ -100,8 +100,8 @@ RSpec.describe "Users can create a budget" do
       scenario "they can view but not create budgets" do
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        expect(page).to have_content(t("page_content.activity.budgets"))
-        expect(page).not_to have_content(t("page_content.budgets.button.create"))
+        expect(page).to have_content("Budgets")
+        expect(page).not_to have_content("Add budget")
       end
     end
 
@@ -111,11 +111,11 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         fill_in_and_submit_budget_form
 
-        expect(page).to have_content(t("action.budget.create.success"))
+        expect(page).to have_content("Budget successfully created")
       end
 
       scenario "successfully creates an external budget", js: true do
@@ -123,32 +123,32 @@ RSpec.describe "Users can create a budget" do
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
 
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         choose("Other official development assistance")
         fill_in("Providing organisation name", with: "Any org in the world")
         select("International NGO")
         select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
         fill_in "budget[value]", with: "1000.00"
-        click_button t("default.button.submit")
+        click_button "Submit"
 
-        expect(page).to have_content(t("action.budget.create.success"))
+        expect(page).to have_content("Budget successfully created")
       end
 
       scenario "for an external budget it shows an error if the user doesn't input a providing organisation name and type", js: true do
         _report = create(:report, :active, organisation: user.organisation, fund: fund_activity)
 
         visit organisation_activity_path(programme_activity.organisation, project_activity)
-        click_on(t("page_content.budgets.button.create"))
+        click_on("Add budget")
 
         choose("Other official development assistance")
         select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
         fill_in "budget[value]", with: "1000.00"
-        click_button t("default.button.submit")
+        click_button "Submit"
 
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content t("activerecord.errors.models.budget.attributes.providing_organisation_name.blank")
-        expect(page).to have_content t("activerecord.errors.models.budget.attributes.providing_organisation_type.blank")
+        expect(page).to have_content "Enter the name of the providing organisation"
+        expect(page).to have_content "Select the type of the providing organisation"
       end
 
       context "without JavaScript" do
@@ -156,16 +156,16 @@ RSpec.describe "Users can create a budget" do
           _report = create(:report, :active, organisation: user.organisation, fund: fund_activity)
 
           visit organisation_activity_path(project_activity.organisation, project_activity)
-          click_on(t("page_content.budgets.button.create"))
+          click_on("Add budget")
 
           choose("Other official development assistance")
           select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
           fill_in "budget[value]", with: "1000.00"
-          click_button t("default.button.submit")
+          click_button "Submit"
 
           expect(page).to have_content("There is a problem")
-          expect(page).to have_content t("activerecord.errors.models.budget.attributes.providing_organisation_name.blank")
-          expect(page).to have_content t("activerecord.errors.models.budget.attributes.providing_organisation_type.blank")
+          expect(page).to have_content "Enter the name of the providing organisation"
+          expect(page).to have_content "Select the type of the providing organisation"
         end
       end
     end
@@ -177,6 +177,6 @@ RSpec.describe "Users can create a budget" do
     expect(page).to have_checked_field("budget[budget_type]", with: "direct", visible: false)
     select "#{Date.current.year}-#{Date.current.next_year.year}", from: "budget[financial_year]"
     fill_in "budget[value]", with: "1000.00"
-    click_button t("default.button.submit")
+    click_button "Submit"
   end
 end

--- a/spec/features/staff/users_can_create_a_comment_spec.rb
+++ b/spec/features/staff/users_can_create_a_comment_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Users can create a comment" do
         context "when the report is editable" do
           scenario "the user cannot add a comment" do
             visit report_path(report)
-            click_on t("tabs.report.variance.heading")
-            expect(page).not_to have_content t("table.body.report.add_comment")
+            click_on "Variance"
+            expect(page).not_to have_content "Add comment"
           end
         end
 
@@ -30,8 +30,8 @@ RSpec.describe "Users can create a comment" do
           let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
           scenario "the user cannot add a comment" do
             visit report_path(report)
-            click_on t("tabs.report.variance.heading")
-            expect(page).not_to have_content t("table.body.report.add_comment")
+            click_on "Variance"
+            expect(page).not_to have_content "Add comment"
           end
         end
       end
@@ -50,7 +50,7 @@ RSpec.describe "Users can create a comment" do
               expect(Comment.all.count).to eq(1)
               expect(Comment.last.body).to eq(form.comment)
 
-              expect(page).to have_content t("action.comment.create.success")
+              expect(page).to have_content "Comment successfully created"
 
               within ".activity_comments" do
                 expect(page).to have_content form.comment
@@ -65,8 +65,8 @@ RSpec.describe "Users can create a comment" do
           let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
           scenario "the user cannot add a comment" do
             visit report_path(report)
-            click_on t("tabs.report.variance.heading")
-            expect(page).not_to have_content t("table.body.report.add_comment")
+            click_on "Variance"
+            expect(page).not_to have_content "Add comment"
           end
         end
 
@@ -74,7 +74,7 @@ RSpec.describe "Users can create a comment" do
           let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
           scenario "the user cannot add a comment" do
             visit report_path(report)
-            expect(page).to have_content t("not_authorised.default")
+            expect(page).to have_content "You have not been authorised to see this page."
           end
         end
       end
@@ -89,11 +89,11 @@ RSpec.describe "Users can create a comment" do
         scenario "the user can create a comment" do
           visit organisation_activity_comments_path(activity.organisation, activity)
           expect(page).to have_css(".govuk-button")
-          click_on t("page_content.comment.add")
+          click_on "Add a comment"
           fill_in "comment[body]", with: "Amendments have been made"
-          click_button t("default.button.submit")
+          click_button "Submit"
           expect(page).to have_content "Amendments have been made"
-          expect(page).to have_content t("action.comment.create.success")
+          expect(page).to have_content "Comment successfully created"
         end
       end
 
@@ -101,7 +101,7 @@ RSpec.describe "Users can create a comment" do
         let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
         scenario "the user cannot create a comment" do
           visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.add")
+          expect(page).not_to have_content "Add a comment"
         end
       end
     end

--- a/spec/features/staff/users_can_create_a_forecast_spec.rb
+++ b/spec/features/staff/users_can_create_a_forecast_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe "Users can create a forecast" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to have_content t("page_content.activity.forecasts")
+      expect(page).to have_content "Forecasted spend"
 
-      click_on t("page_content.forecasts.button.create")
+      click_on "Add forecasted spend"
 
-      expect(page).to have_content t("page_title.forecast.new")
+      expect(page).to have_content "Add forecasted spend"
 
       fill_in_forecast_form_for_activity(project)
 
       expect(page).to have_current_path organisation_activity_path(user.organisation, project)
-      expect(page).to have_content t("action.forecast.create.success")
+      expect(page).to have_content "Forecasted spend successfully created"
     end
 
     scenario "they can go back if they try to add a forecast in error" do
@@ -28,9 +28,9 @@ RSpec.describe "Users can create a forecast" do
       visit activities_path
       click_on project.title
 
-      click_on t("page_content.forecasts.button.create")
+      click_on "Add forecasted spend"
 
-      click_on t("form.link.activity.back")
+      click_on "Back to activity details"
 
       expect(page).to have_title t("document_title.activity.financials", name: project.title)
     end
@@ -42,7 +42,7 @@ RSpec.describe "Users can create a forecast" do
           project = create(:project_activity, :with_report, organisation: user.organisation, parent: programme)
           visit activities_path
           click_on project.title
-          click_on t("page_content.forecasts.button.create")
+          click_on "Add forecasted spend"
 
           expect(page).to have_checked_field "Q1"
           expect(page).to have_select "Financial year", selected: "2019-2020"
@@ -57,7 +57,7 @@ RSpec.describe "Users can create a forecast" do
           project = create(:project_activity, :with_report, organisation: user.organisation, parent: programme)
           visit activities_path
           click_on project.title
-          click_on t("page_content.forecasts.button.create")
+          click_on "Add forecasted spend"
 
           expect(page).to have_checked_field "Q4"
           expect(page).to have_select "Financial year", selected: "2019-2020"
@@ -70,7 +70,7 @@ RSpec.describe "Users can create a forecast" do
 
       visit organisation_activity_path(activity.organisation, activity)
 
-      expect(page).not_to have_link t("page_content.forecasts.button.create"),
+      expect(page).not_to have_link "Add forecasted spend",
         href: new_activity_forecast_path(activity)
     end
 
@@ -83,7 +83,7 @@ RSpec.describe "Users can create a forecast" do
       visit activities_path
 
       click_on(project.title)
-      click_on(t("page_content.forecasts.button.create"))
+      click_on("Add forecasted spend")
 
       fill_in_forecast_form_for_activity(project)
 
@@ -99,8 +99,8 @@ RSpec.describe "Users can create a forecast" do
       visit activities_path
       click_on project.title
 
-      expect(page).to have_content t("page_content.activity.forecasts")
-      expect(page).not_to have_link t("page_content.forecasts.button.create")
+      expect(page).to have_content "Forecasted spend"
+      expect(page).not_to have_link "Add forecasted spend"
     end
 
     scenario "they receive an error message if the forecast is not in the future" do
@@ -110,7 +110,7 @@ RSpec.describe "Users can create a forecast" do
         visit activities_path
         click_on project.title
 
-        click_on t("page_content.forecasts.button.create")
+        click_on "Add forecasted spend"
 
         report = Report.editable_for_activity(project)
         year = report.financial_year
@@ -120,7 +120,7 @@ RSpec.describe "Users can create a forecast" do
           financial_year: "#{year}-#{year + 1}"
         )
 
-        expect(page).to have_content t("activerecord.errors.models.forecast.attributes.financial_quarter.in_the_past")
+        expect(page).to have_content "The forecast must be for a future financial quarter"
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe "Users can create a forecast" do
       visit activities_path
       click_on project.title
 
-      click_on t("page_content.forecasts.button.create")
+      click_on "Add forecasted spend"
 
       report = Report.editable_for_activity(project)
       year = report.financial_year
@@ -141,7 +141,7 @@ RSpec.describe "Users can create a forecast" do
         value: ""
       )
 
-      expect(page).to have_content t("activerecord.errors.models.forecast.attributes.value.not_a_number")
+      expect(page).to have_content "Value must be a valid number"
     end
   end
 
@@ -156,11 +156,11 @@ RSpec.describe "Users can create a forecast" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_link t("page_content.forecasts.button.create"), href: new_activity_forecast_path(project)
+      expect(page).not_to have_link "Add forecasted spend", href: new_activity_forecast_path(project)
 
       visit new_activity_forecast_path(project)
 
-      expect(page).to have_content t("page_title.errors.not_authorised")
+      expect(page).to have_content "You are not authorised"
     end
   end
 end

--- a/spec/features/staff/users_can_create_a_matched_effort_spec.rb
+++ b/spec/features/staff/users_can_create_a_matched_effort_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Users can create a matched effort" do
       visit organisation_activity_path(project.organisation, project)
 
       click_on "Other funding"
-      click_on t("page_content.matched_effort.button.create")
+      click_on "Add matched effort"
     end
 
     scenario "they can add a matched effort" do
@@ -28,7 +28,7 @@ RSpec.describe "Users can create a matched effort" do
 
       fill_in_matched_effort_form(template)
 
-      expect(page).to have_content(t("action.matched_effort.create.success"))
+      expect(page).to have_content("The matched effort has been successfully created")
 
       matched_effort = MatchedEffort.order("created_at ASC").last
 
@@ -57,7 +57,7 @@ RSpec.describe "Users can create a matched effort" do
 
       fill_in_matched_effort_form(template)
 
-      expect(page).to_not have_content(t("action.matched_effort.create.success"))
+      expect(page).to_not have_content("The matched effort has been successfully created")
       expect(page).to have_content(
         t(
           "activerecord.errors.models.matched_effort.attributes.category.invalid",
@@ -71,7 +71,7 @@ RSpec.describe "Users can create a matched effort" do
     scenario "they recieve errors when required fields are left blank" do
       page.find(:xpath, "//input[@value='in_kind']").set(true)
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
       expect(page).to have_content("Organisation can't be blank")
       expect(page).to have_content("Category can't be blank")

--- a/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_project_level_activity_spec.rb
@@ -8,9 +8,9 @@ RSpec.feature "Users can create a project" do
         programme_activity = create(:programme_activity, :newton_funded, extending_organisation: user.organisation)
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
-        click_on t("tabs.activity.children")
+        click_on "Child activities"
 
-        expect(page).to have_no_button(t("action.activity.add_child"))
+        expect(page).to have_no_button("Add child activity")
       end
 
       scenario "a new project can be added to the programme" do
@@ -25,13 +25,13 @@ RSpec.feature "Users can create a project" do
 
         visit activities_path
         click_on programme.title
-        click_on t("tabs.activity.children")
-        click_on t("action.activity.add_child")
+        click_on "Child activities"
+        click_on "Add child activity"
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "newton")
         form.complete!
 
-        expect(page).to have_content t("action.project.create.success")
+        expect(page).to have_content "Project (level C) successfully created"
         expect(programme.child_activities.count).to eq 1
 
         created_activity = form.created_activity
@@ -83,10 +83,10 @@ RSpec.feature "Users can create a project" do
 
         visit organisation_activity_path(programme.organisation, programme)
 
-        click_link t("tabs.activity.children")
-        click_button t("action.activity.add_child")
+        click_link "Child activities"
+        click_button "Add child activity"
         fill_in "activity[delivery_partner_identifier]", with: "foo"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(page).to have_content t("form.legend.activity.purpose", level: "project (level C)")
       end

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Users can create a refund" do
   end
 
   def and_i_expect_to_see_that_a_new_refund_has_been_created
-    expect(page).to have_content(t("action.refund.create.success"))
+    expect(page).to have_content("Refund successfully created")
 
     newly_created_refund = Refund.last
 

--- a/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/staff/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -10,9 +10,9 @@ RSpec.feature "Users can create a third-party project" do
 
         visit activities_path
         click_on project.title
-        click_on t("tabs.activity.children")
+        click_on "Child activities"
 
-        expect(page).to_not have_button(t("action.activity.add_child"))
+        expect(page).to_not have_button("Add child activity")
       end
 
       scenario "a new third party project can be added to the project" do
@@ -29,14 +29,14 @@ RSpec.feature "Users can create a third-party project" do
         visit activities_path
 
         click_on(project.title)
-        click_on t("tabs.activity.children")
+        click_on "Child activities"
 
-        click_on(t("action.activity.add_child"))
+        click_on("Add child activity")
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "gcrf")
         form.complete!
 
-        expect(page).to have_content t("action.third_party_project.create.success")
+        expect(page).to have_content "Third-party project (level D) successfully created"
         expect(project.child_activities.count).to eq 1
 
         created_activity = form.created_activity
@@ -85,9 +85,9 @@ RSpec.feature "Users can create a third-party project" do
           visit activities_path
 
           click_on(project.title)
-          click_on t("tabs.activity.children")
+          click_on "Child activities"
 
-          expect(page).to have_no_button t("action.activity.add_child")
+          expect(page).to have_no_button "Add child activity"
         end
       end
     end

--- a/spec/features/staff/users_can_create_an_actual_spec.rb
+++ b/spec/features/staff/users_can_create_an_actual_spec.rb
@@ -8,11 +8,11 @@ RSpec.feature "Users can create an actual" do
 
       visit organisation_activity_path(activity.organisation, activity)
 
-      click_on(t("page_content.actuals.button.create"))
+      click_on("Add an actual")
 
-      expect(page).to have_content t("page_title.actual.new")
-      expect(page).to have_content t("form.label.actual.value")
-      expect(page).to have_content t("form.legend.actual.receiving_organisation")
+      expect(page).to have_content "Add an actual"
+      expect(page).to have_content "Actual amount"
+      expect(page).to have_content "Receiving organisation (optional)"
     end
 
     scenario "successfully creates a actual on an activity" do
@@ -20,11 +20,11 @@ RSpec.feature "Users can create an actual" do
 
       visit organisation_activity_path(activity.organisation, activity)
 
-      click_on(t("page_content.actuals.button.create"))
+      click_on("Add an actual")
 
       fill_in_actual_form
 
-      expect(page).to have_content(t("action.actual.create.success"))
+      expect(page).to have_content("Actual successfully created")
     end
 
     context "when all values are missing" do
@@ -33,11 +33,11 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
-        click_on(t("default.button.submit"))
+        click_on("Add an actual")
+        click_on("Submit")
 
-        expect(page).to_not have_content(t("action.actual.create.success"))
-        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.blank")
+        expect(page).to_not have_content("Actual successfully created")
+        expect(page).to have_content "Enter an actual spend amount"
       end
     end
 
@@ -47,12 +47,12 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
         fill_in "actual[value]", with: "234r.67"
-        click_on(t("default.button.submit"))
+        click_on("Submit")
 
-        expect(page).to_not have_content(t("action.actual.create.success"))
-        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.not_a_number")
+        expect(page).to_not have_content("Actual successfully created")
+        expect(page).to have_content "Value must be a valid number"
       end
     end
 
@@ -62,14 +62,14 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in "actual[value]", with: "100000000000"
         choose "4", name: "actual[financial_quarter]"
         select "2019-2020", from: "actual[financial_year]"
-        click_on(t("default.button.submit"))
+        click_on("Submit")
 
-        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.less_than_or_equal_to")
+        expect(page).to have_content "Value must be less than or equal to 99,999,999,999.00"
       end
 
       scenario "Value cannot be 0" do
@@ -77,14 +77,14 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in "actual[value]", with: "0"
         choose "4", name: "actual[financial_quarter]"
         select "2019-2020", from: "actual[financial_year]"
-        click_on(t("default.button.submit"))
+        click_on("Submit")
 
-        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.other_than")
+        expect(page).to have_content "Value must not be zero"
       end
 
       scenario "Value cannot be negative" do
@@ -92,16 +92,16 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in "actual[value]", with: "-500000"
         choose "4", name: "actual[financial_quarter]"
         select "2019-2020", from: "actual[financial_year]"
         fill_in "actual[receiving_organisation_name]", with: "Company"
         select "Government", from: "actual[receiving_organisation_type]"
-        click_on(t("default.button.submit"))
+        click_on("Submit")
 
-        expect(page).to have_content t("activerecord.errors.models.actual.attributes.value.greater_than")
+        expect(page).to have_content "Value cannot be negative"
       end
 
       scenario "When the value includes a pound sign" do
@@ -109,7 +109,7 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(value: "£123", expectations: false)
 
@@ -121,7 +121,7 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(value: "abc123def", expectations: false)
 
@@ -133,7 +133,7 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(value: "100.12", expectations: false)
 
@@ -145,7 +145,7 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(value: "123,000,000", expectations: false)
 
@@ -159,14 +159,14 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(
           receiving_organisation: OpenStruct.new(name: "Example receiver", reference: "GB-COH-123", type: nil),
           expectations: false
         )
 
-        expect(page).to have_content(t("activerecord.errors.models.actual.attributes.receiving_organisation_type.blank"))
+        expect(page).to have_content("Select the organisation type")
       end
 
       it "shows an error when the organisation name is blank, but not the type" do
@@ -174,14 +174,14 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(
           receiving_organisation: OpenStruct.new(name: nil, reference: "GB-COH-123", type: "Private Sector"),
           expectations: false
         )
 
-        expect(page).to have_content(t("activerecord.errors.models.actual.attributes.receiving_organisation_name.blank"))
+        expect(page).to have_content("Enter a receiving organisation name")
       end
 
       it "shows errors if the organisation reference is present, but not the name or reference" do
@@ -189,15 +189,15 @@ RSpec.feature "Users can create an actual" do
 
         visit organisation_activity_path(activity.organisation, activity)
 
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form(
           receiving_organisation: OpenStruct.new(name: nil, reference: "GB-COH-123", type: nil),
           expectations: false
         )
 
-        expect(page).to have_content(t("activerecord.errors.models.actual.attributes.receiving_organisation_name.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.actual.attributes.receiving_organisation_type.blank"))
+        expect(page).to have_content("Enter a receiving organisation name")
+        expect(page).to have_content("Select the organisation type")
       end
     end
 
@@ -206,9 +206,9 @@ RSpec.feature "Users can create an actual" do
 
       visit organisation_activity_path(activity.organisation, activity)
 
-      click_on(t("page_content.actuals.button.create"))
+      click_on("Add an actual")
 
-      click_on(t("form.link.activity.back"))
+      click_on("Back to activity details")
 
       expect(page).to have_content(activity.title)
     end
@@ -227,7 +227,7 @@ RSpec.feature "Users can create an actual" do
 
       visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-      expect(page).not_to have_content(t("page_content.actuals.button.create"))
+      expect(page).not_to have_content("Add an actual")
     end
 
     context "and the activity is a third-party project" do
@@ -237,7 +237,7 @@ RSpec.feature "Users can create an actual" do
         project = create(:project_activity, :with_report, organisation: user.organisation, parent: programme)
 
         visit organisation_activity_path(user.organisation, project)
-        click_on(t("page_content.actuals.button.create"))
+        click_on("Add an actual")
 
         fill_in_actual_form
 
@@ -253,7 +253,7 @@ RSpec.feature "Users can create an actual" do
 
       visit organisation_activity_path(activity.organisation, activity)
 
-      expect(page).not_to have_link t("page_content.actuals.button.create"), href: new_activity_actual_path(activity)
+      expect(page).not_to have_link "Add an actual", href: new_activity_actual_path(activity)
     end
   end
 end

--- a/spec/features/staff/users_can_create_an_adjustment_spec.rb
+++ b/spec/features/staff/users_can_create_an_adjustment_spec.rb
@@ -56,22 +56,22 @@ RSpec.feature "Users can create an adjustment (correcting spend in an approved r
   end
 
   def when_i_submit_the_new_adjustment_form_correctly
-    click_on t("page_content.adjustment.button.create")
+    click_on "Add an adjustment"
     fill_in "adjustment_form[value]", with: "100.01"
     select "Actual", from: "adjustment_form[adjustment_type]"
     choose "1", name: "adjustment_form[financial_quarter]"
     select "2020-2021", from: "adjustment_form[financial_year]"
     fill_in "adjustment_form[comment]", with: "There was a typo in the original 'actual'"
-    click_on(t("default.button.submit"))
+    click_on("Submit")
   end
 
   def when_i_submit_the_new_adjustment_form_incorrectly
-    click_on t("page_content.adjustment.button.create")
-    click_on(t("default.button.submit"))
+    click_on "Add an adjustment"
+    click_on("Submit")
   end
 
   def then_i_expect_to_see_the_new_adjustment
-    expect(page).to have_content(t("action.adjustment.create.success"))
+    expect(page).to have_content("Adjustment successfully created")
     adjustment = activity.adjustments.first
 
     fail "Expect activity to have an adjustment" unless adjustment
@@ -143,13 +143,13 @@ RSpec.feature "Users can create an adjustment (correcting spend in an approved r
   end
 
   def when_i_try_to_create_an_adjustment_for_the_current_financial_period
-    click_on t("page_content.adjustment.button.create")
+    click_on "Add an adjustment"
     fill_in "adjustment_form[value]", with: "100.01"
     select "Actual", from: "adjustment_form[adjustment_type]"
     choose "2", name: "adjustment_form[financial_quarter]"
     select "2021-2022", from: "adjustment_form[financial_year]"
     fill_in "adjustment_form[comment]", with: "There was a typo in the original 'actual'"
-    click_on(t("default.button.submit"))
+    click_on("Submit")
   end
 
   def then_i_should_see_an_explanation_of_when_adjustments_are_appropriate
@@ -162,6 +162,6 @@ RSpec.feature "Users can create an adjustment (correcting spend in an approved r
   def when_i_choose_a_valid_financial_period
     choose "1", name: "adjustment_form[financial_quarter]"
     select "2020-2021", from: "adjustment_form[financial_year]"
-    click_on(t("default.button.submit"))
+    click_on("Submit")
   end
 end

--- a/spec/features/staff/users_can_create_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_create_an_external_income_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Users can create a external income" do
       visit organisation_activity_path(project.organisation, project)
 
       click_on "Other funding"
-      click_on t("page_content.external_income.button.create")
+      click_on "Add external income"
     end
 
     scenario "they can add an external income" do
@@ -25,7 +25,7 @@ RSpec.describe "Users can create a external income" do
 
       fill_in_external_income_form(template)
 
-      expect(page).to have_content(t("action.external_income.create.success"))
+      expect(page).to have_content("The external income has been successfully created")
 
       external_income = ExternalIncome.order("created_at ASC").last
 
@@ -44,7 +44,7 @@ RSpec.describe "Users can create a external income" do
     end
 
     scenario "they are shown errors when required fields are left blank" do
-      click_on t("default.button.submit")
+      click_on "Submit"
 
       expect(page).to have_content("Organisation can't be blank")
       expect(page).to have_content("Financial quarter can't be blank")

--- a/spec/features/staff/users_can_delete_a_forecast_spec.rb
+++ b/spec/features/staff/users_can_delete_a_forecast_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe "Users can delete a forecast" do
         click_on "Edit"
       end
 
-      click_on t("default.button.delete")
+      click_on "Delete"
 
       expect(page).to have_title t("document_title.activity.financials", name: project.title)
-      expect(page).to have_content t("action.forecast.destroy.success")
+      expect(page).to have_content "Forecasted spend successfully deleted"
 
       expect(page).to_not have_selector "##{forecast.id}"
     end

--- a/spec/features/staff/users_can_delete_an_actual_spec.rb
+++ b/spec/features/staff/users_can_delete_an_actual_spec.rb
@@ -13,11 +13,11 @@ RSpec.feature "Users can delete an actual" do
       visit organisation_activity_path(activity.organisation, activity)
 
       within("##{actual.id}") do
-        click_on(t("default.link.edit"))
+        click_on("Edit")
       end
 
-      expect { click_on t("default.button.delete") }.to change { Actual.count }.by(-1)
-      expect(page).to have_content(t("action.actual.destroy.success"))
+      expect { click_on "Delete" }.to change { Actual.count }.by(-1)
+      expect(page).to have_content("Actual sucessfully deleted")
     end
   end
 
@@ -30,11 +30,11 @@ RSpec.feature "Users can delete an actual" do
       visit organisation_activity_path(activity.organisation, activity)
 
       within("##{actual.id}") do
-        click_on(t("default.link.edit"))
+        click_on("Edit")
       end
 
-      expect { click_on t("default.button.delete") }.to change { Actual.count }.by(-1)
-      expect(page).to have_content(t("action.actual.destroy.success"))
+      expect { click_on "Delete" }.to change { Actual.count }.by(-1)
+      expect(page).to have_content("Actual sucessfully deleted")
     end
   end
 end

--- a/spec/features/staff/users_can_edit_a_budget_spec.rb
+++ b/spec/features/staff/users_can_edit_a_budget_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Users can edit a budget" do
     before do
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
     end
 
@@ -17,10 +17,10 @@ RSpec.describe "Users can edit a budget" do
       fill_in "budget[value]", with: "20"
 
       expect {
-        click_on t("default.button.submit")
+        click_on "Submit"
       }.to change { HistoricalEvent.count }.by(1)
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated")
       within("##{budget.id}") do
         expect(page).to have_content("20.00")
       end
@@ -37,9 +37,9 @@ RSpec.describe "Users can edit a budget" do
     end
 
     scenario "a budget can be successfully deleted" do
-      click_on t("default.button.delete")
+      click_on "Delete"
 
-      expect(page).to have_content(t("action.budget.destroy.success"))
+      expect(page).to have_content("Budget successfully deleted")
       expect(page).to_not have_content("10.00")
 
       expect { budget.reload }.to raise_error { ActiveRecord::RecordNotFound }
@@ -56,7 +56,7 @@ RSpec.describe "Users can edit a budget" do
     before do
       visit organisation_activity_path(user.organisation, activity)
       within("##{budget.id}") do
-        click_on t("default.link.edit")
+        click_on "Edit"
       end
     end
 
@@ -64,10 +64,10 @@ RSpec.describe "Users can edit a budget" do
       fill_in "budget[value]", with: "20"
 
       expect {
-        click_on t("default.button.submit")
+        click_on "Submit"
       }.to change { HistoricalEvent.count }.by(1)
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated")
       within("##{budget.id}") do
         expect(page).to have_content("20.00")
       end
@@ -84,9 +84,9 @@ RSpec.describe "Users can edit a budget" do
     end
 
     scenario "a budget can be successfully deleted" do
-      click_on t("default.button.delete")
+      click_on "Delete"
 
-      expect(page).to have_content(t("action.budget.destroy.success"))
+      expect(page).to have_content("Budget successfully deleted")
       expect(page).to_not have_content("10.00")
 
       expect { budget.reload }.to raise_error { ActiveRecord::RecordNotFound }
@@ -95,10 +95,10 @@ RSpec.describe "Users can edit a budget" do
     scenario "validation errors work as expected" do
       fill_in "budget[value]", with: ""
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
       expect(page).to have_content("There is a problem")
-      expect(page).to have_content(t("activerecord.errors.models.budget.attributes.value.blank"))
+      expect(page).to have_content("Enter a budget amount")
     end
   end
 end

--- a/spec/features/staff/users_can_edit_a_comment_spec.rb
+++ b/spec/features/staff/users_can_edit_a_comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Users can edit a comment" do
       context "when the report is editable" do
         scenario "the user cannot edit comments" do
           visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.edit")
+          expect(page).not_to have_content "Edit comment"
         end
       end
 
@@ -22,7 +22,7 @@ RSpec.describe "Users can edit a comment" do
         let(:report) { create(:report, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
         scenario "the user cannot edit comments" do
           visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.edit")
+          expect(page).not_to have_content "Edit comment"
         end
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe "Users can edit a comment" do
           expect(form).to have_report_summary_information
           form.complete(comment: "Amendments have been made")
 
-          expect(page).to have_content t("action.comment.update.success")
+          expect(page).to have_content "Comment successfully updated"
           expect(page).to have_content form.comment
         end
       end
@@ -46,7 +46,7 @@ RSpec.describe "Users can edit a comment" do
         let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: delivery_partner_user.organisation) }
         scenario "the user cannot edit any comments" do
           visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("default.link.edit")
+          expect(page).not_to have_content "Edit"
         end
       end
     end

--- a/spec/features/staff/users_can_edit_a_forecast_spec.rb
+++ b/spec/features/staff/users_can_edit_a_forecast_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Users can edit a forecast" do
 
       expect { click_button "Submit" }.to not_create_a_historical_event
 
-      expect(page).to have_content t("action.forecast.update.success")
+      expect(page).to have_content "Forecasted spend successfully updated"
       expect(page).to have_content "£20,000"
     end
 
@@ -49,7 +49,7 @@ RSpec.describe "Users can edit a forecast" do
         report: Report.editable_for_activity(project)
       )
 
-      click_on I18n.t("tabs.activity.historical_events")
+      click_on "Change history"
 
       expect(page).to have_content("Revising a forecast for #{FinancialQuarter.new(2018, 4)}")
     end
@@ -68,7 +68,7 @@ RSpec.describe "Users can edit a forecast" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_link t("default.link.edit"),
+      expect(page).not_to have_link "Edit",
         href: edit_activity_forecasts_path(project, forecast.financial_year, forecast.financial_quarter)
     end
 
@@ -82,7 +82,7 @@ RSpec.describe "Users can edit a forecast" do
       fill_in "Forecasted spend amount", with: ""
       click_button "Submit"
 
-      expect(page).to have_content t("activerecord.errors.models.forecast.attributes.value.not_a_number")
+      expect(page).to have_content "Value must be a valid number"
     end
   end
 end

--- a/spec/features/staff/users_can_edit_a_matched_effort_spec.rb
+++ b/spec/features/staff/users_can_edit_a_matched_effort_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Users can create a matched effort" do
 
       fill_in_matched_effort_form(matched_effort)
 
-      expect(page).to have_content(t("action.matched_effort.update.success"))
+      expect(page).to have_content("The matched effort has been successfully updated")
 
       expect(matched_effort.reload.organisation).to eq(matched_effort_provider)
       expect(matched_effort.notes).to eq("Here are some new notes")
@@ -31,9 +31,9 @@ RSpec.describe "Users can create a matched effort" do
 
     scenario "they see errors when a required field is missing" do
       select("", from: "matched_effort[organisation_id]")
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to_not have_content(t("action.matched_effort.update.success"))
+      expect(page).to_not have_content("The matched effort has been successfully updated")
 
       expect(page).to have_content("Organisation can't be blank")
     end

--- a/spec/features/staff/users_can_edit_a_refund_spec.rb
+++ b/spec/features/staff/users_can_edit_a_refund_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Users can edit a refund" do
       fill_in "refund_form[comment]", with: "Comment goes here"
 
       expect {
-        click_on(t("default.button.submit"))
+        click_on("Submit")
       }.to change {
         refund.reload.attributes.slice("financial_year", "financial_quarter", "value")
       }.to({
@@ -35,13 +35,13 @@ RSpec.feature "Users can edit a refund" do
         "value" => BigDecimal("-100")
       }).and change { refund.comment.reload.body }.to("Comment goes here")
 
-      expect(page).to have_content(t("action.refund.update.success"))
+      expect(page).to have_content("Refund successfully updated")
 
       and_the_refund_update_appears_in_the_change_history
     end
 
     scenario "they can delete a refund" do
-      expect { click_on t("default.button.delete") }.to change(Refund, :count).by(-1)
+      expect { click_on "Delete" }.to change(Refund, :count).by(-1)
     end
   end
 

--- a/spec/features/staff/users_can_edit_an_activity_spec.rb
+++ b/spec/features/staff/users_can_edit_an_activity_spec.rb
@@ -11,26 +11,26 @@ RSpec.feature "Users can edit an activity" do
       third_party_project_activity = create(:third_party_project_activity, parent: project_activity)
 
       visit organisation_activity_path(project_activity.organisation, project_activity)
-      click_on t("tabs.activity.details")
+      click_on "Details"
 
       within ".publish_to_iati" do
-        click_on(t("default.link.edit"))
+        click_on("Edit")
       end
 
-      choose t("summary.label.activity.publish_to_iati.false")
-      click_button t("form.button.activity.submit")
+      choose "No"
+      click_button "Continue"
 
-      click_on t("tabs.activity.details")
+      click_on "Details"
 
       within ".publish_to_iati" do
-        expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
+        expect(page).to have_content("No")
       end
 
       visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
-      click_on t("tabs.activity.details")
+      click_on "Details"
 
       within ".publish_to_iati" do
-        expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
+        expect(page).to have_content("No")
       end
 
       expect_change_to_be_recorded_as_historical_event(
@@ -59,13 +59,13 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".description") do
-            click_on(t("default.link.edit"))
+            click_on("Edit")
           end
 
           fill_in "activity[description]", with: updated_description
-          click_button t("form.button.activity.submit")
+          click_button "Continue"
 
-          expect(page).to have_content t("action.fund.update.success")
+          expect(page).to have_content "Fund (level A) successfully updated"
           expect(page.current_path).to eq organisation_activity_details_path(activity.organisation, activity)
 
           expect_change_to_be_recorded_as_historical_event(
@@ -108,7 +108,7 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".transparency-identifier") do
-            expect(page).to_not have_content t("default.link.edit")
+            expect(page).to_not have_content "Edit"
           end
         end
       end
@@ -120,9 +120,9 @@ RSpec.feature "Users can edit an activity" do
           visit organisation_activity_details_path(activity.organisation, activity)
 
           within(".description") do
-            click_on(t("default.link.edit"))
+            click_on("Edit")
           end
-          click_button t("form.button.activity.submit")
+          click_button "Continue"
 
           within("#main-content") do
             expect(page).to have_content t("form.legend.activity.sector_category", level: "fund (level A)")
@@ -139,11 +139,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
         end
 
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content(t("action.programme.update.success"))
+        click_button "Continue"
+        expect(page).to have_content("Programme (level B) successfully updated")
       end
     end
   end
@@ -160,11 +160,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
         end
 
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content(t("action.project.update.success"))
+        click_button "Continue"
+        expect(page).to have_content("Project (level C) successfully updated")
       end
 
       scenario "the delivery partner identifier cannot be changed" do
@@ -176,25 +176,25 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".planned_start_date") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
         end
 
         fill_in "activity[planned_start_date(2i)]", with: "15"
 
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content t("activerecord.errors.models.activity.attributes.planned_start_date.invalid")
+        click_button "Continue"
+        expect(page).to have_content "Please enter a valid date"
       end
 
       it "the policy markers can be added" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".policy_marker_gender") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
           expect(page.current_url).to match(activity_step_path(activity, :policy_markers, anchor: "gender"))
         end
 
         choose "activity-policy-marker-gender-significant-objective-field"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(page).to have_css(".policy_marker_gender", text: "Significant objective")
 
@@ -215,7 +215,7 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page.find(:css, "#activity-policy-marker-desertification-significant-objective-field")).to be_checked
 
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(page).to have_css(".policy_marker_desertification", text: "Significant objective")
       end
@@ -229,11 +229,11 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".title") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
         end
 
-        click_button t("form.button.activity.submit")
-        expect(page).to have_content(t("action.third_party_project.update.success"))
+        click_button "Continue"
+        expect(page).to have_content("Third-party project (level D) successfully updated")
       end
     end
 
@@ -247,12 +247,12 @@ RSpec.feature "Users can edit an activity" do
         visit organisation_activity_details_path(activity.organisation, activity)
 
         within(".collaboration_type") do
-          click_on(t("default.link.edit"))
+          click_on("Edit")
         end
         choose "Bilateral"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
-        expect(page).to have_content(t("action.project.update.success"))
+        expect(page).to have_content("Project (level C) successfully updated")
         expect(activity.reload.collaboration_type).to eql("1")
       end
     end

--- a/spec/features/staff/users_can_edit_an_actual_spec.rb
+++ b/spec/features/staff/users_can_edit_an_actual_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can edit an actual" do
       expect(page).to have_content(actual.value)
 
       within("##{actual.id}") do
-        click_on(t("default.link.edit"))
+        click_on("Edit")
       end
 
       fill_in_actual_form(
@@ -28,7 +28,7 @@ RSpec.feature "Users can edit an actual" do
         financial_year: "2019-2020"
       )
 
-      expect(page).to have_content(t("action.actual.update.success"))
+      expect(page).to have_content("Actual sucessfully updated")
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.feature "Users can edit an actual" do
       scenario "can be edited, with 'change history'" do
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).to have_link t("default.link.edit"), href: edit_activity_actual_path(activity, actual)
+        expect(page).to have_link "Edit", href: edit_activity_actual_path(activity, actual)
 
         within ".actuals" do
           expect(page).to have_content("£110.01")
@@ -58,7 +58,7 @@ RSpec.feature "Users can edit an actual" do
 
         fill_in "actual[value]", with: 221.12
 
-        click_on(t("default.button.submit"))
+        click_on("Submit")
 
         within ".actuals" do
           expect(page).to have_content("£221.12")
@@ -73,7 +73,7 @@ RSpec.feature "Users can edit an actual" do
       scenario "does not show the edit link" do
         visit organisation_activity_path(activity.organisation, activity)
 
-        expect(page).not_to have_link t("default.link.edit"), href: edit_activity_actual_path(activity, actual)
+        expect(page).not_to have_link "Edit", href: edit_activity_actual_path(activity, actual)
       end
     end
   end

--- a/spec/features/staff/users_can_edit_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_edit_an_external_income_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Users can edit an external income" do
 
       fill_in_external_income_form(external_income)
 
-      expect(page).to have_content(t("action.external_income.update.success"))
+      expect(page).to have_content("The external income has been successfully updated")
 
       expect(external_income.reload.organisation).to eq(external_income_provider)
       expect(external_income.financial_quarter).to eq(4)
@@ -31,9 +31,9 @@ RSpec.describe "Users can edit an external income" do
 
     scenario "they see errors when a required field is missing" do
       select("", from: "external_income[organisation_id]")
-      click_on t("default.button.submit")
+      click_on "Submit"
 
-      expect(page).to_not have_content(t("action.external_income.update.success"))
+      expect(page).to_not have_content("The external income has been successfully updated")
 
       expect(page).to have_content("Organisation can't be blank")
     end

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -20,19 +20,19 @@ RSpec.feature "Users can edit organisations" do
     visit organisation_path(beis_organisation)
 
     within ".govuk-header__navigation" do
-      click_link t("page_title.organisation.index")
+      click_link "Organisations"
     end
 
     within("##{another_organisation.id}") do
-      click_link t("default.link.edit")
+      click_link "Edit"
     end
 
-    expect(page).to have_content(t("page_title.organisation.edit"))
+    expect(page).to have_content("Edit organisation")
     fill_in "organisation[name]", with: ""
 
-    click_button t("default.button.submit")
-    expect(page).to_not have_content t("action.organisation.update.success")
-    expect(page).to have_content t("activerecord.errors.models.organisation.attributes.name.blank")
+    click_button "Submit"
+    expect(page).to_not have_content "Organisation successfully updated"
+    expect(page).to have_content "Enter an organisation name"
   end
 
   context "when the organisation is a matched effort provider organisation" do
@@ -44,23 +44,23 @@ RSpec.feature "Users can edit organisations" do
       visit organisation_path(beis_organisation)
 
       within ".govuk-header__navigation" do
-        click_link t("page_title.organisation.index")
+        click_link "Organisations"
       end
 
-      click_link t("tabs.organisations.matched_effort_providers")
+      click_link "Matched effort providers"
 
       within("##{another_organisation.id}") do
-        click_link t("default.link.edit")
+        click_link "Edit"
       end
 
-      choose t("form.label.organisation.active.false"), name: "organisation[active]"
+      choose "Inactive", name: "organisation[active]"
       expect {
-        click_button t("default.button.submit")
+        click_button "Submit"
       }.to change {
         another_organisation.reload.active
       }.from(true).to(false)
 
-      expect(page).to have_content t("action.organisation.update.success")
+      expect(page).to have_content "Organisation successfully updated"
     end
   end
 
@@ -73,23 +73,23 @@ RSpec.feature "Users can edit organisations" do
       visit organisation_path(beis_organisation)
 
       within ".govuk-header__navigation" do
-        click_link t("page_title.organisation.index")
+        click_link "Organisations"
       end
 
-      click_link t("tabs.organisations.external_income_providers")
+      click_link "External income providers"
 
       within("##{another_organisation.id}") do
-        click_link t("default.link.edit")
+        click_link "Edit"
       end
 
-      choose t("form.label.organisation.active.false"), name: "organisation[active]"
+      choose "Inactive", name: "organisation[active]"
       expect {
-        click_button t("default.button.submit")
+        click_button "Submit"
       }.to change {
         another_organisation.reload.active
       }.from(true).to(false)
 
-      expect(page).to have_content t("action.organisation.update.success")
+      expect(page).to have_content "Organisation successfully updated"
     end
   end
 
@@ -97,20 +97,20 @@ RSpec.feature "Users can edit organisations" do
     visit organisation_path(beis_organisation)
 
     within ".govuk-header__navigation" do
-      click_link t("page_title.organisation.index")
+      click_link "Organisations"
     end
 
     within("##{another_organisation.id}") do
-      click_link t("default.link.edit")
+      click_link "Edit"
     end
 
-    expect(page).to have_content(t("page_title.organisation.edit"))
+    expect(page).to have_content("Edit organisation")
     fill_in "organisation[name]", with: organisation_name
     fill_in "organisation[iati_reference]", with: "CZH-GOV-1234"
     select "Government", from: "organisation[organisation_type]"
     select "Czech", from: "organisation[language_code]"
     select "Zloty", from: "organisation[default_currency]"
-    click_button t("default.button.submit")
-    expect(page).to have_content t("action.organisation.update.success")
+    click_button "Submit"
+    expect(page).to have_content "Organisation successfully updated"
   end
 end

--- a/spec/features/staff/users_can_export_spending_breakdown_spec.rb
+++ b/spec/features/staff/users_can_export_spending_breakdown_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can export spending breakdown" do
       expect(page.status_code).to eq 200
 
       headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
-      expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))
+      expect(headers).to include("RODA identifier")
     end
 
     scenario "they can download the spending breakdown export for a single organisation" do
@@ -24,7 +24,7 @@ RSpec.feature "Users can export spending breakdown" do
       expect(page.status_code).to eq 200
 
       headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
-      expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))
+      expect(headers).to include("RODA identifier")
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.feature "Users can export spending breakdown" do
       expect(page.status_code).to eq 200
 
       headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
-      expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))
+      expect(headers).to include("RODA identifier")
     end
   end
 end

--- a/spec/features/staff/users_can_manage_activity_sector_spec.rb
+++ b/spec/features/staff/users_can_manage_activity_sector_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can manage Sectors" do
         activity = create(:fund_activity, :at_identifier_step, delivery_partner_identifier: "GCRF", organisation: user.organisation)
         visit activity_step_path(activity, :sector_category)
         choose "Basic Education"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(page).to have_current_path(activity_step_path(activity, :sector))
         expect(page).to have_content t("form.legend.activity.sector", sector_category: t("activity.sector_category.#{activity.reload.sector_category}"), level: "fund (level A)")
@@ -27,9 +27,9 @@ RSpec.feature "Users can manage Sectors" do
         expect(page).to have_current_path(activity_step_path(activity, :sector_category))
 
         choose "Basic Education"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
         choose "Early childhood education"
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(page).to have_current_path(organisation_activity_details_path(user.organisation, activity))
         within ".sector" do

--- a/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
+++ b/spec/features/staff/users_can_manage_collaboration_type_for_activities_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can add a collaboration type for an activity" do
     context "and they save this step without changing the selected radio button" do
       it "saves collaboration_type as value '1' (Bilateral)" do
         visit activity_step_path(activity, :collaboration_type)
-        click_button t("form.button.activity.submit")
+        click_button "Continue"
 
         expect(activity.reload.collaboration_type).to eq("1")
       end
@@ -26,13 +26,13 @@ RSpec.feature "Users can add a collaboration type for an activity" do
       programme = create(:programme_activity, organisation: user.organisation, collaboration_type: "2")
       visit organisation_activity_details_path(programme.organisation, programme)
       within(".collaboration_type") do
-        click_on(t("default.link.edit"))
+        click_on("Edit")
       end
 
       expect(find_field("activity-collaboration-type-2-field")).to be_checked
 
       choose "Bilateral, core contributions to NGOs and other private bodies / PPPs"
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
       expect(programme.reload.collaboration_type).to eq("3")
     end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Users can manage the implementing organisations" do
     scenario "they can add an implementing org from a list of all organisations" do
       def then_i_see_a_list_containing_all_organisations
         expect(page).to have_select(
-          t("form.label.implementing_organisation"),
+          "Choose organisation from list",
           options: Organisation.sorted_by_name.pluck(:name)
         )
       end
@@ -54,12 +54,12 @@ RSpec.feature "Users can manage the implementing organisations" do
       end
 
       def when_i_select_the_implementing_organisation(name)
-        select(name, from: t("form.label.implementing_organisation"))
+        select(name, from: "Choose organisation from list")
       end
 
       def then_i_see_that_the_implementing_org_was_added(implementing_org)
         expect(current_path).to eq organisation_activity_details_path(project.organisation, project)
-        expect(page).to have_content t("action.implementing_organisation.create.success")
+        expect(page).to have_content "Implementing organisation successfully added to activity"
 
         expect(page).to have_content implementing_org.name
         expect(page).to have_content implementing_org.iati_reference
@@ -67,14 +67,14 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       visit organisation_activity_details_path(project.organisation, project)
 
-      expect(page).to have_content t("page_content.activity.implementing_organisation.button.new")
-      click_on t("page_content.activity.implementing_organisation.button.new")
+      expect(page).to have_content "Add implementing organisation"
+      click_on "Add implementing organisation"
 
       then_i_see_a_list_containing_all_organisations
       then_i_see_guidance_about_adding_to_this_list
       when_i_select_the_implementing_organisation("Implementing org")
 
-      click_on t("default.button.submit")
+      click_on "Submit"
 
       then_i_see_that_the_implementing_org_was_added(implementing_org)
     end
@@ -95,7 +95,7 @@ RSpec.feature "Users can manage the implementing organisations" do
 
       def then_i_see_only_the_first_org_associated_with_the_project
         expect(page).to have_content(
-          t("action.implementing_organisation.delete.success")
+          "Implementing organisation successfully removed"
         )
         expect(page).to have_css(".implementing_organisation", count: 1)
       end
@@ -134,7 +134,7 @@ RSpec.feature "Users can manage the implementing organisations" do
     scenario "they cannot add implementing organisations" do
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).not_to have_button t("page_content.activity.implementing_organisation.button.new")
+      expect(page).not_to have_button "Add implementing organisation"
     end
   end
 end

--- a/spec/features/staff/users_can_manage_sdgs_for_activities_spec.rb
+++ b/spec/features/staff/users_can_manage_sdgs_for_activities_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can add Sustainable Development Goals for an activity" do
       select "Gender Equality", from: "activity[sdg_2]"
       select "Climate Action", from: "activity[sdg_3]"
 
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
       activity.reload
 
@@ -28,9 +28,9 @@ RSpec.feature "Users can add Sustainable Development Goals for an activity" do
       choose "activity[sdgs_apply]", option: "true"
       select "N/A", from: "activity[sdg_1]"
 
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
-      expect(page).to have_content t("activerecord.errors.models.activity.attributes.sdg_1.blank")
+      expect(page).to have_content "Select the first most relevant goal"
     end
 
     scenario "when selecting 'SDGs do not apply' radio button, no SDGs are stored" do
@@ -43,7 +43,7 @@ RSpec.feature "Users can add Sustainable Development Goals for an activity" do
 
       choose "activity[sdgs_apply]", option: "false"
 
-      click_button t("form.button.activity.submit")
+      click_button "Continue"
 
       activity.reload
 

--- a/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
@@ -12,8 +12,8 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
 
       perform_enqueued_jobs do
         visit report_path(report)
-        click_link t("action.report.request_changes.button")
-        click_button t("action.report.request_changes.confirm.button")
+        click_link "Request changes"
+        click_button "Confirm"
       end
 
       expect(page).to have_content "awaiting changes"
@@ -22,7 +22,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
       expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count)
 
       organisation.users.each do |user|
-        expect(user).to have_received_email.with_subject(t("mailer.report.awaiting_changes.subject", application_name: t("app.title")))
+        expect(user).to have_received_email.with_subject(t("mailer.report.awaiting_changes.subject", application_name: "Report your Official Development Assistance"))
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
 
         visit report_path(report)
 
-        expect(page).not_to have_link t("action.report.request_changes.button")
+        expect(page).not_to have_link "Request changes"
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
 
       visit report_path(report)
 
-      expect(page).not_to have_link t("action.report.request_changes.button")
+      expect(page).not_to have_link "Request changes"
     end
   end
 end

--- a/spec/features/staff/users_can_mark_a_report_in_review_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_in_review_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Users can move reports into review" do
       report = create(:report, state: :submitted)
 
       visit report_path(report)
-      click_link t("table.body.report.action.in_review")
-      click_button t("action.report.in_review.confirm.button")
+      click_link "Mark as in review"
+      click_button "Confirm"
 
       expect(page).to have_content "in review"
       expect(report.reload.state).to eql "in_review"
@@ -23,7 +23,7 @@ RSpec.feature "Users can move reports into review" do
 
         visit report_path(report)
 
-        expect(page).not_to have_link t("table.body.report.action.in_review")
+        expect(page).not_to have_link "Mark as in review"
       end
     end
   end
@@ -40,7 +40,7 @@ RSpec.feature "Users can move reports into review" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link t("table.body.report.action.in_review")
+      expect(page).not_to have_link "Mark as in review"
 
       visit edit_report_state_path(report)
 

--- a/spec/features/staff/users_can_search_for_activities_spec.rb
+++ b/spec/features/staff/users_can_search_for_activities_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Users can search for activities" do
   before do
     visit "/"
     fill_in :query, with: "roda-id"
-    click_button t("form.activity_search.submit")
+    click_button "Search"
   end
 
   scenario "searching by RODA identifier" do
@@ -21,9 +21,9 @@ RSpec.describe "Users can search for activities" do
 
   scenario "searching for an empty string shows an error message" do
     fill_in :query, with: ""
-    click_button t("form.activity_search.submit")
+    click_button "Search"
 
-    expect(page).to have_content(t("page_content.activity_search.empty_query"))
+    expect(page).to have_content("The search query must contain at least 1 character!")
   end
 
   scenario "user sees breadcrumb context when accessing an activity from search results" do

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -8,12 +8,12 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(t("start_page.title"))
+    expect(page).to have_content("Report your official development assistance (ODA)")
 
-    expect(page).to have_content(t("header.link.sign_in"))
-    click_on t("header.link.sign_in")
+    expect(page).to have_content("Sign in")
+    click_on "Sign in"
 
-    expect(page).to have_content(t("header.link.sign_out"))
+    expect(page).to have_content("Sign out")
   end
 
   scenario "successful sign in via button link" do
@@ -23,12 +23,12 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(t("start_page.title"))
+    expect(page).to have_content("Report your official development assistance (ODA)")
 
-    expect(page).to have_content(t("header.link.sign_in"))
-    click_on t("header.link.sign_in")
+    expect(page).to have_content("Sign in")
+    click_on "Sign in"
 
-    expect(page).to have_content(t("header.link.sign_out"))
+    expect(page).to have_content("Sign out")
   end
 
   scenario "a user is redirected to a link they originally requested" do
@@ -40,7 +40,7 @@ RSpec.feature "Users can sign in with Auth0" do
       uid: user.identifier, name: user.name, email: user.email
     )
 
-    click_on t("header.link.sign_in")
+    click_on "Sign in"
 
     expect(current_path).to eq(reports_path)
   end
@@ -53,10 +53,10 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(t("start_page.title"))
+    expect(page).to have_content("Report your official development assistance (ODA)")
 
-    expect(page).to have_content(t("header.link.sign_in"))
-    click_on t("header.link.sign_in")
+    expect(page).to have_content("Sign in")
+    click_on "Sign in"
 
     expect(page.current_path).to eql home_path
   end
@@ -69,10 +69,10 @@ RSpec.feature "Users can sign in with Auth0" do
     )
 
     visit root_path
-    expect(page).to have_content(t("start_page.title"))
+    expect(page).to have_content("Report your official development assistance (ODA)")
 
-    expect(page).to have_content(t("header.link.sign_in"))
-    click_on t("header.link.sign_in")
+    expect(page).to have_content("Sign in")
+    click_on "Sign in"
 
     expect(page.current_path).to eql home_path
   end
@@ -80,7 +80,7 @@ RSpec.feature "Users can sign in with Auth0" do
   scenario "protected pages cannot be visited unless signed in" do
     visit root_path
 
-    expect(page).to have_content(t("start_page.title"))
+    expect(page).to have_content("Report your official development assistance (ODA)")
   end
 
   context "when the Auth0 identifier does not match a user record" do
@@ -92,11 +92,11 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit root_path
 
-      expect(page).to have_content(t("header.link.sign_in"))
-      click_on t("header.link.sign_in")
+      expect(page).to have_content("Sign in")
+      click_on "Sign in"
 
-      expect(page).to have_content(t("page_title.errors.not_authorised"))
-      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content("You are not authorised")
+      expect(page).to have_content("Whilst you have successfully signed in you have not been authorised to see this page.")
     end
   end
 
@@ -108,12 +108,12 @@ RSpec.feature "Users can sign in with Auth0" do
     it "displays the error message so they can try to correct the problem themselves" do
       visit root_path
 
-      expect(page).to have_content(t("header.link.sign_in"))
-      click_on t("header.link.sign_in")
+      expect(page).to have_content("Sign in")
+      click_on "Sign in"
 
-      expect(page).to have_content(t("page_content.errors.auth0.failed.explanation"))
-      expect(page).to have_content(t("page_content.errors.auth0.error_messages.invalid_credentials"))
-      expect(page).to have_content(t("page_content.errors.auth0.failed.prompt"))
+      expect(page).to have_content("Your request to sign in failed")
+      expect(page).to have_content("Invalid credentials")
+      expect(page).to have_content("Try signing in again and if you continue to have this issue please contact support.")
     end
   end
 
@@ -127,10 +127,10 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit root_path
 
-      click_button t("header.link.sign_in")
+      click_button "Sign in"
 
       expect(page).not_to have_content("unknown_failure")
-      expect(page).to have_content(t("page_content.errors.auth0.error_messages.generic"))
+      expect(page).to have_content("There was a problem signing you in.")
       expect(Rollbar).to have_received(:log).with(:info, "Unknown response from Auth0", "unknown_failure")
     end
   end
@@ -144,11 +144,11 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit root_path
 
-      expect(page).to have_content(t("header.link.sign_in"))
-      click_on t("header.link.sign_in")
+      expect(page).to have_content("Sign in")
+      click_on "Sign in"
 
-      expect(page).to have_content(t("page_title.errors.not_authorised"))
-      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content("You are not authorised")
+      expect(page).to have_content("Whilst you have successfully signed in you have not been authorised to see this page.")
     end
 
     scenario "a user who is logged in and then deactivated sees an error message" do
@@ -159,7 +159,7 @@ RSpec.feature "Users can sign in with Auth0" do
       )
 
       visit root_path
-      click_on t("header.link.sign_in")
+      click_on "Sign in"
 
       expect(page.current_path).to eql home_path
 
@@ -168,8 +168,8 @@ RSpec.feature "Users can sign in with Auth0" do
 
       visit home_path
 
-      expect(page).to have_content(t("page_title.errors.not_authorised"))
-      expect(page).to have_content(t("page_content.errors.not_authorised.explanation"))
+      expect(page).to have_content("You are not authorised")
+      expect(page).to have_content("Whilst you have successfully signed in you have not been authorised to see this page.")
     end
   end
 end

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -15,9 +15,9 @@ RSpec.feature "Users can submit a report" do
 
         perform_enqueued_jobs do
           visit report_path(report)
-          click_link t("action.report.submit.button")
+          click_link "Submit report"
 
-          click_button t("action.report.submit.confirm.button")
+          click_button "Confirm submission"
         end
 
         expect(page).to have_content t("action.report.submit.complete.title",
@@ -27,10 +27,10 @@ RSpec.feature "Users can submit a report" do
 
         expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count + 1)
 
-        expect(service_owner).to have_received_email.with_subject(t("mailer.report.submitted.service_owner.subject", application_name: t("app.title")))
+        expect(service_owner).to have_received_email.with_subject(t("mailer.report.submitted.service_owner.subject", application_name: "Report your Official Development Assistance"))
 
         organisation.users.each do |user|
-          expect(user).to have_received_email.with_subject(t("mailer.report.submitted.delivery_partner.subject", application_name: t("app.title")))
+          expect(user).to have_received_email.with_subject(t("mailer.report.submitted.delivery_partner.subject", application_name: "Report your Official Development Assistance"))
         end
       end
     end
@@ -41,9 +41,9 @@ RSpec.feature "Users can submit a report" do
         report_presenter = ReportPresenter.new(report)
 
         visit report_path(report)
-        click_link t("action.report.submit.button")
+        click_link "Submit report"
 
-        click_button t("action.report.submit.confirm.button")
+        click_button "Confirm submission"
 
         expect(page).to have_content t("action.report.submit.complete.title",
           report_organisation: report.organisation.name,
@@ -58,7 +58,7 @@ RSpec.feature "Users can submit a report" do
 
         visit report_path(report)
 
-        expect(page).not_to have_link t("action.report.submit.button"), href: edit_report_state_path(report)
+        expect(page).not_to have_link "Submit report", href: edit_report_state_path(report)
 
         visit edit_report_state_path(report)
 
@@ -79,7 +79,7 @@ RSpec.feature "Users can submit a report" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link t("action.report.submit.button"), href: edit_report_state_path(report)
+      expect(page).not_to have_link "Submit report", href: edit_report_state_path(report)
 
       visit edit_report_state_path(report)
 

--- a/spec/features/staff/users_can_upload_actuals_spec.rb
+++ b/spec/features/staff/users_can_upload_actuals_spec.rb
@@ -16,14 +16,14 @@ RSpec.feature "users can upload actuals" do
   before do
     authenticate!(user: user)
     visit report_actuals_path(report)
-    click_link t("page_content.actuals.button.upload")
+    click_link "Upload actuals data"
   end
 
   def expect_to_see_successful_upload_summary_with(count:, total:)
-    expect(page).to have_text(t("page_title.actual.upload_success"))
+    expect(page).to have_text("Successful uploads")
     expect(page).to have_css(".actuals tr", count: count)
     expect(page).to have_link(
-      t("importer.success.actual.back_link"),
+      "Back to report",
       href: report_actuals_path(report)
     )
     within ".totals" do
@@ -37,7 +37,7 @@ RSpec.feature "users can upload actuals" do
     expect(page.html).to include t("page_content.actuals.upload.copy_html",
       report_actuals_template_path: report_actual_upload_path(report, format: :csv))
 
-    expect(page.html).to include t("page_content.actuals.upload.warning_html")
+    expect(page.html).to include "Uploading actuals data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details."
   end
 
   scenario "downloading a CSV template with activities for the current report" do
@@ -75,9 +75,9 @@ RSpec.feature "users can upload actuals" do
   end
 
   scenario "not uploading a file" do
-    click_button t("action.actual.upload.button")
+    click_button "Upload and continue"
     expect(Actual.count).to eq(0)
-    expect(page).to have_text(t("action.actual.upload.file_missing_or_invalid"))
+    expect(page).to have_text("Please upload a valid CSV file")
   end
 
   scenario "uploading a valid set of actuals" do
@@ -95,7 +95,7 @@ RSpec.feature "users can upload actuals" do
 
     # Then I should see a summary of my upload
     expect(Actual.count).to eq(2)
-    expect(page).to have_text(t("action.actual.upload.success"))
+    expect(page).to have_text("The transactions were successfully imported.")
     expect(page).not_to have_css("table.govuk-table.errors")
     expect(page).to have_text("A unique comment")
 
@@ -122,7 +122,7 @@ RSpec.feature "users can upload actuals" do
     CSV
 
     expect(Actual.count).to eq(2)
-    expect(page).to have_text(t("action.actual.upload.success"))
+    expect(page).to have_text("The transactions were successfully imported.")
 
     expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
@@ -137,7 +137,7 @@ RSpec.feature "users can upload actuals" do
     CSV
 
     expect(Actual.count).to eq(1)
-    expect(page).to have_text(t("action.actual.upload.success"))
+    expect(page).to have_text("The transactions were successfully imported.")
 
     expect_to_see_successful_upload_summary_with(count: 1, total: 30)
   end
@@ -152,20 +152,20 @@ RSpec.feature "users can upload actuals" do
     CSV
 
     expect(Actual.count).to eq(0)
-    expect(page).not_to have_text(t("action.actual.upload.success"))
+    expect(page).not_to have_text("The transactions were successfully imported.")
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[1]", text: "Value")
       expect(page).to have_xpath("td[2]", text: "2")
       expect(page).to have_xpath("td[3]", text: "fish")
-      expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.non_numeric_value"))
+      expect(page).to have_xpath("td[4]", text: "The value must be numeric")
     end
 
     within "//tbody/tr[2]" do
       expect(page).to have_xpath("td[1]", text: "Receiving Organisation Type")
       expect(page).to have_xpath("td[2]", text: "3")
       expect(page).to have_xpath("td[3]", text: "61")
-      expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.invalid_iati_organisation_type"))
+      expect(page).to have_xpath("td[4]", text: "The receiving organisation type must be a valid IATI Organisation Type code")
     end
   end
 
@@ -183,13 +183,13 @@ RSpec.feature "users can upload actuals" do
     file.close
 
     attach_file "report[actual_csv]", file.path
-    click_button t("action.actual.upload.button")
+    click_button "Upload and continue"
 
     file.unlink
 
     expect(Actual.count).to eq(0)
 
-    expect(page).to have_content(t("action.forecast.upload.file_missing_or_invalid"))
+    expect(page).to have_content("Please upload a valid CSV file")
   end
 
   scenario "uploading a valid set of actuals with a BOM at the start of the file" do
@@ -203,7 +203,7 @@ RSpec.feature "users can upload actuals" do
     CSV
 
     expect(Actual.count).to eq(2)
-    expect(page).to have_text(t("action.actual.upload.success"))
+    expect(page).to have_text("The transactions were successfully imported.")
 
     expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
@@ -214,7 +214,7 @@ RSpec.feature "users can upload actuals" do
     file.close
 
     attach_file "report[actual_csv]", file.path
-    click_button t("action.actual.upload.button")
+    click_button "Upload and continue"
 
     file.unlink
   end

--- a/spec/features/staff/users_can_upload_forecasts_spec.rb
+++ b/spec/features/staff/users_can_upload_forecasts_spec.rb
@@ -18,14 +18,14 @@ RSpec.feature "users can upload forecasts" do
   before do
     authenticate!(user: user)
     visit report_forecasts_path(report)
-    click_link t("page_content.forecasts.button.upload")
+    click_link "Upload forecast data"
   end
 
   def expect_to_see_successful_upload_summary_with(count:, total:)
-    expect(page).to have_text(t("importer.success.heading"))
+    expect(page).to have_text("Successful uploads")
     expect(page).to have_css(".forecasts tr", count: count)
     expect(page).to have_link(
-      t("importer.success.back_link"),
+      "Back to report",
       href: report_forecasts_path(report)
     )
     within ".totals" do
@@ -35,7 +35,7 @@ RSpec.feature "users can upload forecasts" do
 
   describe "downloading a CSV template with activities for the current report" do
     before do
-      click_link t("action.forecast.download.button")
+      click_link "Download CSV template"
       @csv_data = page.body.delete_prefix("\uFEFF")
     end
 
@@ -106,9 +106,9 @@ RSpec.feature "users can upload forecasts" do
   end
 
   scenario "not uploading a file" do
-    click_button t("action.forecast.upload.button")
+    click_button "Upload and continue"
     expect(Forecast.unscoped.count).to eq(0)
-    expect(page).to have_text(t("action.forecast.upload.file_missing_or_invalid"))
+    expect(page).to have_text("Please upload a valid CSV file")
   end
 
   scenario "uploading a valid set of forecasts" do
@@ -121,7 +121,7 @@ RSpec.feature "users can upload forecasts" do
     CSV
 
     expect(Forecast.unscoped.count).to eq(6)
-    expect(page).to have_text(t("action.forecast.upload.success"))
+    expect(page).to have_text("The forecasts were successfully imported.")
     expect_to_see_successful_upload_summary_with(count: 6, total: "£110.00")
   end
 
@@ -135,17 +135,17 @@ RSpec.feature "users can upload forecasts" do
     CSV
 
     expect(Forecast.unscoped.count).to eq(0)
-    expect(page).not_to have_text(t("action.forecast.upload.success"))
+    expect(page).not_to have_text("The forecasts were successfully imported.")
 
     # upload info not present
-    expect(page).not_to have_text(t("importer.success.heading"))
-    expect(page).not_to have_link(t("importer.success.back_link"))
+    expect(page).not_to have_text("Successful uploads")
+    expect(page).not_to have_link("Back to report")
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[1]", text: "FC 2021/22 FY Q3")
       expect(page).to have_xpath("td[2]", text: "3")
       expect(page).to have_xpath("td[3]", text: "not a number")
-      expect(page).to have_xpath("td[4]", text: t("importer.errors.forecast.non_numeric_value"))
+      expect(page).to have_xpath("td[4]", text: "The value must be numeric")
     end
   end
 
@@ -159,7 +159,7 @@ RSpec.feature "users can upload forecasts" do
     CSV
 
     expect(Forecast.unscoped.count).to eq(3)
-    expect(page).to have_text(t("action.forecast.upload.success"))
+    expect(page).to have_text("The forecasts were successfully imported.")
     expect_to_see_successful_upload_summary_with(count: 3, total: "£110.00")
   end
 
@@ -176,13 +176,13 @@ RSpec.feature "users can upload forecasts" do
     file.close
 
     attach_file "report[forecast_csv]", file.path
-    click_button t("action.forecast.upload.button")
+    click_button "Upload and continue"
 
     file.unlink
 
     expect(Forecast.unscoped.count).to eq(0)
 
-    expect(page).to have_content(t("action.forecast.upload.file_missing_or_invalid"))
+    expect(page).to have_content("Please upload a valid CSV file")
   end
 
   scenario "uploading a set of forecasts with a BOM at the start of the file" do
@@ -196,7 +196,7 @@ RSpec.feature "users can upload forecasts" do
     CSV
 
     expect(Forecast.unscoped.count).to eq(6)
-    expect(page).to have_text(t("action.forecast.upload.success"))
+    expect(page).to have_text("The forecasts were successfully imported.")
     expect_to_see_successful_upload_summary_with(count: 6, total: "£210.00")
   end
 
@@ -206,7 +206,7 @@ RSpec.feature "users can upload forecasts" do
     file.close
 
     attach_file "report[forecast_csv]", file.path
-    click_button t("action.forecast.upload.button")
+    click_button "Upload and continue"
 
     file.unlink
   end

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "users can view a home page" do
       visit home_path
 
       expect(page.current_path).to eql home_path
-      expect(page).to have_content t("page_content.reports.title")
+      expect(page).to have_content "Reports"
       expect(page).to have_button("Search")
       expect(page).to have_content(programme.title)
     end

--- a/spec/features/staff/users_can_view_activities_spec.rb
+++ b/spec/features/staff/users_can_view_activities_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view activities" do
     scenario "they can see and navigate current delivery partner activities", js: true do
       visit activities_path(organisation_id: organisation.id)
 
-      expect(page).to have_content t("page_title.activity.index")
+      expect(page).to have_content "Activities"
 
       expect(page).to have_css(".govuk-tabs__tab", count: 2)
       expect(page).to have_css(".govuk-tabs__tab", text: "Current")
@@ -84,9 +84,9 @@ RSpec.feature "Users can view activities" do
       _report = create(:report, :active, fund: gcrf, organisation: delivery_partner_organisation)
 
       visit organisation_activity_path(programme.organisation, programme)
-      click_on t("tabs.activity.children")
+      click_on "Child activities"
 
-      expect(page).to_not have_link(t("action.activity.add_child"), exact: true)
+      expect(page).to_not have_link("Add child activity", exact: true)
     end
   end
 

--- a/spec/features/staff/users_can_view_actuals_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_on_an_activity_page_spec.rb
@@ -64,9 +64,9 @@ RSpec.feature "Users can view actuals on an activity page" do
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
 
-        expect(page).to_not have_content(t("page_content.actuals.button.create"))
+        expect(page).to_not have_content("Add an actual")
         within("tr##{actual.id}") do
-          expect(page).not_to have_content(t("default.link.edit"))
+          expect(page).not_to have_content("Edit")
         end
       end
     end

--- a/spec/features/staff/users_can_view_actuals_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_actuals_within_report_spec.rb
@@ -90,10 +90,10 @@ RSpec.feature "Users can view actuals in tab within a report" do
 
       visit report_path(report.id)
 
-      click_link t("tabs.report.actuals.heading")
+      click_link "Actuals"
 
       expect(page).to have_content("Actuals")
-      expect(page).to have_link(t("action.actual.upload.link"))
+      expect(page).to have_link("Upload actuals")
 
       expect_to_see_a_table_of_actuals_grouped_by_activity(activities)
       expect_to_see_a_table_of_refunds_grouped_by_activity(activities)
@@ -109,7 +109,7 @@ RSpec.feature "Users can view actuals in tab within a report" do
 
         click_link "Actuals"
 
-        expect(page).not_to have_link(t("action.actual.upload.link"))
+        expect(page).not_to have_link("Upload actuals")
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_activity_spec.rb
+++ b/spec/features/staff/users_can_view_an_activity_spec.rb
@@ -35,11 +35,11 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(fund.organisation, fund)
 
         within(".programmes") do
-          expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
+          expect(page).to_not have_content "Publish to IATI?"
         end
 
         within("##{programme.id}") do
-          expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
+          expect(page).to_not have_content "Yes"
         end
       end
     end
@@ -74,7 +74,7 @@ RSpec.feature "Users can view an activity" do
         visit organisation_activity_children_path(programme.organisation, programme)
 
         within(".projects") do
-          expect(page).to have_content t("summary.label.activity.publish_to_iati.label")
+          expect(page).to have_content "Publish to IATI?"
         end
 
         within("##{project.id}") do
@@ -103,7 +103,7 @@ RSpec.feature "Users can view an activity" do
 
         visit organisation_activity_children_path(project.organisation, project)
 
-        expect(page).to have_content t("summary.label.activity.publish_to_iati.label")
+        expect(page).to have_content "Publish to IATI?"
 
         within("##{third_party_project.id}") do
           expect(page).to have_content "Yes"
@@ -211,7 +211,7 @@ RSpec.feature "Users can view an activity" do
           actual_end_date: Date.new(2020, 1, 29))
 
         visit organisation_activity_path(user.organisation, activity)
-        click_on t("tabs.activity.details")
+        click_on "Details"
 
         within(".planned_start_date") do
           expect(page).to have_content("3 Feb 2020")
@@ -252,10 +252,10 @@ RSpec.feature "Users can view an activity" do
 
       visit organisation_activity_children_path(project.organisation, project)
 
-      expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
+      expect(page).to_not have_content "Publish to IATI?"
 
       within("##{third_party_project.id}") do
-        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
+        expect(page).to_not have_content "Yes"
       end
     end
   end

--- a/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_change_history_spec.rb
@@ -68,8 +68,8 @@ RSpec.feature "Users can view an activity's 'Change History' within a tab" do
 
       click_link "Change history"
 
-      expect(page).to have_css("h2", text: t("page_title.activity.change_history"))
-      expect(page).to have_content(t("page_content.tab_content.change_history.guidance"))
+      expect(page).to have_css("h2", text: "Change history")
+      expect(page).to have_content("Changes made to this activity")
 
       expect_to_see_change_history_with_reference(
         events: HistoricalEvent.last(2),

--- a/spec/features/staff/users_can_view_an_activitys_children_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_children_spec.rb
@@ -12,16 +12,16 @@ RSpec.feature "Users can an activitys children" do
 
       visit organisation_activity_path(user.organisation.id, project)
 
-      click_on t("tabs.activity.details")
+      click_on "Details"
       within(".activity-details") do
         click_on programme.title
       end
-      click_on t("tabs.activity.children")
+      click_on "Child activities"
 
-      expect(page).to_not have_content t("summary.label.activity.publish_to_iati.label")
+      expect(page).to_not have_content "Publish to IATI?"
 
       within("##{project.id}") do
-        expect(page).to_not have_content t("summary.label.activity.publish_to_iati.true")
+        expect(page).to_not have_content "Yes"
       end
     end
 
@@ -34,9 +34,9 @@ RSpec.feature "Users can an activitys children" do
       within(".activity-details") do
         click_on(programme.title)
       end
-      click_on t("tabs.activity.children")
+      click_on "Child activities"
       click_on activity.title
-      click_on t("tabs.activity.details")
+      click_on "Details"
 
       activity_presenter = ActivityPresenter.new(activity)
 

--- a/spec/features/staff/users_can_view_an_activitys_details_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_details_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can view an activitys details" do
         expect(page).to have_content "Details"
       end
       expect(page).to have_content activity.title
-      expect(page).to have_link t("page_content.activity.implementing_organisation.button.new")
+      expect(page).to have_link "Add implementing organisation"
     end
 
     scenario "activities have human readable date format" do
@@ -28,7 +28,7 @@ RSpec.feature "Users can view an activitys details" do
           organisation: user.organisation)
 
         visit organisation_activity_path(user.organisation, activity)
-        click_on t("tabs.activity.details")
+        click_on "Details"
 
         within(".planned_start_date") do
           expect(page).to have_content("3 Feb 2020")

--- a/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
+++ b/spec/features/staff/users_can_view_an_activitys_funding_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Users can view an activity's other funding" do
 
     it "lists the matched efforts" do
       visit organisation_activity_path(activity.organisation, activity)
-      click_on t("tabs.activity.other_funding")
+      click_on "Other funding"
 
       expect(page).to have_content(matched_effort_provider.name)
       expect(page).to have_content("In kind")
@@ -37,7 +37,7 @@ RSpec.feature "Users can view an activity's other funding" do
 
     it "lists the external incomes" do
       visit organisation_activity_path(activity.organisation, activity)
-      click_on t("tabs.activity.other_funding")
+      click_on "Other funding"
 
       expect(page).to have_content(external_income_provider.name)
       expect(page).to have_content("Q1 2021-2022")
@@ -52,14 +52,14 @@ RSpec.feature "Users can view an activity's other funding" do
 
     it "lists the matched efforts" do
       visit organisation_activity_path(activity.organisation, activity)
-      click_on t("tabs.activity.other_funding")
+      click_on "Other funding"
 
       expect(page).to have_content(matched_effort_provider.name)
     end
 
     it "lists the external incomes" do
       visit organisation_activity_path(activity.organisation, activity)
-      click_on t("tabs.activity.other_funding")
+      click_on "Other funding"
 
       expect(page).to have_content(external_income_provider.name)
     end

--- a/spec/features/staff/users_can_view_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_view_an_organisation_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can view an organisation" do
       scenario "does not see a back link on their organisation page" do
         visit organisation_path(user.organisation)
 
-        expect(page).to_not have_content(t("default.link.back"))
+        expect(page).to_not have_content("Back")
       end
     end
 
@@ -26,11 +26,11 @@ RSpec.feature "Users can view an organisation" do
         visit organisation_path(user.organisation)
 
         within ".govuk-header__navigation" do
-          click_link t("page_title.organisation.index")
+          click_link "Organisations"
         end
 
         within("##{other_organisation.id}") do
-          click_link t("default.link.show")
+          click_link "View"
         end
         expect(page).to have_content(other_organisation.name)
       end
@@ -53,7 +53,7 @@ RSpec.feature "Users can view an organisation" do
     scenario "does not see a back link on their organisation home page" do
       visit organisation_path(organisation)
 
-      expect(page).to_not have_content(t("default.link.back"))
+      expect(page).to_not have_content("Back")
     end
   end
 end

--- a/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/staff/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -71,9 +71,9 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
 
-        expect(page).to_not have_content(t("page_content.budgets.button.create"))
+        expect(page).to_not have_content("Add budget")
         within("tr##{budget.id}") do
-          expect(page).not_to have_content(t("default.link.edit"))
+          expect(page).not_to have_content("Edit")
         end
       end
     end
@@ -91,9 +91,9 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit activities_path
         within "#activity-#{project_activity.id}" do
-          click_link t("table.body.activity.view_activity")
+          click_link "View"
         end
-        click_link t("tabs.activity.details")
+        click_link "Details"
         within(".activity-details") do
           click_link programme_activity.title
         end
@@ -109,7 +109,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
         within "##{budget.id}" do
-          expect(page).to_not have_content t("default.link.edit")
+          expect(page).to_not have_content "Edit"
         end
       end
     end
@@ -125,7 +125,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link programme_activity.title
-        click_on t("tabs.activity.children")
+        click_on "Child activities"
         click_link project_activity.title
 
         budget_information_is_shown_on_page(budget_presenter)
@@ -141,12 +141,12 @@ RSpec.feature "Users can view budgets on an activity page" do
         visit activities_path
 
         click_link programme_activity.title
-        click_on t("tabs.activity.children")
+        click_on "Child activities"
         click_link project_activity.title
 
-        expect(page).to have_content(t("page_content.budgets.button.create"))
+        expect(page).to have_content("Add budget")
         within("tr##{budget.id}") do
-          expect(page).to have_content(t("default.link.edit"))
+          expect(page).to have_content("Edit")
         end
       end
     end

--- a/spec/features/staff/users_can_view_comments_spec.rb
+++ b/spec/features/staff/users_can_view_comments_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can view comments on an activity page" do
       refund = create(:refund, parent_activity: activity, report: report)
 
       visit organisation_activity_details_path(user.organisation, activity)
-      click_on t("tabs.activity.comments")
+      click_on "Comments"
 
       within "#comment_#{comment.id}" do
         expect(page).to have_content comment.body

--- a/spec/features/staff/users_can_view_forecasts_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Users can view forecasts" do
 
       visit organisation_activity_path(user.organisation, project)
 
-      expect(page).to have_content t("page_content.activity.forecasts")
+      expect(page).to have_content "Forecasted spend"
       expect(page).to have_selector "##{forecast.id}"
     end
 
@@ -25,7 +25,7 @@ RSpec.describe "Users can view forecasts" do
 
       visit organisation_activity_path(user.organisation, third_party_project)
 
-      expect(page).to have_content t("page_content.activity.forecasts")
+      expect(page).to have_content "Forecasted spend"
       expect(page).to have_selector "##{forecast.id}"
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe "Users can view forecasts" do
 
       visit organisation_activity_path(beis_user.organisation, project)
 
-      expect(page).to have_content t("page_content.activity.forecasts")
+      expect(page).to have_content "Forecasted spend"
       expect(page).to have_selector "##{forecast.id}"
     end
 
@@ -50,7 +50,7 @@ RSpec.describe "Users can view forecasts" do
 
       visit organisation_activity_path(beis_user.organisation, third_party_project)
 
-      expect(page).to have_content t("page_content.activity.forecasts")
+      expect(page).to have_content "Forecasted spend"
       expect(page).to have_selector "##{forecast.id}"
     end
   end

--- a/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/staff/users_can_view_forecasts_within_report_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can view forecasts in tab within a report" do
 
     def expect_to_see_a_table_of_forecasts_grouped_by_activity(activities, report)
       expect(page).to have_content(
-        t("page_content.tab_content.forecasts.per_activity_heading")
+        "Forecast spend per activity"
       )
 
       forecasts = ForecastOverview.new(activities.map(&:id))
@@ -95,8 +95,8 @@ RSpec.feature "Users can view forecasts in tab within a report" do
 
       click_link "Forecasts"
 
-      expect(page).to have_content(t("page_content.tab_content.forecasts.heading"))
-      expect(page).to have_link(t("page_content.forecasts.button.upload"))
+      expect(page).to have_content("Forecasts in this report")
+      expect(page).to have_link("Upload forecast data")
 
       # guidance with 2 links
       expect(page).to have_content("This page shows all the new or updated forecasts")
@@ -117,7 +117,7 @@ RSpec.feature "Users can view forecasts in tab within a report" do
 
         click_link "Forecasts"
 
-        expect(page).not_to have_link(t("action.forecast.upload.link"))
+        expect(page).not_to have_link("Upload forecasts")
       end
     end
   end

--- a/spec/features/staff/users_can_view_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_project_level_activities_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Users can view project level activities" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to_not have_content t("default.button.download_as_xml")
+      expect(page).to_not have_content "Download as XML"
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.feature "Users can view project level activities" do
       visit organisation_activity_path(project.organisation, project)
 
       expect(page).to have_content project.title
-      expect(page).to have_no_button t("action.activity.add_child")
+      expect(page).to have_no_button "Add child activity"
     end
 
     scenario "can download a project as XML" do
@@ -73,9 +73,9 @@ RSpec.feature "Users can view project level activities" do
 
       visit organisation_activity_path(project.organisation, project)
 
-      expect(page).to have_content t("default.button.download_as_xml")
+      expect(page).to have_content "Download as XML"
 
-      click_on t("default.button.download_as_xml")
+      click_on "Download as XML"
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Users can view reports" do
 
       visit reports_path
 
-      expect(page).to have_content t("page_title.report.index")
+      expect(page).to have_content "Reports"
 
       expect_to_see_a_table_of_reports_grouped_by_organisation(
         selector: "#current",
@@ -70,7 +70,7 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.show")
+        click_on "View"
       end
 
       expect(page).to have_content report.financial_quarter
@@ -83,7 +83,7 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.show")
+        click_on "View"
       end
 
       expect(page).to have_content report.description
@@ -107,7 +107,7 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.show")
+        click_on "View"
       end
 
       within ".govuk-tabs" do
@@ -124,7 +124,7 @@ RSpec.feature "Users can view reports" do
 
         visit report_path(report.id)
 
-        expect(page).not_to have_content t("form.label.report.description")
+        expect(page).not_to have_content "Report description"
       end
     end
 
@@ -146,13 +146,13 @@ RSpec.feature "Users can view reports" do
       visit reports_path
 
       within "##{report.id}" do
-        click_on t("default.link.show")
+        click_on "View"
       end
 
       expect(page).to have_content("Download a CSV file to review offline.")
       expect(page).to have_link("guidance in the help centre (opens in new tab)")
 
-      click_link t("action.report.download.button")
+      click_link "Download report as CSV file"
 
       expect(page.response_headers["Content-Type"]).to include("text/csv")
       expect(page.status_code).to eq 200
@@ -175,10 +175,10 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on t("default.link.show")
+          click_on "View"
         end
 
-        click_on t("action.report.download.button")
+        click_on "Download report as CSV file"
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
         header = page.response_headers["Content-Disposition"]
@@ -191,7 +191,7 @@ RSpec.feature "Users can view reports" do
       scenario "an empty state is shown" do
         visit reports_path
 
-        expect(page).to have_content t("table.body.report.no_reports")
+        expect(page).to have_content "You have no current reports. Once active, any new reports will appear here. You can view approved reports in the Approved tab."
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.feature "Users can view reports" do
       before do
         visit reports_path
         within "##{report.id}" do
-          click_on t("default.link.show")
+          click_on "View"
         end
       end
 
@@ -266,7 +266,7 @@ RSpec.feature "Users can view reports" do
 
       visit reports_path
 
-      expect(page).to have_content t("page_title.report.index")
+      expect(page).to have_content "Reports"
 
       expect_to_see_a_table_of_reports(selector: "#current", reports: reports_awaiting_changes)
       expect_to_see_a_table_of_reports(selector: "#approved", reports: approved_reports)
@@ -281,7 +281,7 @@ RSpec.feature "Users can view reports" do
         expect_to_see_a_table_of_reports(selector: "#current", reports: [report])
 
         within "##{report.id}" do
-          click_on t("default.link.show")
+          click_on "View"
         end
 
         expect(page).to have_content report.financial_quarter
@@ -294,7 +294,7 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within "##{report.id}" do
-          click_on t("default.link.show")
+          click_on "View"
         end
 
         expect(page).to have_content report.description
@@ -322,13 +322,13 @@ RSpec.feature "Users can view reports" do
         travel_to quarter_two_2019 do
           visit reports_path
           within "##{report.id}" do
-            click_on t("default.link.show")
+            click_on "View"
           end
 
-          click_on t("tabs.report.variance.heading")
+          click_on "Variance"
 
-          expect(page).to have_content t("table.header.activity.identifier")
-          expect(page).to have_content t("table.header.activity.forecasted_spend")
+          expect(page).to have_content "RODA Identifier"
+          expect(page).to have_content "Forecasted spend"
           within "##{activity.id}" do
             expect(page).to have_content "£1,000.00"
             expect(page).to have_content "£1,100.00"
@@ -346,8 +346,8 @@ RSpec.feature "Users can view reports" do
 
         visit report_actuals_path(report)
 
-        expect(page.html).to include t("tabs.actuals.upload.copy_html")
-        expect(page).to have_link t("page_content.actuals.button.download_template"),
+        expect(page.html).to include "Large numbers of actuals can be added via the actuals upload."
+        expect(page).to have_link "Download actuals data template",
           href: report_actual_upload_path(report, format: :csv)
         expect(page).to have_link "guidance in the help centre (opens in new tab)",
           href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload"
@@ -363,7 +363,7 @@ RSpec.feature "Users can view reports" do
         within "##{budget.id}" do
           expect(page).to have_content budget.parent_activity.roda_identifier
           expect(page).to have_content budget.value
-          expect(page).to have_link t("default.link.edit"), href: edit_activity_budget_path(budget.parent_activity, budget)
+          expect(page).to have_link "Edit", href: edit_activity_budget_path(budget.parent_activity, budget)
         end
       end
 
@@ -396,13 +396,13 @@ RSpec.feature "Users can view reports" do
 
         visit reports_path
         within "##{report.id}" do
-          click_on t("default.link.show")
+          click_on "View"
         end
 
         expect(page).to have_content("Download a CSV file to review offline.")
         expect(page).to have_link("guidance in the help centre (opens in new tab)")
 
-        click_link t("action.report.download.button")
+        click_link "Download report as CSV file"
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
 

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -18,10 +18,10 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link t("page_title.home"), href: home_path
-      expect(page).to have_link t("page_title.report.index"), href: reports_path
-      expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path, class: "govuk-header__link"
-      expect(page).not_to have_link t("page_title.users.index"), href: users_path
+      expect(page).to have_link "Home", href: home_path
+      expect(page).to have_link "Reports", href: reports_path
+      expect(page).not_to have_link "Organisations", href: organisations_path, class: "govuk-header__link"
+      expect(page).not_to have_link "Users", href: users_path
     end
   end
 
@@ -33,10 +33,10 @@ RSpec.feature "Users can view the site navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
-      expect(page).to have_link t("page_title.home"), href: home_path
-      expect(page).to have_link t("page_title.report.index"), href: reports_path
-      expect(page).to have_link t("page_title.organisation.index"), href: organisations_path
-      expect(page).to have_link t("page_title.users.index"), href: users_path
+      expect(page).to have_link "Home", href: home_path
+      expect(page).to have_link "Reports", href: reports_path
+      expect(page).to have_link "Organisations", href: organisations_path
+      expect(page).to have_link "Users", href: users_path
     end
   end
 end

--- a/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
+++ b/spec/features/staff/users_can_view_third_party_project_level_activities_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view third-party project level activities" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to_not have_content t("default.button.download_as_xml")
+      expect(page).to_not have_content "Download as XML"
     end
 
     scenario "can view and add budgets and actuals on a third-party project" do
@@ -30,8 +30,8 @@ RSpec.feature "Users can view third-party project level activities" do
 
       expect(page).to have_content(budget.value)
       expect(page).to have_content(actual.value)
-      expect(page).to have_content(t("page_content.budgets.button.create"))
-      expect(page).to have_content(t("page_content.actuals.button.create"))
+      expect(page).to have_content("Add budget")
+      expect(page).to have_content("Add an actual")
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.feature "Users can view third-party project level activities" do
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
       expect(page).to have_content third_party_project.title
-      expect(page).to have_no_button t("action.activity.add_child")
+      expect(page).to have_no_button "Add child activity"
     end
 
     scenario "can download a third-party project as XML" do
@@ -53,9 +53,9 @@ RSpec.feature "Users can view third-party project level activities" do
 
       visit organisation_activity_path(third_party_project.organisation, third_party_project)
 
-      expect(page).to have_content t("default.button.download_as_xml")
+      expect(page).to have_content "Download as XML"
 
-      click_on t("default.button.download_as_xml")
+      click_on "Download as XML"
 
       expect(page.response_headers["Content-Type"]).to include("application/xml")
 

--- a/spec/features/user_can_view_static_pages_spec.rb
+++ b/spec/features/user_can_view_static_pages_spec.rb
@@ -5,12 +5,12 @@ RSpec.feature "Users can view the static pages" do
     visit root_path
 
     within "footer" do
-      expect(page).to have_link t("footer.link.privacy_policy"), href: page_path("privacy_policy")
-      expect(page).to have_link t("footer.link.cookie_statement"), href: page_path("cookie_statement")
-      expect(page).to have_link t("footer.link.accessibility_statement"), href: page_path("accessibility_statement")
-      expect(page).to have_link t("footer.link.terms_of_service"), href: page_path("terms_of_service")
-      expect(page).to have_link t("footer.link.service_performance"), href: "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance"
-      expect(page).to have_link t("footer.link.support_site"), href: "https://beisodahelp.zendesk.com/"
+      expect(page).to have_link "Privacy policy", href: page_path("privacy_policy")
+      expect(page).to have_link "Cookies", href: page_path("cookie_statement")
+      expect(page).to have_link "Accessibility statement", href: page_path("accessibility_statement")
+      expect(page).to have_link "Terms of service", href: page_path("terms_of_service")
+      expect(page).to have_link "Service performance", href: "https://beisodahelp.zendesk.com/hc/en-gb/sections/1500001330861-Service-Performance"
+      expect(page).to have_link "Support", href: "https://beisodahelp.zendesk.com/"
     end
   end
 end


### PR DESCRIPTION
We've been finding it quite hard to understand what a test is actually trying to do due to the indirection created by using the translation.

While this may make the tests a bit more brittle, the cost of having to fix a spec if some copy changes is considerably smaller than a developer struggling to understand what a spec is testing.