### PR TITLE
(2601) Add budgets link to top nav

### DIFF
--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -12,6 +12,10 @@
       %li{ class: navigation_item_class(organisation_activities_path(organisation_id: current_user.organisation_id)) }
         = link_to t("page_title.activity.index"), organisation_activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
 
+      - if policy(:level_b).budget_upload?
+        %li{ class: navigation_item_class(new_level_b_budgets_upload_path) }
+          = link_to t("page_title.budget.index"), new_level_b_budgets_upload_path, class: "govuk-header__link"
+
       - if policy([:export, Organisation]).index?
         %li{ class: navigation_item_class(exports_path) }
           = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -65,6 +65,7 @@ en:
   page_title:
     budget:
       edit: Edit budget
+      index: Budgets
       new: Create budget
       upload_level_b: Bulk upload budget data for Level B activities
   breadcrumb:

--- a/spec/features/staff/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/staff/users_can_view_the_site_navigation_spec.rb
@@ -18,13 +18,17 @@ RSpec.feature "Users can view the site navigation" do
     let(:user) { create(:partner_organisation_user) }
     before { authenticate!(user: user) }
 
-    it "shows the appropriate naviation" do
+    it "shows the appropriate navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
       expect(page).to have_link t("page_title.home"), href: home_path
       expect(page).to have_link t("page_title.report.index"), href: reports_path
-      expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path, class: "govuk-header__link"
+      expect(page).to have_link t("page_title.activity.index"), href: organisation_activities_path(user.organisation)
+      expect(page).to have_link t("page_title.export.index"), href: exports_organisation_path(user.organisation)
+      expect(page).to have_link t("header.link.sign_out"), href: destroy_user_session_path
+      expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path
+      expect(page).not_to have_link t("page_title.budget.index"), href: new_level_b_budgets_upload_path
       expect(page).not_to have_link t("page_title.users.index"), href: users_path
     end
   end
@@ -33,14 +37,18 @@ RSpec.feature "Users can view the site navigation" do
     let(:user) { create(:beis_user) }
     before { authenticate!(user: user) }
 
-    it "shows the appropriate naviation" do
+    it "shows the appropriate navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
       expect(page).to have_link t("page_title.home"), href: home_path
       expect(page).to have_link t("page_title.report.index"), href: reports_path
+      expect(page).to have_link t("page_title.activity.index"), href: organisation_activities_path(user.organisation)
+      expect(page).to have_link t("page_title.budget.index"), href: new_level_b_budgets_upload_path
+      expect(page).to have_link t("page_title.export.index"), href: exports_path
       expect(page).to have_link t("page_title.organisation.index"), href: organisations_path
       expect(page).to have_link t("page_title.users.index"), href: users_path
+      expect(page).to have_link t("header.link.sign_out"), href: destroy_user_session_path
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

This adds a link to the Level B budgets bulk upload page to the top nav for BEIS users

## Screenshots of UI changes

### Before

<img width="567" alt="image" src="https://user-images.githubusercontent.com/40244233/193563107-f09df19f-8d70-4f6e-9d9e-4bdf4d4fa700.png">

### After

<img width="646" alt="image" src="https://user-images.githubusercontent.com/40244233/193563179-b8674d79-841e-4135-86fe-821dca94a3e9.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
