### PR TITLE
2423: Add numeric codes to fields in report export, add Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1013,6 +1013,7 @@
 - Rename `activity.comments` association to better reflect its purpose of collecting all comments on an
 activity and on its child transactions (which can be actuals, refunds, and adjustments)
 - Remove Auth0 user identifier from user management
+- Add sector and sector category codes to radio button text when adding a new activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-102...HEAD
 [release-102]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-101...release-102

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -47,12 +47,13 @@ module CodelistHelper
   end
 
   def sector_category_radio_options
-    Codelist.new(type: "sector_category").to_objects(with_empty_item: false)
+    list = Codelist.new(type: "sector_category").to_objects(with_empty_item: false)
+    list.each { |item| item.name = "#{item.code}: #{item.name}" }
   end
 
   def sector_radio_options(category: nil)
     options = Codelist.new(type: "sector").to_objects_with_categories
-    options.each { |option| option.name = "#{option.name} (#{option.code})" }
+    options.each { |option| option.name = "#{option.code}: #{option.name}" }
     if category.present?
       options.filter { |sector| sector.category == category.to_s }
     else

--- a/app/models/codelist.rb
+++ b/app/models/codelist.rb
@@ -77,7 +77,7 @@ class Codelist
 
   def to_objects_with_description(code_displayed_in_name: false, entity: "activity", type: "")
     data = list.collect { |item|
-      name = code_displayed_in_name ? "#{item["name"]} (#{item["code"]})" : item["name"]
+      name = code_displayed_in_name ? "#{item["code"]}: #{item["name"]}" : item["name"]
       description = I18n.t("form.hint.activity.options.#{type}.#{item["code"]}", default: item["description"])
 
       OpenStruct.new(name: name, code: item["code"], description: description)

--- a/app/models/export/activity_attributes_columns.rb
+++ b/app/models/export/activity_attributes_columns.rb
@@ -29,9 +29,8 @@ class Export::ActivityAttributesColumns
   def rows
     return [] if @activities.empty?
     @activities.map { |activity|
-      values = @attributes.map { |att|
-        ActivityCsvPresenter.new(activity).send(att)
-      }
+      presenter = ActivityCsvPresenter.new(activity)
+      values = @attributes.map { |att| presenter.send(att) }
       [activity.id, values]
     }.to_h
   end

--- a/app/models/export/activity_attributes_columns.rb
+++ b/app/models/export/activity_attributes_columns.rb
@@ -19,7 +19,7 @@ class Export::ActivityAttributesColumns
 
   def initialize(activities:, attributes:)
     @activities = activities
-    @attributes = clean_attrbutes(attributes)
+    @attributes = clean_attributes(attributes)
   end
 
   def headers
@@ -37,7 +37,7 @@ class Export::ActivityAttributesColumns
 
   private
 
-  def clean_attrbutes(attributes)
+  def clean_attributes(attributes)
     attributes.reject do |att|
       next if DYNAMIC_ATTRIBUTES.include?(att)
       attribute_error(att) unless Activity.has_attribute?(att)

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -27,10 +27,28 @@ class ActivityCsvPresenter < ActivityPresenter
     super ? "yes" : "no"
   end
 
-  # We want the sectors to be displayed with their codes
+  # We want the sectors, aid type and flow to be displayed with their codes
+  # so we replicate X_with_code without creating an infinite loop
   def sector
     return if super.blank?
     "#{to_model.sector}: #{super}"
+  end
+
+  def aid_type
+    return if super.blank?
+    "#{to_model.aid_type}: #{super}"
+  end
+
+  def flow
+    "#{to_model.flow}: #{super}"
+  end
+
+  def finance
+    "#{to_model.finance}: #{super}"
+  end
+
+  def tied_status
+    "#{to_model.tied_status}: #{super}"
   end
 
   private

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -27,6 +27,12 @@ class ActivityCsvPresenter < ActivityPresenter
     super ? "yes" : "no"
   end
 
+  # We want the sectors to be displayed with their codes
+  def sector
+    return if super.blank?
+    "#{to_model.sector}: #{super}"
+  end
+
   private
 
   def list_of_benefitting_countries(country_code_list)

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -11,7 +11,7 @@ class ActivityPresenter < SimpleDelegator
 
   def aid_type_with_code
     return if aid_type.blank?
-    "#{aid_type} (#{to_model.aid_type})"
+    "#{to_model.aid_type}: #{aid_type}"
   end
 
   def covid19_related
@@ -114,7 +114,7 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def flow_with_code
-    "#{flow} (#{to_model.flow})"
+    "#{to_model.flow}: #{flow}"
   end
 
   def policy_marker_gender
@@ -220,12 +220,20 @@ class ActivityPresenter < SimpleDelegator
     custom_capitalisation(activity_level)
   end
 
+  def tied_status
+    translate("activity.tied_status.#{super}")
+  end
+
   def tied_status_with_code
-    "#{translate("activity.tied_status.#{tied_status}")} (#{tied_status})"
+    "#{to_model.tied_status}: #{translate("activity.tied_status.#{to_model.tied_status}")}"
+  end
+
+  def finance
+    translate("activity.finance.#{super}")
   end
 
   def finance_with_code
-    "#{translate("activity.finance.#{finance}")} (#{finance})"
+    "#{to_model.finance}: #{translate("activity.finance.#{to_model.finance}")}"
   end
 
   def fund_pillar

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -25,7 +25,7 @@ class ActivityPresenter < SimpleDelegator
 
   def sector_with_code
     return if sector.blank?
-    "#{sector} (#{to_model.sector})"
+    "#{to_model.sector}: #{sector}"
   end
 
   def call_present

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -54,17 +54,17 @@ RSpec.describe CodelistHelper, type: :helper do
         options = helper.sector_radio_options
 
         expect(options.length).to eq 295
-        expect(options).to include OpenStruct.new(name: "Women's rights organisations and movements, and government institutions (15170)", code: "15170", category: "151")
-        expect(options).to include OpenStruct.new(name: "Action relating to debt (60010)", code: "60010", category: "600")
+        expect(options).to include OpenStruct.new(name: "15170: Women's rights organisations and movements, and government institutions", code: "15170", category: "151")
+        expect(options).to include OpenStruct.new(name: "60010: Action relating to debt", code: "60010", category: "600")
       end
 
       it "returns only the sectors from the category when one is passed" do
         options = helper.sector_radio_options(category: 112)
 
         expect(options.length).to eq 7
-        expect(options).to include OpenStruct.new(name: "Basic life skills for youth (11231)", code: "11231", category: "112")
-        expect(options).to include OpenStruct.new(name: "School feeding (11250)", code: "11250", category: "112")
-        expect(options).not_to include OpenStruct.new(name: "Immediate post-emergency reconstruction and rehabilitation", code: "73010", category: "730")
+        expect(options).to include OpenStruct.new(name: "11231: Basic life skills for youth", code: "11231", category: "112")
+        expect(options).to include OpenStruct.new(name: "11250: School feeding", code: "11250", category: "112")
+        expect(options).not_to include OpenStruct.new(name: "73010: Immediate post-emergency reconstruction and rehabilitation", code: "73010", category: "730")
       end
     end
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe CodelistHelper, type: :helper do
         options = helper.aid_type_radio_options
 
         expect(options.length).to eq 8
-        expect(options.first.name).to eq "Core contributions to multilateral institutions (B02)"
-        expect(options.last.name).to eq "Administrative costs not included elsewhere (G01)"
+        expect(options.first.name).to eq "B02: Core contributions to multilateral institutions"
+        expect(options.last.name).to eq "G01: Administrative costs not included elsewhere"
       end
     end
 

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe ActivityCsvPresenter do
+  describe "#sector" do
+    context "when there is a non-empty sector" do
+      it "returns 'sector code: description'" do
+        activity = build(:project_activity, sector: 11110)
+        result = described_class.new(activity).sector
+        expect(result).to eq("11110: Education policy and administrative management")
+      end
+    end
+  end
+
   describe "#benefitting_countries" do
     context "when there are benefitting countries" do
       it "returns the benefitting countries separated by semicolons" do

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -11,6 +11,46 @@ RSpec.describe ActivityCsvPresenter do
     end
   end
 
+  describe "#aid_type" do
+    context "when there is a non-empty aid_type" do
+      it "returns 'aid type code: description'" do
+        activity = build(:project_activity, aid_type: "D02")
+        result = described_class.new(activity).aid_type
+        expect(result).to eq("D02: Other technical assistance")
+      end
+    end
+  end
+
+  describe "#flow" do
+    context "when there is a non-empty flow" do
+      it "returns 'flow code: description'" do
+        activity = build(:project_activity)
+        result = described_class.new(activity).flow
+        expect(result).to eq("10: ODA")
+      end
+    end
+  end
+
+  describe "#finance" do
+    context "when there is a non-empty finance" do
+      it "returns 'finance code: description'" do
+        activity = build(:project_activity)
+        result = described_class.new(activity).finance
+        expect(result).to eq("110: Standard grant")
+      end
+    end
+  end
+
+  describe "#tied_status" do
+    context "when there is a non-empty tied status" do
+      it "returns 'tied status code: description'" do
+        activity = build(:project_activity)
+        result = described_class.new(activity).tied_status
+        expect(result).to eq("5: Untied")
+      end
+    end
+  end
+
   describe "#benefitting_countries" do
     context "when there are benefitting countries" do
       it "returns the benefitting countries separated by semicolons" do

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe ActivityPresenter do
 
   describe "#aid_type_with_code" do
     context "when the aid_type exists" do
-      it "returns the locale value for the code with the code in brackets" do
+      it "returns the code and the locale value separated by a colon" do
         activity = build(:project_activity, aid_type: "A01")
         result = described_class.new(activity).aid_type_with_code
-        expect(result).to eql("General budget support (A01)")
+        expect(result).to eql("A01: General budget support")
       end
     end
 
@@ -415,7 +415,7 @@ RSpec.describe ActivityPresenter do
   describe "#flow_with_code" do
     it "returns the default flow string & code number" do
       fund = create(:project_activity)
-      expect(described_class.new(fund).flow_with_code).to eql("ODA (10)")
+      expect(described_class.new(fund).flow_with_code).to eql("10: ODA")
     end
   end
 
@@ -634,16 +634,16 @@ RSpec.describe ActivityPresenter do
   end
 
   describe "#tied_status_with_code" do
-    it "returns the tied status string & code number" do
+    it "returns the code number & tied status string" do
       fund = create(:project_activity)
-      expect(described_class.new(fund).tied_status_with_code).to eql("Untied (5)")
+      expect(described_class.new(fund).tied_status_with_code).to eql("5: Untied")
     end
   end
 
   describe "#finance_with_code" do
-    it "returns the finance string & code number" do
+    it "returns the code number & finance string" do
       fund = create(:project_activity)
-      expect(described_class.new(fund).finance_with_code).to eql("Standard grant (110)")
+      expect(described_class.new(fund).finance_with_code).to eql("110: Standard grant")
     end
   end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe ActivityPresenter do
 
   describe "#sector_with_code" do
     context "when the sector exists" do
-      it "returns the locale value for the code with the code in brackets" do
+      it "returns the code followed by the locale value separated by a colon" do
         activity = build(:project_activity, sector: "11110")
         result = described_class.new(activity).sector_with_code
-        expect(result).to eql("Education policy and administrative management (11110)")
+        expect(result).to eql("11110: Education policy and administrative management")
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

When viewing the CSV export of a Report or creating a new activity, the Sector, Sector Category, Aid Type, Flow, Finance Type, and Tied Status codes are given in a similar format to the Channel of Delivery codes (e.g. `1234: Kittens and other felines`)

## Screenshots of UI changes

<img width="365" alt="image" src="https://user-images.githubusercontent.com/85497046/160158407-ee7e7534-96cf-46e1-9a87-b13bf423829a.png">

![image](https://user-images.githubusercontent.com/85497046/160158679-5c94fa07-0dde-4ccc-9725-55496cbe997e.png)

![image](https://user-images.githubusercontent.com/85497046/160158746-15bbafab-090c-4a5a-9499-13c8ce7cb3ad.png)

## Next steps

- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
