### PR TITLE
Generate public rather than pre-signed url for download link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ CMD ["bundle", "exec", "puma"]
 # ------------------------------------------------------------------------------
 FROM web as test
 
-RUN apt-get install -qq -y firefox-esr \
+RUN apt-get install -qq -y --fix-missing firefox-esr \
   shellcheck
 
 ARG gecko_driver_version=0.26.0

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -25,7 +25,7 @@ module Export
       raise "Unexpected response." unless response&.etag
 
       OpenStruct.new(
-        url: bucket.object(filename).presigned_url(:get, expires_in: 1.day.in_seconds),
+        url: bucket.object(filename).public_url,
         timestamped_filename: filename
       )
     rescue => error

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Export::S3Uploader do
   let(:timestamp) { Time.current }
   let(:timestamped_filename) { "spending_breakdown-#{timestamp.to_formatted_s(:number)}.csv" }
 
-  let(:s3_object) { double("s3 object", presigned_url: "https://s3.example.com/xyz321") }
+  let(:s3_object) { double("s3 object", public_url: "https://s3.example.com/xyz321") }
   let(:s3_bucket) { double("s3 bucket", object: s3_object) }
   let(:s3_bucket_finder) { instance_double(Aws::S3::Resource, bucket: s3_bucket) }
 
@@ -80,16 +80,13 @@ RSpec.describe Export::S3Uploader do
         expect(s3_bucket).to have_received(:object).with(timestamped_filename)
       end
 
-      it "asks for a presigned_url valid for 24 hours" do
+      it "asks for a public_url" do
         subject.upload
 
-        expect(s3_object).to have_received(:presigned_url).with(
-          :get,
-          expires_in: 1.day.in_seconds
-        )
+        expect(s3_object).to have_received(:public_url)
       end
 
-      it "returns the presigned_url of the uploaded object and the timestamped filename" do
+      it "returns the public_url of the uploaded object and the timestamped filename" do
         expect(subject.upload).to eq(
           OpenStruct.new(
             url: "https://s3.example.com/xyz321",


### PR DESCRIPTION
It seems to be impossible to generate a pre-signed GET url
using the GPaaS S3 config, either on a bucket which is
created as "public" or "private".

I've identified two ways of generating a working download
link using Terraform / GPaaS:

### 1. Generate a public url rather than a pre-signed url

This has the disadvantage that the links never expire.
However, I think it's adequate in terms of security as the
url is essentially unguessable e.g.

`https://paas-s3-broker-prod-lon-8cc9c2c5-43f7-44bf-a5c1-11c4256feba8.s3.eu-west-2.amazonaws.com/GCRF_spending_breakdown-20220411170906.csv`

### 2. Create a pre-signed url using separate "service key" creds

By generating a separate set of AWS credentials which are
explicitly set to enable external access:

```
cf create-service-key \
  beis-roda-staging-s3-export-download-bucket \
  beis-roda-staging-s3-export-download-bucket \
  -c '{"allow_external_access": true}'
```

and using these to generate a pre-signed URL (on a private
bucket). e.g.

```
presigner_client = Aws::S3::Client.new(
  region: Export::S3UploaderConfig.region,
  credentials: Aws::Credentials.new(
    S3UploaderConfig.presigner_key_id,
    "S3UploaderConfig.presigner_secret"
  )
)

signer = Aws::S3::Presigner.new(client: presigner_client)

url = signer.presigned_url(
  :get_object,
  bucket: Export::S3UploaderConfig.bucket,
  key: "filename"
)
```

However, these "service key" credentials are not
readily available as environment variables. I've asked GPaaS
support for some help in understanding how we might access
them in Terraform.

### Recommendation


I think that (1): the use of public url is a better
(simpler) solution which is adequate in terms of governance
and security.

This data is not sensitive, contains no personally identifiable information
and will ultimately published publicly via IATI.

The contents of the CSV looks like:

```
RODA identifier,Delivery partner identifier,Activity title,Activity level,Activity status,Delivery partner organisation,Actual spend FQ1 2016-2017,Refund FQ1 2016-2017,Actual net FQ1 2016-2017,Actual spend FQ2 2016-2017,Refund FQ2 2016-2017,Actual net FQ2 2016-2017,Actual spend FQ3 2016-2017,Refund FQ3 2016-2017,Actual net FQ3 2016-2017,Actual spend FQ4 2016-2017,Refund FQ4 2016-2017,Actual net FQ4 2016-2017,Actual spend FQ1 2017-2018,Refund FQ1 2017-2018,Actual net FQ1 2017-2018,Actual spend FQ2 2017-2018,Refund FQ2 2017-2018,Actual net FQ2 2017-2018,Actual spend FQ3 2017-2018,Refund FQ3 2017-2018,Actual net FQ3 2017-2018,Actual spend FQ4 2017-2018,Refund FQ4 2017-2018,Actual net FQ4 2017-2018,Actual spend FQ1 2018-2019,Refund FQ1 2018-2019,Actual net FQ1 2018-2019,Actual spend FQ2 2018-2019,Refund FQ2 2018-2019,Actual net FQ2 2018-2019,Actual spend FQ3 2018-2019,Refund FQ3 2018-2019,Actual net FQ3 2018-2019,Actual spend FQ4 2018-2019,Refund FQ4 2018-2019,Actual net FQ4 2018-2019,Actual spend FQ1 2019-2020,Refund FQ1 2019-2020,Actual net FQ1 2019-2020,Actual spend FQ2 2019-2020,Refund FQ2 2019-2020,Actual net FQ2 2019-2020,Actual spend FQ3 2019-2020,Refund FQ3 2019-2020,Actual net FQ3 2019-2020,Actual spend FQ4 2019-2020,Refund FQ4 2019-2020,Actual net FQ4 2019-2020,Actual spend FQ1 2020-2021,Refund FQ1 2020-2021,Actual net FQ1 2020-2021,Actual spend FQ2 2020-2021,Refund FQ2 2020-2021,Actual net FQ2 2020-2021,Actual spend FQ3 2020-2021,Refund FQ3 2020-2021,Actual net FQ3 2020-2021,Actual spend FQ4 2020-2021,Refund FQ4 2020-2021,Actual net FQ4 2020-2021,Actual spend FQ1 2021-2022,Refund FQ1 2021-2022,Actual net FQ1 2021-2022,Actual spend FQ2 2021-2022,Refund FQ2 2021-2022,Actual net FQ2 2021-2022,Forecast FQ3 2021-2022,Forecast FQ4 2021-2022,Forecast FQ1 2022-2023,Forecast FQ2 2022-2023,Forecast FQ3 2022-2023,Forecast FQ4 2022-2023,Forecast FQ1 2023-2024,Forecast FQ2 2023-2024,Forecast FQ3 2023-2024,Forecast FQ4 2023-2024,Forecast FQ1 2024-2025,Forecast FQ2 2024-2025,Forecast FQ3 2024-2025,Forecast FQ4 2024-2025,Forecast FQ1 2025-2026,Forecast FQ2 2025-2026,Forecast FQ3 2025-2026,Forecast FQ4 2025-2026
GCRF-CICA-R12018-ICA\R1\180100,GCRF_RS_BRA_International Collaboration Awards ICA\R1\180100,For a Climate Resilient Amazon - 'FORAMA',Third-party project (level D),Spend in progress,Royal Society,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,74884.11,0,74884.11,0,0,0,0,0,0,74993.38,0,74993.38,0,0,0,0,0,0,0,0,0,74698.22,0,74698.22,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
GCRF-MR_C_HSRI-C1_1314MR/M002306/1,MR/M002306/1,Determinants of medical equipment performance to improve management capacity within health system in Viet Nam,Third-party project (level D),Completed,Medical Research Council,6439.4,0,6439.4,0,0,0,0,0,0,0,0,0,6439.38,0,6439.38,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
GCRF-ES_CIm_ECE-2019ES/T004118/1,ES/T004118/1,Supporting Oral Language Development,Third-party project (level D),Spend in progress,Economic & Social Research Council,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,152387.99,0,152387.99,154030.51,0,154030.51,154030.51,0,154030.51,154030.51,0,154030.51,155278.16,0,155278.16,155278.16,0,155278.16,58059.73,0,58059.73,6300.33,6300.33,154866.67,154866.67,154866.75,0,0,0,0,0,0,0,0,0,0,0,0,0
```


