### PR TITLE
(2474) Declare rememberable user token on statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1025,6 +1025,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Validate XML against IATI schema on export
 - Fix some accessibility issues with tables and tab lists
+- Declare `remember_user_token` on cookies statement
+- Fix declared duration of default session from 24 hours to the actual value of 12 hours
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-104...HEAD
 [release-104]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-103...release-104

--- a/app/views/pages/cookie_statement.html.haml
+++ b/app/views/pages/cookie_statement.html.haml
@@ -76,18 +76,35 @@
           %tr.govuk-table__row
             %td.govuk-table__cell{scope: "row"} _roda_session
             %td.govuk-table__cell Identifies your session in RODA
-            %td.govuk-table__cell When you close your browser or 24 hours
+            %td.govuk-table__cell When you close your browser or 12 hours
           %tr.govuk-table__row
             %td.govuk-table__cell{scope: "row"} govuk-cookie-consent
             %td.govuk-table__cell Identifies if cookies have been accepted or not
             %td.govuk-table__cell 90 days
 
+      %h2.govuk-heading-m
+        Functional cookies
+
+      %p.govuk-body
+        These cookies are used to enhance your use of the service by remembering your choices:
+
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "col"} Name
+            %th.govuk-table__header{scope: "col"} Purpose
+            %th.govuk-table__header{scope: "col"} Expires
+        %tbody.govuk-table__body
+          %tr.govuk-table__row
+            %td.govuk-table__cell{scope: "row"} remember_user_token
+            %td.govuk-table__cell Remembers your RODA login if you selected "Remember me" when signing in
+            %td.govuk-table__cell 30 days
 
       %h2.govuk-heading-m
         Gathering your feedback
 
       %p.govuk-body
-        We use google forms software to collect information about what you
+        We use Google Forms software to collect information about what you
         thought of the RODA service. We do this to help make sure the site is
         meeting the needs of its users and to help us make improvements.
 
@@ -105,4 +122,4 @@
             reloading this page
 
       %p.govuk-body.published-dates
-        Last updated 21 May 2020
+        Last updated 31 March 2022


### PR DESCRIPTION
## Changes in this PR
- Declare `remember_user_token` on cookies statement
- Fix declared duration of default session from 24 hours to the actual value of 12 hours

## Screenshots of UI changes

### Before

<img width="1161" alt="Screenshot 2022-03-31 at 12 00 37" src="https://user-images.githubusercontent.com/579522/161040578-9d8744d6-7e0c-4c2b-a8d5-6b84dbeaeff8.png">

### After

<img width="1137" alt="Screenshot 2022-03-31 at 11 59 31" src="https://user-images.githubusercontent.com/579522/161040459-d6d4925c-58c9-4fed-83da-c8dc1e3652f2.png">

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
