### PR TITLE
Fix: Include previous year in drop-down when posting external income

### DIFF
--- a/app/views/staff/external_incomes/_form.html.haml
+++ b/app/views/staff/external_incomes/_form.html.haml
@@ -11,7 +11,7 @@
           legend: { text: "Financial quarter" }
       .govuk-grid-column-one-third
         = f.govuk_collection_select :financial_year,
-          list_of_financial_years,
+          list_of_financial_years(FinancialYear.next_ten.prepend(FinancialYear.new(Date.today.year).pred)),
           :id,
           :name,
           label: { text: "Financial year", tag: :h2, size: "m" }

--- a/spec/features/staff/users_can_create_an_external_income_spec.rb
+++ b/spec/features/staff/users_can_create_an_external_income_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe "Users can create a external income" do
       end
     end
 
+    context "when the current fin. year has advanced from the period being reported" do
+      scenario "can choose the previous financial year" do
+        options = page.all("#external-income-financial-year-field option").map(&:text)
+        expect(options).to include(FinancialYear.new(Date.today.year).pred.to_s)
+      end
+    end
+
     scenario "they are shown errors when required fields are left blank" do
       click_on t("default.button.submit")
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -98,8 +98,9 @@ module FormHelpers
   end
 
   def fill_in_external_income_form(template = build(:external_income))
+    current_year = FinancialYear.new(Date.today.year).to_s
     page.find(:xpath, "//input[@value='#{template.financial_quarter}']").set(true)
-    select template.financial_year, from: "external_income[financial_year]"
+    select current_year, from: "external_income[financial_year]"
     select template.organisation.name, from: "external_income[organisation_id]"
     fill_in "external_income[amount]", with: template.amount
     check "external_income[oda_funding]" if template.oda_funding


### PR DESCRIPTION
On April 1st 2022 (financial year 2022-2023) I may be
needing to post external income for the period Q4 2021-2022.

Previously we were offering only the ten years starting from
the "currrent" financial year, i.e. 2022-2023. We now
include the previous year also.

## Screenshots of UI changes

<img width="1039" alt="years" src="https://user-images.githubusercontent.com/20245/162170864-5b90aeab-56d0-4cb0-8f11-5deaeb034869.png">


## Next steps

- [  ] Identify other places suffering from the same problem. Where the "previous" financial year also needs to be displayed!
