### PR TITLE
rake users:active:send_password_resets

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,4 +20,12 @@ class UserMailer < ApplicationMailer
       to: user.email,
       subject: t("devise.mailer.reset_password_instructions.subject"))
   end
+
+  def first_time_devise_reset_password_instructions(user, token, opts = {})
+    @token = token
+
+    view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
+      to: user.email,
+      subject: t("devise.mailer.first_time_devise_reset_password_instructions.subject"))
+  end
 end

--- a/app/views/user_mailer/first_time_devise_reset_password_instructions.text.erb
+++ b/app/views/user_mailer/first_time_devise_reset_password_instructions.text.erb
@@ -1,0 +1,17 @@
+Hi All,
+
+As you will already know, BEIS is changing the way you authenticate to RODA. In order to do this you need to set your password now via the link below.
+
+<%= edit_user_password_url(reset_password_token: @token) %>
+
+You will be asked to enter your mobile number for two-factor authentication. You will continue to receive six-digit codes to this mobile number as before.
+
+For reasons of security, we can't transfer your mobile number over automatically.
+
+PLEASE NOTE - You can keep the password you currently use to log into RODA but this must meet these criteria:
+
+<%= t("form.hint.user.new_password") %>
+
+This link will expire in two weeks; after this, you can still reset your password at https://www.report-official-development-assistance.service.gov.uk/users/password/new
+
+Please get in touch with BEIS via Zendesk if you need further support: support@beisodahelp.zendesk.com

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -24,6 +24,8 @@ en:
         subject: "Confirmation instructions"
       reset_password_instructions:
         subject: "Reset password instructions"
+      first_time_devise_reset_password_instructions:
+        subject: "Action required: RODA password reset"
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,14 @@
+desc "Send mass password reset"
+namespace :users do
+  namespace :active do
+    task send_password_resets: :environment do
+      User.active.find_each do |user|
+        puts user.email
+        user_token = user.send(:set_reset_password_token)
+        UserMailer.with(params: {}).first_time_devise_reset_password_instructions(user, user_token).deliver!
+      rescue Notifications::Client::BadRequestError => e
+        warn "Not sending to #{user.email}: #{e}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
A one-time mass email to send password reset links to every RODA user on
migration from Auth0 to Devise.

Run this after deployment of a merged Devise authentication solution.

Co-authored-by: Dragon <david.mckee@dxw.com>

## Screenshot of Email

<img width="581" alt="image" src="https://user-images.githubusercontent.com/194511/158223172-df653050-8933-4624-a648-b2aa161df80d.png">




- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
