### PR TITLE
Provide specific error message to spec

### DIFF
--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1371,7 +1371,7 @@ RSpec.describe Activity, type: :model do
 
     context "when the programme status is an invalid text string" do
       it "raises an error" do
-        expect { Activity.new(programme_status: "kitten") }.to raise_error
+        expect { Activity.new(programme_status: "kitten") }.to raise_error("'kitten' is not a valid programme_status")
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

The test was throwing a warning:
“Using the `raise_error` matcher without providing a specific error or
message risks false positives, since `raise_error` will match when Ruby
raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially
allowing the expectation to pass without even executing the method you
are intending to call.”

Fix by matching against a specific error message.