### PR TITLE
16367 no validation for oda eligibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1050,6 +1050,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Generates public (rather than pre-signed) URL for download link to fetch reports from S3 bucket
 
 ## [unreleased]
+- Do not parse arbitary text in oda_eligibilities or programme_status as being 0.
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-109...HEAD
 [release-109]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-108...release-109

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -414,7 +414,7 @@ module Activities
         valid_codes = gcrf_challenge_area_options.map { |area| area.code.to_s }
         raise I18n.t("importer.errors.activity.invalid_gcrf_challenge_area") unless valid_codes.include?(gcrf_challenge_area)
 
-        gcrf_challenge_area.to_i
+        Integer(gcrf_challenge_area)
       end
 
       def convert_gcrf_strategic_area(gcrf_strategic_area)

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -474,7 +474,12 @@ module Activities
       end
 
       def convert_programme_status(programme_status)
-        status = Activity.programme_statuses.key(programme_status.to_i)
+        begin
+          numeric_status = Integer(programme_status)
+        rescue
+          I18n.t("importer.errors.activity.invalid_programme_status")
+        end
+        status = Activity.programme_statuses.key(numeric_status)
 
         raise I18n.t("importer.errors.activity.invalid_programme_status") if status.nil?
 

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -460,7 +460,13 @@ module Activities
       end
 
       def convert_oda_eligibility(oda_eligibility)
-        option = Activity.oda_eligibilities.key(oda_eligibility.to_i)
+        begin
+          numeric_eligibility = Integer(oda_eligibility)
+        rescue
+          raise I18n.t("importer.errors.activity.invalid_oda_eligibility")
+        end
+
+        option = Activity.oda_eligibilities.key(numeric_eligibility)
 
         raise I18n.t("importer.errors.activity.invalid_oda_eligibility") if option.nil?
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -479,6 +479,14 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    context "when oda_eligibility is an invalid text string" do
+      subject(:activity) { build(:project_activity, oda_eligibility: "kitten") }
+
+      it "should raise an error" do
+        expect { activity }.to raise_error("'kitten' is not a valid oda_eligibility")
+      end
+    end
+
     context "when saving in the oda_eligibility_lead_step context" do
       context "and the activity is a fund" do
         subject { build(:project_activity, level: :fund) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1368,6 +1368,12 @@ RSpec.describe Activity, type: :model do
         expect(activity.iati_status).to eql "2"
       end
     end
+
+    context "when the programme status is an invalid text string" do
+      it "raises an error" do
+        expect { Activity.new(programme_status: "kitten") }.to raise_error
+      end
+    end
   end
 
   describe ".hierarchically_grouped_projects" do


### PR DESCRIPTION
https://dxw.zendesk.com/agent/tickets/16367 reports the following bug:

Issue: delivery partners are accidently changing ODA eligible activities to 'no longer eligible.

Expected behaviour: If a delivery partner doesn't use one of the three upload codes for ODA eligibility in activities bulk upload RODA won't accept the CSV and list the error in the 'List of errors in your updated CSV file'.

Defective behaviour: If a delivery partner uses 'text' rather than the designated bulk upload codes (i.e. 'eligible') the eligibility status changes in the activity (unknown to the user).

This is caused by "kitten".to_i returning 0, rather surprisingly. Integer("kitten") raises an error as expected.

## Next steps

It might be worth reviewing the use of `to_i` on user-generated input more generally.

- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.