### PR TITLE
(2513) Make inactive organisations unusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1101,6 +1101,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page
 - Comments in report CSVs are delimited by a pipe, instead of a newline, to enable BEIS users' QA workflow
 - Fix the command invoking the password reset script when updating training environment with the latest data from production
+- Prevent inactive organisations being added to activities as implementing organisations
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/app/models/org_participation.rb
+++ b/app/models/org_participation.rb
@@ -14,6 +14,16 @@ class OrgParticipation < ApplicationRecord
 
   scope :implementing, -> { where(role: :implementing) }
 
+  validate :organisation_is_active, if: :implementing?, on: :create
+
+  private
+
+  def organisation_is_active
+    unless organisation&.active
+      errors.add(:base, I18n.t("activerecord.errors.models.org_participation.attributes.organisation.inactive"))
+    end
+  end
+
   # At present this join model is only linking orgs with the "Implementing" role
   # to their "Activity" but we plan to use this for all type of Organisation, e.g.
   #

--- a/config/locales/models/org_participation.en.yml
+++ b/config/locales/models/org_participation.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        org_participation:
+          attributes:
+            organisation:
+              inactive: Implementing organisation must be active

--- a/spec/controllers/staff/implementing_organisations_controller_spec.rb
+++ b/spec/controllers/staff/implementing_organisations_controller_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe Staff::ImplementingOrganisationsController do
+  let(:activity) { create(:project_activity) }
+  let!(:report) { create(:report, fund: activity.associated_fund, organisation: activity.organisation) }
+  let(:user) { create(:partner_organisation_user, organisation: activity.organisation) }
+  let(:active_organisation) { create(:partner_organisation) }
+  let(:inactive_organisation) { create(:partner_organisation, :inactive) }
+
+  before do
+    authenticate!(user: user)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  after { logout }
+
+  describe "#new" do
+    render_views
+
+    it "shows the submit input" do
+      get :new, params: {activity_id: activity.id}
+
+      expect(response.body).to include(t("default.button.submit"))
+    end
+
+    context "when signed in as a BEIS user" do
+      let(:user) { create(:beis_user) }
+
+      it "responds with a 401" do
+        get :new, params: {activity_id: activity.id}
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when the activity has no editable report" do
+      it "responds with a 401" do
+        report.destroy
+
+        get :new, params: {activity_id: activity.id}
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe "#create" do
+    before do
+      allow(OrgParticipation).to receive(:find_or_initialize_by).and_call_original
+    end
+
+    it "asks OrgParticipation to find or initialise an instance" do
+      post_org_participation
+
+      expect(OrgParticipation).to have_received(:find_or_initialize_by).with(
+        activity: activity,
+        organisation: active_organisation
+      )
+    end
+
+    context "when organisation is active" do
+      it "redirects to the activity details tab" do
+        post_org_participation
+
+        expect(response).to redirect_to(organisation_activity_details_path(activity.organisation, activity))
+      end
+    end
+
+    context "when organisation is inactive" do
+      it "redirects back to the form" do
+        post_org_participation(active: false)
+
+        expect(response).to redirect_to(new_activity_implementing_organisation_path(activity))
+      end
+    end
+  end
+
+  describe "#destroy" do
+    it "redirects to the activity details tab" do
+      delete_org_participation
+
+      expect(response).to redirect_to(organisation_activity_details_path(activity.organisation, activity))
+    end
+
+    context "when logged in as another partner organisation user" do
+      let(:other_user) { create(:partner_organisation_user) }
+
+      it "responds with a 401" do
+        logout
+        authenticate!(user: other_user)
+        allow(controller).to receive(:current_user).and_return(other_user)
+
+        delete_org_participation
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  def post_org_participation(active: true)
+    organisation_id = active ? active_organisation.id : inactive_organisation.id
+
+    post :create, params: {
+      implementing_organisation: {
+        activity_id: activity.id,
+        organisation_id: organisation_id
+      },
+      activity_id: activity.id
+    }
+  end
+
+  def delete_org_participation
+    delete :destroy, params: {
+      implementing_organisation: {organisation_id: activity.organisation.id},
+      activity_id: activity.id,
+      id: activity.organisation.id
+    }
+  end
+end

--- a/spec/factories/org_participation.rb
+++ b/spec/factories/org_participation.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :org_participation do
-    association :organisation
+    association :organisation, factory: :partner_organisation
     association :activity, factory: :programme_activity
     role { :implementing }
+
+    trait :inactive_organisation do
+      association :organisation, factory: [:partner_organisation, :inactive]
+    end
   end
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     factory :partner_organisation do
       role { "partner_organisation" }
 
+      trait :inactive do
+        active { false }
+      end
+
       trait :non_government do
         organisation_type { "22" }
       end

--- a/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/staff/users_can_manage_implementing_organisations_spec.rb
@@ -32,6 +32,8 @@ RSpec.feature "Users can manage the implementing organisations" do
       end
     end
 
+    let!(:inactive_implementing_org) { create(:partner_organisation, :inactive) }
+
     before do
       authenticate!(
         user: create(:partner_organisation_user, organisation: partner_organisation)
@@ -42,10 +44,10 @@ RSpec.feature "Users can manage the implementing organisations" do
     after { logout }
 
     scenario "they can add an implementing org from a list of all organisations" do
-      def then_i_see_a_list_containing_all_organisations
+      def then_i_see_a_list_containing_all_active_organisations
         expect(page).to have_select(
           t("form.label.implementing_organisation"),
-          options: Organisation.sorted_by_name.pluck(:name)
+          options: Organisation.active.sorted_by_name.pluck(:name)
         )
       end
 
@@ -72,7 +74,7 @@ RSpec.feature "Users can manage the implementing organisations" do
       expect(page).to have_content t("page_content.activity.implementing_organisation.button.new")
       click_on t("page_content.activity.implementing_organisation.button.new")
 
-      then_i_see_a_list_containing_all_organisations
+      then_i_see_a_list_containing_all_active_organisations
       then_i_see_guidance_about_adding_to_this_list
       when_i_select_the_implementing_organisation("Implementing org")
 

--- a/spec/models/org_participation_spec.rb
+++ b/spec/models/org_participation_spec.rb
@@ -3,4 +3,46 @@ require "rails_helper"
 RSpec.describe OrgParticipation, type: :model do
   it { should belong_to(:activity) }
   it { should belong_to(:organisation) }
+
+  context "when the org participation is unpersisted" do
+    context "when the role is implementing and the organisation is inactive" do
+      subject(:org_participation) { build(:org_participation, :inactive_organisation) }
+
+      it "should not be valid" do
+        expect(org_participation).to_not be_valid
+      end
+    end
+
+    describe "#organisation_is_active" do
+      context "when the organisation is active" do
+        subject(:org_participation) { build(:org_participation) }
+
+        it "should be valid" do
+          expect(org_participation).to be_valid
+        end
+      end
+
+      context "when the organisation is inactive" do
+        subject(:org_participation) { build(:org_participation, :inactive_organisation) }
+
+        it "has an appropriate error" do
+          expect(org_participation).to_not be_valid
+          expect(org_participation.errors.count).to eq(1)
+          expect(org_participation.errors.full_messages.first).to eq(I18n.t("activerecord.errors.models.org_participation.attributes.organisation.inactive"))
+        end
+      end
+    end
+  end
+
+  context "when the org participation is persisted" do
+    let(:existing_org_participation) { create(:org_participation) }
+
+    context "when the role is implementing and the organisation becomes inactive" do
+      it "should be valid" do
+        existing_org_participation.organisation.update(active: false)
+
+        expect(existing_org_participation).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

This prevents users from adding inactive organisations as implementing organisations for activities

## Screenshots of UI changes

If the database is in sync with production, NERC CENTRE FOR ECOLOGY & HYRDOLOGY will appear before, but not after

### Before

<img width="876" alt="image" src="https://user-images.githubusercontent.com/40244233/193881211-31858559-9030-4620-876e-6ff0f55a271f.png">

### After

<img width="877" alt="image" src="https://user-images.githubusercontent.com/40244233/193881095-66706915-054d-4cea-90a5-cd9137fcc62a.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
