### PR TITLE
Sort organisations by active status first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1027,6 +1027,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Fix some accessibility issues with tables and tab lists
 - Declare `remember_user_token` on cookies statement
 - Fix declared duration of default session from 24 hours to the actual value of 12 hours
+- Organisations are sorted by active status on the organisations page (applies to all types of organisation: delivery partner, matched effort providers, external income providers, and implementing organisations)
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-104...HEAD
 [release-104]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-103...release-104

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -38,10 +38,11 @@ class Organisation < ApplicationRecord
     if: proc { |organisation| organisation.is_reporter? },
     format: {with: /\A[A-Z]{2,5}\z/, message: I18n.t("activerecord.errors.models.organisation.attributes.beis_organisation_reference.format")}
 
+  scope :sorted_by_active, -> { order(active: :desc) }
   scope :sorted_by_name, -> { order(name: :asc) }
-  scope :delivery_partners, -> { sorted_by_name.where(role: "delivery_partner") }
-  scope :matched_effort_providers, -> { sorted_by_name.where(role: "matched_effort_provider") }
-  scope :external_income_providers, -> { sorted_by_name.where(role: "external_income_provider") }
+  scope :delivery_partners, -> { sorted_by_active.sorted_by_name.where(role: "delivery_partner") }
+  scope :matched_effort_providers, -> { sorted_by_active.sorted_by_name.where(role: "matched_effort_provider") }
+  scope :external_income_providers, -> { sorted_by_active.sorted_by_name.where(role: "external_income_provider") }
   scope :implementing, -> {
     where(<<~SQL
       organisations.id IN
@@ -61,7 +62,7 @@ class Organisation < ApplicationRecord
       )
     SQL
          )
-      .sorted_by_name
+      .sorted_by_active.sorted_by_name
   }
   scope :reporters, -> { sorted_by_name.where(role: ["delivery_partner", "service_owner"]) }
   scope :active, -> { where(active: true) }

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -31,7 +31,10 @@
             %tbody.govuk-table__body
               - organisations.each do |organisation|
                 %tr.govuk-table__row.organisation{id: organisation.id}
-                  %td.govuk-table__cell= organisation.name
+                  %td.govuk-table__cell
+                    = organisation.name
+                    - unless organisation.active
+                      %span.govuk-tag.govuk-tag--grey= t('form.label.organisation.active.false')
                   %td.govuk-table__cell= organisation.beis_organisation_reference
                   %td.govuk-table__cell
                     - if policy(organisation).show?

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -32,6 +32,7 @@ en:
         name: Name
         iati_reference: International Aid Transparency Initiative (IATI) reference
         beis_organisation_reference: Short name
+        active: Active?
   tabs:
     organisations:
       implementing_organisations: Implementing organisations

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -66,16 +66,22 @@ RSpec.feature "BEIS users can view other organisations" do
     let!(:delivery_partner_organisations) { create_list(:delivery_partner_organisation, 3) }
     let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
     let!(:external_income_provider_organisations) { create_list(:external_income_provider, 2) }
-    let!(:implementing_organisations) do
-      2.times {
+    before do
+      [
+        {name: "Z_is_active", active: true},
+        {name: "A_is_inactive", active: false}
+      ].each do |attrs|
         create(:implementing_organisation).tap do |org|
           OrgParticipation.create(
             organisation: org,
             activity: create(:project_activity),
             role: "implementing"
           )
+          org.active = attrs[:active]
+          org.name = attrs[:name]
+          org.save!
         end
-      }
+      end
     end
 
     before do
@@ -100,6 +106,9 @@ RSpec.feature "BEIS users can view other organisations" do
           end
           expect(page).to have_css(".organisation", count: Organisation.implementing.count)
           then_breadcrumb_shows_type_of_organisation(name: "Implementing organisations")
+          # check that inactive organisations come after active ones
+          # despite alphabetical order
+          expect(page.text).to match(/Z_is_active.*A_is_inactive/m)
         end
       end
 


### PR DESCRIPTION
## Changes in this PR
- Organisations are sorted by active status on the organisations page (applies to all types of organisation: delivery partner, matched effort providers, external income providers, and implementing organisations)

## Screenshots of UI changes

### After
![image](https://user-images.githubusercontent.com/85497046/161057788-44f07523-98b5-4dc8-bcce-5043b3e55ed1.png)

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
