### PR TITLE
(2565) Build level b bulk budget upload functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1096,6 +1096,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Refactor the importers (including associated uploads controllers and views) to use a unified approach for all entities being imported
 - Ensure `Forecast.set_value` always returns a forecast or nil; this will ensure that uploaded forecasts are correctly displayed back to the user on the success page
+- Add Level B budget bulk upload functionality - form with errors/confirmation view; link in top nav
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/app/controllers/staff/level_b/activities/uploads_controller.rb
+++ b/app/controllers/staff/level_b/activities/uploads_controller.rb
@@ -5,13 +5,13 @@ class Staff::LevelB::Activities::UploadsController < Staff::BaseController
   include StreamCsvDownload
 
   def new
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
   end
 
   def show
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
     filename = @organisation_presenter.filename_for_activities_template
@@ -20,7 +20,7 @@ class Staff::LevelB::Activities::UploadsController < Staff::BaseController
   end
 
   def update
-    authorize organisation, :bulk_upload?
+    authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
     upload = CsvFileUpload.new(params[:organisation], :activity_csv)

--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
+  include Secured
+
+  def new
+    authorize :level_b, :budget_upload?
+  end
+end

--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -2,8 +2,27 @@
 
 class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
   include Secured
+  include StreamCsvDownload
 
   def new
     authorize :level_b, :budget_upload?
+  end
+
+  def show
+    authorize :level_b, :budget_upload?
+
+    headers = [
+      "Type",
+      "Financial year",
+      "Budget amount",
+      "Providing organisation",
+      "Providing organisation type",
+      "IATI reference",
+      "Activity RODA ID",
+      "Fund RODA ID",
+      "Partner organisation name"
+    ]
+
+    stream_csv_download(filename: "Level_B_budgets_upload.csv", headers: headers)
   end
 end

--- a/app/controllers/staff/level_b/budgets/uploads_controller.rb
+++ b/app/controllers/staff/level_b/budgets/uploads_controller.rb
@@ -12,13 +12,7 @@ class Staff::LevelB::Budgets::UploadsController < Staff::BaseController
     authorize :level_b, :budget_upload?
 
     headers = [
-      "Type",
-      "Financial year",
-      "Budget amount",
-      "Providing organisation",
-      "Providing organisation type",
-      "IATI reference",
-      "Activity RODA ID",
+      *::Budget::Import::Converter::FIELDS.values,
       "Fund RODA ID",
       "Partner organisation name"
     ]

--- a/app/models/budget_upload.rb
+++ b/app/models/budget_upload.rb
@@ -1,0 +1,3 @@
+class BudgetUpload
+  include ActiveModel::Model
+end

--- a/app/policies/level_b_policy.rb
+++ b/app/policies/level_b_policy.rb
@@ -1,0 +1,5 @@
+class LevelBPolicy < ApplicationPolicy
+  def budget_upload?
+    return true if beis_user?
+  end
+end

--- a/app/policies/level_b_policy.rb
+++ b/app/policies/level_b_policy.rb
@@ -1,4 +1,8 @@
 class LevelBPolicy < ApplicationPolicy
+  def activity_upload?
+    return true if beis_user?
+  end
+
   def budget_upload?
     return true if beis_user?
   end

--- a/app/services/budget/import.rb
+++ b/app/services/budget/import.rb
@@ -1,0 +1,207 @@
+class Budget
+  class Import
+    Error = Struct.new(:row, :column, :value, :message) {
+      def csv_row
+        row + 2
+      end
+
+      def csv_column
+        Converter::FIELDS[column] || column.to_s
+      end
+    }
+
+    attr_reader :errors, :created
+
+    def initialize(uploader:)
+      @uploader = uploader
+      @uploader_organisation = uploader.organisation
+      @errors = []
+      @created = []
+    end
+
+    def import(budgets)
+      ActiveRecord::Base.transaction do
+        budgets.each_with_index { |row, index| import_row(row, index) }
+
+        if @errors.present?
+          @created = []
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    def import_row(row, index)
+      action = create_budget(row, index)
+
+      return if action.nil?
+
+      action.errors.each do |attr_name, (value, message)|
+        add_error(index, attr_name, value, message)
+      end
+    end
+
+    def create_budget(row, index)
+      if row["Activity RODA ID"].present?
+        creator = BudgetCreator.new(row: row, uploader: @uploader)
+        creator.create
+        created << creator.budget unless creator.errors.any?
+
+        creator
+      else
+        add_error(index, :parent_activity_id, row["Activity RODA ID"], I18n.t("importer.errors.budget.cannot_create")) && return
+      end
+    end
+
+    def add_error(row_number, column, value, message)
+      @errors << Error.new(row_number, column, value, message)
+    end
+
+    class BudgetCreator
+      attr_reader :errors, :row, :budget
+
+      def initialize(row:, uploader:)
+        @row = row
+        @uploader = uploader
+        @errors = {}
+        @parent_activity = fetch_parent(@row["Activity RODA ID"])
+        @converter = Converter.new(row, @parent_activity)
+
+        @errors.update(@converter.errors)
+      end
+
+      def create
+        return unless @errors.blank?
+
+        result = CreateBudget.new(activity: @parent_activity).call(attributes: @converter.to_h)
+        @budget = result.object
+
+        return true if @budget.save
+
+        @budget.errors.each do |error|
+          @errors[error.attribute] ||= [@converter.raw(error.attribute), error.message]
+        end
+      end
+
+      private
+
+      def fetch_parent(roda_id)
+        Activity.by_roda_identifier(roda_id)
+      end
+    end
+
+    class Converter
+      attr_reader :errors
+
+      FIELDS = {
+        budget_type: "Type",
+        financial_year: "Financial year",
+        value: "Budget amount",
+        providing_organisation_name: "Providing organisation",
+        providing_organisation_type: "Providing organisation type",
+        providing_organisation_reference: "IATI reference",
+        parent_activity_id: "Activity RODA ID"
+      }
+
+      ALLOWED_BLANK_FIELDS = ["IATI reference"]
+
+      DIRECT_ALLOWED_BLANK_FIELDS = [
+        *ALLOWED_BLANK_FIELDS,
+        "Providing organisation",
+        "Providing organisation type"
+      ]
+
+      def initialize(row, parent_activity)
+        @row = row
+        @parent_activity = parent_activity
+        @errors = {}
+        @attributes = convert_to_attributes
+      end
+
+      def raw(attr_name)
+        @row[FIELDS[attr_name]]
+      end
+
+      def to_h
+        @attributes
+      end
+
+      def convert_to_attributes
+        FIELDS.each_with_object({}) { |(attr_name, column_name), attrs|
+          attrs[attr_name] = convert_to_attribute(attr_name, @row[column_name]) if field_should_be_converted?(column_name)
+        }
+      end
+
+      def field_should_be_converted?(column_name)
+        !field_can_be_blank?(column_name) || @row[column_name].present?
+      end
+
+      def field_can_be_blank?(column_name)
+        type_is_direct = @row["Type"] == Budget.budget_types["direct"].to_s
+        allowed_blank_fields = type_is_direct ? DIRECT_ALLOWED_BLANK_FIELDS : ALLOWED_BLANK_FIELDS
+
+        allowed_blank_fields.include?(column_name)
+      end
+
+      def convert_to_attribute(attr_name, value)
+        original_value = value.clone
+        value = value.to_s.strip
+
+        converter = "convert_#{attr_name}"
+        value = __send__(converter, value) if respond_to?(converter)
+
+        value
+      rescue => error
+        @errors[attr_name] = [original_value, error.message]
+        nil
+      end
+
+      def convert_budget_type(budget_type)
+        valid_budget_types = Budget.budget_types.values.map(&:to_s)
+        raise I18n.t("importer.errors.budget.invalid_budget_type") unless valid_budget_types.include?(budget_type)
+
+        budget_type.to_i
+      end
+
+      def convert_financial_year(financial_year)
+        financial_year.strip!
+        start_year = financial_year[0, 4].to_i
+        end_year = financial_year[5, 9].to_i
+
+        raise I18n.t("importer.errors.budget.invalid_financial_year") if end_year != start_year + 1
+
+        start_year
+      end
+
+      def convert_parent_activity_id(_parent_activity_id)
+        raise I18n.t("importer.errors.budget.parent_not_found") if @parent_activity.nil?
+
+        @parent_activity.id
+      end
+
+      def convert_providing_organisation_name(providing_organisation_name)
+        raise I18n.t("importer.errors.budget.invalid_providing_organisation_name") if providing_organisation_name.blank?
+
+        providing_organisation_name
+      end
+
+      def convert_providing_organisation_type(providing_organisation_type)
+        organisation_types = ApplicationController.helpers.organisation_type_options
+        organisation_type_codes = []
+
+        organisation_types.each do |organisation_type|
+          organisation_type_codes << organisation_type.code if organisation_type.code.present?
+        end
+
+        raise I18n.t("importer.errors.budget.invalid_providing_organisation_type") unless organisation_type_codes.include?(providing_organisation_type)
+
+        providing_organisation_type
+      end
+
+      def convert_value(value)
+        raise I18n.t("importer.errors.budget.invalid_value") unless value.present? && value.to_d != "0".to_d && value.to_d <= "99_999_999_999.00".to_d
+
+        value
+      end
+    end
+  end
+end

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -12,6 +12,10 @@
       %li{ class: navigation_item_class(organisation_activities_path(organisation_id: current_user.organisation_id)) }
         = link_to t("page_title.activity.index"), organisation_activities_path(organisation_id: current_user.organisation_id), class: "govuk-header__link"
 
+      - if policy(:level_b).budget_upload?
+        %li{ class: navigation_item_class(new_level_b_budgets_upload_path) }
+          = link_to t("page_title.budget.index"), new_level_b_budgets_upload_path, class: "govuk-header__link"
+
       - if policy([:export, Organisation]).index?
         %li{ class: navigation_item_class(exports_path) }
           = link_to t("page_title.export.index"), exports_path, class: "govuk-header__link"

--- a/app/views/staff/level_b/activities/uploads/update.html.haml
+++ b/app/views/staff/level_b/activities/uploads/update.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.activity.upload")
+        = t("page_title.activity.upload_level_b", organisation_name: @organisation_presenter.name)
 
   - unless @errors.empty?
     .govuk-grid-row

--- a/app/views/staff/level_b/budgets/uploads/create.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/create.html.haml
@@ -1,0 +1,22 @@
+= content_for :page_title_prefix, t("page_title.budget.upload_level_b")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.upload_level_b")
+
+  - unless @errors.empty?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "staff/shared/budgets/uploads/error_table"
+
+  - if @success
+    - if @budgets[:created].any?
+      = render partial: "staff/shared/budgets/uploads/budgets_table", locals: { action: "created", budgets: @budgets[:created], table_caption: t("table.caption.budget.new_budgets") }
+  - else
+    = render partial: "staff/shared/budgets/uploads/upload_form", locals: { model: BudgetUpload.new, path_helper: "level_b_budgets_upload_path" }
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to "Back to home", home_path

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -12,7 +12,9 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h2.govuk-heading-m
-        = link_to t("action.budget.bulk_download.button"), "", class: "govuk-link"
+        = link_to t("action.budget.bulk_download.button"),
+          level_b_budgets_upload_path(format: :csv),
+          class: "govuk-link"
 
       %p.govuk-body
         = t("action.budget.bulk_download.hint_html")

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -20,7 +20,7 @@
         = t("action.budget.bulk_download.hint_html")
 
       .govuk-body.upload-form
-        = form_with model: BudgetUpload.new, url: "#", method: :get do |f|
+        = form_with model: BudgetUpload.new, url: level_b_budgets_upload_path do |f|
 
           = f.govuk_file_field :csv,
             label: { text: t("form.label.budget.csv_file") },

--- a/app/views/staff/level_b/budgets/uploads/new.html.haml
+++ b/app/views/staff/level_b/budgets/uploads/new.html.haml
@@ -1,0 +1,31 @@
+= content_for :page_title_prefix, t("page_title.budget.upload_level_b")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.budget.upload_level_b")
+
+      %p.govuk-body
+        Use the template to ensure your data is in the correct format.
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h2.govuk-heading-m
+        = link_to t("action.budget.bulk_download.button"), "", class: "govuk-link"
+
+      %p.govuk-body
+        = t("action.budget.bulk_download.hint_html")
+
+      .govuk-body.upload-form
+        = form_with model: BudgetUpload.new, url: "#", method: :get do |f|
+
+          = f.govuk_file_field :csv,
+            label: { text: t("form.label.budget.csv_file") },
+            hint: { text: t("form.hint.budget.csv_file") }
+
+          = f.govuk_submit t("action.budget.upload.button")
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to "Back to home", home_path

--- a/app/views/staff/shared/budgets/uploads/_budgets_table.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_budgets_table.html.haml
@@ -1,0 +1,17 @@
+%table{ class: "govuk-table govuk-!-margin-bottom-9" }
+  %caption.govuk-table__caption.govuk-table__caption--m
+    = table_caption
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Activity RODA ID
+      %th.govuk-table__header{scope: "col"} Type
+      %th.govuk-table__header{scope: "col"} Financial year
+      %th.govuk-table__header{scope: "col"} Budget amount
+  %tbody.govuk-table__body
+    - budgets.each do |budget|
+      - budget_presenter = BudgetPresenter.new(budget)
+      %tr.govuk-table__row
+        %td.govuk-table__cell= budget_presenter.parent_activity.roda_identifier
+        %td.govuk-table__cell= budget_presenter.budget_type
+        %td.govuk-table__cell= budget_presenter.financial_year
+        %td.govuk-table__cell= budget_presenter.value

--- a/app/views/staff/shared/budgets/uploads/_error_table.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_error_table.html.haml
@@ -1,0 +1,15 @@
+%table.govuk-table
+  %caption.govuk-table__caption List of errors in your uploaded CSV file
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{scope: "col"} Column
+      %th.govuk-table__header{scope: "col"} Row
+      %th.govuk-table__header{scope: "col"} Current Value
+      %th.govuk-table__header{scope: "col"} Error description
+  %tbody.govuk-table__body
+    - @errors.each do |error|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= error.csv_column
+        %td.govuk-table__cell= error.csv_row
+        %td{class: "govuk-table__cell govuk-!-font-weight-bold error-text"}= error.value
+        %td.govuk-table__cell= error.message

--- a/app/views/staff/shared/budgets/uploads/_upload_form.html.haml
+++ b/app/views/staff/shared/budgets/uploads/_upload_form.html.haml
@@ -1,0 +1,9 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    = form_with model: model, url: send(path_helper, model) do |f|
+
+      = f.govuk_file_field :csv,
+        label: { text: t("form.label.budget.csv_file_recover_from_error") },
+        hint: { text: t("form.hint.budget.csv_file_recover_from_error_html", link: send(path_helper, model, format: :csv)) }
+
+      = f.govuk_submit t("action.budget.upload.button")

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -96,3 +96,14 @@ en:
               blank: Enter the name of the providing organisation
             providing_organisation_type:
               blank: Select the type of the providing organisation
+  importer:
+    errors:
+      budget:
+        cannot_create: There is no activity RODA ID present, so cannot create a budget
+        invalid_budget_type: The budget type code is not valid
+        invalid_financial_year: The financial year is not valid
+        invalid_providing_organisation_name: The providing organisation is not valid
+        invalid_providing_organisation_reference: The IATI reference is not valid
+        invalid_providing_organisation_type: The providing organisation type code is not valid
+        invalid_value: The budget amount is not valid
+        parent_not_found: The parent activity cannot be found

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -65,6 +65,7 @@ en:
   page_title:
     budget:
       edit: Edit budget
+      index: Budgets
       new: Create budget
       upload_level_b: Bulk upload budget data for Level B activities
   breadcrumb:

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -8,6 +8,11 @@ en:
         success: Budget successfully updated
       destroy:
         success: Budget successfully deleted
+      bulk_download:
+        button: Download CSV template
+        hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update budgets.</p><p class='govuk-body'>Edit it to add the values for the relevant budgets, then upload it through the form.</p>"
+      upload:
+        button: Upload and continue
   form:
     label:
       budget:
@@ -19,6 +24,7 @@ en:
         budget_type:
           direct: Direct
           other_official: Other official development assistance
+        csv_file: Upload CSV spreadsheet
     legend:
       budget:
         budget_type: Type
@@ -33,6 +39,7 @@ en:
         budget_type:
           direct: Budget allocated directly from the parent activity
           other_official: Budget allocated from an external organisation that is still considered ODA funding
+        csv_file: Upload a spreadsheet containing budget data in CSV format.
   table:
     header:
       budget:
@@ -52,6 +59,7 @@ en:
     budget:
       edit: Edit budget
       new: Create budget
+      upload_level_b: Bulk upload budget data for Level B activities
   breadcrumb:
     budget:
       edit: Edit budget

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -13,6 +13,8 @@ en:
         hint_html: "<p class='govuk-body'>This CSV contains all the columns that can be used to create or update budgets.</p><p class='govuk-body'>Edit it to add the values for the relevant budgets, then upload it through the form.</p>"
       upload:
         button: Upload and continue
+        file_missing_or_invalid: Please upload a valid CSV file
+        success: The budgets were successfully imported
   form:
     label:
       budget:
@@ -25,6 +27,7 @@ en:
           direct: Direct
           other_official: Other official development assistance
         csv_file: Upload CSV spreadsheet
+        csv_file_recover_from_error: Re-upload CSV spreadsheet
     legend:
       budget:
         budget_type: Type
@@ -40,7 +43,11 @@ en:
           direct: Budget allocated directly from the parent activity
           other_official: Budget allocated from an external organisation that is still considered ODA funding
         csv_file: Upload a spreadsheet containing budget data in CSV format.
+        csv_file_recover_from_error_html: Upload a spreadsheet containing budget data in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
   table:
+    caption:
+      budget:
+        new_budgets: New budgets
     header:
       budget:
         financial_year: Financial year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
 
     namespace :level_b do
       namespace :budgets do
-        resource :upload, only: [:new, :show]
+        resource :upload, only: [:new, :show, :create]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,12 @@ Rails.application.routes.draw do
       end
     end
 
+    namespace :level_b do
+      namespace :budgets do
+        resource :upload, only: [:new]
+      end
+    end
+
     resources :organisations, except: [:destroy, :index, :new] do
       get "reports" => "organisation_reports#index"
       resources :activities, except: [:create, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
 
     namespace :level_b do
       namespace :budgets do
-        resource :upload, only: [:new]
+        resource :upload, only: [:new, :show]
       end
     end
 

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe Staff::LevelB::Budgets::UploadsController do
       expect(response.body).to include(t("action.budget.bulk_download.button"))
     end
   end
+
+  describe "#show" do
+    it "downloads the CSV template with the correct filename" do
+      get :show
+
+      expect(response.headers.to_h).to include({
+        "Content-Type" => "text/csv",
+        "Content-Disposition" => "attachment; filename=Level_B_budgets_upload.csv"
+      })
+    end
+  end
 end

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Staff::LevelB::Budgets::UploadsController do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#new" do
+    render_views
+
+    it "shows the upload button" do
+      get :new
+
+      expect(response.body).to include(t("action.budget.bulk_download.button"))
+    end
+  end
+end

--- a/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
+++ b/spec/controllers/staff/level_b/budgets/uploads_controller_spec.rb
@@ -28,4 +28,54 @@ RSpec.describe Staff::LevelB::Budgets::UploadsController do
       })
     end
   end
+
+  describe "#create" do
+    let(:file_upload) { "file upload double" }
+    let(:uploaded_rows) { double("uploaded rows") }
+    let(:upload) { instance_double(CsvFileUpload, rows: uploaded_rows, valid?: true) }
+
+    let(:importer) do
+      instance_double(
+        Budget::Import,
+        import: true,
+        errors: [],
+        created: double
+      )
+    end
+
+    before do
+      allow(CsvFileUpload).to receive(:new).and_return(upload)
+      allow(Budget::Import).to receive(:new).and_return(importer)
+    end
+
+    it "asks CsvFileUpload to prepare the uploaded budgets" do
+      put :create, params: {budget_upload: file_upload}
+
+      expect(CsvFileUpload).to have_received(:new).with(file_upload, :csv)
+    end
+
+    context "when upload is valid" do
+      before { allow(upload).to receive(:valid?).and_return(true) }
+
+      it "asks Budget::Import to import the uploaded rows" do
+        put :create, params: {budget_upload: file_upload}
+
+        expect(Budget::Import).to have_received(:new).with(
+          uploader: user
+        )
+
+        expect(importer).to have_received(:import).with(uploaded_rows)
+      end
+    end
+
+    context "when upload is NOT valid" do
+      before { allow(upload).to receive(:valid?).and_return(false) }
+
+      it "does NOT ask Budget::Import to import the uploaded rows" do
+        put :create, params: {budget_upload: file_upload}
+
+        expect(Budget::Import).not_to have_received(:new)
+      end
+    end
+  end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -1,5 +1,17 @@
 RSpec.feature "BEIS users can upload Level B budgets" do
   let(:user) { create(:beis_user) }
+  let(:organisation) { create(:partner_organisation) }
+
+  let!(:programme) {
+    create(
+      :programme_activity,
+      :newton_funded,
+      extending_organisation: create(:partner_organisation),
+      roda_identifier: "AFUND-B-PROG",
+      parent: create(:fund_activity, roda_identifier: "AFUND")
+    )
+  }
+
   before { authenticate!(user: user) }
 
   before do
@@ -27,5 +39,101 @@ RSpec.feature "BEIS users can upload Level B budgets" do
       "Fund RODA ID",
       "Partner organisation name"
     ])
+  end
+
+  scenario "not uploading a file" do
+    click_button t("action.budget.upload.button")
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  scenario "uploading an empty file" do
+    upload_empty_csv
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  scenario "uploading a valid set of budgets" do
+    old_count = Budget.count
+
+    attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/valid_level_b_budgets_upload.csv").path
+    click_button t("action.budget.upload.button")
+
+    expect(Budget.count - old_count).to eq(2)
+
+    visit organisation_activity_path(organisation, programme)
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[1]", text: "FY 2016-2017")
+      expect(page).to have_xpath("td[2]", text: "Other official development assistance")
+      expect(page).to have_xpath("td[3]", text: "£67,890.00")
+      expect(page).to have_xpath("td[4]", text: "Lovely Co")
+    end
+
+    within "//tbody/tr[2]" do
+      expect(page).to have_xpath("td[1]", text: "FY 2011-2012")
+      expect(page).to have_xpath("td[2]", text: "Direct")
+      expect(page).to have_xpath("td[3]", text: "£12,345.00")
+      expect(page).to have_xpath("td[4]", text: "Department for Business, Energy and Industrial Strategy")
+    end
+  end
+
+  scenario "uploading a set of activities with a BOM at the start" do
+    freeze_time do
+      attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/valid_level_b_budgets_upload.csv").path
+      click_button t("action.budget.upload.button")
+
+      expect(page).to have_text(t("action.budget.upload.success"))
+
+      new_budgets = Budget.where(created_at: DateTime.now)
+
+      expect(new_budgets.count).to eq(2)
+      expect(new_budgets.pluck(:value)).to match_array(["12345".to_d, "67890".to_d])
+    end
+  end
+
+  scenario "uploading an invalid set of budgets" do
+    old_count = Budget.count
+
+    attach_file "budget_upload[csv]", File.new("spec/fixtures/csv/invalid_level_b_budgets_upload.csv").path
+    click_button t("action.budget.upload.button")
+
+    expect(Budget.count - old_count).to eq(0)
+    expect(page).not_to have_text(t("action.budget.upload.success"))
+
+    within "//tbody/tr[1]" do
+      expect(page).to have_xpath("td[1]", text: "Type")
+      expect(page).to have_xpath("td[2]", text: "2")
+      expect(page).to have_xpath("td[3]", text: "99999")
+      expect(page).to have_xpath("td[4]", text: t("importer.errors.budget.invalid_budget_type"))
+    end
+
+    within "//tbody/tr[4]" do
+      expect(page).to have_xpath("td[1]", text: "Budget amount")
+      expect(page).to have_xpath("td[2]", text: "3")
+      expect(page).to have_xpath("td[3]", text: "")
+      expect(page).to have_xpath("td[4]", text: t("importer.errors.budget.invalid_value"))
+    end
+  end
+
+  scenario "upload a set of budgets from the error page after a failed upload" do
+    2.times { upload_empty_csv }
+
+    expect(page).to have_text(t("action.budget.upload.file_missing_or_invalid"))
+  end
+
+  def upload_csv(content)
+    file = Tempfile.new("new_budgets.csv")
+    file.write(content.gsub(/ *\| */, ","))
+    file.close
+
+    attach_file "budget_upload[csv]", file.path
+    click_button t("action.budget.upload.button")
+
+    file.unlink
+  end
+
+  def upload_empty_csv
+    upload_csv(Budget::Import::Converter::FIELDS.values.join(", "))
   end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -9,4 +9,23 @@ RSpec.feature "BEIS users can upload Level B budgets" do
   scenario "viewing the page for downloading or uploading a CSV template" do
     expect(page).to have_content(t("page_title.budget.upload_level_b"))
   end
+
+  scenario "downloading the CSV template" do
+    click_link t("action.budget.bulk_download.button")
+
+    csv_data = page.body.delete_prefix("\uFEFF")
+    rows = CSV.parse(csv_data, headers: false).first
+
+    expect(rows).to match_array([
+      "Type",
+      "Financial year",
+      "Budget amount",
+      "Providing organisation",
+      "Providing organisation type",
+      "IATI reference",
+      "Activity RODA ID",
+      "Fund RODA ID",
+      "Partner organisation name"
+    ])
+  end
 end

--- a/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/staff/beis_users_can_upload_level_b_budgets_spec.rb
@@ -1,0 +1,12 @@
+RSpec.feature "BEIS users can upload Level B budgets" do
+  let(:user) { create(:beis_user) }
+  before { authenticate!(user: user) }
+
+  before do
+    visit new_level_b_budgets_upload_path
+  end
+
+  scenario "viewing the page for downloading or uploading a CSV template" do
+    expect(page).to have_content(t("page_title.budget.upload_level_b"))
+  end
+end

--- a/spec/fixtures/csv/invalid_level_b_budgets_upload.csv
+++ b/spec/fixtures/csv/invalid_level_b_budgets_upload.csv
@@ -1,0 +1,3 @@
+﻿Type,Financial year,Budget amount,Providing organisation,Providing organisation type,IATI reference,Activity RODA ID,Fund RODA ID,Partner organisation name
+99999,2011-2012,12345,,,,AFUND-B-PROG,AFUND,The Most Extending Organisation in the Multiverse
+1,2016-2017,,Lovely Co,24,top-tier-transparency,AFUND-B-PROG,AFUND,The Second Most Extending Organisation in the Multiverse

--- a/spec/fixtures/csv/valid_level_b_budgets_upload.csv
+++ b/spec/fixtures/csv/valid_level_b_budgets_upload.csv
@@ -1,0 +1,3 @@
+﻿Type,Financial year,Budget amount,Providing organisation,Providing organisation type,IATI reference,Activity RODA ID,Fund RODA ID,Partner organisation name
+0,2011-2012,12345,,,,AFUND-B-PROG,AFUND,The Most Extending Organisation in the Multiverse
+1,2016-2017,67890,Lovely Co,24,top-tier-transparency,AFUND-B-PROG,AFUND,The Second Most Extending Organisation in the Multiverse

--- a/spec/policies/level_b_policy_spec.rb
+++ b/spec/policies/level_b_policy_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe LevelBPolicy do
     let(:user) { build_stubbed(:beis_user) }
 
     it "permits all actions" do
+      is_expected.to permit_action(:activity_upload)
       is_expected.to permit_action(:budget_upload)
     end
   end
@@ -15,6 +16,7 @@ RSpec.describe LevelBPolicy do
     let(:user) { build_stubbed(:partner_organisation_user) }
 
     it "forbids all actions" do
+      is_expected.to forbid_action(:activity_upload)
       is_expected.to forbid_action(:budget_upload)
     end
   end

--- a/spec/policies/level_b_policy_spec.rb
+++ b/spec/policies/level_b_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe LevelBPolicy do
+  subject { described_class.new(user, nil) }
+
+  context "as user that belongs to BEIS" do
+    let(:user) { build_stubbed(:beis_user) }
+
+    it "permits all actions" do
+      is_expected.to permit_action(:budget_upload)
+    end
+  end
+
+  context "as user that does NOT belong to BEIS" do
+    let(:user) { build_stubbed(:partner_organisation_user) }
+
+    it "forbids all actions" do
+      is_expected.to forbid_action(:budget_upload)
+    end
+  end
+end

--- a/spec/services/budget/import_level_b_spec.rb
+++ b/spec/services/budget/import_level_b_spec.rb
@@ -1,0 +1,261 @@
+require "rails_helper"
+
+RSpec.describe Budget::Import do
+  let(:uploader) { create(:beis_user) }
+  let(:programme_activity) { create(:programme_activity) }
+
+  let(:new_direct_budget_attributes) do
+    {
+      "Type" => "0",
+      "Financial year" => "2011-2012",
+      "Budget amount" => "12345",
+      "Activity RODA ID" => programme_activity.roda_identifier
+    }
+  end
+
+  subject { described_class.new(uploader: uploader) }
+
+  context "when creating a new budget" do
+    let(:level_b_policy_double) { instance_double("LevelBPolicy", budget_upload?: true) }
+
+    before do
+      allow(LevelBPolicy).to receive(:new).with(uploader, nil).and_return(level_b_policy_double)
+    end
+
+    context "with a type of direct" do
+      it "creates the budget" do
+        expect { subject.import([new_direct_budget_attributes]) }.to change { Budget.count }.by(1)
+
+        expect(subject.created.count).to eq(1)
+
+        expect(subject.errors.count).to eq(0)
+
+        new_budget = Budget.order(:created_at).last
+        budget_type = "direct"
+        financial_year = FinancialYear.new(new_direct_budget_attributes["Financial year"])
+
+        expect(new_budget.budget_type).to eq(budget_type)
+        expect(new_budget.financial_year).to eq(financial_year)
+        expect(new_budget.value).to eq(new_direct_budget_attributes["Budget amount"].to_f)
+        expect(new_budget.parent_activity).to eq(programme_activity)
+
+        expect(new_budget.period_start_date).to eq(financial_year.start_date)
+        expect(new_budget.period_end_date).to eq(financial_year.end_date)
+        expect(new_budget.currency).to eq("GBP")
+        expect(new_budget.ingested).to eq(false)
+        expect(new_budget.report_id).to be_nil
+        expect(new_budget.funding_type).to be_nil
+        expect(new_budget.providing_organisation_id).to eq(beis_organisation_id)
+        expect(new_budget.providing_organisation_name).to be_nil
+        expect(new_budget.providing_organisation_type).to be_nil
+        expect(new_budget.providing_organisation_reference).to be_nil
+      end
+
+      it "has errors if the budget type is invalid" do
+        new_direct_budget_attributes["Type"] = "99999"
+
+        expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(3)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Type")
+        expect(subject.errors.first.column).to eq(:budget_type)
+        expect(subject.errors.first.value).to eq("99999")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_budget_type"))
+
+        expect(subject.errors.second.column).to eq(:providing_organisation_name)
+        expect(subject.errors.third.column).to eq(:providing_organisation_type)
+      end
+
+      context "financial year" do
+        [
+          {
+            statement: "has an error if the start and end years are non-contiguous",
+            value: "1999-2013"
+          },
+          {
+            statement: "has an error if only one year is provided",
+            value: "2020"
+          }
+        ].each do |example|
+          it example[:statement] do
+            new_direct_budget_attributes["Financial year"] = example[:value]
+
+            expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+            expect(subject.created.count).to eq(0)
+
+            expect(subject.errors.count).to eq(1)
+            expect(subject.errors.first.csv_row).to eq(2)
+            expect(subject.errors.first.csv_column).to eq("Financial year")
+            expect(subject.errors.first.column).to eq(:financial_year)
+            expect(subject.errors.first.value).to eq(example[:value])
+            expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_financial_year"))
+          end
+        end
+      end
+
+      context "budget amount" do
+        [
+          {
+            statement: "has an error when missing",
+            value: ""
+          },
+          {
+            statement: "has an error when zero",
+            value: "0"
+          },
+          {
+            statement: "has an error when too high",
+            value: "99999999999.01"
+          }
+        ].each do |example|
+          it example[:statement] do
+            new_direct_budget_attributes["Budget amount"] = example[:value]
+
+            expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+            expect(subject.created.count).to eq(0)
+
+            expect(subject.errors.count).to eq(1)
+            expect(subject.errors.first.csv_row).to eq(2)
+            expect(subject.errors.first.csv_column).to eq("Budget amount")
+            expect(subject.errors.first.column).to eq(:value)
+            expect(subject.errors.first.value).to eq(example[:value])
+            expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_value"))
+          end
+        end
+      end
+
+      context "parent activity" do
+        it "has an error when missing" do
+          new_direct_budget_attributes["Activity RODA ID"] = ""
+
+          expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+          expect(subject.created.count).to eq(0)
+
+          expect(subject.errors.count).to eq(1)
+          expect(subject.errors.first.csv_row).to eq(2)
+          expect(subject.errors.first.csv_column).to eq("Activity RODA ID")
+          expect(subject.errors.first.column).to eq(:parent_activity_id)
+          expect(subject.errors.first.value).to eq("")
+          expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.cannot_create"))
+        end
+
+        it "has an error when not found" do
+          new_direct_budget_attributes["Activity RODA ID"] = "111111"
+
+          expect { subject.import([new_direct_budget_attributes]) }.to_not change { Budget.count }
+
+          expect(subject.created.count).to eq(0)
+
+          expect(subject.errors.count).to eq(1)
+          expect(subject.errors.first.csv_row).to eq(2)
+          expect(subject.errors.first.csv_column).to eq("Activity RODA ID")
+          expect(subject.errors.first.column).to eq(:parent_activity_id)
+          expect(subject.errors.first.value).to eq("111111")
+          expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.parent_not_found"))
+        end
+      end
+    end
+
+    context "with a type of other official" do
+      let(:new_other_official_budget_attributes) do
+        {
+          "Type" => "1",
+          "Financial year" => "2016-2017",
+          "Budget amount" => "67890",
+          "Providing organisation" => "Lovely Co",
+          "Providing organisation type" => "24",
+          "IATI reference" => "top-tier-transparency",
+          "Activity RODA ID" => programme_activity.roda_identifier
+        }
+      end
+
+      [
+        {
+          statement: "with an IATI reference",
+          value: "top-tier-transparency"
+        },
+        {
+          statement: "without an IATI reference",
+          value: ""
+        }
+      ].each do |example|
+        context example[:statement] do
+          it "creates the budget" do
+            new_other_official_budget_attributes["IATI reference"] = example[:value]
+
+            expect { subject.import([new_other_official_budget_attributes]) }.to change { Budget.count }.by(1)
+
+            expect(subject.created.count).to eq(1)
+
+            expect(subject.errors.count).to eq(0)
+
+            new_budget = Budget.order(:created_at).last
+            budget_type = "other_official"
+            financial_year = FinancialYear.new(new_other_official_budget_attributes["Financial year"])
+
+            expect(new_budget.budget_type).to eq(budget_type)
+            expect(new_budget.financial_year).to eq(financial_year)
+            expect(new_budget.value).to eq(new_other_official_budget_attributes["Budget amount"].to_f)
+            expect(new_budget.parent_activity).to eq(programme_activity)
+            expect(new_budget.providing_organisation_name).to eq(new_other_official_budget_attributes["Providing organisation"])
+            expect(new_budget.providing_organisation_type).to eq(new_other_official_budget_attributes["Providing organisation type"])
+
+            if example[:value].present?
+              expect(new_budget.providing_organisation_reference).to eq(new_other_official_budget_attributes["IATI reference"])
+            else
+              expect(new_budget.providing_organisation_reference).to be_nil
+            end
+
+            expect(new_budget.period_start_date).to eq(financial_year.start_date)
+            expect(new_budget.period_end_date).to eq(financial_year.end_date)
+            expect(new_budget.currency).to eq("GBP")
+            expect(new_budget.ingested).to eq(false)
+            expect(new_budget.report_id).to be_nil
+            expect(new_budget.funding_type).to be_nil
+            expect(new_budget.providing_organisation_id).to be_nil
+          end
+        end
+      end
+
+      it "has an error if the providing organisation is missing" do
+        new_other_official_budget_attributes["Providing organisation"] = ""
+
+        expect { subject.import([new_other_official_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Providing organisation")
+        expect(subject.errors.first.column).to eq(:providing_organisation_name)
+        expect(subject.errors.first.value).to eq("")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_providing_organisation_name"))
+      end
+
+      it "has an error if the providing organisation type is not valid" do
+        new_other_official_budget_attributes["Providing organisation type"] = "99999"
+
+        expect { subject.import([new_other_official_budget_attributes]) }.to_not change { Budget.count }
+
+        expect(subject.created.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("Providing organisation type")
+        expect(subject.errors.first.column).to eq(:providing_organisation_type)
+        expect(subject.errors.first.value).to eq("99999")
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.budget.invalid_providing_organisation_type"))
+      end
+    end
+  end
+
+  def beis_organisation_id
+    Organisation.find_by(name: "Department for Business, Energy and Industrial Strategy").id
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This adds the Level B budgets bulk upload functionality for BEIS users

## Screenshots of UI changes

### Before

<img width="567" alt="image" src="https://user-images.githubusercontent.com/40244233/193563107-f09df19f-8d70-4f6e-9d9e-4bdf4d4fa700.png">

### After

(This will fail the first time because of using the 'invalid' CSV, then the second time because the 'valid' CSV has a parent activity that isn't in my local database)

https://user-images.githubusercontent.com/40244233/193571743-33533669-e42b-471e-b8f8-e52df62d659f.mov

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
