### PR TITLE
Temporarily extend password reset expiry

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -231,7 +231,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 2.weeks
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.


### PR DESCRIPTION
## Changes in this PR

Extend the password expiry link to 2 weeks. After the 2 weeks is up, we'll bring it back down to a more sensible period.
