### PR TITLE
(2447) On password reset, redirect to login

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -235,7 +235,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      updated_not_active: "Your password has been changed successfully. Please log in with your new password."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."

--- a/spec/features/staff/users_can_reset_password_spec.rb
+++ b/spec/features/staff/users_can_reset_password_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Users can reset their password" do
   scenario "successful password reset" do
     # Given a user exists
-    user = create(:administrator)
+    user = create(:administrator, :mfa_enabled)
 
     # When I follow the reset password link
     visit root_path
@@ -47,7 +47,11 @@ RSpec.feature "Users can reset their password" do
     fill_in "Confirm new password", with: "LlEeTtMmEeIin1!"
     click_on "Change my password"
 
-    # Then my password should be changed and I should be logged in
-    expect(page).to have_content("Your password has been changed successfully. You are now signed in.")
+    # Then I should be asked to log in with my new password
+    expect(page).to have_content("Your password has been changed successfully. Please log in with your new password.")
+
+    # And I should be on the log in page
+    expect(page).to have_field("Email address")
+    expect(page).to have_field("Password")
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Set `Devise.sign_in_after_reset_password = false` in order to ensure users go through the full MFA authentication flow after resetting their password

It's a more Devise-y way of fixing the bug that we previously fixed by hooking into Devise internals.