### PR TITLE
Fix error-raising code

### DIFF
--- a/app/services/activities/import_from_csv.rb
+++ b/app/services/activities/import_from_csv.rb
@@ -404,7 +404,7 @@ module Activities
       def convert_policy_marker(policy_marker)
         return "not_assessed" if policy_marker.blank?
 
-        raise I18n.t("importer.errors.activity.invalid_policy_marker") if Integer(policy_marker).to_s != policy_marker
+        raise I18n.t("importer.errors.activity.invalid_policy_marker") if policy_marker.to_i.to_s != policy_marker
 
         marker = policy_markers_iati_codes_to_enum(policy_marker)
         raise I18n.t("importer.errors.activity.invalid_policy_marker") if marker.nil?
@@ -422,7 +422,7 @@ module Activities
       def convert_policy_marker_desertification(policy_marker)
         return "not_assessed" if policy_marker.blank?
 
-        raise I18n.t("importer.errors.activity.invalid_policy_marker") if Integer(policy_marker).to_s != policy_marker
+        raise I18n.t("importer.errors.activity.invalid_policy_marker") if policy_marker.to_i.to_s != policy_marker
 
         marker = policy_markers_desertification_iati_codes_to_enum(policy_marker)
         raise I18n.t("importer.errors.activity.invalid_policy_marker") if marker.nil?


### PR DESCRIPTION
## Changes in this PR

The policy marker convertor methods have their own error checking, so we don’t want the `Integer` conversion to raise an exception.

The commit dd28a23b20f05573f7eb4dfe6a841d945e15feb1 which made this change made it on the `master` branch somehow (investigation pending), despite the intention being to revert it, as the commit message of the commit
that made it into release-111 attests: dc61b9daf89b6bd68a407c62a52e9df154025d73.
