### PR TITLE
(2425) Activities can be searched by IATI identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -994,6 +994,7 @@
 - OTP resend for delivery failures
 - Relax user model validation to permit capitalisation changes and whitespace removal from email addresses
 - Use Devise case-insensitive method when retrieving users for authentication
+- Add functionality to search for activities by IATI identifier
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-99...HEAD
 [release-99]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-98...release-99

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -13,7 +13,8 @@ class ActivitySearch
       :roda_identifier,
       :delivery_partner_identifier,
       :beis_identifier,
-      :previous_identifier
+      :previous_identifier,
+      :transparency_identifier
     ]
 
     result = search_fields

--- a/config/locales/views/activity_search.en.yml
+++ b/config/locales/views/activity_search.en.yml
@@ -15,6 +15,6 @@ en:
   form:
     activity_search:
       query: Enter your search query
-      hint: You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title
+      hint: You can search by RODA, Delivery Partner, BEIS, or IATI identifier, or by the activity's title
       heading: Search for activities
       submit: Search

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Users can sign in" do
       expect(page).to have_content("Signed in successfully.")
 
       # And at the home page
-      expect(page).to have_content("You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title")
+      expect(page).to have_content("You can search by RODA, Delivery Partner, BEIS, or IATI identifier, or by the activity's title")
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.feature "Users can sign in" do
         expect(page).to have_content("Signed in successfully.")
 
         # And I should be at the home page
-        expect(page).to have_content("You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title")
+        expect(page).to have_content("You can search by RODA, Delivery Partner, BEIS, or IATI identifier, or by the activity's title")
       end
 
       scenario "unsuccessful OTP attempt" do
@@ -142,7 +142,7 @@ RSpec.feature "Users can sign in" do
         # And I should be logged in at the home page
         expect(page).to have_link(t("header.link.sign_out"))
         expect(page).to have_content("Signed in successfully.")
-        expect(page).to have_content("You can search by RODA, Delivery Partner, or BEIS identifier, or by the activity's title")
+        expect(page).to have_content("You can search by RODA, Delivery Partner, BEIS, or IATI identifier, or by the activity's title")
       end
     end
 

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe ActivitySearch do
       end
     end
 
+    describe "searching for IATI identifiers" do
+      let(:query) { bob_programme.transparency_identifier }
+
+      before do
+        bob_programme.update!(transparency_identifier: "programme-iati-id")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [bob_programme]
+      end
+    end
+
     describe "searching by title" do
       let(:query) { "Search" }
 
@@ -109,6 +121,18 @@ RSpec.describe ActivitySearch do
 
       it "returns nothing" do
         expect(activity_search.results).to match_array []
+      end
+    end
+
+    describe "searching for their own project's IATI identifiers" do
+      let(:query) { alice_project.transparency_identifier }
+
+      before do
+        alice_project.update!(transparency_identifier: "project-iati-id")
+      end
+
+      it "returns the matching activities" do
+        expect(activity_search.results).to match_array [alice_project]
       end
     end
 


### PR DESCRIPTION
## Changes in this PR
- Add functionality to search for activities by IATI identifier

## Screenshots of UI changes

### Before
<img width="878" alt="Screenshot 2022-03-15 at 18 05 39" src="https://user-images.githubusercontent.com/579522/158443122-5a21f108-18f8-402b-931a-68a4b64be53a.png">

### After
<img width="976" alt="Screenshot 2022-03-15 at 17 40 46" src="https://user-images.githubusercontent.com/579522/158443000-1297b703-3957-4fa5-93bc-e3c4c385cd88.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
