### PR TITLE
Fix: 16160 - Bulk update of activities including implementing organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,9 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [release-110] 2022-06-21
 - Do not parse arbitary text in oda_eligibilities or programme_status as being 0.
 
+## [unreleased]
+- Fix handling of implementing organisations when updating activities through CSV upload
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-110...HEAD
 [release-110]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-109...release-110
 [release-109]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-108...release-109

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -17,7 +17,11 @@ module Activities
     attr_reader :errors, :created, :updated
 
     def self.column_headings
-      ["Parent RODA ID"] + Converter::FIELDS.values - ["BEIS ID"] + ["Comments"]
+      ["Parent RODA ID"] +
+        Converter::FIELDS.values -
+        ["BEIS ID"] +
+        ["Comments"] +
+        ["Implementing organisation name"]
     end
 
     def initialize(uploader:, delivery_partner_organisation:, report:)

--- a/spec/features/staff/users_can_upload_activities_spec.rb
+++ b/spec/features/staff/users_can_upload_activities_spec.rb
@@ -58,7 +58,8 @@ RSpec.feature "users can upload activities" do
       "UK DP Named Contact",
       "NF Partner Country DP",
       "Benefitting Countries",
-      "Comments"
+      "Comments",
+      "Implementing organisation names"
     ])
   end
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Activities::ImportFromCsv do
 
   subject { described_class.new(uploader: uploader, delivery_partner_organisation: organisation, report: report) }
 
+  describe "::column_headings" do
+    it "includes a column for implementing organisation name" do
+      expect(described_class.column_headings).to include("Implementing organisation name")
+    end
+  end
+
   context "when updating an existing activity" do
     let(:activity_policy_double) { instance_double("ActivityPolicy", update?: true) }
 

--- a/spec/services/activities/import_from_csv_spec.rb
+++ b/spec/services/activities/import_from_csv_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Activities::ImportFromCsv do
       "BEIS ID" => "BEIS_ID_EXAMPLE_01",
       "UK DP Named Contact" => "Jo Soap",
       "NF Partner Country DP" => "Association of Example Companies (AEC) | | Board of Sample Organisations (BSO)",
-      "Implementing organisation name" => "Impl. Org 1",
+      "Implementing organisation names" => "Impl. Org 1",
       "Comments" => "Cat"
     }
   end
@@ -74,7 +74,7 @@ RSpec.describe Activities::ImportFromCsv do
       "RODA ID" => "",
       "Parent RODA ID" => parent_activity.roda_identifier,
       "Transparency identifier" => "23232332323",
-      "Implementing organisation name" => "Impl. Org 2",
+      "Implementing organisation names" => "Impl. Org 2",
       "Comments" => "Kitten"
     })
   end
@@ -82,8 +82,8 @@ RSpec.describe Activities::ImportFromCsv do
   subject { described_class.new(uploader: uploader, delivery_partner_organisation: organisation, report: report) }
 
   describe "::column_headings" do
-    it "includes a column for implementing organisation name" do
-      expect(described_class.column_headings).to include("Implementing organisation name")
+    it "includes a column for implementing organisation names" do
+      expect(described_class.column_headings).to include("Implementing organisation names")
     end
   end
 
@@ -130,7 +130,7 @@ RSpec.describe Activities::ImportFromCsv do
     it "does not fail when the import row has no implementing organisation" do
       expect(existing_activity.implementing_organisations.count).to eq(1)
 
-      existing_activity_attributes["Implementing organisation name"] = nil
+      existing_activity_attributes["Implementing organisation names"] = nil
 
       subject.import([existing_activity_attributes])
 
@@ -284,9 +284,9 @@ RSpec.describe Activities::ImportFromCsv do
         expect(subject.errors.first.message).to eq("Select a category")
       end
 
-      it "has the expected errors if the activity is invalid and the implementing organisation is invalid" do
+      it "has the expected errors if the activity is invalid and one or more implementing organisation is invalid" do
         attributes["Title"] = "New Title"
-        attributes["Implementing organisation name"] = "Unknown Organisation"
+        attributes["Implementing organisation names"] = "Impl. Org 1 | Unknown 1 | Unknown 2"
 
         existing_activity.implementing_organisations.delete_all
 
@@ -299,9 +299,14 @@ RSpec.describe Activities::ImportFromCsv do
         expect(subject.updated.count).to eq(0)
         expect(subject.errors.count).to eq(2)
 
+        expect(subject.errors.map(&:value)).to match_array([
+          "Unknown 1 | Unknown 2",
+          nil
+        ])
+
         expect(subject.errors.map(&:message)).to match_array([
           "Select a category",
-          "is not a known implementing organisation"
+          "is/are not a known implementing organisation(s)"
         ])
       end
     end
@@ -341,7 +346,7 @@ RSpec.describe Activities::ImportFromCsv do
     end
 
     it "does not fail when the row has no implementing organisation" do
-      new_activity_attributes["Implementing organisation name"] = nil
+      new_activity_attributes["Implementing organisation names"] = nil
       new_activity_attributes["Implementing organisation reference"] = nil
       new_activity_attributes["Implementing organisation sector"] = nil
       rows = [new_activity_attributes]
@@ -438,7 +443,7 @@ RSpec.describe Activities::ImportFromCsv do
 
       new_activity = Activity.order(:created_at).last
 
-      expect(new_activity.implementing_organisations.first.name).to eq(new_activity_attributes["Implementing organisation name"])
+      expect(new_activity.implementing_organisations.first.name).to eq(new_activity_attributes["Implementing organisation names"])
     end
 
     it "allows the Call Open and Close Dates to be blank" do
@@ -757,7 +762,7 @@ RSpec.describe Activities::ImportFromCsv do
 
     context "implementing organisation" do
       it "does not set when left blank" do
-        new_activity_attributes["Implementing organisation name"] = ""
+        new_activity_attributes["Implementing organisation names"] = ""
 
         expect { subject.import([new_activity_attributes]) }.to change { Activity.count }.by(1)
 
@@ -911,6 +916,26 @@ RSpec.describe Activities::ImportFromCsv do
       expect(OrgParticipation.all.map { |p| p.organisation.name })
         .not_to include("Original Impl. Org")
       expect(OrgParticipation.all.map { |p| p.organisation.name })
+        .to include("Impl. Org 1", "Impl. Org 2")
+
+      expect(subject.errors.count).to eq(0)
+    end
+
+    it "imports multiple implementing organisations" do
+      rows = [existing_activity_attributes.merge({
+        "Implementing organisation names" => "Impl. Org 1 | Impl. Org 2"
+      })]
+
+      expect(existing_activity.implementing_organisations.map(&:name))
+        .to include("Original Impl. Org")
+      expect(existing_activity.implementing_organisations.map(&:name))
+        .not_to include("Impl. Org 1", "Impl. Org 2")
+
+      subject.import(rows)
+
+      expect(existing_activity.reload.implementing_organisations.map(&:name))
+        .not_to include("Original Impl. Org")
+      expect(existing_activity.reload.implementing_organisations.map(&:name))
         .to include("Impl. Org 1", "Impl. Org 2")
 
       expect(subject.errors.count).to eq(0)

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Export::Report do
       financial_year: financial_year.to_i
     )
 
-    @project = create(:project_activity_with_implementing_organisations)
+    @project = create(
+      :project_activity_with_implementing_organisations,
+      implementing_organisations_count: 2
+    )
 
     @implementing_organisation =
       create(
@@ -113,8 +116,13 @@ RSpec.describe Export::Report do
 
         expect(roda_identifier_value_for_row(first_row))
           .to eq(@project.roda_identifier)
+
+        # includes names of both implementing organisations
         expect(implementing_organisation_value_for_row(first_row))
-          .to include(@project.implementing_organisations.first.name)
+          .to match(@project.implementing_organisations.first.name)
+        expect(implementing_organisation_value_for_row(first_row))
+          .to match(@project.implementing_organisations.second.name)
+
         expect(delivery_partner_organisation_value_for_row(first_row))
           .to eq(@project.organisation.name)
         expect(change_state_value_for_row(first_row))


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the handling of implementing organisations when updating activities using the bulk upload method:

1. the bulk upload CSV template for activities was missing a column for describing each activity's implementing organisations. This resulted in any pre-existing associations being removed when an activity was updated in this way. We now have a `Implementing organisation names` column which takes a pipe-delimited list of organisation names
2. the update code (in `Activity::ImportFromCsv`) did not handle an activity being associated with multiple implementing organisations. 

## Details

This work results from a [bug report 16160](https://dxw.zendesk.com/agent/tickets/16160) showing that whenever an
activity with a pre-existing implementing organisation
association is updated via the bulk upload CSV mechanism,
the activity was stripped of its implementing organisations.

However, it makes sense that any pre-existing implementing organisation associations
which are not present in an update should be removed when the update is
applied. e.g.:

**pre-existing state:**
implementing orgs = [Org A, Org B]

**desired post-update state:**
implementing orgs = [Org A, Org C]

In the bulk upload CSV for the update, in column "Implementing organisation names",
I should expect to find: "Org A | Org C".

i.e. any implementing orgs not present in the update will be removed and any orgs
which are not present on the activity will be added.

### The fix

Multiple implementing orgs are now supplied in pipe-delimited
form, e.g. under the column "Implementing organisation names"
I can list:

```
Existing Org | Additional Org 1 | Additional Org 2
```

(NB: whitespace around the pipe is not signficant)

If one or more of the given organisation names does not
match up with a pre-defined organisation (that organisation
has not been set up in RODA) then I will be shown an error
message identifying the problem organisation(s), e.g.

"Additional Org 1 | Additional Org 2 is/are not a known implementing organisation(s)"

Error handling when 2 unknown implementing organisations are supplied in the CSV:

<img width="1173" alt="error_handling" src="https://user-images.githubusercontent.com/20245/173305274-8b7df645-97ff-41ed-911d-93c4044c4f2f.png">

### We will need guidance for delivery partners

We need *guidance* to let DPs know that failure to provide this
implementing organisation information will be destructive,
i.e. if they don't re-supply all the implementing orgs which
should be associated with an activity, then any associations
will be removed as part of the update.

## Next steps

- [x ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
