### PR TITLE
(2569) `Forecast.set_value` must return a forecast or nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1095,6 +1095,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Refactor the importers (including associated uploads controllers and views) to use a unified approach for all entities being imported
+- Ensure `Forecast.set_value` always returns a forecast or nil; this will ensure that uploaded forecasts are correctly displayed back to the user on the success page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/app/services/forecast_history.rb
+++ b/app/services/forecast_history.rb
@@ -66,6 +66,7 @@ class ForecastHistory
     elsif latest_entry
       new_entry = revise_entry(latest_entry, value, report)
       record_historical_event(latest_entry, new_entry, report)
+      new_entry
     else
       create_original_entry(value, report)
     end

--- a/spec/services/forecast_history_spec.rb
+++ b/spec/services/forecast_history_spec.rb
@@ -211,6 +211,10 @@ RSpec.describe ForecastHistory do
       it "does not create a historical event when the value is first set" do
         expect { history.set_value(20) }.to not_create_a_historical_event
       end
+
+      it "returns a _Forecast_" do
+        expect(history.set_value(20)).to be_a(Forecast)
+      end
     end
 
     context "when the original entry is part of an approved report" do
@@ -298,6 +302,10 @@ RSpec.describe ForecastHistory do
           report: Report.editable_for_activity(activity)
         )
       end
+
+      it "returns a _Forecast_" do
+        expect(history.set_value(20)).to be_a(Forecast)
+      end
     end
 
     context "when the original entry is part of an older approved report" do
@@ -323,6 +331,10 @@ RSpec.describe ForecastHistory do
           new_value: 20,
           report: Report.editable_for_activity(activity)
         )
+      end
+
+      it "returns a _Forecast_" do
+        expect(history.set_value(20)).to be_a(Forecast)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
- Ensure `Forecast.set_value` always returns a forecast or nil

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
