### PR TITLE
(2590) Add budget importer

### DIFF
--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
   include Secured
   include StreamCsvDownload

--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -10,13 +10,7 @@ class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
     authorize :level_b, :budget_upload?
 
     headers = [
-      "Type",
-      "Financial year",
-      "Budget amount",
-      "Providing organisation",
-      "Providing organisation type",
-      "IATI reference",
-      "Activity RODA ID",
+      *::Budget::Import::Converter::FIELDS.values,
       "Fund RODA ID",
       "Partner organisation name"
     ]

--- a/app/services/budget/import.rb
+++ b/app/services/budget/import.rb
@@ -1,0 +1,207 @@
+class Budget
+  class Import
+    Error = Struct.new(:row, :column, :value, :message) {
+      def csv_row
+        row + 2
+      end
+
+      def csv_column
+        Converter::FIELDS[column] || column.to_s
+      end
+    }
+
+    attr_reader :errors, :created
+
+    def initialize(uploader:)
+      @uploader = uploader
+      @uploader_organisation = uploader.organisation
+      @errors = []
+      @created = []
+    end
+
+    def import(budgets)
+      ActiveRecord::Base.transaction do
+        budgets.each_with_index { |row, index| import_row(row, index) }
+
+        if @errors.present?
+          @created = []
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    def import_row(row, index)
+      action = create_budget(row, index)
+
+      return if action.nil?
+
+      action.errors.each do |attr_name, (value, message)|
+        add_error(index, attr_name, value, message)
+      end
+    end
+
+    def create_budget(row, index)
+      if row["Activity RODA ID"].present?
+        creator = BudgetCreator.new(row: row, uploader: @uploader)
+        creator.create
+        created << creator.budget unless creator.errors.any?
+
+        creator
+      else
+        add_error(index, :parent_activity_id, row["Activity RODA ID"], I18n.t("importer.errors.budget.cannot_create")) && return
+      end
+    end
+
+    def add_error(row_number, column, value, message)
+      @errors << Error.new(row_number, column, value, message)
+    end
+
+    class BudgetCreator
+      attr_reader :errors, :row, :budget
+
+      def initialize(row:, uploader:)
+        @row = row
+        @uploader = uploader
+        @errors = {}
+        @parent_activity = fetch_parent(@row["Activity RODA ID"])
+        @converter = Converter.new(row, @parent_activity)
+
+        @errors.update(@converter.errors)
+      end
+
+      def create
+        return unless @errors.blank?
+
+        result = CreateBudget.new(activity: @parent_activity).call(attributes: @converter.to_h)
+        @budget = result.object
+
+        return true if @budget.save
+
+        @budget.errors.each do |error|
+          @errors[error.attribute] ||= [@converter.raw(error.attribute), error.message]
+        end
+      end
+
+      private
+
+      def fetch_parent(roda_id)
+        Activity.by_roda_identifier(roda_id)
+      end
+    end
+
+    class Converter
+      attr_reader :errors
+
+      FIELDS = {
+        budget_type: "Type",
+        financial_year: "Financial year",
+        value: "Budget amount",
+        providing_organisation_name: "Providing organisation",
+        providing_organisation_type: "Providing organisation type",
+        providing_organisation_reference: "IATI reference",
+        parent_activity_id: "Activity RODA ID"
+      }
+
+      ALLOWED_BLANK_FIELDS = ["IATI reference"]
+
+      DIRECT_ALLOWED_BLANK_FIELDS = [
+        *ALLOWED_BLANK_FIELDS,
+        "Providing organisation",
+        "Providing organisation type"
+      ]
+
+      def initialize(row, parent_activity)
+        @row = row
+        @parent_activity = parent_activity
+        @errors = {}
+        @attributes = convert_to_attributes
+      end
+
+      def raw(attr_name)
+        @row[FIELDS[attr_name]]
+      end
+
+      def to_h
+        @attributes
+      end
+
+      def convert_to_attributes
+        FIELDS.each_with_object({}) { |(attr_name, column_name), attrs|
+          attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if field_should_be_converted?(column_name)
+        }
+      end
+
+      def field_should_be_converted?(column_name)
+        !field_can_be_blank?(column_name) || @row[column_name].present?
+      end
+
+      def field_can_be_blank?(column_name)
+        type_is_direct = @row["Type"] == Budget.budget_types["direct"].to_s
+        allowed_blank_fields = type_is_direct ? DIRECT_ALLOWED_BLANK_FIELDS : ALLOWED_BLANK_FIELDS
+
+        allowed_blank_fields.include?(column_name)
+      end
+
+      def convert_to_attribute(attr_name, value)
+        original_value = value.clone
+        value = value.to_s.strip
+
+        converter = "convert_#{attr_name}"
+        value = __send__(converter, value) if respond_to?(converter)
+
+        value
+      rescue => error
+        @errors[attr_name] = [original_value, error.message]
+        nil
+      end
+
+      def convert_budget_type(budget_type)
+        valid_budget_types = Budget.budget_types.values.map(&:to_s)
+        raise I18n.t("importer.errors.budget.invalid_budget_type") unless valid_budget_types.include?(budget_type)
+
+        budget_type.to_i
+      end
+
+      def convert_financial_year(financial_year)
+        financial_year.strip!
+        start_year = financial_year[0, 4].to_i
+        end_year = financial_year[5, 9].to_i
+
+        raise I18n.t("importer.errors.budget.invalid_financial_year") if end_year != start_year + 1
+
+        start_year
+      end
+
+      def convert_parent_activity_id(_parent_activity_id)
+        raise I18n.t("importer.errors.budget.parent_not_found") if @parent_activity.nil?
+
+        @parent_activity.id
+      end
+
+      def convert_providing_organisation_name(providing_organisation_name)
+        raise I18n.t("importer.errors.budget.invalid_providing_organisation_name") if providing_organisation_name.blank?
+
+        providing_organisation_name
+      end
+
+      def convert_providing_organisation_type(providing_organisation_type)
+        organisation_types = ApplicationController.helpers.organisation_type_options
+        organisation_type_codes = []
+
+        organisation_types.each do |organisation_type|
+          organisation_type_codes << organisation_type.code if organisation_type.code.present?
+        end
+
+        raise I18n.t("importer.errors.budget.invalid_providing_organisation_type") unless organisation_type_codes.include?(providing_organisation_type)
+
+        providing_organisation_type
+      end
+
+      def convert_value(value)
+        raise I18n.t("importer.errors.budget.invalid_value") unless value.present? && value.to_d != "0".to_d && value.to_d <= "99_999_999_999.00".to_d
+
+        value
+      end
+    end
+  end
+end

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -96,3 +96,14 @@ en:
               blank: Enter the name of the providing organisation
             providing_organisation_type:
               blank: Select the type of the providing organisation
+  importer:
+    errors:
+      budget:
+        cannot_create: There is no activity RODA ID present, so cannot create a budget
+        invalid_budget_type: The budget type code is not valid
+        invalid_financial_year: The financial year is not valid
+        invalid_providing_organisation_name: The providing organisation is not valid
+        invalid_providing_organisation_reference: The IATI reference is not valid
+        invalid_providing_organisation_type: The providing organisation type code is not valid
+        invalid_value: The budget amount is not valid
+        parent_not_found: The parent activity cannot be found

--- a/spec/services/budget/import_level_b_spec.rb
+++ b/spec/services/budget/import_level_b_spec.rb
@@ -1,0 +1,261 @@
+require "rails_helper"
+
+RSpec.describe Budget::Import do
+  let(:uploader) { create(:beis_user) }
+  let(:programme_activity) { create(:programme_activity) }
+
+  let(:new_direct_budget_attributes) do
+    {
+      "Type" => "0",
+      "Financial year" => "2011-2012",
+      "Budget amount" => "12345",
+      "Activity RODA ID" => programme_activity.roda_identifier
+    }
+  end
+
+  subject { described_class.new(uploader: uploader) }
+
+  context "when creating a new budget" do
+    let(:level_b_policy_double) { instance_double("LevelBPolicy", budget_upload?: true) }
+
+    before do
+      allow(LevelBPolicy).to receive(:new).with(uploader, nil).and_return(level_b_policy_double)
+    end
+
+    context "with a type of direct" do
+      it "creates the budget" do
+        expect { subject.import([new_direct_budget_attributes]) }.to change { Budget.count }.by(1)
+
+        expect(subject.created.count).to eq(1)
+
+        expect(subject.errors.count).to eq(0)
+
+        new_budget = Budget.order(:created_at).last
+        budget_type = "direct"
+        financial_year = FinancialYear.new(new_direct_budget_attributes["Financial year"])
+
+        expect(new_budget.budget_type).to eq(budget_type)
+        expect(new_budget.financial_year).to eq(financial_year)
+        expect(new_budget.value).to eq(new_direct_budget_attributes["Budget amount"].to_f)
+        expect(new_budget.parent_activity).to eq(programme_activity)
+
+        expect(new_budget.period_start_date).to eq(financial_year.start_date)
+        expect(new_budget.period_end_date).to eq(financial_year.end_date)
+        expect(new_budget.currency).to eq("GBP")
+        expect(new_budget.ingested).to eq(false)
+        expect(new_budget.report_id).to be_nil
+        expect(new_budget.funding_type).to be_nil
+        expect(new_budget.providing_organisation_id).to eq(beis_organisation_id)
+        expect(new_budget.providing_organisation_name).to be_nil
+        expect(new_budget.providing_organisation_type).to be_nil
+        expect(new_budget.providing_organisation_reference).to be_nil
+      end
+
+      it "has errors if the budget type is invalid" do
+        new_direct_budget_attributes["Type"] = "99999"
+
+        expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(3)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Type")
+        expect(subject.errors.first.column).to eq(:budget_type)
+        expect(subject.errors.first.value).to eq("99999")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_budget_type"))
+
+        expect(subject.errors.second.column).to eq(:providing_organisation_name)
+        expect(subject.errors.third.column).to eq(:providing_organisation_type)
+      end
+
+      context "financial year" do
+        [
+          {
+            statement: "has an error if the start and end years are non-contiguous",
+            value: "1999-2013"
+          },
+          {
+            statement: "has an error if only one year is provided",
+            value: "2020"
+          }
+        ].each do |example|
+          it example[:statement] do
+            new_direct_budget_attributes["Financial year"] = example[:value]
+
+            expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+            expect(subject.created.count).to eq(0)
+
+            expect(subject.errors.count).to eq(1)
+            expect(subject.errors.first.csv_row).to eq(2)
+            expect(subject.errors.first.csv_column).to eq("Financial year")
+            expect(subject.errors.first.column).to eq(:financial_year)
+            expect(subject.errors.first.value).to eq(example[:value])
+            expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_financial_year"))
+          end
+        end
+      end
+
+      context "budget amount" do
+        [
+          {
+            statement: "has an error when missing",
+            value: ""
+          },
+          {
+            statement: "has an error when zero",
+            value: "0"
+          },
+          {
+            statement: "has an error when too high",
+            value: "99999999999.01"
+          }
+        ].each do |example|
+          it example[:statement] do
+            new_direct_budget_attributes["Budget amount"] = example[:value]
+
+            expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+            expect(subject.created.count).to eq(0)
+
+            expect(subject.errors.count).to eq(1)
+            expect(subject.errors.first.csv_row).to eq(2)
+            expect(subject.errors.first.csv_column).to eq("Budget amount")
+            expect(subject.errors.first.column).to eq(:value)
+            expect(subject.errors.first.value).to eq(example[:value])
+            expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_value"))
+          end
+        end
+      end
+
+      context "parent activity" do
+        it "has an error when missing" do
+          new_direct_budget_attributes["Activity RODA ID"] = ""
+
+          expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+          expect(subject.created.count).to eq(0)
+
+          expect(subject.errors.count).to eq(1)
+          expect(subject.errors.first.csv_row).to eq(2)
+          expect(subject.errors.first.csv_column).to eq("Activity RODA ID")
+          expect(subject.errors.first.column).to eq(:parent_activity_id)
+          expect(subject.errors.first.value).to eq("")
+          expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.cannot_create"))
+        end
+
+        it "has an error when not found" do
+          new_direct_budget_attributes["Activity RODA ID"] = "111111"
+
+          expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+          expect(subject.created.count).to eq(0)
+
+          expect(subject.errors.count).to eq(1)
+          expect(subject.errors.first.csv_row).to eq(2)
+          expect(subject.errors.first.csv_column).to eq("Activity RODA ID")
+          expect(subject.errors.first.column).to eq(:parent_activity_id)
+          expect(subject.errors.first.value).to eq("111111")
+          expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.parent_not_found"))
+        end
+      end
+    end
+
+    context "with a type of other official" do
+      let(:new_other_official_budget_attributes) do
+        {
+          "Type" => "1",
+          "Financial year" => "2016-2017",
+          "Budget amount" => "67890",
+          "Providing organisation" => "Lovely Co",
+          "Providing organisation type" => "24",
+          "IATI reference" => "top-tier-transparency",
+          "Activity RODA ID" => programme_activity.roda_identifier
+        }
+      end
+
+      [
+        {
+          statement: "with an IATI reference",
+          value: "top-tier-transparency"
+        },
+        {
+          statement: "without an IATI reference",
+          value: ""
+        }
+      ].each do |example|
+        context example[:statement] do
+          it "creates the budget" do
+            new_other_official_budget_attributes["IATI reference"] = example[:value]
+
+            expect { subject.import([new_other_official_budget_attributes]) }.to change { Budget.count }.by(1)
+
+            expect(subject.created.count).to eq(1)
+
+            expect(subject.errors.count).to eq(0)
+
+            new_budget = Budget.order(:created_at).last
+            budget_type = "other_official"
+            financial_year = FinancialYear.new(new_other_official_budget_attributes["Financial year"])
+
+            expect(new_budget.budget_type).to eq(budget_type)
+            expect(new_budget.financial_year).to eq(financial_year)
+            expect(new_budget.value).to eq(new_other_official_budget_attributes["Budget amount"].to_f)
+            expect(new_budget.parent_activity).to eq(programme_activity)
+            expect(new_budget.providing_organisation_name).to eq(new_other_official_budget_attributes["Providing organisation"])
+            expect(new_budget.providing_organisation_type).to eq(new_other_official_budget_attributes["Providing organisation type"])
+
+            if example[:value].present?
+              expect(new_budget.providing_organisation_reference).to eq(new_other_official_budget_attributes["IATI reference"])
+            else
+              expect(new_budget.providing_organisation_reference).to be_nil
+            end
+
+            expect(new_budget.period_start_date).to eq(financial_year.start_date)
+            expect(new_budget.period_end_date).to eq(financial_year.end_date)
+            expect(new_budget.currency).to eq("GBP")
+            expect(new_budget.ingested).to eq(false)
+            expect(new_budget.report_id).to be_nil
+            expect(new_budget.funding_type).to be_nil
+            expect(new_budget.providing_organisation_id).to be_nil
+          end
+        end
+      end
+
+      it "has an error if the providing organisation is missing" do
+        new_other_official_budget_attributes["Providing organisation"] = ""
+
+        expect { subject.import([new_other_official_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Providing organisation")
+        expect(subject.errors.first.column).to eq(:providing_organisation_name)
+        expect(subject.errors.first.value).to eq("")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_providing_organisation_name"))
+      end
+
+      it "has an error if the providing organisation type is not valid" do
+        new_other_official_budget_attributes["Providing organisation type"] = "99999"
+
+        expect { subject.import([new_other_official_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Providing organisation type")
+        expect(subject.errors.first.column).to eq(:providing_organisation_type)
+        expect(subject.errors.first.value).to eq("99999")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_providing_organisation_type"))
+      end
+    end
+  end
+
+  def beis_organisation_id
+    Organisation.find_by(name: "Department for Business, Energy and Industrial Strategy").id
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This adds a budget importer for processing bulk uploads in a similar way to the activities importer

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
