### PR TITLE
(2517) Fix misspelling of “FSTC” in codelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,7 +1072,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Display total of refunds in the report summary
-
+- Fix the misspelling of "FSTC" in a codelist and in the service using the codelist
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...HEAD
 [release-114]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...release-114

--- a/app/services/activity/inference.rb
+++ b/app/services/activity/inference.rb
@@ -18,8 +18,8 @@ class Activity
           rule.fix(:collaboration_type, item["collaboration_type"])
         end
 
-        if item.key?("ftsc_applies")
-          rule.fix(:fstc_applies, item["ftsc_applies"])
+        if item.key?("fstc_applies")
+          rule.fix(:fstc_applies, item["fstc_applies"])
         end
       end
 

--- a/vendor/data/codelists/BEIS/aid_type.yml
+++ b/vendor/data/codelists/BEIS/aid_type.yml
@@ -14,7 +14,7 @@ data:
       assets. See Annex 2 of the DAC Directives for a comprehensive list of agencies
       core contributions to which may be reported under B02 (Section I. Multilateral
       institutions).
-    ftsc_applies: false
+    fstc_applies: false
     collaboration_type: "2"
   - category: B
     code: B03
@@ -57,7 +57,7 @@ data:
       Experts, consultants, teachers, academics, researchers, volunteers
       and contributions to public and private bodies for sending experts to developing
       countries.
-    ftsc_applies: true
+    fstc_applies: true
   - category: D
     code: D02
     name: Other technical assistance
@@ -70,17 +70,17 @@ data:
       universities and organisations); local scholarships; development-oriented social
       and cultural programmes. This category also covers ad hoc contributions such as
       conferences, seminars and workshops, exchange visits, publications, etc.
-    ftsc_applies: true
+    fstc_applies: true
   - category: E
     code: E01
     name: Scholarships/training in donor country
     description: Financial aid awards for individual students and contributions to trainees.
-    ftsc_applies: true
+    fstc_applies: true
   - category: E
     code: E02
     name: Imputed student costs
     description: Indirect (“imputed”) costs of tuition in donor countries.
-    ftsc_applies: true
+    fstc_applies: true
   - category: G
     code: G01
     name: Administrative costs not included elsewhere
@@ -91,7 +91,7 @@ data:
       auditing activities. As regards the salaries component of administrative costs,
       it relates to in-house agency staff and contractors only; costs associated with
       donor experts/consultants are to be reported under category C or D01.
-    ftsc_applies: false
+    fstc_applies: false
 metadata:
   url: http://www.oecd.org/dac/stats/dacandcrscodelists.htm
   name: Aid Type


### PR DESCRIPTION
## Changes in this PR
- Fix the misspelling of "FSTC" in a codelist and in the service using the codelist

FSTC stands for “Free-standing Technical Cooperation”.[1]

The misspelling in the codelist is consistent with the code that checks
for that key, and the activity attribute is correctly spelled. However,
the misspelling is a source of confusion, so we want to fix it.

[1] If we were to use the official acronym, via OECD:
https://stats.oecd.org/glossary/detail.asp?ID=6022
we would be switching all of them to “FTC”. However, I feel that would
be more disruptive than helpful at this point.

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.