### PR TITLE
(2454) Better handling of non-lowercase email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -992,6 +992,8 @@
 - User deactivation via Devise
 - Two-factor authentication via SMS/OTP and a phased login including mobile number provision/confirmation
 - OTP resend for delivery failures
+- Relax user model validation to permit capitalisation changes and whitespace removal from email addresses
+- Use Devise case-insensitive method when retrieving users for authentication
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-99...HEAD
 [release-99]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-98...release-99

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -81,7 +81,7 @@ class Users::SessionsController < Devise::SessionsController
     if session[:otp_user_id]
       User.find(session[:otp_user_id])
     elsif user_params[:email]
-      User.find_by(email: user_params[:email]).tap do |user|
+      User.find_for_authentication(email: user_params[:email]).tap do |user|
         session[:otp_user_id] = user&.id
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   end
 
   def email_cannot_be_changed_after_create
-    if email_changed?
+    if email.to_s.squish.downcase != email_was.to_s.squish.downcase
       errors.add(:email, :cannot_be_changed)
     end
   end

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -180,6 +180,23 @@ RSpec.feature "Users can sign in" do
         expect(page).to have_content("Signed in successfully.")
       end
     end
+
+    scenario "they can sign in using a different capitalisation of their email address" do
+      # Given a user exists
+      user = create(:administrator, :mfa_enabled, email: "forename.lastname@somesite.org")
+
+      # When I go to log in
+      visit root_path
+      click_on t("header.link.sign_in")
+
+      # And I use a different capitalisation of the email than that in the database
+      fill_in "Email", with: "Forename.Lastname@SOMEsite.org"
+      fill_in "Password", with: user.password
+      click_on "Log in"
+
+      # Then I should be prompted for the OTP
+      expect(page).to have_field("Please enter your six-digit verification code")
+    end
   end
 
   scenario "a user is redirected to a link they originally requested" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe User, type: :model do
       expect(user).to be_invalid
       expect(user.errors[:email]).to eq([I18n.t("activerecord.errors.models.user.attributes.email.cannot_be_changed")])
     end
+
+    it "is not case sensitive" do
+      # When a non-lowercase email address exists (Devise lowercases emails on creation so this is for pre-existing addresses)
+      user = create(:delivery_partner_user)
+      user.update_column(:email, "ForenameMacSurname@ClanMacSurname.org")
+      expect(user.email).to eql("ForenameMacSurname@ClanMacSurname.org")
+
+      # And Devise automatically lowercases the address on editing
+      user.email = "forenamemacsurname@clanmacsurname.org"
+
+      expect(user).to be_valid
+    end
   end
 
   describe "associations" do


### PR DESCRIPTION
## Changes in this PR
- Relax user model validation to permit capitalisation changes and whitespace removal from email addresses
- Use Devise case-insensitive method when retrieving users for authentication
 