### PR TITLE
(2532) Add hub page for being able to download template upload CSV file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1084,6 +1084,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Replace references to `delivery_partner` with `partner_organisation` (or `partner_organisation_user` depending on context)
   across the code, including a database migration to rename `delivery_partner_identifier` to `partner_organisation_identifier`
 - Replace references to `country_delivery_partners` with `country_partner_organisations`, including database migration
+- Add Level B activity bulk upload form and link from partner organisations table
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-115...HEAD
 [release-115]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...release-115

--- a/app/controllers/staff/level_b_activity_uploads_controller.rb
+++ b/app/controllers/staff/level_b_activity_uploads_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Staff::LevelBActivityUploadsController < Staff::BaseController
+  include Secured
+
+  def new
+    @organisation ||= Organisation.find(params[:organisation_id])
+    authorize @organisation, :bulk_upload?
+  end
+end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -7,6 +7,10 @@ class OrganisationPolicy < ApplicationPolicy
     beis_user? || associated_user?
   end
 
+  def bulk_upload?
+    beis_user?
+  end
+
   def create?
     beis_user?
   end

--- a/app/views/staff/home/_partner_organisations_table.html.haml
+++ b/app/views/staff/home/_partner_organisations_table.html.haml
@@ -13,6 +13,7 @@
         %td.govuk-table__cell
           = a11y_action_link partner_organisation.name, organisation_path(partner_organisation), t("table.cell.organisations.details"), ["govuk-link--no-visited-state"]
         %td.govuk-table__cell
+          = a11y_action_link t("table.cell.organisations.upload_data"), new_organisation_level_b_activity_upload_path(partner_organisation), "for #{partner_organisation.name}", ["govuk-link--no-visited-state"]
           = a11y_action_link t("table.cell.organisations.view_activities"), organisation_activities_path(partner_organisation), "for #{partner_organisation.name}", ["govuk-link--no-visited-state"]
           = a11y_action_link t("table.cell.organisations.view_exports"), exports_organisation_path(partner_organisation), "for #{partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]
           = a11y_action_link t("table.cell.organisations.view_reports"), organisation_reports_path(partner_organisation), "for #{partner_organisation.name}", ["govuk-link--no-visited-state", "govuk-!-margin-left-7"]

--- a/app/views/staff/level_b_activity_uploads/new.html.haml
+++ b/app/views/staff/level_b_activity_uploads/new.html.haml
@@ -1,0 +1,31 @@
+= content_for :page_title_prefix, t("page_title.activity.upload_level_b", organisation_name: @organisation.name)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.activity.upload_level_b", organisation_name: @organisation.name)
+
+      %p.govuk-body
+        Use the template to ensure your data is in the correct format.
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h2.govuk-heading-m
+        = link_to t("action.activity.bulk_download.button"), "", class: "govuk-link"
+
+      %p.govuk-body
+        = t("action.activity.bulk_download.hint_html")
+
+      .govuk-body.upload-form
+        = form_with model: @organisation, url: "#", method: :get do |f|
+
+          = f.govuk_file_field :activity_csv,
+            label: { text: t("form.label.activity.csv_file") },
+            hint: { text: t("form.hint.activity.csv_file") }
+
+          = f.govuk_submit t("action.activity.upload.button")
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to "Back to home", organisations_path

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -39,6 +39,7 @@ en:
         no_actions_available: No actions available
       organisations:
         details: details
+        upload_data: Upload data
         view_activities: View activities
         view_exports: View exports
         view_reports: View reports

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -3,6 +3,9 @@ en:
   action:
     activity:
       add_child: Add child activity
+      bulk_download:
+        button: Download CSV template
+        hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update Level B activities.</p><p class='govuk-body'>Edit it to add the values for the selected organisation's activities, then upload it through the form.</p>"
       download:
         button: Download CSV template
         hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update activities related to your current report.</p><p class='govuk-body'>Edit it to add the values for your organisation's activities, then upload it through the form.</p>"
@@ -355,6 +358,7 @@ en:
       financials: Financials
       children: Child activities
       upload: Upload bulk activity data
+      upload_level_b: Bulk upload activity data for %{organisation_name}
       other_funding: Other funding
       transfers: Transfers
       change_history: Change history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
           get tab, to: "activities#show", defaults: {tab: tab}
         end
       end
+      resource :level_b_activity_upload, only: [:new]
     end
 
     resources :reports, only: [:new, :create, :show, :edit, :update, :index] do

--- a/spec/controllers/staff/level_b_activity_uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b_activity_uploads_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Staff::LevelBActivityUploadsController do
+  let(:organisation) { create(:partner_organisation) }
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#new" do
+    render_views
+
+    it "shows the upload button" do
+      get :new, params: {organisation_id: organisation.id}
+
+      expect(response.body).to include(t("action.activity.bulk_download.button"))
+    end
+  end
+end

--- a/spec/features/staff/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_activities_spec.rb
@@ -1,0 +1,13 @@
+RSpec.feature "BEIS users can upload Level B activities" do
+  let(:organisation) { create(:partner_organisation) }
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    visit new_organisation_level_b_activity_upload_path(organisation)
+  end
+
+  scenario "viewing the page for downloading or uploading a CSV template" do
+    expect(page).to have_content(t("page_title.activity.upload_level_b", organisation_name: organisation.name))
+  end
+end

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe OrganisationPolicy do
     it "permits all actions" do
       is_expected.to permit_action(:index)
       is_expected.to permit_action(:show)
+      is_expected.to permit_action(:bulk_upload)
       is_expected.to permit_new_and_create_actions
       is_expected.to permit_edit_and_update_actions
       is_expected.to permit_action(:destroy)
@@ -25,6 +26,7 @@ RSpec.describe OrganisationPolicy do
       it "controls actions as expected" do
         is_expected.to forbid_action(:index)
         is_expected.to permit_action(:show)
+        is_expected.to forbid_action(:bulk_upload)
         is_expected.to forbid_new_and_create_actions
         is_expected.to permit_edit_and_update_actions
         is_expected.to forbid_action(:destroy)
@@ -38,6 +40,7 @@ RSpec.describe OrganisationPolicy do
       it "forbids all actions" do
         is_expected.to forbid_action(:index)
         is_expected.to forbid_action(:show)
+        is_expected.to forbid_action(:bulk_upload)
         is_expected.to forbid_new_and_create_actions
         is_expected.to forbid_edit_and_update_actions
         is_expected.to forbid_action(:destroy)

--- a/spec/views/home/service_owner_spec.rb
+++ b/spec/views/home/service_owner_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "staff/home/service_owner" do
     stub_template "staff/searches/_form" => "search form"
 
     allow(view).to receive(:organisation_path).and_return("/organisations/id")
+    allow(view).to receive(:new_organisation_level_b_activity_upload_path).and_return("/organisation/id/level_b_activity_uploads/new")
     allow(view).to receive(:organisation_activities_path).and_return("/organisation/id/activities")
     allow(view).to receive(:exports_organisation_path).and_return("/exports/organisation/id")
     allow(view).to receive(:organisation_reports_path).and_return("/organisation/id/reports")
@@ -17,6 +18,7 @@ RSpec.describe "staff/home/service_owner" do
 
   it "has links to a partner organisation's details, activities, exports and reports" do
     expect(rendered).to have_link("Partner Org 1", href: "/organisations/id")
+    expect(rendered).to have_link(t("table.cell.organisations.upload_data"), href: "/organisation/id/level_b_activity_uploads/new")
     expect(rendered).to have_link(t("table.cell.organisations.view_activities"), href: "/organisation/id/activities")
     expect(rendered).to have_link(t("table.cell.organisations.view_exports"), href: "/exports/organisation/id")
     expect(rendered).to have_link(t("table.cell.organisations.view_reports"), href: "/organisation/id/reports")


### PR DESCRIPTION
## Changes in this PR

Add Level B activity bulk upload form view and a link to it from the [partner organisations table](http://localhost:3000/home). The view for the form includes a link to download the template CSV files, but it currently points nowhere

I'm not sure why the organisation names are title case on my end - the before screenshot is taken from #1753 (i.e. @Gweaton's setup), so it hopefully isn't a change I've introduced, just a local environment quirk (can look into this tomorrow)

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/40244233/188733770-b2f540ee-fadf-4ecd-bfe6-2ece39a3de70.png)

### After

![image](https://user-images.githubusercontent.com/40244233/188734862-10e3f19d-e9eb-469c-973c-058f86b47cd4.png)

---

![image](https://user-images.githubusercontent.com/40244233/188734627-9d9131ad-1be7-44c7-89b1-63665eafa866.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
