### PR TITLE
Remove users.identifier / mashed potato from our hair*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1012,6 +1012,7 @@
 - Add bulk uploading to Refunds via the Actual importer
 - Rename `activity.comments` association to better reflect its purpose of collecting all comments on an
 activity and on its child transactions (which can be actuals, refunds, and adjustments)
+- Remove Auth0 user identifier from user management
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-102...HEAD
 [release-102]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-101...release-102

--- a/app/views/staff/users/show.html.haml
+++ b/app/views/staff/users/show.html.haml
@@ -27,11 +27,6 @@
             = @user.organisation.name
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            = t("summary.label.user.identifier")
-          %dd.govuk-summary-list__value
-            = @user.identifier
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
             = t("summary.label.user.active")
           %dd.govuk-summary-list__value
             = t("form.user.active.#{@user.active}")

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -46,7 +46,6 @@ en:
       user:
         name: Full name
         email: Email address
-        identifier: Identifier
         organisation: Organisation
         active: Active?
         confirmed_for_mfa:

--- a/db/migrate/20220328164915_remove_users_identifier.rb
+++ b/db/migrate/20220328164915_remove_users_identifier.rb
@@ -1,0 +1,5 @@
+class RemoveUsersIdentifier < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :identifier, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_01_145502) do
+ActiveRecord::Schema.define(version: 2022_03_28_164915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -314,7 +314,6 @@ ActiveRecord::Schema.define(version: 2022_03_01_145502) do
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "identifier"
     t.string "name"
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
@@ -329,11 +328,10 @@ ActiveRecord::Schema.define(version: 2022_03_01_145502) do
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
+    t.boolean "otp_required_for_login", default: true
     t.string "mobile_number"
     t.datetime "mobile_number_confirmed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.boolean "otp_required_for_login", default: true
-    t.index ["identifier"], name: "index_users_on_identifier"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :administrator, class: "User" do
-    identifier { SecureRandom.uuid }
     name { Faker::Name.name }
     email { Faker::Internet.email }
     active { true }

--- a/spec/features/staff/users_can_sign_in_spec.rb
+++ b/spec/features/staff/users_can_sign_in_spec.rb
@@ -328,7 +328,7 @@ RSpec.feature "Users can sign in" do
 
   context "when the user has been deactivated" do
     scenario "the user cannot log in and sees an informative message" do
-      user = create(:delivery_partner_user, active: false, identifier: "deactivated-user")
+      user = create(:delivery_partner_user, active: false)
 
       visit root_path
       log_in_via_form(user)

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -2,10 +2,6 @@ module AuthenticationHelpers
   include Warden::Test::Helpers
 
   def authenticate!(user: build_stubbed(:administrator))
-    allow(User).to receive(:find_by)
-      .with(identifier: user.identifier)
-      .and_return(user)
-
     login_as(user, scope: :user)
   end
 end


### PR DESCRIPTION
## Changes in this PR

The last legacy of Auth0. Also remove:

- a mock still allowing it
- factory still setting it
- user view still displaying it
- a translation serving the view
- a spec still using one

\* Thanks @CristinaRO 
 
## Screenshots of UI changes

### Before

Imagine the identifier field, on the users show page

### After

Now imagine it gone

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
