### PR TITLE
Data migration: lowercase all emails

### DIFF
--- a/db/data/20220317145400_lowercase_all_emails.rb
+++ b/db/data/20220317145400_lowercase_all_emails.rb
@@ -1,0 +1,3 @@
+ActiveRecord::Base.connection.execute(
+  "UPDATE users SET email = LOWER(email)"
+)


### PR DESCRIPTION
Devise expects all emails to be lowercase and whilst it supports
searching for mixed-case emails agains the lowercase emails in the DB
it fails if the DB emails are not already lowercase.

So we force all email addresses to be lowercase.