### PR TITLE
(2619) Improve error message when trying to create a Level C activity on an incomplete Level B activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1110,6 +1110,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Improve error message when trying to create child activities on incomplete parent activities
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...HEAD
 [release-119]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-118...release-119
 [release-118]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-117...release-118

--- a/app/services/activity/import.rb
+++ b/app/services/activity/import.rb
@@ -210,7 +210,7 @@ class Activity
         @errors = {}
         @row = row
         @converter = Converter.new(row)
-        @parent_activity = fetch_parent(@row["Parent RODA ID"])
+        @parent_activity = fetch_and_validate_parent_activity(@row["Parent RODA ID"])
         @report = report
 
         if @parent_activity && !ActivityPolicy.new(@uploader, @parent_activity).create_child?
@@ -255,11 +255,11 @@ class Activity
         implementing_organisation_builder.add_errors(@errors) if @activity.implementing_organisations.include?(nil)
       end
 
-      private def fetch_parent(roda_id)
-        parent = Activity.by_roda_identifier(roda_id)
+      private def fetch_and_validate_parent_activity(parent_roda_id)
+        parent = Activity.by_roda_identifier(parent_roda_id)
 
-        @errors[:parent_id] = [roda_id, I18n.t("importer.errors.activity.parent_not_found")] if parent.nil?
-        @errors[:parent_id] = [roda_id, I18n.t("importer.errors.activity.incomplete_parent")] if parent.present? && !parent.form_steps_completed?
+        @errors[:parent_id] = [parent_roda_id, I18n.t("importer.errors.activity.parent_not_found")] if parent.nil?
+        @errors[:parent_id] = [parent_roda_id, I18n.t("importer.errors.activity.incomplete_parent")] if parent.present? && !parent.form_steps_completed?
 
         parent
       end

--- a/app/services/activity/import.rb
+++ b/app/services/activity/import.rb
@@ -259,7 +259,7 @@ class Activity
         parent = Activity.by_roda_identifier(roda_id)
 
         @errors[:parent_id] = [roda_id, I18n.t("importer.errors.activity.parent_not_found")] if parent.nil?
-        @errors[:parent_id] = [roda_id, I18n.t("importer.errors.activity.invalid_parent")] if parent.present? && !parent.form_steps_completed?
+        @errors[:parent_id] = [roda_id, I18n.t("importer.errors.activity.incomplete_parent")] if parent.present? && !parent.form_steps_completed?
 
         parent
       end

--- a/app/services/budget/import.rb
+++ b/app/services/budget/import.rb
@@ -63,7 +63,7 @@ class Budget
         @row = row
         @uploader = uploader
         @errors = {}
-        @parent_activity = fetch_parent(@row["Activity RODA ID"])
+        @parent_activity = Activity.by_roda_identifier(@row["Activity RODA ID"])
         @converter = Converter.new(row, @parent_activity)
 
         @errors.update(@converter.errors)
@@ -80,12 +80,6 @@ class Budget
         @budget.errors.each do |error|
           @errors[error.attribute] ||= [@converter.raw(error.attribute), error.message]
         end
-      end
-
-      private
-
-      def fetch_parent(roda_id)
-        Activity.by_roda_identifier(roda_id)
       end
     end
 

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -571,7 +571,7 @@ en:
         invalid_aid_type: The aid type code is not valid
         invalid_fstc_applies: The free standing technical cooperation column is not valid
         invalid_policy_marker: This is not a valid code for this policy marker
-        invalid_parent: The parent activity is not valid
+        incomplete_parent: The parent activity is incomplete
         parent_not_found: The parent activity cannot be found
         cannot_create: There is no RODA fragment or parent activity present, so cannot create an Activity
         cannot_update:

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe Activity::Import do
         expect(subject.errors.first.csv_column).to eq("Parent RODA ID")
         expect(subject.errors.first.column).to eq(:parent_id)
         expect(subject.errors.first.value).to eq(parent_activity.roda_identifier)
-        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.invalid_parent"))
+        expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.incomplete_parent"))
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

Makes incomplete parent activity error more explicit

Users have reported being unable to add Level C and D activities to some Level B activities, as they were met with the error message: "The parent activity is not valid". The error was caused by the Level B activity not being in the correct `form_state` (it must be `completed`).

This message didn't feel clear enough, as it didn't tell the user how to rectify the issue - stating that the parent is actually "incomplete".

Hopefully this should make it clearer to the user that they have to go in and finish creating the Level B activity.

This PR also includes a couple of smaller bits of renaming - while I'd like to refactor the importer class, this felt like a bigger job than was necessary for solving this issue.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/195390480-8b8140f6-4d7d-4e5f-a5c6-f032b0b243f4.png)

### After

![image](https://user-images.githubusercontent.com/19826940/195390161-a678ac64-1795-40c8-b238-00ec5ba31538.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
