### PR TITLE
View link has trailing spaces

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,8 +18,8 @@ module ApplicationHelper
     if context.blank?
       link_to(text, href, class: css_classes)
     else
-      span = content_tag :span, context, class: "govuk-visually-hidden"
-      link_to("#{text} #{raw(span)}".html_safe, href, class: css_classes)
+      span = content_tag :span, " #{context}", class: "govuk-visually-hidden"
+      link_to("#{text}#{raw(span)}".html_safe, href, class: css_classes)
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#a11y_action_link" do
     it "gives action links more context available to a screen reader" do
-      span = content_tag :span, "Pear", class: "govuk-visually-hidden"
-      accessible_action_link = link_to("Edit #{raw(span)}".html_safe, "pear.com", class: "govuk-link")
+      span = content_tag :span, " Pear", class: "govuk-visually-hidden"
+      accessible_action_link = link_to("Edit#{raw(span)}".html_safe, "pear.com", class: "govuk-link")
       expect(helper.a11y_action_link("Edit", "pear.com", "Pear")).to eql accessible_action_link
     end
 
     it "merges any supplied css classes" do
-      span = content_tag :span, "Pear", class: "govuk-visually-hidden"
-      accessible_action_link = link_to("Edit #{raw(span)}".html_safe, "pear.com", class: "pear govuk-link")
+      span = content_tag :span, " Pear", class: "govuk-visually-hidden"
+      accessible_action_link = link_to("Edit#{raw(span)}".html_safe, "pear.com", class: "pear govuk-link")
       expect(helper.a11y_action_link("Edit", "pear.com", "Pear", ["pear"])).to eql accessible_action_link
     end
 


### PR DESCRIPTION
On the implementing organisations index page, the View link has a visible space
which is part of the hyperlink (so it looks like View_). We move the space to
be a part of the visually hidden content instead.

## Changes in this PR

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/85497046/161057399-fddbc65b-e35f-4ae2-8d12-721c82f793fd.png)

### After
![image](https://user-images.githubusercontent.com/85497046/161057477-279073c6-a146-45b8-b3b2-b2564c021850.png)

## Next steps
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
