### PR TITLE
"Reset password" links expire after 24 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,6 +1028,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Declare `remember_user_token` on cookies statement
 - Fix declared duration of default session from 24 hours to the actual value of 12 hours
 - Organisations are sorted by active status on the organisations page (applies to all types of organisation: delivery partner, matched effort providers, external income providers, and implementing organisations)
+- Reduce "Password Reset" link validity period to 24 hours
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-104...HEAD
 [release-104]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-103...release-104

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -231,7 +231,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 2.weeks
+  config.reset_password_within = 24.hours
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.


### PR DESCRIPTION
We had extended the validity of "Reset password" links to two weeks to enable
users recieving the password reset link that we'd sent them sufficient time to
log in with the link provided.

The 31st of March is the fourteen-day anniversary of us making that change --
the reset links will become invalid soon, so now is a good time to change this
setting back to something more reasonable.

There was some discussion about the most appropriate amount of time: 24 hours
is an arbitarily-chosen compromise.

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
