### PR TITLE
(2531) Add Level B template CSV download action

### DIFF
--- a/app/controllers/staff/level_b_activity_uploads_controller.rb
+++ b/app/controllers/staff/level_b_activity_uploads_controller.rb
@@ -2,9 +2,30 @@
 
 class Staff::LevelBActivityUploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   def new
+    authorize organisation, :bulk_upload?
+
+    @organisation_presenter = OrganisationPresenter.new(organisation)
+  end
+
+  def show
+    authorize organisation, :bulk_upload?
+
+    @organisation_presenter = OrganisationPresenter.new(organisation)
+    filename = @organisation_presenter.filename_for_activities_template
+
+    stream_csv_download(filename: filename, headers: csv_headers)
+  end
+
+  private
+
+  def csv_headers
+    ["RODA ID"] + Activities::ImportFromCsv.level_b_column_headings
+  end
+
+  def organisation
     @organisation ||= Organisation.find(params[:organisation_id])
-    authorize @organisation, :bulk_upload?
   end
 end

--- a/app/presenters/organisation_presenter.rb
+++ b/app/presenters/organisation_presenter.rb
@@ -16,4 +16,11 @@ class OrganisationPresenter < SimpleDelegator
   def organisation_type
     I18n.t("organisation.organisation_type.#{super}")
   end
+
+  def filename_for_activities_template
+    [
+      beis_organisation_reference,
+      "Level_B_activities_upload"
+    ].compact.join("-") + ".csv"
+  end
 end

--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -24,6 +24,12 @@ module Activities
         ["Implementing organisation names"]
     end
 
+    def self.level_b_column_headings
+      ["Parent RODA ID"] +
+        Converter::FIELDS.values -
+        sub_level_b_column_headings
+    end
+
     def initialize(uploader:, partner_organisation:, report:)
       @uploader = uploader
       @uploader_organisation = uploader.organisation
@@ -89,6 +95,29 @@ module Activities
 
     def add_error(row_number, column, value, message)
       @errors << Error.new(row_number, column, value, message)
+    end
+
+    class << self
+      private
+
+      def sub_level_b_column_headings
+        [
+          "BEIS ID",
+          "Call close date", "Call open date",
+          "DFID policy marker - Biodiversity",
+          "DFID policy marker - Climate Change - Adaptation",
+          "DFID policy marker - Climate Change - Mitigation",
+          "DFID policy marker - Desertification",
+          "DFID policy marker - Disability",
+          "DFID policy marker - Disaster Risk Reduction",
+          "DFID policy marker - Gender",
+          "DFID policy marker - Nutrition",
+          "ODA Eligibility Lead",
+          "Total applications",
+          "Total awards",
+          "UK PO Named Contact"
+        ]
+      end
     end
 
     class ActivityUpdater

--- a/app/views/staff/level_b_activity_uploads/new.html.haml
+++ b/app/views/staff/level_b_activity_uploads/new.html.haml
@@ -1,10 +1,10 @@
-= content_for :page_title_prefix, t("page_title.activity.upload_level_b", organisation_name: @organisation.name)
+= content_for :page_title_prefix, t("page_title.activity.upload_level_b", organisation_name: @organisation_presenter.name)
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.activity.upload_level_b", organisation_name: @organisation.name)
+        = t("page_title.activity.upload_level_b", organisation_name: @organisation_presenter.name)
 
       %p.govuk-body
         Use the template to ensure your data is in the correct format.
@@ -12,13 +12,15 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m
-        = link_to t("action.activity.bulk_download.button"), "", class: "govuk-link"
+        = link_to t("action.activity.bulk_download.button"),
+          organisation_level_b_activity_upload_path(@organisation_presenter.id, format: :csv),
+          class: "govuk-link"
 
       %p.govuk-body
         = t("action.activity.bulk_download.hint_html")
 
       .govuk-body.upload-form
-        = form_with model: @organisation, url: "#", method: :get do |f|
+        = form_with model: @organisation_presenter, url: "#", method: :get do |f|
 
           = f.govuk_file_field :activity_csv,
             label: { text: t("form.label.activity.csv_file") },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
           get tab, to: "activities#show", defaults: {tab: tab}
         end
       end
-      resource :level_b_activity_upload, only: [:new]
+      resource :level_b_activity_upload, only: [:new, :show]
     end
 
     resources :reports, only: [:new, :create, :show, :edit, :update, :index] do

--- a/spec/controllers/staff/level_b_activity_uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b_activity_uploads_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Staff::LevelBActivityUploadsController do
-  let(:organisation) { create(:partner_organisation) }
+  let(:organisation) { create(:partner_organisation, beis_organisation_reference: "porg") }
   let(:user) { create(:beis_user) }
   before { authenticate!(user: user) }
 
@@ -16,6 +16,17 @@ RSpec.describe Staff::LevelBActivityUploadsController do
       get :new, params: {organisation_id: organisation.id}
 
       expect(response.body).to include(t("action.activity.bulk_download.button"))
+    end
+  end
+
+  describe "#show" do
+    it "downloads the CSV template with the correct filename" do
+      get :show, params: {organisation_id: organisation.id}
+
+      expect(response.headers.to_h).to include({
+        "Content-Type" => "text/csv",
+        "Content-Disposition" => "attachment; filename=PORG-Level_B_activities_upload.csv"
+      })
     end
   end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_activities_spec.rb
@@ -10,4 +10,38 @@ RSpec.feature "BEIS users can upload Level B activities" do
   scenario "viewing the page for downloading or uploading a CSV template" do
     expect(page).to have_content(t("page_title.activity.upload_level_b", organisation_name: organisation.name))
   end
+
+  scenario "downloading the CSV template" do
+    click_link t("action.activity.bulk_download.button")
+
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: false).first
+
+    expect(rows).to match_array([
+      "RODA ID",
+      "Parent RODA ID",
+      "Transparency identifier",
+      "Title",
+      "Description",
+      "Benefitting Countries",
+      "Partner organisation identifier",
+      "GDI",
+      "GCRF Strategic Area",
+      "GCRF Challenge Area",
+      "SDG 1", "SDG 2", "SDG 3",
+      "Newton Fund Pillar",
+      "Covid-19 related research",
+      "ODA Eligibility",
+      "Activity Status",
+      "Planned start date", "Planned end date",
+      "Actual start date", "Actual end date",
+      "Sector",
+      "Channel of delivery code",
+      "Collaboration type (Bi/Multi Marker)",
+      "Aid type",
+      "Free Standing Technical Cooperation",
+      "Aims/Objectives (PO Definition)",
+      "NF Partner Country PO"
+    ])
+  end
 end


### PR DESCRIPTION
## Changes in this PR

This adds a controller action to enable users to download the template CSV for Level B activity data bulk uploads, linked from the view/form created in the previous commit. Currently it will respond with a template with the same headers as the standard activity upload

The changelog will be updated after 2533 (processing the upload)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
