### PR TITLE
Fix: tweak S3UploaderConfig to match Terraform naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ NOTIFY_OTP_VERIFICATION_TEMPLATE=1a832f2e-b13b-47f0-b32a-9cd6672364d2
 VCAP_SERVICES='{
    "aws-s3-bucket":[
       {
-         "name":"s3-export-download-bucket",
+         "name":"beis-roda-staging-s3-export-download-bucket",
          "credentials":{
             "bucket_name":"paas-s3-broker-prod-lon-id",
             "aws_access_key_id":"KEY_ID",

--- a/.env.test
+++ b/.env.test
@@ -17,7 +17,7 @@ NOTIFY_OTP_VERIFICATION_TEMPLATE=1a832f2e-b13b-47f0-b32a-9cd6672364d2
 VCAP_SERVICES='{
    "aws-s3-bucket":[
       {
-         "name":"s3-export-download-bucket",
+         "name":"beis-roda-test-s3-export-download-bucket",
          "credentials":{
             "bucket_name":"paas-s3-broker-prod-lon-id",
             "aws_access_key_id":"KEY_ID",

--- a/app/services/export/s3_uploader_config.rb
+++ b/app/services/export/s3_uploader_config.rb
@@ -19,7 +19,7 @@ module Export
     def self.credentials
       JSON.parse(ENV.fetch("VCAP_SERVICES"))
         .fetch("aws-s3-bucket")
-        .find { |config| config.fetch("name").match?(/^s3-export-download-bucket/) }
+        .find { |config| config.fetch("name").match?(/s3-export-download-bucket/) }
         .fetch("credentials")
     rescue KeyError, NoMethodError => _error
       raise "AWS S3 credentials not found"

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -8,7 +8,7 @@ module Export
           {
             "aws-s3-bucket":[
                 {
-                   "name": "s3-export-download-bucket",
+                   "name": "beis-roda-staging-s3-export-download-bucket",
                    "credentials":{
                       "bucket_name":"exports_bucket",
                       "aws_access_key_id":"KEY_ID",
@@ -32,7 +32,7 @@ module Export
           {
             "aws-s3-bucket":[
                 {
-                   "name": "s3-export-download-bucket",
+                   "name": "beis-roda-staging-s3-export-download-bucket",
                    "incorrect_credentials_key":{
                       "bucket_name":"exports_bucket",
                       "aws_access_key_id":"KEY_ID",
@@ -95,7 +95,7 @@ module Export
           {
             "aws-s3-bucket":[
                 {
-                   "name": "s3-export-download-bucket",
+                   "name": "beis-roda-staging-s3-export-download-bucket",
                    "credentials":{
                       "bucket_name":"exports_bucket",
                       "aws_access_key_id":"KEY_ID",


### PR DESCRIPTION
We originally planned to have the buckets named:

`s3-export-download-bucket-{environment}`

but the Terraform convention which we've followed (see
`terraform/s3-export-download-bucket.tf`) gives us:

`beis-roda-{environment}-s3-export-download-bucket`

In this commit we relax the "matcher" regex in the
`S3UploaderConfig` helper and update our sample env
dotfiles.
