### PR TITLE
Fix attempt to use an unloaded gem

### DIFF
--- a/app/controllers/concerns/hide_from_bullet.rb
+++ b/app/controllers/concerns/hide_from_bullet.rb
@@ -1,9 +1,11 @@
 module HideFromBullet
   def skip_bullet
-    previous_value = Bullet.enable?
-    Bullet.enable = false
+    if defined?(Bullet)
+      previous_value = Bullet.enable?
+      Bullet.enable = false
+    end
     yield
   ensure
-    Bullet.enable = previous_value
+    Bullet.enable = previous_value if defined?(Bullet)
   end
 end


### PR DESCRIPTION
## Changes in this PR

- The gem `bullet` is only bundled for test and development environments,
so when skipping it we first need to make sure it’s defined.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
