### PR TITLE
Hotfix puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.6.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
## Changes in this PR

Update puma to address https://github.com/advisories/GHSA-h99w-9q5r-gjq9

While the vulnerability can only be exploited under specific conditions, I've opened this PR in case we think it's better safe than sorry, to be able to expedite releasing it.