### PR TITLE
Update rebase action in workflows to 1.7

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
         if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@1.7
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
         if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}

--- a/.github/workflows/trigger_rebase.yml
+++ b/.github/workflows/trigger_rebase.yml
@@ -35,6 +35,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.ref }}
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.5
+        uses: cirrus-actions/rebase@1.7
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Changes in this PR

This is currently failing the "automatic rebase" step of the build with the following error:

```
fatal: detected dubious ownership in repository at '/github/workspace'
```

This is due to a change in the `actions/checkout` package, it has now been fixed in [version 1.6](https://github.com/cirrus-actions/rebase/releases/tag/1.6) but let's update to version 1.7 as it's the latest now.