### PR TITLE
Adjust rowcount for test which passed due to invisible text

### DIFF
--- a/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_actuals_history_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "BEIS users upload actual history" do
 
       expect(page).to have_content(t("actions.uploads.actual_histories.failed"))
       expect(page).to have_content("Value")
-      expect(page).to have_content("1")
+      expect(page).to have_content("2")
       expect(page).to have_content("Ten thousand pounds")
       expect(page).to have_content("Value must be a valid number")
     end


### PR DESCRIPTION
At some point in the last eighteen hours since 9f5299d336ad425184e1ba565534ea7f98f13e4d
passed CI I suspect a version of the testing software (Capybara?) has been silently
updated causing the tests to fail with:

Failure/Error: expect(page).to have_content("1")
       expected to find text "1" in
Value 2 Ten thousand pounds Value must be a valid number [highly abbreviated]
(However, it was found 1 time including non-visible text.)

My suspicion is that the line number in the CSV always should have been 2, but 1 passed
because it was in some invisible text somewhere, until this update.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
