### PR TITLE
Make refund form validate numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1014,6 +1014,7 @@
 activity and on its child transactions (which can be actuals, refunds, and adjustments)
 - Remove Auth0 user identifier from user management
 - Add sector and sector category codes to radio button text when adding a new activity
+- Fix an error where a new refund creation would silently fail when the value was non-numeric
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-102...HEAD
 [release-102]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-101...release-102

--- a/app/models/refund_form.rb
+++ b/app/models/refund_form.rb
@@ -6,7 +6,7 @@ class RefundForm
 
   validates :financial_quarter, presence: true
   validates :financial_year, presence: true
-  validates :value, presence: true
+  validates :value, presence: true, numericality: {other_than: 0, less_than_or_equal_to: 99_999_999_999.00}
   validates :comment, presence: true
 
   def initialize(params = {})

--- a/spec/features/staff/users_can_create_a_refund_spec.rb
+++ b/spec/features/staff/users_can_create_a_refund_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature "Users can create a refund" do
       given_i_am_on_the_new_refund_form
       and_i_submit_the_new_refund_form_incorrectly
       then_i_expect_to_see_how_i_need_to_correct_the_refund_form
+      when_i_submit_the_new_refund_form_with_a_non_numeric_value
+      then_i_should_see_that_my_value_was_non_numeric
     end
   end
 
@@ -55,10 +57,23 @@ RSpec.feature "Users can create a refund" do
     )
   end
 
+  def when_i_submit_the_new_refund_form_with_a_non_numeric_value
+    @refund_form.complete(
+      value: "I am not numerical",
+      financial_quarter: 4,
+      financial_year: 2019,
+      comment: "Comment goes here"
+    )
+  end
+
   def then_i_expect_to_see_how_i_need_to_correct_the_refund_form
     expect(page).to have_content("Select a financial quarter")
     expect(page).to have_content("Select a financial year")
     expect(page).to have_content("Enter a refund amount")
+  end
+
+  def then_i_should_see_that_my_value_was_non_numeric
+    expect(page).to have_content("Refund amount must be a valid number")
   end
 
   def then_a_new_refund_should_be_created


### PR DESCRIPTION
## Changes in this PR

This validation wasn't being copied up from the object, and so `CreateRefund`
was silently failing. Copy the validation up to fix this error.

In addition, make sure further mismatches between RefundForm and
CreateRefund can't silently fail by checking the return value of
CreateRefund#call.

Co-authored-by: Cristina Rotaru <cristina@dxw.com>

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
