### PR TITLE
(2522) Inaccurate message on reports approved tab when no approved reports exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1074,6 +1074,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Display total of refunds in the report summary
 - Fix the misspelling of "FSTC" in a codelist and in the service using the codelist
 - Add parent programme ID and title, and parent project ID and title where applicable, to activity rows in report CSVs
+- Make the message shown when there are no approved reports more accurate
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...HEAD
 [release-114]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...release-114

--- a/app/views/staff/shared/reports/_grouped_table.html.haml
+++ b/app/views/staff/shared/reports/_grouped_table.html.haml
@@ -1,5 +1,5 @@
 - if grouped_reports.empty?
-  = render partial: "staff/shared/reports/table_empty"
+  = render partial: "staff/shared/reports/table_empty", locals: { type: type }
 - else
   %table.govuk-table
     = render partial: "staff/shared/reports/table_header", locals: { type: type }

--- a/app/views/staff/shared/reports/_table.html.haml
+++ b/app/views/staff/shared/reports/_table.html.haml
@@ -1,5 +1,5 @@
 - if reports.empty?
-  = render partial: "staff/shared/reports/table_empty"
+  = render partial: "staff/shared/reports/table_empty", locals: { type: type }
 - else
   %table.govuk-table
     = render partial: "staff/shared/reports/table_header", locals: { type: type }

--- a/app/views/staff/shared/reports/_table_empty.html.haml
+++ b/app/views/staff/shared/reports/_table_empty.html.haml
@@ -6,4 +6,4 @@
       %td.govuk-table__cell
         .govuk-grid-row
           .govuk-grid-column-two-thirds
-            =t("table.body.report.no_reports")
+            = t("table.body.report.no_#{type}_reports")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -25,8 +25,10 @@ en:
           edit: Edit
           activate: Activate
           in_review: Mark as in review
-        no_reports:
+        no_current_reports:
           You have no current reports. Once active, any new reports will appear here. You can view approved reports in the Approved tab.
+        no_approved_reports:
+          You have no approved reports.
         add_comment: Add comment
         view_comments: View comments
         comment: Comment

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -457,15 +457,17 @@ RSpec.feature "Users can view reports" do
       expect(page).to_not have_edit_buttons_for_comments(adjustment_comments)
       expect(page).to_not have_edit_buttons_for_comments(comments_for_report)
     end
-  end
 
-  context "when there are no active reports" do
-    scenario "they see no reports" do
-      report = create(:report, :approved)
+    context "when there are no active reports" do
+      scenario "they see no reports on the current tab" do
+        report = create(:report, :approved, organisation: delivery_partner_user.organisation)
 
-      visit reports_path
+        visit reports_path
 
-      expect(page).not_to have_content report.description
+        within("#current") do
+          expect(page).not_to have_content report.description
+        end
+      end
     end
   end
 end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -459,13 +459,14 @@ RSpec.feature "Users can view reports" do
     end
 
     context "when there are no active reports" do
-      scenario "they see no reports on the current tab" do
+      scenario "they see an empty state on the current tab" do
         report = create(:report, :approved, organisation: delivery_partner_user.organisation)
 
         visit reports_path
 
         within("#current") do
           expect(page).not_to have_content report.description
+          expect(page).to have_content t("table.body.report.no_reports")
         end
       end
     end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -193,11 +193,23 @@ RSpec.feature "Users can view reports" do
       end
     end
 
-    context "when there are no reports in a given state" do
-      scenario "an empty state is shown" do
+    context "when there are no active reports" do
+      scenario "they see an empty state on the current tab" do
         visit reports_path
 
-        expect(page).to have_content t("table.body.report.no_reports")
+        within("#current") do
+          expect(page).to have_content t("table.body.report.no_reports")
+        end
+      end
+    end
+
+    context "when there are no approved reports" do
+      scenario "they see an empty state on the approved tab" do
+        visit reports_path
+
+        within("#approved") do
+          expect(page).to have_content t("table.body.report.no_reports")
+        end
       end
     end
 
@@ -465,6 +477,19 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within("#current") do
+          expect(page).not_to have_content report.description
+          expect(page).to have_content t("table.body.report.no_reports")
+        end
+      end
+    end
+
+    context "when there are no approved reports" do
+      scenario "they see an empty state on the approved tab" do
+        report = create(:report, organisation: delivery_partner_user.organisation)
+
+        visit reports_path
+
+        within("#approved") do
           expect(page).not_to have_content report.description
           expect(page).to have_content t("table.body.report.no_reports")
         end

--- a/spec/features/staff/users_can_view_reports_spec.rb
+++ b/spec/features/staff/users_can_view_reports_spec.rb
@@ -198,7 +198,7 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within("#current") do
-          expect(page).to have_content t("table.body.report.no_reports")
+          expect(page).to have_content t("table.body.report.no_current_reports")
         end
       end
     end
@@ -208,7 +208,7 @@ RSpec.feature "Users can view reports" do
         visit reports_path
 
         within("#approved") do
-          expect(page).to have_content t("table.body.report.no_reports")
+          expect(page).to have_content t("table.body.report.no_approved_reports")
         end
       end
     end
@@ -478,7 +478,7 @@ RSpec.feature "Users can view reports" do
 
         within("#current") do
           expect(page).not_to have_content report.description
-          expect(page).to have_content t("table.body.report.no_reports")
+          expect(page).to have_content t("table.body.report.no_current_reports")
         end
       end
     end
@@ -491,7 +491,7 @@ RSpec.feature "Users can view reports" do
 
         within("#approved") do
           expect(page).not_to have_content report.description
-          expect(page).to have_content t("table.body.report.no_reports")
+          expect(page).to have_content t("table.body.report.no_approved_reports")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR
- Make the message shown when there are no approved reports more accurate

## Screenshots of UI changes

### Before
![Screenshot 2022-08-25 at 18 08 41](https://user-images.githubusercontent.com/579522/186727765-6b08e253-e1f8-4a33-8f88-b071fd915534.png)

### After
![Screenshot 2022-08-25 at 18 07 42](https://user-images.githubusercontent.com/579522/186727787-c46913e4-71e6-41df-92ce-4a2809bb5c8b.png)

## Next steps

- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.