### PR TITLE
Don't setup backend for `terraform_test` script

### DIFF
--- a/script/terraform_test
+++ b/script/terraform_test
@@ -7,6 +7,6 @@ git clone https://github.com/tfutils/tfenv.git ~/.tfenv
 export PATH="$HOME/.tfenv/bin:$PATH"
 tfenv install
 ../install-terraform-provider-for-cf.sh
-terraform init
+terraform init -backend=false
 terraform fmt  -diff -check -recursive
 terraform validate


### PR DESCRIPTION
## Changes in this PR

Passes `-backend=false` to `terraform_test`'s `terraform init` command, to ensure we don't try and configure a backend for it.

This is currently failing on CI due to it trying to configure S3. Passing this flag should allow Dependabot to be able to run CI without us needing to set its own secrets e.g. CF username and password
