### PR TITLE
Revert "Bump spring-watcher-listen from 2.0.1 to 2.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development do
   gem "listen", ">= 3.0.5", "< 3.8"
   gem "spring"
   gem "spring-commands-rspec"
-  gem "spring-watcher-listen", "~> 2.1.0"
+  gem "spring-watcher-listen", "~> 2.0.0"
   gem "rails_layout"
   gem "web-console", ">= 3.3.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,7 +334,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    rb-fsevent (0.11.2)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.5.1)
@@ -423,12 +423,12 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     smart_properties (1.17.0)
-    spring (4.1.0)
+    spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    spring-watcher-listen (2.1.0)
+    spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
-      spring (>= 4)
+      spring (>= 1.2, < 3.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -548,7 +548,7 @@ DEPENDENCIES
   sidekiq (~> 5.2)
   spring
   spring-commands-rspec
-  spring-watcher-listen (~> 2.1.0)
+  spring-watcher-listen (~> 2.0.0)
   standard
   strip_attributes
   tzinfo-data


### PR DESCRIPTION
Reverts UKGovernmentBEIS/beis-report-official-development-assistance#1798

See https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1798#issuecomment-1270725149 for details - this breaks test migrations and introduces a warning message when running tests. The comment notes what we can do to unbreak the migrations, but the warnings remain, and the tests (at least feature tests) run a little slower, so it's one to investigate later