### PR TITLE
(2585) Add placeholder Level B budget upload page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1094,6 +1094,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Add Level B budget bulk upload form
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117
 [release-116]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-115...release-116

--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -1,0 +1,7 @@
+class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
+  include Secured
+
+  def new
+    authorize :level_b, :budget_upload?
+  end
+end

--- a/app/controllers/staff/level_b_activity_uploads_controller.rb
+++ b/app/controllers/staff/level_b_activity_uploads_controller.rb
@@ -5,13 +5,13 @@ class Staff::LevelBActivityUploadsController < Staff::BaseController
   include StreamCsvDownload
 
   def new
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
   end
 
   def show
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
     filename = @organisation_presenter.filename_for_activities_template
@@ -20,7 +20,7 @@ class Staff::LevelBActivityUploadsController < Staff::BaseController
   end
 
   def update
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
     upload = CsvFileUpload.new(params[:organisation], :activity_csv)

--- a/app/models/budget_upload.rb
+++ b/app/models/budget_upload.rb
@@ -1,0 +1,3 @@
+class BudgetUpload
+  include ActiveModel::Model
+end

--- a/app/policies/level_b_policy.rb
+++ b/app/policies/level_b_policy.rb
@@ -1,0 +1,5 @@
+class LevelBPolicy < ApplicationPolicy
+  def budget_upload?
+    return true if beis_user?
+  end
+end

--- a/app/policies/level_b_policy.rb
+++ b/app/policies/level_b_policy.rb
@@ -1,4 +1,8 @@
 class LevelBPolicy < ApplicationPolicy
+  def activity_upload?
+    return true if beis_user?
+  end
+
   def budget_upload?
     return true if beis_user?
   end

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -1,0 +1,31 @@
+= content_for :page_title_prefix, t("page_title.budget.upload_level_b")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.upload_level_b")
+
+      %p.govuk-body
+        Use the template to ensure your data is in the correct format.
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h2.govuk-heading-m
+        = link_to t("action.budget.bulk_download.button"), "", class: "govuk-link"
+
+      %p.govuk-body
+        = t("action.budget.bulk_download.hint_html")
+
+      .govuk-body.upload-form
+        = form_with model: BudgetUpload.new, url: "#", method: :get do |f|
+
+          = f.govuk_file_field :csv,
+            label: { text: t("form.label.budget.csv_file") },
+            hint: { text: t("form.hint.budget.csv_file") }
+
+          = f.govuk_submit t("action.budget.upload.button")
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to "Back to home", home_path

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -8,6 +8,11 @@ en:
         success: Budget successfully updated
       destroy:
         success: Budget successfully deleted
+      bulk_download:
+        button: Download CSV template
+        hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update budgets.</p><p class='govuk-body'>Edit it to add the values for the relevant budgets, then upload it through the form.</p>"
+      upload:
+        button: Upload and continue
   form:
     label:
       budget:
@@ -19,6 +24,7 @@ en:
         budget_type:
           direct: Direct
           other_official: Other official development assistance
+        csv_file: Upload CSV spreadsheet
     legend:
       budget:
         budget_type: Type
@@ -33,6 +39,7 @@ en:
         budget_type:
           direct: Budget allocated directly from the parent activity
           other_official: Budget allocated from an external organisation that is still considered ODA funding
+        csv_file: Upload a spreadsheet containing budget data in CSV format.
   table:
     header:
       budget:
@@ -52,6 +59,7 @@ en:
     budget:
       edit: Edit budget
       new: Create budget
+      upload_level_b: Bulk upload budget data for Level B activities
   breadcrumb:
     budget:
       edit: Edit budget

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,12 @@ Rails.application.routes.draw do
       end
     end
 
+    namespace :level_b do
+      namespace :budgets do
+        resource :upload, only: [:new]
+      end
+    end
+
     resources :organisations, except: [:destroy, :index, :new] do
       get "reports" => "organisation_reports#index"
       resources :activities, except: [:create, :destroy] do

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Staff::LevelB::Budgets::UploadsController do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#new" do
+    render_views
+
+    it "shows the upload button" do
+      get :new
+
+      expect(response.body).to include(t("action.budget.bulk_download.button"))
+    end
+  end
+end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -1,0 +1,12 @@
+RSpec.feature "BEIS users can upload Level B budgets" do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    visit new_level_b_budgets_upload_path
+  end
+
+  scenario "viewing the page for downloading or uploading a CSV template" do
+    expect(page).to have_content(t("page_title.budget.upload_level_b"))
+  end
+end

--- a/spec/policies/level_b_policy_spec.rb
+++ b/spec/policies/level_b_policy_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe LevelBPolicy do
     let(:user) { build_stubbed(:beis_user) }
 
     it "permits all actions" do
+      is_expected.to permit_action(:activity_upload)
       is_expected.to permit_action(:budget_upload)
     end
   end
@@ -15,6 +16,7 @@ RSpec.describe LevelBPolicy do
     let(:user) { build_stubbed(:partner_organisation_user) }
 
     it "forbids all actions" do
+      is_expected.to forbid_action(:activity_upload)
       is_expected.to forbid_action(:budget_upload)
     end
   end

--- a/spec/policies/level_b_policy_spec.rb
+++ b/spec/policies/level_b_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe LevelBPolicy do
+  subject { described_class.new(user, nil) }
+
+  context "as user that belongs to BEIS" do
+    let(:user) { build_stubbed(:beis_user) }
+
+    it "permits all actions" do
+      is_expected.to permit_action(:budget_upload)
+    end
+  end
+
+  context "as user that does NOT belong to BEIS" do
+    let(:user) { build_stubbed(:partner_organisation_user) }
+
+    it "forbids all actions" do
+      is_expected.to forbid_action(:budget_upload)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This adds a new view for bulk uploading Level B budget data via CSV. Currently the CSV template download and upload form are non-functional - these will be added in later commits

We added a new budget upload model and policy as this upload is not attached to a specific activity (or any entity) - budgets can be uploaded for multiple funds and organisations all in one CSV file

**Note:** linked in the parent Trello card is an design screenshot (`uploads_form.png`), which slightly differs in structure to the Level B activities upload form. We decided to keep it similar to the latter - we weren't sure how recent the design was - but we could change it to match the design more closely if preferred

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/40244233/192001309-6da5d01e-5e7b-494e-87b5-a5a1ec1af354.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
