### PR TITLE
Remove UserNotAuthorised paraphernalia

### DIFF
--- a/app/controllers/concerns/auth.rb
+++ b/app/controllers/concerns/auth.rb
@@ -1,5 +1,3 @@
-class UserNotAuthorised < StandardError; end
-
 module Auth
   extend ActiveSupport::Concern
 
@@ -7,13 +5,8 @@ module Auth
     helper_method :current_user
     helper_method :authenticated?
 
-    rescue_from(UserNotAuthorised, Pundit::NotAuthorizedError) do |exception|
-      error_message = if exception.respond_to?(:policy)
-        t("#{exception.policy.class.to_s.underscore}.#{exception.query}", scope: "not_authorised", default: :default)
-      else
-        t("page_content.errors.not_authorised.explanation")
-      end
-
+    rescue_from(Pundit::NotAuthorizedError) do |exception|
+      error_message = t("page_content.errors.not_authorised.explanation")
       render "pages/errors/not_authorised", formats: [:html], status: 401, locals: {error_message: error_message}
     end
   end

--- a/spec/features/staff/users_can_create_a_comment_spec.rb
+++ b/spec/features/staff/users_can_create_a_comment_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Users can create a comment" do
           let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:delivery_partner_organisation)) }
           scenario "the user cannot add a comment" do
             visit report_path(report)
-            expect(page).to have_content t("not_authorised.default")
+            expect(page).to have_content t("page_title.errors.not_authorised")
           end
         end
       end


### PR DESCRIPTION
Context for change, from
https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1599#discussion_r818889659

Because we've removed the only thing that could raise `UserNotAuthorised` and the only usage of it is on L10 of `app/controllers/concerns/auth.rb`, we should remove the class and also the branch of the if on L11 that does not respond to `:policy`

We also update the text one spec expected to see.

@rgarner: The card implies that there's more to do, but I couldn't find a loose thread to pull, so I expect this isn't fully done.
