### PR TITLE
(2502) Include detail of activities within RODA hierarchy in CSVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1073,6 +1073,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Display total of refunds in the report summary
 - Fix the misspelling of "FSTC" in a codelist and in the service using the codelist
+- Add parent programme ID and title, and parent project ID and title where applicable, to activity rows in report CSVs
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...HEAD
 [release-114]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...release-114

--- a/app/models/export/activity_attributes_columns.rb
+++ b/app/models/export/activity_attributes_columns.rb
@@ -14,7 +14,11 @@ class Export::ActivityAttributesColumns
     :benefitting_region,
     :flow,
     :finance,
-    :tied_status
+    :tied_status,
+    :parent_programme_identifier,
+    :parent_programme_title,
+    :parent_project_identifier,
+    :parent_project_title
   ]
 
   def initialize(activities:, attributes:)
@@ -28,7 +32,7 @@ class Export::ActivityAttributesColumns
 
   def rows
     return [] if @activities.empty?
-    @activities.map { |activity|
+    @activities.includes([:parent]).map { |activity|
       presenter = ActivityCsvPresenter.new(activity)
       values = @attributes.map { |att| presenter.send(att) }
       [activity.id, values]

--- a/app/models/export/activity_attributes_order.rb
+++ b/app/models/export/activity_attributes_order.rb
@@ -3,6 +3,10 @@ class Export::ActivityAttributesOrder
     [
       :roda_identifier,
       :level,
+      :parent_programme_identifier,
+      :parent_programme_title,
+      :parent_project_identifier,
+      :parent_project_title,
       :delivery_partner_identifier,
       :beis_identifier,
       :transparency_identifier,

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -51,6 +51,24 @@ class ActivityCsvPresenter < ActivityPresenter
     "#{to_model.tied_status}: #{super}"
   end
 
+  def parent_programme_identifier
+    return parent.roda_identifier if to_model.level == "project"
+    return parent.parent.roda_identifier if to_model.level == "third_party_project"
+  end
+
+  def parent_programme_title
+    return parent.title if to_model.level == "project"
+    return parent.parent.title if to_model.level == "third_party_project"
+  end
+
+  def parent_project_identifier
+    return parent.roda_identifier if to_model.level == "third_party_project"
+  end
+
+  def parent_project_title
+    return parent.title if to_model.level == "third_party_project"
+  end
+
   private
 
   def list_of_benefitting_countries(country_code_list)

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -401,6 +401,10 @@ en:
     attributes:
       activity:
         roda_identifier: RODA identifier
+        parent_programme_identifier: Parent level B ID
+        parent_programme_title: Parent level B title
+        parent_project_identifier: Parent level C ID
+        parent_project_title: Parent level C title
         transparency_identifier: IATI identifier
         beis_identifier: Original BEIS tracker identifier
         level: Activity level

--- a/spec/models/export/activity_attributes_columns_spec.rb
+++ b/spec/models/export/activity_attributes_columns_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe Export::ActivityAttributesColumns do
   before(:all) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
-    @activities = create_list(:project_activity, 5)
+    create_list(:project_activity, 5)
+    @activities = Activity.where(level: "project")
   end
 
   after(:all) do
@@ -12,12 +13,14 @@ RSpec.describe Export::ActivityAttributesColumns do
   subject { Export::ActivityAttributesColumns.new(activities: @activities, attributes: attributes) }
 
   context "when the attributes exist on the Activity model" do
-    let(:attributes) { [:roda_identifier, :delivery_partner_identifier, :programme_status, :benefitting_region] }
+    let(:attributes) { [:roda_identifier, :parent_programme_identifier, :parent_programme_title, :delivery_partner_identifier, :programme_status, :benefitting_region] }
 
     describe "#headers" do
       it "returns an array of the column headers for the attributes" do
         headers = [
           I18n.t("activerecord.attributes.activity.roda_identifier"),
+          I18n.t("activerecord.attributes.activity.parent_programme_identifier"),
+          I18n.t("activerecord.attributes.activity.parent_programme_title"),
           I18n.t("activerecord.attributes.activity.delivery_partner_identifier"),
           I18n.t("activerecord.attributes.activity.programme_status"),
           I18n.t("activerecord.attributes.activity.benefitting_region")
@@ -25,7 +28,7 @@ RSpec.describe Export::ActivityAttributesColumns do
         expect(subject.headers).to match_array(headers)
       end
 
-      it "includes a dynmic (non-active record) attribute header" do
+      it "includes a dynamic (non-active record) attribute header" do
         expect(subject.headers).to include(I18n.t("activerecord.attributes.activity.benefitting_region"))
       end
 
@@ -50,6 +53,8 @@ RSpec.describe Export::ActivityAttributesColumns do
 
         first_row_values = [
           first_row_activity_presenter.roda_identifier,
+          first_row_activity_presenter.parent_programme_identifier,
+          first_row_activity_presenter.parent_programme_title,
           first_row_activity_presenter.delivery_partner_identifier,
           first_row_activity_presenter.programme_status,
           first_row_activity_presenter.benefitting_region
@@ -57,6 +62,8 @@ RSpec.describe Export::ActivityAttributesColumns do
 
         last_row_values = [
           last_row_activity_presenter.roda_identifier,
+          last_row_activity_presenter.parent_programme_identifier,
+          last_row_activity_presenter.parent_programme_title,
           last_row_activity_presenter.delivery_partner_identifier,
           last_row_activity_presenter.programme_status,
           last_row_activity_presenter.benefitting_region
@@ -67,7 +74,7 @@ RSpec.describe Export::ActivityAttributesColumns do
         expect(subject.rows.fetch(@activities.last.id)).to match_array(last_row_values)
       end
 
-      it "Returns the values in the correct format" do
+      it "returns the values in the correct format" do
         last_row_programme_status = ActivityCsvPresenter.new(@activities.last).programme_status
 
         expect(subject.rows.fetch(@activities.last.id)).to include last_row_programme_status
@@ -81,6 +88,8 @@ RSpec.describe Export::ActivityAttributesColumns do
         it "returns the headers" do
           headers = [
             I18n.t("activerecord.attributes.activity.roda_identifier"),
+            I18n.t("activerecord.attributes.activity.parent_programme_identifier"),
+            I18n.t("activerecord.attributes.activity.parent_programme_title"),
             I18n.t("activerecord.attributes.activity.delivery_partner_identifier"),
             I18n.t("activerecord.attributes.activity.programme_status"),
             I18n.t("activerecord.attributes.activity.benefitting_region")

--- a/spec/models/export/activity_attributes_order_spec.rb
+++ b/spec/models/export/activity_attributes_order_spec.rb
@@ -1,9 +1,13 @@
 RSpec.describe Export::ActivityAttributesOrder do
   describe ".attributes_in_order" do
-    it "describes the attributes and order for the exporting a report" do
+    it "describes the attributes and order for exporting a report" do
       expect(described_class.attributes_in_order).to eq [
         :roda_identifier,
         :level,
+        :parent_programme_identifier,
+        :parent_programme_title,
+        :parent_project_identifier,
+        :parent_project_title,
         :delivery_partner_identifier,
         :beis_identifier,
         :transparency_identifier,

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -160,4 +160,140 @@ RSpec.describe ActivityCsvPresenter do
       expect(described_class.new(activity).fstc_applies).to eq "no"
     end
   end
+
+  describe "#parent_programme_identifier" do
+    let(:programme) { build(:programme_activity, roda_identifier: "lvl-b") }
+    let(:project) { build(:project_activity, parent: programme, roda_identifier: "lvl-c") }
+
+    context "when the activity is a third_party_project" do
+      it "returns the RODA ID of the programme to which this third_party_project ultimately belongs" do
+        activity = build(:third_party_project_activity, parent: project)
+        result = described_class.new(activity).parent_programme_identifier
+        expect(result).to eq("lvl-b")
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns the RODA ID of the programme to which this project belongs" do
+        result = described_class.new(project).parent_programme_identifier
+        expect(result).to eq("lvl-b")
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns nil" do
+        result = described_class.new(programme).parent_programme_identifier
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a fund" do
+      it "returns nil" do
+        result = described_class.new(programme.parent).parent_programme_identifier
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#parent_programme_title" do
+    let(:programme) { build(:programme_activity, title: "Level B activity") }
+    let(:project) { build(:project_activity, parent: programme, title: "Level C activity") }
+
+    context "when the activity is a third_party_project" do
+      it "returns the title of the programme to which this third_party_project ultimately belongs" do
+        activity = build(:third_party_project_activity, parent: project)
+        result = described_class.new(activity).parent_programme_title
+        expect(result).to eq("Level B activity")
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns the title of the programme to which this project belongs" do
+        result = described_class.new(project).parent_programme_title
+        expect(result).to eq("Level B activity")
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns nil" do
+        result = described_class.new(programme).parent_programme_title
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a fund" do
+      it "returns nil" do
+        result = described_class.new(programme.parent).parent_programme_title
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#parent_project_identifier" do
+    let(:programme) { build(:programme_activity, roda_identifier: "lvl-b") }
+    let(:project) { build(:project_activity, parent: programme, roda_identifier: "lvl-c") }
+
+    context "when the activity is a third_party_project" do
+      it "returns the RODA ID of the project to which this third_party_project belongs" do
+        activity = build(:third_party_project_activity, parent: project)
+        result = described_class.new(activity).parent_project_identifier
+        expect(result).to eq("lvl-c")
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns nil" do
+        result = described_class.new(project).parent_project_identifier
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns nil" do
+        result = described_class.new(programme).parent_project_identifier
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a fund" do
+      it "returns nil" do
+        result = described_class.new(programme.parent).parent_project_identifier
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#parent_project_title" do
+    let(:programme) { build(:programme_activity, title: "Level B activity") }
+    let(:project) { build(:project_activity, parent: programme, title: "Level C activity") }
+
+    context "when the activity is a third_party_project" do
+      it "returns the title of the project to which this third_party_project ultimately belongs" do
+        activity = build(:third_party_project_activity, parent: project)
+        result = described_class.new(activity).parent_project_title
+        expect(result).to eq("Level C activity")
+      end
+    end
+
+    context "when the activity is a project" do
+      it "returns nil" do
+        result = described_class.new(project).parent_project_title
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a programme" do
+      it "returns nil" do
+        result = described_class.new(programme).parent_project_title
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the activity is a fund" do
+      it "returns nil" do
+        result = described_class.new(programme.parent).parent_project_title
+        expect(result).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- Add parent programme ID and title, and parent project ID and title where applicable, to activity rows in report CSVs

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [x] BEIS to confirm that they need both titles and IDs (last minute item)
