### PR TITLE
(2555) Separate comments in reports CSV with a pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,6 +1099,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add Level B budget bulk upload functionality - form with errors/confirmation view; link in top nav
 - Include refunds and adjustments in the calculation of an activity's total spend (previously only actuals were included)
 - Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page
+- Comments in report CSVs are delimited by a pipe, instead of a newline, to enable BEIS users' QA workflow
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/app/models/export/activity_comments_column.rb
+++ b/app/models/export/activity_comments_column.rb
@@ -12,7 +12,13 @@ class Export::ActivityCommentsColumn
     return [] if @activities.empty?
 
     @activities.map { |activity|
-      [activity.id, activity.comments_for_report(report_id: @report.id).pluck(:body).join("\n----\n")]
+      [activity.id, comments_formatted_for_csv(activity.comments_for_report(report_id: @report.id))]
     }.to_h
+  end
+
+  private
+
+  def comments_formatted_for_csv(comments)
+    comments.pluck(:body).join("|")
   end
 end

--- a/app/services/report/export.rb
+++ b/app/services/report/export.rb
@@ -1,4 +1,6 @@
 class Report
+  # this service creates the legacy report export and should not have any further updates
+
   class Export
     def initialize(report:)
       @report = report

--- a/spec/models/export/activity_comments_column_spec.rb
+++ b/spec/models/export/activity_comments_column_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Export::ActivityCommentsColumn do
       end
 
       context "when the activity has multiple comments" do
-        it "returns the body of each comment separated by `----`" do
+        it "returns the body of each comment separated by `|`" do
           value_for_activity = subject.rows.fetch(@activity_with_multiple_comments_in_report.id)
 
-          expect(value_for_activity).to include "----"
+          expect(value_for_activity).to include "|"
           expect(value_for_activity).to include(@actual_comment.body)
           expect(value_for_activity).to include(@refund_comment.body)
           expect(value_for_activity).to include(@adjustment_comment.body)

--- a/spec/services/report/export_spec.rb
+++ b/spec/services/report/export_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Report::Export do
+  # this service creates the legacy report export and should not have any further updates
+
   subject { described_class.new(report: report) }
 
   let(:report) { build(:report) }


### PR DESCRIPTION
## Changes in this PR
- Comments in reports CSV are delimited by a pipe, instead of a newline, to enable BEIS users' QA workflow

## Screenshots of UI changes

### Before
![Screenshot 2022-10-05 at 14 49 41](https://user-images.githubusercontent.com/579522/194077376-d39119d9-0199-4a61-b553-db4aaa04c720.png)

### After
![Screenshot 2022-10-05 at 14 50 29](https://user-images.githubusercontent.com/579522/194077431-3d5062b9-db60-4702-94a8-ce79592d59bf.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
