### PR TITLE
(2571) Add data migration to migrate `country_delivery_partner` form state to `country_partner_organisation`

### DIFF
--- a/db/data/20220920112227_rename_dp_to_po_in_form_state.rb
+++ b/db/data/20220920112227_rename_dp_to_po_in_form_state.rb
@@ -1,0 +1,12 @@
+# Run me with `rails runner db/data/20220920112227_rename_dp_to_po_in_form_state.rb`
+
+# Put your Ruby code here
+
+activities_to_update = Activity.where(form_state: "country_delivery_partners")
+total_activities_to_update = activities_to_update.count
+
+puts "Updating #{total_activities_to_update} activities..."
+activities_to_update.update_all(form_state: "country_partner_organisations")
+
+country_partner_org_activities_count = Activity.where(form_state: "country_partner_organisations").count
+puts "There are now #{country_partner_org_activities_count} activities with the new value"


### PR DESCRIPTION
## Changes in this PR

Adds a data migration for renaming an Activity's `form_state` value from `country_delivery_partners` to `country_partner_organisations`. Now that we've renamed `delivery_partners` to `partner_organisations` in the codebase, this data field is out of date. I believe there's only actually 1 Activity at this step, but we should always use a script to do this rather than the Rails console on production.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
