### PR TITLE
Allow 2005 start date for historical activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1065,6 +1065,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Temporary allow activities to be added with the earliest actual start date of mid 2005 for historical data migration
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...HEAD
 [release-113]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-112...release-113
 [release-112]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-111...release-112

--- a/app/validators/date_within_boundaries_validator.rb
+++ b/app/validators/date_within_boundaries_validator.rb
@@ -1,5 +1,5 @@
 class DateWithinBoundariesValidator < ActiveModel::EachValidator
-  MIN = 10
+  MIN = 17
   MAX = 25
 
   def validate_each(record, attribute, value)

--- a/spec/features/staff/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/staff/beis_users_can_edit_a_report_spec.rb
@@ -53,7 +53,8 @@ RSpec.feature "BEIS users can edit a report" do
       expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.not_in_past")
     end
 
-    scenario "the deadline cannot be very far in the future" do
+    # Temporarily suspended as BEIS are inputting historical activities with a longer-ago start date
+    xscenario "the deadline cannot be very far in the future" do
       authenticate!(user: beis_user)
       report = create(:report)
 
@@ -71,6 +72,28 @@ RSpec.feature "BEIS users can edit a report" do
 
       expect(page).to_not have_content t("action.report.update.success")
       expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 10, max: 25)
+    end
+
+    # TODO: Remove this test when historical activities migration is complete
+    # The earliest date BEIS have provided is 2005 (17 years ago)
+    scenario "the deadline cannot be very far in the future or before 2005" do
+      authenticate!(user: beis_user)
+      report = create(:report)
+
+      visit reports_path
+
+      within "##{report.id}" do
+        click_on t("default.link.edit")
+      end
+
+      fill_in "report[deadline(3i)]", with: "31"
+      fill_in "report[deadline(2i)]", with: "1"
+      fill_in "report[deadline(1i)]", with: "200020"
+
+      click_on t("default.button.submit")
+
+      expect(page).to_not have_content t("action.report.update.success")
+      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 17, max: 25)
     end
 
     scenario "they can edit a Report to change the description (Reporting Period)" do

--- a/spec/validators/date_within_boundaries_validator_spec.rb
+++ b/spec/validators/date_within_boundaries_validator_spec.rb
@@ -27,9 +27,19 @@ RSpec.describe DateWithinBoundariesValidator do
     end
   end
 
+  # Temporarily suspended as BEIS are inputting historical activities with a longer-ago start date
   describe "when date is more than 10 years ago" do
-    it "is not valid" do
+    xit "is not valid" do
       subject.date = 11.years.ago
+      expect(subject.valid?).to be false
+    end
+  end
+
+  # TODO: Remove this test when historical activities migration is complete
+  # The earliest date BEIS have provided is 2005 (17 years ago)
+  describe "when date is more than 17 years ago" do
+    it "is not valid" do
+      subject.date = 18.years.ago
       expect(subject.valid?).to be false
     end
   end


### PR DESCRIPTION
## Changes in this PR

As per: https://dxw.zendesk.com/agent/tickets/16783

Allow 2005 start date for historical activities

This is a temporary solution to allow migration of historical data in
the service, as BEIS are currently adding historical activities and this
feels like a safe sensible earliest date to allow.

We will undo this commit once the new activities have been added.

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
