### PR TITLE
Release 118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1092,7 +1092,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add ability for BEIS users to create and update Level B activities in bulk by uploading a CSV
 - Make partner organisation identifier optional for Level B activities (both via the individual new activity form and bulk upload)
 
-## [unreleased]
+## [release-118] 2022-10-11
 
 - Refactor the importers (including associated uploads controllers and views) to use a unified approach for all entities being imported
 - Ensure `Forecast.set_value` always returns a forecast or nil; this will ensure that uploaded forecasts are correctly displayed back to the user on the success page
@@ -1104,7 +1104,10 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Prevent inactive organisations being added to activities as implementing organisations
 - Remove the "staff" namespace
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-118...HEAD
+[release-118]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...release-118
 [release-117]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-116...release-117
 [release-116]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-115...release-116
 [release-115]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-114...release-115


### PR DESCRIPTION
- Refactor the importers (including associated uploads controllers and views) to use a unified approach for all entities being imported
- Ensure `Forecast.set_value` always returns a forecast or nil; this will ensure that uploaded forecasts are correctly displayed back to the user on the success page
- Add Level B budget bulk upload functionality - form with errors/ confirmation view; link in top nav
- Include refunds and adjustments in the calculation of an activity's total spend (previously only actuals were included)
- Point the "Back to home" link on the Level B activities bulk upload to the home page instead of the organisations page
- Comments in report CSVs are delimited by a pipe, instead of a newline, to enable BEIS users' QA workflow
- Fix the command invoking the password reset script when updating training environment with the latest data from production
- Prevent inactive organisations being added to activities as implementing organisations
- Remove the "staff" namespace

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
