### PR TITLE
(2455) SPIKE: Sort organisations by active status first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1023,6 +1023,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Organisations are sorted by active status on the organisations page (applies to all types of organisation: delivery partner, matched effort providers, external income providers, and implementing organisations)
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-104...HEAD
 [release-104]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-103...release-104
 [release-103]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-102...release-103

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -38,10 +38,11 @@ class Organisation < ApplicationRecord
     if: proc { |organisation| organisation.is_reporter? },
     format: {with: /\A[A-Z]{2,5}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
 
+  scope :sorted_by_active, -> { order(active: :desc) }
   scope :sorted_by_name, -> { order(name: :asc) }
-  scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
-  scope :matched_effort_providers, -> { sorted_by_name.where(role: "matched_effort_provider") }
-  scope :external_income_providers, -> { sorted_by_name.where(role: "external_income_provider") }
+  scope :delivery_partners, -> { sorted_by_active.sorted_by_name.where(role: "delivery_partner") }
+  scope :matched_effort_providers, -> { sorted_by_active.sorted_by_name.where(role: "matched_effort_provider") }
+  scope :external_income_providers, -> { sorted_by_active.sorted_by_name.where(role: "external_income_provider") }
   scope :implementing, -> {
     where(<<~SQL
       organisations.id IN
@@ -61,7 +62,7 @@ class Organisation < ApplicationRecord
       )
     SQL
          )
-      .sorted_by_name
+      .sorted_by_active.sorted_by_name
   }
   scope :reporters, -> { sorted_by_name.where(role: ["delivery_partner", "service_owner"]) }
   scope :active, -> { where(active: true) }

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -25,6 +25,8 @@
                 %th.govuk-table__header
                   =t("table.header.organisation.beis_organisation_reference")
                 %th.govuk-table__header
+                  = t("table.header.organisation.active")
+                %th.govuk-table__header
                   %span.govuk-visually-hidden
                     = t("table.header.default.actions")
 
@@ -33,6 +35,7 @@
                 %tr.govuk-table__row.organisation{id: organisation.id}
                   %td.govuk-table__cell= organisation.name
                   %td.govuk-table__cell= organisation.beis_organisation_reference
+                  %td.govuk-table__cell= t("form.label.organisation.active.#{organisation.active}")
                   %td.govuk-table__cell
                     - if policy(organisation).show?
                       = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -32,6 +32,7 @@ en:
         name: Name
         iati_reference: International Aid Transparency Initiative (IATI) reference
         beis_organisation_reference: Short name
+        active: Active?
   tabs:
     organisations:
       implementing_organisations: Implementing organisations


### PR DESCRIPTION
## Changes in this PR
- Organisations are sorted by active status on the organisations page (applies to all types of organisation: delivery partner, matched effort providers, external income providers, and implementing organisations)

## Screenshots of UI changes

### After
<img width="1129" alt="Screenshot 2022-03-30 at 13 49 25" src="https://user-images.githubusercontent.com/579522/160839609-3ae290ca-4f33-4e7d-899b-f60b56b96d79.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
