### PR TITLE
(2460) Catch GOV.UK mobile phone validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1000,6 +1000,7 @@
 
 - Add 'Other ODA' fund
 - Change the HTML title tag of the Users page to be Users, not Home
+- Prevent server errors when a mobile number is invalid
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-100...HEAD
 [release-100]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-99...release-100

--- a/app/views/devise/sessions/mobile_number.html.haml
+++ b/app/views/devise/sessions/mobile_number.html.haml
@@ -9,6 +9,7 @@
             %h1.govuk-fieldset__heading
               Enter your mobile number
 
+          = f.govuk_error_summary
           = f.govuk_text_field :mobile_number, label: { text: "Enter your mobile number" }
 
       .actions

--- a/lib/notify/otp_message.rb
+++ b/lib/notify/otp_message.rb
@@ -3,6 +3,10 @@ module Notify
   # Requires the existence of a NOTIFY_OTP_VERIFICATION_TEMPLATE uuid
   # in the GOV.UK Notify account associated with the client NOTIFY_KEY.
   class OTPMessage
+    attr_accessor :error
+
+    ERROR_ON_PHONE_NUMBER = /ValidationError: phone_number (?<message>.*)/
+
     # @param mobile_number [String] The mobile number to {#deliver} to
     # @param current_otp [String] The six-digit one-time password
     def initialize(mobile_number, current_otp)
@@ -18,6 +22,12 @@ module Notify
         template_id: ENV["NOTIFY_OTP_VERIFICATION_TEMPLATE"],
         personalisation: {otp: @current_otp}
       )
+    rescue Notifications::Client::BadRequestError => e
+      match = ERROR_ON_PHONE_NUMBER.match(e.body)
+      raise unless match
+
+      self.error = match[:message]
+      false
     end
 
     private

--- a/spec/lib/notify/otp_message_spec.rb
+++ b/spec/lib/notify/otp_message_spec.rb
@@ -9,16 +9,44 @@ RSpec.describe Notify::OTPMessage do
   end
 
   describe "#deliver" do
-    before { message.deliver }
+    context "the GOV.UK Notify request is successful" do
+      before { message.deliver }
 
-    it "sends a template ID and personalisation hash to Notify" do
-      expect(fake_client).to have_received(:send_sms).with(
-        {
-          personalisation: {otp: "123456"},
-          phone_number: "+447700900000",
-          template_id: ENV["NOTIFY_OTP_VERIFICATION_TEMPLATE"]
-        }
-      )
+      it "sends a template ID and personalisation hash to Notify" do
+        expect(fake_client).to have_received(:send_sms).with(
+          {
+            personalisation: {otp: "123456"},
+            phone_number: "+447700900000",
+            template_id: ENV["NOTIFY_OTP_VERIFICATION_TEMPLATE"]
+          }
+        )
+      end
+    end
+
+    context "GOV.UK returns a phone number validation error" do
+      let(:govuk_response) { double("Response", code: 400, body: "ValidationError: phone_number Not enough digits") }
+
+      before do
+        allow(fake_client).to receive(:send_sms).and_raise(Notifications::Client::BadRequestError.new(govuk_response))
+
+        message.deliver
+      end
+
+      it "captures the error and repackages it" do
+        expect(message.error).to eql("Not enough digits")
+      end
+    end
+
+    context "GOV.UK returns any other kind of error" do
+      let(:govuk_response) { double("Response", code: 400, body: "ValidationError: everything went wrong") }
+
+      before do
+        allow(fake_client).to receive(:send_sms).and_raise(Notifications::Client::BadRequestError.new(govuk_response))
+      end
+
+      it "lets the error bubble up" do
+        expect { message.deliver }.to raise_error(Notifications::Client::BadRequestError)
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Prevent server errors when a mobile number is invalid

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
