### PR TITLE
(2588) Add Level B budget bulk upload template CSV download action

### DIFF
--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -1,7 +1,26 @@
 class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   def new
     authorize :level_b, :budget_upload?
+  end
+
+  def show
+    authorize :level_b, :budget_upload?
+
+    headers = [
+      "Type",
+      "Financial year",
+      "Budget amount",
+      "Providing organisation",
+      "Providing organisation type",
+      "IATI reference",
+      "Activity RODA ID",
+      "Fund RODA ID",
+      "Partner organisation name"
+    ]
+
+    stream_csv_download(filename: "Level_B_budgets_upload.csv", headers: headers)
   end
 end

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -12,7 +12,9 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m
-        = link_to t("action.budget.bulk_download.button"), "", class: "govuk-link"
+        = link_to t("action.budget.bulk_download.button"),
+          level_b_budgets_upload_path(format: :csv),
+          class: "govuk-link"
 
       %p.govuk-body
         = t("action.budget.bulk_download.hint_html")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
 
     namespace :level_b do
       namespace :budgets do
-        resource :upload, only: [:new]
+        resource :upload, only: [:new, :show]
       end
     end
 

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe Staff::LevelB::Budgets::UploadsController do
       expect(response.body).to include(t("action.budget.bulk_download.button"))
     end
   end
+
+  describe "#show" do
+    it "downloads the CSV template with the correct filename" do
+      get :show
+
+      expect(response.headers.to_h).to include({
+        "Content-Type" => "text/csv",
+        "Content-Disposition" => "attachment; filename=Level_B_budgets_upload.csv"
+      })
+    end
+  end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -9,4 +9,23 @@ RSpec.feature "BEIS users can upload Level B budgets" do
   scenario "viewing the page for downloading or uploading a CSV template" do
     expect(page).to have_content(t("page_title.budget.upload_level_b"))
   end
+
+  scenario "downloading the CSV template" do
+    click_link t("action.budget.bulk_download.button")
+
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: false).first
+
+    expect(rows).to match_array([
+      "Type",
+      "Financial year",
+      "Budget amount",
+      "Providing organisation",
+      "Providing organisation type",
+      "IATI reference",
+      "Activity RODA ID",
+      "Fund RODA ID",
+      "Partner organisation name"
+    ])
+  end
 end


### PR DESCRIPTION
## Changes in this PR

This adds a controller action to enable users to download the template CSV for Level B budget data bulk uploads, linked from the view/form created in the previous commit

The headers are as per the design collaboration with the client, but may still be subject to change. The naming of some columns differs slightly to that used in the activity templates

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
