### PR TITLE
Ensure logged out specs start with clean state

### DIFF
--- a/spec/controllers/staff/activities_controller_spec.rb
+++ b/spec/controllers/staff/activities_controller_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe Staff::ActivitiesController do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       activity = create(:programme_activity)
       get :index

--- a/spec/controllers/staff/organisations_controller_spec.rb
+++ b/spec/controllers/staff/organisations_controller_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe Staff::OrganisationsController do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       get :index
       expect(response).to redirect_to(root_path)

--- a/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/staff/beis_users_can_create_an_organisation_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "BEIS users can create organisations" do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       visit new_organisation_path
       expect(current_path).to eq(root_path)

--- a/spec/features/staff/beis_users_can_view_organisations_spec.rb
+++ b/spec/features/staff/beis_users_can_view_organisations_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "BEIS users can view other organisations" do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       visit organisations_path
       expect(current_path).to eq(root_path)

--- a/spec/features/staff/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/staff/beis_users_can_view_other_users_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.feature "BEIS users can can view other users" do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       visit users_path
       expect(current_path).to eq(root_path)

--- a/spec/features/staff/users_can_edit_an_actual_spec.rb
+++ b/spec/features/staff/users_can_edit_an_actual_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "Users can edit an actual" do
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       visit activity_step_path(double(Activity, id: "123"), :identifier)
       expect(current_path).to eq(root_path)

--- a/spec/features/staff/users_can_edit_an_organisation_spec.rb
+++ b/spec/features/staff/users_can_edit_an_organisation_spec.rb
@@ -3,6 +3,10 @@ RSpec.feature "Users can edit organisations" do
   let!(:another_organisation) { create(:partner_organisation) }
 
   context "when the user is not logged in" do
+    before do
+      logout
+    end
+
     it "redirects the user to the root path" do
       visit edit_organisation_path(beis_organisation)
       expect(current_path).to eq(root_path)

--- a/spec/features/staff/users_can_view_a_home_page_spec.rb
+++ b/spec/features/staff/users_can_view_a_home_page_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "users can view a home page" do
   context "when not signed in" do
+    before do
+      logout
+    end
+
     scenario "they cannot reach the home page and are redirected to the sign in" do
       visit home_path
 

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -1,5 +1,9 @@
 RSpec.feature "Users can view the site navigation" do
   context "when the user is not signed in" do
+    before do
+      logout
+    end
+
     it "does not show the navigation" do
       activity = create(:project_activity)
 


### PR DESCRIPTION
## Changes in this PR
- Ensure logged out specs start with clean state by logging out any potential users

## Screenshots of UI changes
N/A