### PR TITLE
(2475) Fix some accessibility issues with tables and tab lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1024,6 +1024,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Validate XML against IATI schema on export
+- Fix some accessibility issues with tables and tab lists
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-104...HEAD
 [release-104]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-103...release-104

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,7 @@ module ApplicationHelper
   end
 
   def breadcrumb_tags
-    content_tag :div, class: "govuk-breadcrumbs" do
+    content_tag :nav, class: "govuk-breadcrumbs", aria: {label: "Breadcrumbs"} do
       content_tag :ol, class: "govuk-breadcrumbs__list" do
         render_breadcrumbs tag: :li, separator: ""
       end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -49,7 +49,7 @@
               = t('app.title')
 
     .govuk-width-container
-      .govuk-phase-banner
+      .govuk-phase-banner{role: "region", aria: { label: "Beta: feedback requested" }}
         %p.govuk-phase-banner__content
           %strong.govuk-tag.govuk-phase-banner__content__tag
             beta

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -14,7 +14,7 @@
         = t("document_title.activity.index", delivery_partner_name: @organisation.name)
 
       .govuk-tabs
-        %ul.govuk-tabs__list
+        %ul.govuk-tabs__list{role: "tablist"}
           %li.govuk-tabs__list-item
             = link_to t("tabs.activities.current"),
               organisation_activities_path(@organisation),

--- a/app/views/staff/activities/historic.html.haml
+++ b/app/views/staff/activities/historic.html.haml
@@ -18,12 +18,12 @@
           %li.govuk-tabs__list-item
             = link_to t("tabs.activities.current"),
               organisation_activities_path(@organisation),
-              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { selected: false } }
 
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected
             = link_to t("tabs.activities.historic"),
               historic_organisation_activities_path(@organisation),
-              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "historic", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { selected: true } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -4,7 +4,7 @@
       %h2.govuk-tabs__title
         Organisations
 
-      %ul.govuk-tabs__list
+      %ul.govuk-tabs__list{role: "tablist"}
         - ["delivery_partners", "matched_effort_providers", "external_income_providers", "implementing_organisations"].each do |role|
           %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
             = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { selected: (role == @role) } }

--- a/app/views/staff/organisations/_table.html.haml
+++ b/app/views/staff/organisations/_table.html.haml
@@ -7,7 +7,7 @@
       %ul.govuk-tabs__list
         - ["delivery_partners", "matched_effort_providers", "external_income_providers", "implementing_organisations"].each do |role|
           %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
-            = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: (role == @role) } }
+            = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { selected: (role == @role) } }
 
       .govuk-tabs__panel
         %h2.govuk-heading-l

--- a/app/views/staff/shared/activities/_tab_nav_item.html.haml
+++ b/app/views/staff/shared/activities/_tab_nav_item.html.haml
@@ -1,4 +1,4 @@
 - selected = (@tab_name == tab)
 %li{role: "presentation", class: ["govuk-tabs__list-item", ("govuk-tabs__list-item--selected" if selected)] }
   = link_to t(tab, scope: "tabs.activity"), path,
-    { class: "govuk-tabs__tab", role: "tab", aria: { controls: tab, selected: selected } }
+    { class: "govuk-tabs__tab", role: "tab", aria: { selected: selected } }

--- a/app/views/staff/shared/activities/_table.html.haml
+++ b/app/views/staff/shared/activities/_table.html.haml
@@ -9,12 +9,12 @@
           %li.govuk-tabs__list-item.govuk-tabs__list-item--selected{role: "presentation"}
             = link_to t("tabs.activities.current"),
               organisation_activities_path(@organisation),
-              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "current", selected: true } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { selected: true } }
 
           %li.govuk-tabs__list-item{role: "presentation"}
             = link_to t("tabs.activities.historic"),
               historic_organisation_activities_path(@organisation),
-              { class: "govuk-tabs__tab", role: "tab", aria: { controls: "historic", selected: false } }
+              { class: "govuk-tabs__tab", role: "tab", aria: { selected: false } }
 
         .govuk-tabs__panel
           %h2.govuk-heading-l

--- a/app/views/staff/shared/actuals/_table.html.haml
+++ b/app/views/staff/shared/actuals/_table.html.haml
@@ -9,6 +9,8 @@
         %th.govuk-table__header
           = t("table.header.actual.receiving_organisation")
         %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
     %tbody.govuk-table__body
       - actuals.each do |actual|
@@ -19,3 +21,7 @@
           %td.govuk-table__cell
             - if policy(actual).edit?
               = a11y_action_link(t('default.link.edit'), edit_activity_actual_path(actual.parent_activity_id, actual), t("page_content.actuals.edit_noun"))
+            - else
+              %span.govuk-visually-hidden
+                = t("table.cell.default.no_actions_available")
+

--- a/app/views/staff/shared/adjustments/_table.html.haml
+++ b/app/views/staff/shared/adjustments/_table.html.haml
@@ -11,7 +11,7 @@
         %th.govuk-table__header
           Report
         %th.govuk-table__header
-          Actions
+          = t("table.header.default.actions")
 
     %tbody.govuk-table__body
       - adjustments.each do |adjustment|

--- a/app/views/staff/shared/external_income/_table.html.haml
+++ b/app/views/staff/shared/external_income/_table.html.haml
@@ -10,6 +10,8 @@
       %th.govuk-table__header
         =t("table.header.matched_effort.amount")
       %th.govuk-table__header
+        %span.govuk-visually-hidden
+          = t("table.header.default.actions")
 
   %tbody.govuk-table__body
     - external_incomes.each do |external_income|

--- a/app/views/staff/shared/forecasts/_table.html.haml
+++ b/app/views/staff/shared/forecasts/_table.html.haml
@@ -7,6 +7,8 @@
         %th.govuk-table__header
           =t("table.header.forecast.value")
         %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
     %tbody.govuk-table__body
       - forecasts.each do |forecast|
@@ -15,6 +17,9 @@
           %td.govuk-table__cell= forecast.value
           %td.govuk-table__cell
             - if policy(forecast).edit?
-              = a11y_action_link(t('default.link.edit'),
+              = a11y_action_link(t("default.link.edit"),
                 edit_activity_forecasts_path(forecast.parent_activity, forecast.financial_year, forecast.financial_quarter),
                 t("table.body.forecast.edit_noun"))
+            - else
+              %span.govuk-visually-hidden
+                = t("table.cell.default.no_actions_available")

--- a/app/views/staff/shared/implementing_organisations/_table.html.haml
+++ b/app/views/staff/shared/implementing_organisations/_table.html.haml
@@ -8,6 +8,8 @@
       %th.govuk-table__header
         =t("table.header.implementing_organisation.reference")
       %th.govuk-table__header
+        %span.govuk-visually-hidden
+          = t("table.header.default.actions")
 
   %tbody.govuk-table__body
     - implementing_organisations.each do |organisation|
@@ -21,3 +23,6 @@
               = f.hidden_field :organisation_id, value: organisation.id
               %button.govuk-button.govuk-button--secondary{ name: "delete" }
                 = t("action.implementing_organisation.delete.button")
+          - else
+            %span.govuk-visually-hidden
+              = t("table.cell.default.no_actions_available")

--- a/app/views/staff/shared/matched_effort/_table.html.haml
+++ b/app/views/staff/shared/matched_effort/_table.html.haml
@@ -10,6 +10,8 @@
       %th.govuk-table__header
         =t("table.header.matched_effort.amount")
       %th.govuk-table__header
+        %span.govuk-visually-hidden
+          = t("table.header.default.actions")
 
   %tbody.govuk-table__body
     - matched_efforts.each do |matched_effort|

--- a/app/views/staff/shared/refunds/_table.html.haml
+++ b/app/views/staff/shared/refunds/_table.html.haml
@@ -7,6 +7,8 @@
         %th.govuk-table__header
           = t("table.header.refund.value")
         %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
     %tbody.govuk-table__body
       - refunds.each do |refund|
@@ -16,3 +18,6 @@
           %td.govuk-table__cell
             - if policy(refund).edit?
               = a11y_action_link(t('default.link.edit'), edit_activity_refund_path(refund.parent_activity_id, refund), t("page_content.refund.edit_noun"))
+            - else
+              %span.govuk-visually-hidden
+                = t("table.cell.default.no_actions_available")

--- a/app/views/staff/shared/reports/_table_budgets.html.haml
+++ b/app/views/staff/shared/reports/_table_budgets.html.haml
@@ -11,6 +11,8 @@
         %th.govuk-table__header
           =t("table.header.budget.value")
         %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
     %tbody.govuk-table__body
       - budgets.each do |budget|
@@ -21,3 +23,6 @@
           %td.govuk-table__cell
             - if policy(budget).edit?
               = link_to t("default.link.edit"), edit_activity_budget_path(budget.parent_activity, budget)
+            - else
+              %span.govuk-visually-hidden
+                = t("table.cell.default.no_actions_available")

--- a/app/views/staff/shared/transfers/_index.html.haml
+++ b/app/views/staff/shared/transfers/_index.html.haml
@@ -30,6 +30,9 @@
             %th.govuk-table__header{scope: "col"}
               =t("fields.#{transfer_type}.beis_identifier")
             %th.govuk-table__header{scope: "col"}
+              %span.govuk-visually-hidden
+                = t("table.header.default.actions")
+
         %tbody.govuk-table__body
           - transfers.each do |transfer|
             %tr.govuk-table__row
@@ -45,4 +48,7 @@
               %td.govuk-table__cell
                 - if policy(transfer).update?
                   = link_to "Edit", send("edit_activity_#{transfer_type}_path", @activity.id, transfer.id)
+                - else
+                  %span.govuk-visually-hidden
+                    = t("table.cell.default.no_actions_available")
 

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -34,6 +34,9 @@ en:
       default:
         action: Action
         actions: Actions
+    cell:
+      default:
+        no_actions_available: No actions available
   activerecord:
     attributes:
       default:


### PR DESCRIPTION
## Changes in this PR
- Ensure table cells are not empty for screenreaders
- Remove invalid “aria-controls” attributes
- Add missing tablist role to tab lists
- Add landmarks to page contents that wasn't part of any landmarks

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
