### PR TITLE
(2540) Replace Partner Org "view details" link with clickable Partner Org name link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1079,6 +1079,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Replace "View details" link in the Partner Organisation table for BEIS users with a link on Organisation name instead
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-115...HEAD
 [release-115]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...release-115
 [release-114]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-113...release-114

--- a/app/views/staff/home/_delivery_partner_organisations_table.html.haml
+++ b/app/views/staff/home/_delivery_partner_organisations_table.html.haml
@@ -11,9 +11,8 @@
     - @delivery_partner_organisations.each do |delivery_partner_organisation|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = delivery_partner_organisation.name
+          = a11y_action_link delivery_partner_organisation.name, organisation_path(delivery_partner_organisation), t("table.cell.organisations.details"), ["govuk-link--no-visited-state"]
         %td.govuk-table__cell
-          = a11y_action_link "View details ", organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state"]
-          = a11y_action_link "View activities", organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
+          = a11y_action_link "View activities", organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state"]
           = a11y_action_link "View exports", exports_organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
           = a11y_action_link "View reports", organisation_reports_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]

--- a/app/views/staff/home/_delivery_partner_organisations_table.html.haml
+++ b/app/views/staff/home/_delivery_partner_organisations_table.html.haml
@@ -13,6 +13,6 @@
         %td.govuk-table__cell
           = a11y_action_link delivery_partner_organisation.name, organisation_path(delivery_partner_organisation), t("table.cell.organisations.details"), ["govuk-link--no-visited-state"]
         %td.govuk-table__cell
-          = a11y_action_link "View activities", organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state"]
-          = a11y_action_link "View exports", exports_organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
-          = a11y_action_link "View reports", organisation_reports_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
+          = a11y_action_link t("table.cell.organisations.view_activities"), organisation_activities_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state"]
+          = a11y_action_link t("table.cell.organisations.view_exports"), exports_organisation_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
+          = a11y_action_link t("table.cell.organisations.view_reports"), organisation_reports_path(delivery_partner_organisation), "for #{delivery_partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -39,6 +39,9 @@ en:
         no_actions_available: No actions available
       organisations:
         details: details
+        view_activities: View activities
+        view_exports: View exports
+        view_reports: View reports
   activerecord:
     attributes:
       default:

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -37,6 +37,8 @@ en:
     cell:
       default:
         no_actions_available: No actions available
+      organisations:
+        details: details
   activerecord:
     attributes:
       default:

--- a/spec/views/home/service_owner_spec.rb
+++ b/spec/views/home/service_owner_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "staff/home/service_owner" do
 
   it "has links to a delivery partners details, activities, exports and reports" do
     expect(rendered).to have_link("Partner Org 1", href: "/organisations/id")
-    expect(rendered).to have_link("View activities", href: "/organisation/id/activities")
-    expect(rendered).to have_link("View exports", href: "/exports/organisation/id")
-    expect(rendered).to have_link("View reports", href: "/organisation/id/reports")
+    expect(rendered).to have_link(t("table.cell.organisations.view_activities"), href: "/organisation/id/activities")
+    expect(rendered).to have_link(t("table.cell.organisations.view_exports"), href: "/exports/organisation/id")
+    expect(rendered).to have_link(t("table.cell.organisations.view_reports"), href: "/organisation/id/reports")
   end
 end

--- a/spec/views/home/service_owner_spec.rb
+++ b/spec/views/home/service_owner_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe "staff/home/service_owner" do
   before do
     assign(:current_user, build(:beis_user))
-    assign(:delivery_partner_organisations, build_list(:delivery_partner_organisation, 2))
+    organisation = build(:delivery_partner_organisation, name: "Partner Org 1")
+    assign(:delivery_partner_organisations, [organisation, build(:delivery_partner_organisation)])
 
     stub_template "staff/shared/reports/_delivery_partners_organisations_table" => "table of delivery partners"
     stub_template "staff/searches/_form" => "search form"
@@ -15,7 +16,7 @@ RSpec.describe "staff/home/service_owner" do
   end
 
   it "has links to a delivery partners details, activities, exports and reports" do
-    expect(rendered).to have_link("View details", href: "/organisations/id")
+    expect(rendered).to have_link("Partner Org 1", href: "/organisations/id")
     expect(rendered).to have_link("View activities", href: "/organisation/id/activities")
     expect(rendered).to have_link("View exports", href: "/exports/organisation/id")
     expect(rendered).to have_link("View reports", href: "/organisation/id/reports")


### PR DESCRIPTION
## Changes in this PR

Replace "View details" link with link on Org name to free up some room in future for a link to "Upload activities".

I've also added a visually hidden span for screen readers here, although I wonder if the text could be a bit more obvious?

This PR also refactors text on links on this page to use translation files to be more consistent.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/188623123-d5871fda-fce4-4651-a151-5a445ce014c3.png)

### After

![image](https://user-images.githubusercontent.com/19826940/188623197-0df31473-716c-4e93-9118-1c9d37b0d477.png)

## Next steps

We'll be adding the "Upload data" link to this table in the next chunk of work.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
