### PR TITLE
Fix training db sync script password reset command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1100,6 +1100,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Include refunds and adjustments in the calculation of an activity's total spend (previously only actuals were included)
 - Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page
 - Comments in report CSVs are delimited by a pipe, instead of a newline, to enable BEIS users' QA workflow
+- Fix the command invoking the password reset script when updating training environment with the latest data from production
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117

--- a/script/training_db_sync.rb
+++ b/script/training_db_sync.rb
@@ -106,7 +106,7 @@ class TrainingDbSync
     Kernel.puts "Copying pw reset script to #{destination} ==> #{copy_cmd}"
     CmdRunner.run(copy_cmd)
 
-    reset_cmd = %(cf ssh beis-roda-#{destination} -c "bin/rails runner #{pw_reset_script}")
+    reset_cmd = %(cf ssh beis-roda-#{destination} -c "cd /app; PATH=$PATH:/usr/local/bin bin/rails runner #{pw_reset_script}")
     Kernel.puts "Running pw reset script on #{destination} ==> #{reset_cmd}"
     CmdRunner.run(reset_cmd)
   end


### PR DESCRIPTION
## Changes in this PR

After running the training db sync, which fetches the current users on production and writes them to the training environment database, we encountered the following error on logging in:

```
OpenSSL::Cipher::CipherError
```

This was a difficult one to debug, but after some digging, we discovered it was caused by users' passwords not being reset as expected in the `pw_reset_script` portion of the training db sync script.

This was a difficult one to debug, but we discovered that the `bin/rails` command wasn't being run (albeit silently, without any errors being surfaced to us running the command) due to the `ssh -c` command not placing the user in the `/app` directory where `bin/rails` is available.

Then, we discovered `ruby` wasn't available in the `PATH` as using double quotes around a `-c` argument tells the script to use your user's local PATH, rather than that on the machine running the command. To fix this, we've used single quotes and explicitly specified the Ruby path when running the script remotely.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
