### PR TITLE
Reset env var post-spec

### DIFF
--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe VcapParser do
     end
 
     it "loads redis URL to the ENV" do
+      cached_redis_url = ENV["REDIS_URL"]
+
       vcap_json = '
         {
           "redis": [
@@ -38,6 +40,8 @@ RSpec.describe VcapParser do
         VcapParser.load_service_environment_variables!
         expect(ENV["REDIS_URL"]).to eq("rediss://x:REDACTED@HOST:6379")
       end
+
+      ENV["REDIS_URL"] = cached_redis_url
     end
 
     it "does not error if VCAP_SERVICES is not set" do


### PR DESCRIPTION
## Changes in this PR

The spec `it "loads redis URL to the ENV”` has side effects that can cause other specs to fail, depending on the order in which they are run.

`ClimateControl` can only reset `VCAP_SERVICES` for us, not the other env vars that are set during the spec running.

The default value of `VCAP_SERVICES` (set in .env.test) doesn’t have a value for `REDIS_URL`, so the value being set during this spec sticks, and overwrites the desired value of `REDIS_URL`, which is set in .env.test.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
