### PR TITLE
(2520) Show environment in email subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1061,6 +1061,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Display a banner on non-production environments to make it clearer to users which site they're using
+- Show the environment name (e.g. "training") in the subject of emails sent by the application
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-112...HEAD
 [release-112]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-111...release-112

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,4 +57,10 @@ module ApplicationHelper
   def display_env_name?
     environment_name.in? %w[training staging sandbox development]
   end
+
+  def environment_mailer_prefix
+    return unless display_env_name?
+
+    "[#{environment_name.titleize}] "
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
     end
   end
 
-  def display_env_banner?
+  def display_env_name?
     environment_name.in? %w[training staging sandbox development]
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < Mail::Notify::Mailer
+  include ApplicationHelper
 end

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -9,7 +9,8 @@ class DownloadLinkMailer < ApplicationMailer
       subject: t(
         "mailer.download_link.success.subject",
         application_name: t("app.title"),
-        file_name: file_name
+        file_name: file_name,
+        environment_name: environment_mailer_prefix
       )
     )
   end
@@ -20,7 +21,8 @@ class DownloadLinkMailer < ApplicationMailer
       to: recipient.email,
       subject: t(
         "mailer.download_link.failure.subject",
-        application_name: t("app.title")
+        application_name: t("app.title"),
+        environment_name: environment_mailer_prefix
       )
     )
   end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -6,7 +6,7 @@ class ReportMailer < ApplicationMailer
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: @user.email,
-      subject: t("mailer.report.activated.subject", application_name: t("app.title")))
+      subject: t("mailer.report.activated.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
   end
 
   def submitted
@@ -23,7 +23,7 @@ class ReportMailer < ApplicationMailer
     if @role.present?
       view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
         to: @user.email,
-        subject: t("mailer.report.submitted.#{@role}.subject", application_name: t("app.title")))
+        subject: t("mailer.report.submitted.#{@role}.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
     else
       raise ArgumentError, "User must either be a service owner or belong to the organisation making the report"
     end
@@ -43,7 +43,7 @@ class ReportMailer < ApplicationMailer
     if @role.present?
       view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
         to: @user.email,
-        subject: t("mailer.report.approved.#{@role}.subject", application_name: t("app.title")))
+        subject: t("mailer.report.approved.#{@role}.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
     else
       raise ArgumentError, "User must either be a service owner or belong to the organisation making the report"
     end
@@ -56,7 +56,7 @@ class ReportMailer < ApplicationMailer
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: @user.email,
-      subject: t("mailer.report.awaiting_changes.subject", application_name: t("app.title")))
+      subject: t("mailer.report.awaiting_changes.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
   end
 
   private def raise_unless_active_user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,7 +8,8 @@ class UserMailer < ApplicationMailer
       personalisation: {
         name: user.name,
         link: edit_user_password_url(reset_password_token: token),
-        service_url: ENV["DOMAIN"]
+        service_url: ENV["DOMAIN"],
+        environment_mailer_prefix: environment_mailer_prefix
       }
     )
   end
@@ -18,7 +19,7 @@ class UserMailer < ApplicationMailer
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: user.email,
-      subject: t("devise.mailer.reset_password_instructions.subject"))
+      subject: t("devise.mailer.reset_password_instructions.subject", environment_name: environment_mailer_prefix))
   end
 
   def first_time_devise_reset_password_instructions(user, token, opts = {})
@@ -26,6 +27,6 @@ class UserMailer < ApplicationMailer
 
     view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
       to: user.email,
-      subject: t("devise.mailer.first_time_devise_reset_password_instructions.subject"))
+      subject: t("devise.mailer.first_time_devise_reset_password_instructions.subject", environment_name: environment_mailer_prefix))
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -48,7 +48,7 @@
             %a.govuk-header__link.govuk-header__link--service-name{href: "/"}
               = t('app.title')
 
-    - if display_env_banner?
+    - if display_env_name?
       .environment-info-wrapper
         .environment-info-content{role: "region", aria: { label: "#{environment_name} environment" }}
           = environment_name

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -23,9 +23,9 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "%{environment_name}Reset password instructions"
       first_time_devise_reset_password_instructions:
-        subject: "Action required: RODA password reset"
+        subject: "%{environment_name}Action required: RODA password reset"
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -163,19 +163,19 @@ en:
   mailer:
     report:
       activated:
-        subject: "%{application_name} - A report has been activated"
+        subject: "%{environment_name}%{application_name} - A report has been activated"
       submitted:
         delivery_partner:
-          subject: "%{application_name} - Your report has been submitted"
+          subject: "%{environment_name}%{application_name} - Your report has been submitted"
         service_owner:
-          subject: "%{application_name} - A delivery partner has submitted a report"
+          subject: "%{environment_name}%{application_name} - A delivery partner has submitted a report"
       approved:
         delivery_partner:
-          subject: "%{application_name} - Your report has been approved"
+          subject: "%{environment_name}%{application_name} - Your report has been approved"
         service_owner:
-          subject: "%{application_name} - A report has been approved"
+          subject: "%{environment_name}%{application_name} - A report has been approved"
       awaiting_changes:
-        subject: "%{application_name} - A report is awaiting changes"
+        subject: "%{environment_name}%{application_name} - A report is awaiting changes"
   action:
     report:
       activate:

--- a/config/locales/views/exports.en.yml
+++ b/config/locales/views/exports.en.yml
@@ -42,6 +42,6 @@ en:
   mailer:
     download_link:
       success:
-        subject: "%{application_name} - Your export '%{file_name}' is ready to download"
+        subject: "%{environment_name}%{application_name} - Your export '%{file_name}' is ready to download"
       failure:
-        subject: '%{application_name} - Your export failed'
+        subject: "%{environment_name}%{application_name} - Your export failed"

--- a/spec/features/staff/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/staff/beis_users_can_invite_new_users_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "BEIS users can invite new users to the service" do
       expect(new_user).to have_received_email.with_personalisations(
         link: match(reset_password_link_regex),
         name: new_user_name,
-        service_url: "test.local"
+        service_url: "test.local",
+        environment_mailer_prefix: nil
       )
     end
 

--- a/spec/features/staff/users_can_approve_a_report_spec.rb
+++ b/spec/features/staff/users_can_approve_a_report_spec.rb
@@ -21,10 +21,10 @@ RSpec.feature "Users can approve reports" do
 
       expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count + 1)
 
-      expect(beis_user).to have_received_email.with_subject(t("mailer.report.approved.service_owner.subject", application_name: t("app.title")))
+      expect(beis_user).to have_received_email.with_subject(t("mailer.report.approved.service_owner.subject", application_name: t("app.title"), environment_name: nil))
 
       organisation.users.each do |user|
-        expect(user).to have_received_email.with_subject(t("mailer.report.approved.delivery_partner.subject", application_name: t("app.title")))
+        expect(user).to have_received_email.with_subject(t("mailer.report.approved.delivery_partner.subject", application_name: t("app.title"), environment_name: nil))
       end
     end
 

--- a/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
+++ b/spec/features/staff/users_can_mark_a_report_as_awaiting_changes_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
       expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count)
 
       organisation.users.each do |user|
-        expect(user).to have_received_email.with_subject(t("mailer.report.awaiting_changes.subject", application_name: t("app.title")))
+        expect(user).to have_received_email.with_subject(t("mailer.report.awaiting_changes.subject", application_name: t("app.title"), environment_name: nil))
       end
     end
 

--- a/spec/features/staff/users_can_submit_a_report_spec.rb
+++ b/spec/features/staff/users_can_submit_a_report_spec.rb
@@ -27,10 +27,10 @@ RSpec.feature "Users can submit a report" do
 
         expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count + 1)
 
-        expect(service_owner).to have_received_email.with_subject(t("mailer.report.submitted.service_owner.subject", application_name: t("app.title")))
+        expect(service_owner).to have_received_email.with_subject(t("mailer.report.submitted.service_owner.subject", application_name: t("app.title"), environment_name: nil))
 
         organisation.users.each do |user|
-          expect(user).to have_received_email.with_subject(t("mailer.report.submitted.delivery_partner.subject", application_name: t("app.title")))
+          expect(user).to have_received_email.with_subject(t("mailer.report.submitted.delivery_partner.subject", application_name: t("app.title"), environment_name: nil))
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -130,4 +130,24 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#environment_mailer_prefix" do
+    context "when the environment_name is one of training, staging, sandbox, or development" do
+      it "returns the titleised environment name enclosed in square brackets and with a trailing space" do
+        %w[training staging sandbox development].each do |env_name|
+          allow(helper).to receive(:environment_name).and_return(env_name)
+          expect(helper.environment_mailer_prefix).to eql("[#{env_name.titleize}] ")
+        end
+      end
+    end
+
+    context "when the environment_name is anything else" do
+      it "returns nil" do
+        ["production", "something", "", nil].each do |env_name|
+          allow(helper).to receive(:environment_name).and_return(env_name)
+          expect(helper.environment_mailer_prefix).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#display_env_banner?" do
+  describe "#display_env_name?" do
     context "when the environment_name is one of training, staging, sandbox, or development" do
       it "returns true" do
         %w[training staging sandbox development].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
-          expect(helper.display_env_banner?).to eql(true)
+          expect(helper.display_env_name?).to eql(true)
         end
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns false" do
         ["production", "something", "", nil].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
-          expect(helper.display_env_banner?).to eql(false)
+          expect(helper.display_env_name?).to eql(false)
         end
       end
     end

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -48,6 +48,28 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
     it "includes a link for requesting support" do
       expect(mail.body).to include("https://beisodahelp.zendesk.com")
     end
+
+    context "when the email is from the training site" do
+      it "includes the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq(
+            "[Training] Report your Official Development Assistance - " \
+            "Your export 'spending_breakdown.csv' is ready to download"
+          )
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq(
+            "Report your Official Development Assistance - " \
+            "Your export 'spending_breakdown.csv' is ready to download"
+          )
+        end
+      end
+    end
   end
 
   describe "#send_failure_notification(recipient:)" do
@@ -80,6 +102,26 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
     it "includes a link for requesting support" do
       expect(mail.body).to include("https://beisodahelp.zendesk.com")
+    end
+
+    context "when the email is from the training site" do
+      it "includes the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq(
+            "[Training] Report your Official Development Assistance - Your export failed"
+          )
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq(
+            "Report your Official Development Assistance - Your export failed"
+          )
+        end
+      end
     end
   end
 end

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe ReportMailer, type: :mailer do
         expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
       end
     end
+
+    context "when the email is from the training site" do
+      it "includes the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report has been activated")
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq("Report your Official Development Assistance - A report has been activated")
+        end
+      end
+    end
   end
 
   describe "#submitted" do
@@ -56,6 +72,22 @@ RSpec.describe ReportMailer, type: :mailer do
       it "contains the expected body" do
         expect(mail.body).to include("BEIS have received your report")
       end
+
+      context "when the email is from the training site" do
+        it "includes the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("[Training] Report your Official Development Assistance - Your report has been submitted")
+          end
+        end
+      end
+
+      context "when the email is from the production site" do
+        it "does not include the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("Report your Official Development Assistance - Your report has been submitted")
+          end
+        end
+      end
     end
 
     context "when the user is a service owner" do
@@ -76,6 +108,22 @@ RSpec.describe ReportMailer, type: :mailer do
 
       it "contains the expected body" do
         expect(mail.body).to include("A delivery partner has submitted a report.")
+      end
+
+      context "when the email is from the training site" do
+        it "includes the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A delivery partner has submitted a report")
+          end
+        end
+      end
+
+      context "when the email is from the production site" do
+        it "does not include the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("Report your Official Development Assistance - A delivery partner has submitted a report")
+          end
+        end
       end
     end
 
@@ -119,6 +167,22 @@ RSpec.describe ReportMailer, type: :mailer do
         expect(mail.body).to include("BEIS have approved your report.")
       end
 
+      context "when the email is from the training site" do
+        it "includes the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("[Training] Report your Official Development Assistance - Your report has been approved")
+          end
+        end
+      end
+
+      context "when the email is from the production site" do
+        it "does not include the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("Report your Official Development Assistance - Your report has been approved")
+          end
+        end
+      end
+
       context "when the user is inactive" do
         before do
           user.update!(active: false)
@@ -148,6 +212,22 @@ RSpec.describe ReportMailer, type: :mailer do
 
       it "contains the expected body" do
         expect(mail.body).to include("A report has been approved.")
+      end
+
+      context "when the email is from the training site" do
+        it "includes the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report has been approved")
+          end
+        end
+      end
+
+      context "when the email is from the production site" do
+        it "does not include the site in the email subject" do
+          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+            expect(mail.subject).to eq("Report your Official Development Assistance - A report has been approved")
+          end
+        end
       end
     end
 
@@ -187,6 +267,22 @@ RSpec.describe ReportMailer, type: :mailer do
 
       it "should raise an error" do
         expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
+      end
+    end
+
+    context "when the email is from the training site" do
+      it "includes the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report is awaiting changes")
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the site in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eq("Report your Official Development Assistance - A report is awaiting changes")
+        end
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -15,20 +15,85 @@ RSpec.describe UserMailer, type: :mailer do
   before { allow(user).to receive(:send).with(:set_reset_password_token).and_return("123abc") }
 
   describe("#welcome") do
-    it "sends a welcome email to the user with a set password link" do
-      mail = described_class.welcome(user)
+    let(:mail) { described_class.welcome(user) }
 
+    let(:personalisation_header) do
+      headers = JSON.parse(mail.to_json)["header"]
+      headers.find { |h| h["name"] == "personalisation" }["unparsed_value"]
+    end
+
+    it "sends a welcome email to the user with a set password link" do
       expect(mail.to).to eq([user.email])
 
-      headers = JSON.parse(mail.to_json)["header"]
-      personalisation_header = headers.find { |h| h["name"] == "personalisation" }
-      name = personalisation_header["unparsed_value"]["name"]
-      link = personalisation_header["unparsed_value"]["link"]
-      service_url = personalisation_header["unparsed_value"]["service_url"]
+      name = personalisation_header["name"]
+      link = personalisation_header["link"]
+      service_url = personalisation_header["service_url"]
+      environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
 
       expect(name).to eq(user.name)
       expect(link).to eq("http://test.local/users/password/edit?reset_password_token=123abc")
       expect(service_url).to eq("test.local")
+      expect(environment_mailer_prefix).to be_nil
+    end
+
+    context "when the email is from the training site" do
+      it "includes the environment name in the email personalisations" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
+
+          expect(environment_mailer_prefix).to eql("[Training] ")
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the environment name in the email personalisations" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
+
+          expect(environment_mailer_prefix).to be_nil
+        end
+      end
+    end
+  end
+
+  describe("#reset_password_instructions") do
+    let(:mail) { described_class.reset_password_instructions(user, "123abc") }
+
+    context "when the email is from the training site" do
+      it "includes the environment name in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eql("[Training] Reset password instructions")
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the environment name in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eql("Reset password instructions")
+        end
+      end
+    end
+  end
+
+  describe("#first_time_devise_reset_password_instructions") do
+    let(:mail) { described_class.first_time_devise_reset_password_instructions(user, "123abc") }
+
+    context "when the email is from the training site" do
+      it "includes the environment name in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eql("[Training] Action required: RODA password reset")
+        end
+      end
+    end
+
+    context "when the email is from the production site" do
+      it "does not include the environment name in the email subject" do
+        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          expect(mail.subject).to eql("Action required: RODA password reset")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Show the environment name (e.g. "training") in the subject of emails sent by the application

NOTE: If approved in its present form, this change will require updating the GOV.UK Notify welcome email template to add `environment_mailer_prefix` as a personalisation.

## Next steps

- [ ] Update the GOV.UK Notify welcome email template to add `environment_mailer_prefix` as a personalisation
- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
