### PR TITLE
Exclude vendor from shellcheck

### DIFF
--- a/lib/tasks/shellcheck.rake
+++ b/lib/tasks/shellcheck.rake
@@ -3,6 +3,7 @@ task shellcheck: :environment do
   files = Dir.glob(["**/*.{sh,ksh,bash}", "script/*[^.rb]"])
     .reject { |path| Dir.exist?(path) }
     .reject { |path| Pathname.new(path).descend.first.to_s == "node_modules" }
+    .reject { |path| Pathname.new(path).descend.first.to_s == "vendor" }
 
   success = system("shellcheck #{files.join(" ")}")
 


### PR DESCRIPTION
## Changes in this PR

I'm not quite sure what might have caused this to change, but running
`script/test` failed at the linting stage as it was trying to lint
`vendor/`, a directory of libraries we don't control.
