### PR TITLE
Ensure welcome emails are sent from production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1066,6 +1066,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Temporary allow activities to be added with the earliest actual start date of mid 2005 for historical data migration
+- Fix issue where welcome emails wouldn't be sent on production
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...HEAD
 [release-113]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-112...release-113

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,7 @@ module ApplicationHelper
   end
 
   def environment_mailer_prefix
-    return unless display_env_name?
+    return "" unless display_env_name?
 
     "[#{environment_name.titleize}] "
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -142,10 +142,10 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "when the environment_name is anything else" do
-      it "returns nil" do
+      it "returns an empty string" do
         ["production", "something", "", nil].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
-          expect(helper.environment_mailer_prefix).to be_nil
+          expect(helper.environment_mailer_prefix).to eql("")
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UserMailer, type: :mailer do
       expect(name).to eq(user.name)
       expect(link).to eq("http://test.local/users/password/edit?reset_password_token=123abc")
       expect(service_url).to eq("test.local")
-      expect(environment_mailer_prefix).to be_nil
+      expect(environment_mailer_prefix).to eql("")
     end
 
     context "when the email is from the training site" do
@@ -51,7 +51,7 @@ RSpec.describe UserMailer, type: :mailer do
         ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
           environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
 
-          expect(environment_mailer_prefix).to be_nil
+          expect(environment_mailer_prefix).to eql("")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR

Don't pass nil as environment mailer prefix

This threw an error on production, meaning new users wouldn't receive
the welcome email.

## Next steps
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.


