### PR TITLE
(2587) Point “Back to home” link to homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1098,6 +1098,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Ensure `Forecast.set_value` always returns a forecast or nil; this will ensure that uploaded forecasts are correctly displayed back to the user on the success page
 - Add Level B budget bulk upload functionality - form with errors/confirmation view; link in top nav
 - Include refunds and adjustments in the calculation of an activity's total spend (previously only actuals were included)
+- Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/app/views/staff/level_b/activities/uploads/new.html.haml
+++ b/app/views/staff/level_b/activities/uploads/new.html.haml
@@ -30,4 +30,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", organisations_path
+      %p.govuk-body= link_to "Back to home", home_path

--- a/app/views/staff/level_b/activities/uploads/update.html.haml
+++ b/app/views/staff/level_b/activities/uploads/update.html.haml
@@ -21,4 +21,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", organisations_path
+      %p.govuk-body= link_to "Back to home", home_path


### PR DESCRIPTION
## Changes in this PR
- Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
