### PR TITLE
Use DOMAIN instead of CANONICAL_HOSTNAME

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
   end
 
   def environment_name
-    hostname = ENV.fetch("CANONICAL_HOSTNAME", "").split(".").first
+    hostname = ENV.fetch("DOMAIN", "").sub("https://", "").split(".").first
 
     case hostname
     when "www"

--- a/spec/features/staff/users_can_view_environment_banner_spec.rb
+++ b/spec/features/staff/users_can_view_environment_banner_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "users can view a banner on non-production environments" do
   context "when on the staging site" do
     scenario "I see a banner informing me I am on the staging site" do
-      ClimateControl.modify CANONICAL_HOSTNAME: "staging.report-official-development-assistance.service.gov.uk" do
+      ClimateControl.modify DOMAIN: "https://staging.report-official-development-assistance.service.gov.uk" do
         visit home_path
 
         within(".environment-info-wrapper") do
@@ -13,7 +13,7 @@ RSpec.feature "users can view a banner on non-production environments" do
 
   context "when on the training site" do
     scenario "I see a banner informing me I am on the training site" do
-      ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+      ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
         visit home_path
 
         within(".environment-info-wrapper") do
@@ -25,7 +25,7 @@ RSpec.feature "users can view a banner on non-production environments" do
 
   context "when on the production site" do
     scenario "I do not see a banner" do
-      ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+      ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
         visit home_path
 
         expect(page).to_not have_selector(".environment-info-wrapper")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -52,59 +52,59 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#environment_name" do
-    context "when the hostname is not empty" do
-      context "when the hostname is 'www'" do
+    context "when the domain is not empty" do
+      context "when the domain is 'https://www'" do
         it "returns 'production'" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("production")
           end
         end
       end
 
-      context "when the hostname is 'training'" do
+      context "when the domain is 'https://training'" do
         it "returns 'training" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("training")
           end
         end
       end
 
-      context "when the hostname is 'pentest'" do
+      context "when the domain is 'https://pentest'" do
         it "returns 'training" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "pentest.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://pentest.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("training")
           end
         end
       end
 
-      context "when the hostname is 'sandbox'" do
-        it "returns 'training" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "sandbox.report-official-development-assistance.service.gov.uk" do
+      context "when the domain is 'https://sandbox'" do
+        it "returns 'sandbox" do
+          ClimateControl.modify DOMAIN: "sandbox.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("sandbox")
           end
         end
       end
 
-      context "when the hostname is 'staging'" do
-        it "returns 'training" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "staging.report-official-development-assistance.service.gov.uk" do
+      context "when the domain is 'https://staging'" do
+        it "returns 'staging" do
+          ClimateControl.modify DOMAIN: "https://staging.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("staging")
           end
         end
       end
 
-      context "when the hostname is something not listed" do
+      context "when the domain is something not listed" do
         it "returns the Rails environment" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "something" do
+          ClimateControl.modify DOMAIN: "https://something" do
             expect(helper.environment_name).to eql("test")
           end
         end
       end
     end
 
-    context "when the hostname is not set" do
+    context "when the domain is not set" do
       it "returns the Rails environment" do
-        ClimateControl.modify CANONICAL_HOSTNAME: nil do
+        ClimateControl.modify DOMAIN: nil do
           expect(helper.environment_name).to eql("test")
         end
       end

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq(
             "[Training] Report your Official Development Assistance - " \
             "Your export 'spending_breakdown.csv' is ready to download"
@@ -62,7 +62,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq(
             "Report your Official Development Assistance - " \
             "Your export 'spending_breakdown.csv' is ready to download"
@@ -106,7 +106,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq(
             "[Training] Report your Official Development Assistance - Your export failed"
           )
@@ -116,7 +116,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq(
             "Report your Official Development Assistance - Your export failed"
           )

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report has been activated")
         end
       end
@@ -43,7 +43,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq("Report your Official Development Assistance - A report has been activated")
         end
       end
@@ -75,7 +75,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the training site" do
         it "includes the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("[Training] Report your Official Development Assistance - Your report has been submitted")
           end
         end
@@ -83,7 +83,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the production site" do
         it "does not include the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("Report your Official Development Assistance - Your report has been submitted")
           end
         end
@@ -112,7 +112,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the training site" do
         it "includes the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A delivery partner has submitted a report")
           end
         end
@@ -120,7 +120,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the production site" do
         it "does not include the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("Report your Official Development Assistance - A delivery partner has submitted a report")
           end
         end
@@ -169,7 +169,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the training site" do
         it "includes the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("[Training] Report your Official Development Assistance - Your report has been approved")
           end
         end
@@ -177,7 +177,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the production site" do
         it "does not include the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("Report your Official Development Assistance - Your report has been approved")
           end
         end
@@ -216,7 +216,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the training site" do
         it "includes the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report has been approved")
           end
         end
@@ -224,7 +224,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the email is from the production site" do
         it "does not include the site in the email subject" do
-          ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+          ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
             expect(mail.subject).to eq("Report your Official Development Assistance - A report has been approved")
           end
         end
@@ -272,7 +272,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq("[Training] Report your Official Development Assistance - A report is awaiting changes")
         end
       end
@@ -280,7 +280,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the site in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eq("Report your Official Development Assistance - A report is awaiting changes")
         end
       end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the environment name in the email personalisations" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
 
           expect(environment_mailer_prefix).to eql("[Training] ")
@@ -48,7 +48,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the environment name in the email personalisations" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           environment_mailer_prefix = personalisation_header["environment_mailer_prefix"]
 
           expect(environment_mailer_prefix).to eql("")
@@ -62,7 +62,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the environment name in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eql("[Training] Reset password instructions")
         end
       end
@@ -70,7 +70,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the environment name in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eql("Reset password instructions")
         end
       end
@@ -82,7 +82,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the training site" do
       it "includes the environment name in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "training.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eql("[Training] Action required: RODA password reset")
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     context "when the email is from the production site" do
       it "does not include the environment name in the email subject" do
-        ClimateControl.modify CANONICAL_HOSTNAME: "www.report-official-development-assistance.service.gov.uk" do
+        ClimateControl.modify DOMAIN: "https://www.report-official-development-assistance.service.gov.uk" do
           expect(mail.subject).to eql("Action required: RODA password reset")
         end
       end


### PR DESCRIPTION
## Changes in this PR

The env var `DOMAIN` is set on both app and worker instances, whereas
`CANONICAL_HOSTNAME` is only set on app instances.

In order to have environment name detection working for emails sent via
workers, we need to use the variable that is available to all of them.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
