### PR TITLE
(2509) Add banner to non production envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1060,6 +1060,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Display a banner on non-production environments to make it clearer to users which site they're using
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-112...HEAD
 [release-112]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-111...release-112
 [release-111]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-110...release-111

--- a/app/assets/stylesheets/partials/_alerts.css.scss
+++ b/app/assets/stylesheets/partials/_alerts.css.scss
@@ -22,3 +22,26 @@ ul.govuk-list.govuk-error-summary__list li {
   @include govuk-font($size: 19, $weight: bold)
   color:  $govuk-error-colour;
 }
+
+.environment-info-wrapper {
+  @include govuk-font($size: 19, $weight: normal);
+  width: 2em;
+  height: 1000px;
+  position: fixed;
+  left: 200px;
+  top: -25px;
+  background-color: orange;
+  transform: rotate(50deg);
+  transform-origin: top;
+  z-index: 998;
+  border-color: orangered;
+  border-width: 1px;
+  border-style: dotted;
+}
+
+.environment-info-content {
+  transform: rotate(-91deg);
+  position: relative;
+  bottom: -8em;
+  z-index: 999;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,23 @@ module ApplicationHelper
       end
     end
   end
+
+  def environment_name
+    hostname = ENV.fetch("CANONICAL_HOSTNAME", "").split(".").first
+
+    case hostname
+    when "www"
+      "production"
+    when "staging", "sandbox", "training"
+      hostname
+    when "pentest"
+      "training"
+    else
+      Rails.env
+    end
+  end
+
+  def display_env_banner?
+    environment_name.in? %w[training staging sandbox development]
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -48,6 +48,11 @@
             %a.govuk-header__link.govuk-header__link--service-name{href: "/"}
               = t('app.title')
 
+    - if display_env_banner?
+      .environment-info-wrapper
+        .environment-info-content{role: "region", aria: { label: "#{environment_name} environment" }}
+          = environment_name
+
     .govuk-width-container
       .govuk-phase-banner{role: "region", aria: { label: "Beta: feedback requested" }}
         %p.govuk-phase-banner__content

--- a/spec/features/staff/users_can_view_environment_banner_spec.rb
+++ b/spec/features/staff/users_can_view_environment_banner_spec.rb
@@ -1,0 +1,35 @@
+RSpec.feature "users can view a banner on non-production environments" do
+  context "when on the staging site" do
+    scenario "I see a banner informing me I am on the staging site" do
+      ClimateControl.modify CANONICAL_HOSTNAME: "staging.report-official-development-assistance.service.gov.uk" do
+        visit home_path
+
+        within(".environment-info-wrapper") do
+          expect(page).to have_content("staging")
+        end
+      end
+    end
+  end
+
+  context "when on the training site" do
+    scenario "I see a banner informing me I am on the training site" do
+      ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        visit home_path
+
+        within(".environment-info-wrapper") do
+          expect(page).to have_content("training")
+        end
+      end
+    end
+  end
+
+  context "when on the production site" do
+    scenario "I do not see a banner" do
+      ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        visit home_path
+
+        expect(page).to_not have_selector(".environment-info-wrapper")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -50,4 +50,84 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.link_to_new_tab("Data dictionary", "http://data.dictionary")).to eql(link_to("Data dictionary (opens in new tab)", "http://data.dictionary", class: "govuk-link", target: "_blank", rel: "noreferrer noopener"))
     end
   end
+
+  describe "#environment_name" do
+    context "when the hostname is not empty" do
+      context "when the hostname is 'www'" do
+        it "returns 'production'" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("production")
+          end
+        end
+      end
+
+      context "when the hostname is 'training'" do
+        it "returns 'training" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("training")
+          end
+        end
+      end
+
+      context "when the hostname is 'pentest'" do
+        it "returns 'training" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "pentest.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("training")
+          end
+        end
+      end
+
+      context "when the hostname is 'sandbox'" do
+        it "returns 'training" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "sandbox.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("sandbox")
+          end
+        end
+      end
+
+      context "when the hostname is 'staging'" do
+        it "returns 'training" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "staging.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("staging")
+          end
+        end
+      end
+
+      context "when the hostname is something not listed" do
+        it "returns the Rails environment" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "something" do
+            expect(helper.environment_name).to eql("test")
+          end
+        end
+      end
+    end
+
+    context "when the hostname is not set" do
+      it "returns the Rails environment" do
+        ClimateControl.modify CANONICAL_HOSTNAME: nil do
+          expect(helper.environment_name).to eql("test")
+        end
+      end
+    end
+  end
+
+  describe "#display_env_banner?" do
+    context "when the environment_name is one of training, staging, sandbox, or development" do
+      it "returns true" do
+        %w[training staging sandbox development].each do |env_name|
+          allow(helper).to receive(:environment_name).and_return(env_name)
+          expect(helper.display_env_banner?).to eql(true)
+        end
+      end
+    end
+
+    context "when the environment_name is anything else" do
+      it "returns false" do
+        ["production", "something", "", nil].each do |env_name|
+          allow(helper).to receive(:environment_name).and_return(env_name)
+          expect(helper.display_env_banner?).to eql(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- Display a banner on non-production environments to make it clearer to users which site they're using

## Screenshots of UI changes

### Before

### After
![Screenshot 2022-08-16 at 15 38 08](https://user-images.githubusercontent.com/579522/184907379-a0467fd4-da85-4bb7-bf8b-c01943c084f0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
