### PR TITLE
(2594) Add budgets create action

### DIFF
--- a/app/views/staff/level_b/activities/uploads/update.html.haml
+++ b/app/views/staff/level_b/activities/uploads/update.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.activity.upload")
+        = t("page_title.activity.upload_level_b", organisation_name: @organisation_presenter.name)
 
   - unless @errors.empty?
     .govuk-grid-row

--- a/app/views/staff/level_b/budgets/uploads/create.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/create.html.haml
@@ -1,0 +1,22 @@
+= content_for :page_title_prefix, t("page_title.budget.upload_level_b")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.upload_level_b")
+
+  - unless @errors.empty?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/budgets/uploads/error_table"
+
+  - if @success
+    - if @budgets[:created].any?
+      = render partial: "staff/shared/budgets/uploads/budgets_table", locals: { action: "created", budgets: @budgets[:created], table_caption: t("table.caption.budget.new_budgets") }
+  - else
+    = render partial: "staff/shared/budgets/uploads/upload_form", locals: { model: BudgetUpload.new, path_helper: "level_b_budgets_upload_path" }
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to "Back to home", home_path

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -20,7 +20,7 @@
         = t("action.budget.bulk_download.hint_html")
 
       .govuk-body.upload-form
-        = form_with model: BudgetUpload.new, url: "#", method: :get do |f|
+        = form_with model: BudgetUpload.new, url: level_b_budgets_upload_path do |f|
 
           = f.govuk_file_field :csv,
             label: { text: t("form.label.budget.csv_file") },

--- a/app/views/staff/shared/budgets/uploads/_budgets_table.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_budgets_table.html.haml
@@ -1,0 +1,17 @@
+%table{ class: "govuk-table govuk-!-margin-bottom-9" }
+  %caption.govuk-table__caption.govuk-table__caption--m
+    = table_caption
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Activity RODA ID
+      %th.govuk-table__header{scope: "col"} Type
+      %th.govuk-table__header{scope: "col"} Financial year
+      %th.govuk-table__header{scope: "col"} Budget amount
+  %tbody.govuk-table__body
+    - budgets.each do |budget|
+      - budget_presenter = BudgetPresenter.new(budget)
+      %tr.govuk-table__row
+        %td.govuk-table__cell= budget_presenter.parent_activity.roda_identifier
+        %td.govuk-table__cell= budget_presenter.budget_type
+        %td.govuk-table__cell= budget_presenter.financial_year
+        %td.govuk-table__cell= budget_presenter.value

--- a/app/views/staff/shared/budgets/uploads/_error_table.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_error_table.html.haml
@@ -1,0 +1,15 @@
+%table.govuk-table
+  %caption.govuk-table__caption List of errors in your uploaded CSV file
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Column
+      %th.govuk-table__header{scope: "col"} Row
+      %th.govuk-table__header{scope: "col"} Current Value
+      %th.govuk-table__header{scope: "col"} Error description
+  %tbody.govuk-table__body
+    - @errors.each do |error|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= error.csv_column
+        %td.govuk-table__cell= error.csv_row
+        %td{class: "govuk-table__cell govuk-!-font-weight-bold error-text"}= error.value
+        %td.govuk-table__cell= error.message

--- a/app/views/staff/shared/budgets/uploads/_upload_form.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_upload_form.html.haml
@@ -1,0 +1,9 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    = form_with model: model, url: send(path_helper, model) do |f|
+
+      = f.govuk_file_field :csv,
+        label: { text: t("form.label.budget.csv_file_recover_from_error") },
+        hint: { text: t("form.hint.budget.csv_file_recover_from_error_html", link: send(path_helper, model, format: :csv)) }
+
+      = f.govuk_submit t("action.budget.upload.button")

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -13,6 +13,8 @@ en:
         hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update budgets.</p><p class='govuk-body'>Edit it to add the values for the relevant budgets, then upload it through the form.</p>"
       upload:
         button: Upload and continue
+        file_missing_or_invalid: Please upload a valid CSV file
+        success: The budgets were successfully imported
   form:
     label:
       budget:
@@ -25,6 +27,7 @@ en:
           direct: Direct
           other_official: Other official development assistance
         csv_file: Upload CSV spreadsheet
+        csv_file_recover_from_error: Re-upload CSV spreadsheet
     legend:
       budget:
         budget_type: Type
@@ -40,7 +43,11 @@ en:
           direct: Budget allocated directly from the parent activity
           other_official: Budget allocated from an external organisation that is still considered ODA funding
         csv_file: Upload a spreadsheet containing budget data in CSV format.
+        csv_file_recover_from_error_html: Upload a spreadsheet containing activity data in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
   table:
+    caption:
+      budget:
+        new_budgets: New budgets
     header:
       budget:
         financial_year: Financial year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
 
     namespace :level_b do
       namespace :budgets do
-        resource :upload, only: [:new, :show]
+        resource :upload, only: [:new, :show, :create]
       end
     end
 

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -28,4 +28,54 @@ RSpec.describe Staff::LevelB::Budgets::UploadsController do
       })
     end
   end
+
+  describe "#create" do
+    let(:file_upload) { "file upload double" }
+    let(:uploaded_rows) { double("uploaded rows") }
+    let(:upload) { instance_double(CsvFileUpload, rows: uploaded_rows, valid?: true) }
+
+    let(:importer) do
+      instance_double(
+        Budget::Import,
+        import: true,
+        errors: [],
+        created: double
+      )
+    end
+
+    before do
+      allow(CsvFileUpload).to receive(:new).and_return(upload)
+      allow(Budget::Import).to receive(:new).and_return(importer)
+    end
+
+    it "asks CsvFileUpload to prepare the uploaded budgets" do
+      put :create, params: {budget_upload: file_upload}
+
+      expect(CsvFileUpload).to have_received(:new).with(file_upload, :csv)
+    end
+
+    context "when upload is valid" do
+      before { allow(upload).to receive(:valid?).and_return(true) }
+
+      it "asks Budget::Import to import the uploaded rows" do
+        put :create, params: {budget_upload: file_upload}
+
+        expect(Budget::Import).to have_received(:new).with(
+          uploader: user
+        )
+
+        expect(importer).to have_received(:import).with(uploaded_rows)
+      end
+    end
+
+    context "when upload is NOT valid" do
+      before { allow(upload).to receive(:valid?).and_return(false) }
+
+      it "does NOT ask Budget::Import to import the uploaded rows" do
+        put :create, params: {budget_upload: file_upload}
+
+        expect(Budget::Import).not_to have_received(:new)
+      end
+    end
+  end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -1,5 +1,17 @@
 RSpec.feature "BEIS users can upload Level B budgets" do
   let(:user) { create(:beis_user) }
+  let(:organisation) { create(:partner_organisation) }
+
+  let!(:programme) {
+    create(
+      :programme_activity,
+      :newton_funded,
+      extending_organisation: create(:partner_organisation),
+      roda_identifier: "AFUND-B-PROG",
+      parent: create(:fund_activity, roda_identifier: "AFUND")
+    )
+  }
+
   before { authenticate!(user: user) }
 
   before do
@@ -27,5 +39,101 @@ RSpec.feature "BEIS users can upload Level B budgets" do
       "Fund RODA ID",
       "Partner organisation name"
     ])
+  end
+
+  scenario "not uploading a file" do
+    click_button t("action.budget.upload.button")
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  scenario "uploading an empty file" do
+    upload_empty_csv
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  scenario "uploading a valid set of budgets" do
+    old_count = Budget.count
+
+    attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/valid_level_b_budgets_upload.csv").path
+    click_button t("action.budget.upload.button")
+
+    expect(Budget.count - old_count).to eq(2)
+
+    visit organisation_activity_path(organisation, programme)
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[1]", text: "FY 2016-2017")
+      expect(page).to have_xpath("td[2]", text: "Other official development assistance")
+      expect(page).to have_xpath("td[3]", text: "£67,890.00")
+      expect(page).to have_xpath("td[4]", text: "Lovely Co")
+    end
+
+    within "//tbody/tr[2]" do
+      expect(page).to have_xpath("td[1]", text: "FY 2011-2012")
+      expect(page).to have_xpath("td[2]", text: "Direct")
+      expect(page).to have_xpath("td[3]", text: "£12,345.00")
+      expect(page).to have_xpath("td[4]", text: "Department for Business, Energy and Industrial Strategy")
+    end
+  end
+
+  scenario "uploading a set of activities with a BOM at the start" do
+    freeze_time do
+      attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/valid_level_b_budgets_upload.csv").path
+      click_button t("action.budget.upload.button")
+
+      expect(page).to have_text(t("action.budget.upload.success"))
+
+      new_budgets = Budget.where(created_at: DateTime.now)
+
+      expect(new_budgets.count).to eq(2)
+      expect(new_budgets.pluck(:value)).to match_array(["12345".to_d, "67890".to_d])
+    end
+  end
+
+  scenario "uploading an invalid set of budgets" do
+    old_count = Budget.count
+
+    attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/invalid_level_b_budgets_upload.csv").path
+    click_button t("action.budget.upload.button")
+
+    expect(Budget.count - old_count).to eq(0)
+    expect(page).not_to have_text(t("action.budget.upload.success"))
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[1]", text: "Type")
+      expect(page).to have_xpath("td[2]", text: "2")
+      expect(page).to have_xpath("td[3]", text: "99999")
+      expect(page).to have_xpath("td[4]", text: t("importer.errors.budget.invalid_budget_type"))
+    end
+
+    within "//tbody/tr[4]" do
+      expect(page).to have_xpath("td[1]", text: "Budget amount")
+      expect(page).to have_xpath("td[2]", text: "3")
+      expect(page).to have_xpath("td[3]", text: "")
+      expect(page).to have_xpath("td[4]", text: t("importer.errors.budget.invalid_value"))
+    end
+  end
+
+  scenario "upload a set of budgets from the error page after a failed upload" do
+    2.times { upload_empty_csv }
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  def upload_csv(content)
+    file = Tempfile.new("new_budgets.csv")
+    file.write(content.gsub(/ *\| */, ","))
+    file.close
+
+    attach_file "budget_upload[csv]", file.path
+    click_button t("action.budget.upload.button")
+
+    file.unlink
+  end
+
+  def upload_empty_csv
+    upload_csv(Budget::Import::Converter::FIELDS.values.join(", "))
   end
 end

--- a/spec/fixtures/csv/invalid_level_b_budgets_upload.csv
+++ b/spec/fixtures/csv/invalid_level_b_budgets_upload.csv
@@ -1,0 +1,3 @@
+﻿Type,Financial year,Budget amount,Providing organisation,Providing organisation type,IATI reference,Activity RODA ID,Fund RODA ID,Partner organisation name
+99999,2011-2012,12345,,,,AFUND-B-PROG,AFUND,The Most Extending Organisation in the Multiverse
+1,2016-2017,,Lovely Co,24,top-tier-transparency,AFUND-B-PROG,AFUND,The Second Most Extending Organisation in the Multiverse

--- a/spec/fixtures/csv/valid_level_b_budgets_upload.csv
+++ b/spec/fixtures/csv/valid_level_b_budgets_upload.csv
@@ -1,0 +1,3 @@
+﻿Type,Financial year,Budget amount,Providing organisation,Providing organisation type,IATI reference,Activity RODA ID,Fund RODA ID,Partner organisation name
+0,2011-2012,12345,,,,AFUND-B-PROG,AFUND,The Most Extending Organisation in the Multiverse
+1,2016-2017,67890,Lovely Co,24,top-tier-transparency,AFUND-B-PROG,AFUND,The Second Most Extending Organisation in the Multiverse


### PR DESCRIPTION
## Changes in this PR

This adds the create action to the Level B budget uploads controller, handling the creation of budgets from the provided CSV

## Screenshots of UI changes

### After

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/40244233/193086259-6cd61a6a-5dc1-4018-824f-e6bb3ef6ef25.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
