### PR TITLE
Add sector category codes to radio buttons when adding a new activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1006,6 +1006,7 @@
 ## [unreleased] ...
 
 - Fix bug where Remember me was not working for users logging in with MFA
+- Add sector and sector category codes to radio button text when adding a new activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-101...HEAD
 [release-101]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-100...release-101

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -47,7 +47,8 @@ module CodelistHelper
   end
 
   def sector_category_radio_options
-    Codelist.new(type: "sector_category").to_objects(with_empty_item: false)
+    list = Codelist.new(type: "sector_category").to_objects(with_empty_item: false)
+    list.each { |item| item.name = "#{item.name} (#{item.code})" }
   end
 
   def sector_radio_options(category: nil)


### PR DESCRIPTION
We change the text displayed on the sector category page from
Administrative Costs of Donors
to
Administrative Costs of Donors (910)

We keep the formatting of the Channel of Delivery codes like
11000: Donor Government
because that way both lists are sorted -- Channel of Delivery by hierarchial
order, and Sector and Sector Category codes in alphabetical order.

What the best behaviour is is open to discussion.

## Screenshots of UI changes

Additional context pictures in the [Trello card](https://trello.com/c/Aoiqius3/2423-add-numeric-codes-to-codelists-in-ui-and-export).

### Before

![image](https://user-images.githubusercontent.com/85497046/159746134-8c6887c2-9e27-41bc-a2da-820f1256a8c7.png)

### After

![image](https://user-images.githubusercontent.com/85497046/159746278-6f8cf084-f6a9-4785-b96c-ad4836ff58d2.png)

## Next steps

- [X] Is a changelog entry required? 
