### PR TITLE
Don't create rows with no export data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,9 +1072,11 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Display total of refunds in the report summary
+
 - Fix the misspelling of "FSTC" in a codelist and in the service using the codelist
 - Add parent programme ID and title, and parent project ID and title where applicable, to activity rows in report CSVs
 - Make the message shown when there are no approved reports more accurate
+- Ensure CSV export of report has consistent columns if there are no forecasts
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...HEAD
 [release-114]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...release-114

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -54,8 +54,8 @@ class Export::Report
       row << delivery_partner_organisation_rows.fetch(activity.id, nil)
       row << change_state_rows.fetch(activity.id, nil)
       row << actuals_rows.fetch(activity.id, nil) if actuals_rows.any?
-      row << variance_rows.fetch(activity.id, nil) if actuals_rows.any? && forecast_rows.any?
-      row << forecast_rows.fetch(activity.id, nil) if forecast_rows.any?
+      row << variance_rows.fetch(activity.id, nil) if actuals_rows.any? && has_forecast_rows?
+      row << forecast_rows.fetch(activity.id, nil) if has_forecast_rows?
       row << comment_rows.fetch(activity.id, nil)
       row << link_rows.fetch(activity.id, nil)
       row.flatten
@@ -95,6 +95,10 @@ class Export::Report
 
   def forecast_rows
     @_forecast_rows ||= @forecast_columns.rows
+  end
+
+  def has_forecast_rows?
+    forecast_rows.values.flatten.any?
   end
 
   def variance_rows


### PR DESCRIPTION
## Changes in this PR

The previous implementation was calling `forecast_rows.any?` on some
forecast rows with the following structure:

```
{ 'activity-id'=>[100] }
```

This meant that we were calling `any?` on a hash value which was always
returning `true`, in contrast to the `headers` which would return an
empty array.

This led to the number of headers being out of sync with the number of
rows, causing columns to be out of sync from the `variance` row.

Now we check all the arrays in that hash are empty - if they are, we
don't render the variance row.

For the tests, We've added an entire new spec because the existing setup sets up a forecast, and
there's no easy way we could see to remove it or set it up at a later stage. It's intended
to otherwise be a complete copy of the setup for the with-forecast case.

Resolves https://dxw.zendesk.com/agent/tickets/16785

## Before 
![image](https://user-images.githubusercontent.com/85497046/186718726-f34f6b14-9bf8-48b1-b64d-8ff0ec9bcfdf.png)

## After
<img width="980" alt="image" src="https://user-images.githubusercontent.com/85497046/186718824-249e2c87-42e3-45a6-bd58-791b5006f6a3.png">


## Next steps

- [X] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.


