### PR TITLE
(2621) Allow comments on Level B activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1115,6 +1115,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Configure Rollout and Rollout UI gems to allow BEIS users to manage feature flags
+- Allow comments on Level B activities from BEIS users
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/controllers/activity_comments_controller.rb
+++ b/app/controllers/activity_comments_controller.rb
@@ -9,6 +9,7 @@ class ActivityCommentsController < BaseController
     if @activity.programme?
       @comment = @activity.comments.new
       authorize :level_b, :create_activity_comment?
+      prepare_default_activity_trail(@activity, tab: "comments")
     else
       @comment = @activity.comments.new(report_id: report_id)
       authorize @comment, policy_class: Activity::CommentPolicy

--- a/app/controllers/activity_comments_controller.rb
+++ b/app/controllers/activity_comments_controller.rb
@@ -5,17 +5,28 @@ class ActivityCommentsController < BaseController
 
   def new
     @activity = Activity.find(activity_id)
-    @comment = @activity.comments.new(report_id: report_id)
-    authorize @comment, policy_class: Activity::CommentPolicy
 
-    prepare_default_report_variance_trail(@comment.report)
+    if @activity.programme?
+      @comment = @activity.comments.new
+      authorize :level_b, :create_activity_comment?
+    else
+      @comment = @activity.comments.new(report_id: report_id)
+      authorize @comment, policy_class: Activity::CommentPolicy
+      prepare_default_report_variance_trail(@comment.report)
+    end
+
     add_breadcrumb t("breadcrumb.comment.new"), new_activity_comment_path(@activity)
   end
 
   def create
     @activity = Activity.find(activity_id)
     @comment = @activity.comments.create(comment_params)
-    authorize @comment, policy_class: Activity::CommentPolicy
+
+    if @activity.programme?
+      authorize :level_b, :create_activity_comment?
+    else
+      authorize @comment, policy_class: Activity::CommentPolicy
+    end
 
     @comment.assign_attributes(owner: current_user)
 
@@ -31,9 +42,14 @@ class ActivityCommentsController < BaseController
   def edit
     @comment = Comment.find(id)
     @activity = Activity.find(@comment.commentable_id)
-    @report = Report.find(@comment.report_id)
-    @report_presenter = ReportPresenter.new(@report)
-    authorize @comment, policy_class: Activity::CommentPolicy
+
+    if @activity.programme?
+      authorize :level_b, :update_activity_comment?
+    else
+      @report = Report.find(@comment.report_id)
+      @report_presenter = ReportPresenter.new(@report)
+      authorize @comment, policy_class: Activity::CommentPolicy
+    end
 
     prepare_default_activity_trail(@activity, tab: "comments")
     add_breadcrumb t("breadcrumb.comment.edit"), edit_activity_comment_path(@activity, @comment)
@@ -41,7 +57,12 @@ class ActivityCommentsController < BaseController
 
   def update
     @comment = Comment.find(id)
-    authorize @comment, policy_class: Activity::CommentPolicy
+
+    if @comment.commentable.programme?
+      authorize :level_b, :update_activity_comment?
+    else
+      authorize @comment, policy_class: Activity::CommentPolicy
+    end
 
     @comment.assign_attributes(comment_params)
     if @comment.valid?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,11 +1,12 @@
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
   belongs_to :owner, class_name: "User", optional: true
-  belongs_to :report
+  belongs_to :report, optional: true
 
   before_create :set_commentable_type
 
   validates :body, presence: true
+  validates :report, presence: {unless: -> { commentable_type == "Activity" && commentable.programme? }}
 
   scope :with_commentables, -> {
     joins("left outer join activities on activities.id = comments.commentable_id AND comments.commentable_type = 'Activity'")

--- a/app/policies/level_b_policy.rb
+++ b/app/policies/level_b_policy.rb
@@ -6,4 +6,12 @@ class LevelBPolicy < ApplicationPolicy
   def budget_upload?
     return true if beis_user?
   end
+
+  def create_activity_comment?
+    update_activity_comment?
+  end
+
+  def update_activity_comment?
+    return true if beis_user?
+  end
 end

--- a/app/views/activities/comments.html.haml
+++ b/app/views/activities/comments.html.haml
@@ -20,12 +20,11 @@
           %h2.govuk-heading-l
             = t("page_title.comment.index")
 
-          - if @activity.programme?
-            .govuk-body
-              = t("page_content.comment.index_level_b")
-          - else
-            .govuk-body
-              = t("page_content.comment.index_html")
+          .govuk-body
+            = t("page_content.comment.index.default")
+            - if @activity.is_project?
+              = tag(:br)
+              = t("page_content.comment.index.only_when_reportable")
 
           - if show_link_to_add_comment?(activity: @activity, report: @report)
             .govuk-body

--- a/app/views/activities/comments.html.haml
+++ b/app/views/activities/comments.html.haml
@@ -20,16 +20,19 @@
           %h2.govuk-heading-l
             = t("page_title.comment.index")
 
-          .govuk-body
-            = t("page_content.comment.index_html")
+          - if @activity.programme?
+            .govuk-body
+              = t("page_content.comment.index_level_b")
+          - else
+            .govuk-body
+              = t("page_content.comment.index_html")
 
-          .govuk-body
-            - if policy([:activity, :comment]).create? && @report
-              = link_to(t("page_content.comment.add"), new_activity_comment_path(@activity, report_id: @report.id),  class: "govuk-button")
+          - if show_link_to_add_comment?(activity: @activity, report: @report)
+            .govuk-body
+              = link_to t("page_content.comment.add"), new_activity_comment_path(@activity, report_id: @report&.id), class: "govuk-button"
 
           %ul.govuk-list.activity_comments
             - @comments.each do |comment|
-              - report_presenter = ReportPresenter.new(comment.report)
               %li{id: "comment_#{comment.id}"}
                 %dl.govuk-summary-list
                   .govuk-summary-list__row
@@ -37,7 +40,7 @@
                       = Comment.model_name.human
                     %dd.govuk-summary-list__value
                       = comment.body
-                      - if policy([comment.commentable, comment]).update?
+                      - if show_link_to_edit_comment?(comment: comment)
                         %span.govuk-body-s
                           (#{a11y_action_link(t("default.link.edit"), edit_comment_path_for(comment.commentable, comment))})
                   .govuk-summary-list__row
@@ -50,9 +53,10 @@
                       Type
                     %dd.govuk-summary-list__value
                       = comment.commentable_type
-                  .govuk-summary-list__row
-                    %dt.govuk-summary-list__key
-                      Comment reported in
-                    %dd.govuk-summary-list__value
-                      = link_to "#{report_presenter.financial_quarter_and_year} #{report_presenter.description}", report_path(comment.report)
-
+                  - if comment.report
+                  - report_presenter = ReportPresenter.new(comment.report)
+                    .govuk-summary-list__row
+                      %dt.govuk-summary-list__key
+                        Comment reported in
+                      %dd.govuk-summary-list__value
+                        = link_to "#{report_presenter.financial_quarter_and_year} #{report_presenter.description}", report_path(comment.report)

--- a/app/views/activity_comments/edit.html.haml
+++ b/app/views/activity_comments/edit.html.haml
@@ -6,9 +6,10 @@
       %h2.govuk-heading-l
         = t("page_content.comment.edit_about_activity", activity: @activity.title)
 
-  .govuk-grid-row
-    .govuk-grid-column-full
-      = render partial: "reports/summary_short", locals: { report: ReportPresenter.new(@comment.report) }
+  - if @comment.report
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "reports/summary_short", locals: { report: ReportPresenter.new(@comment.report) }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/activity_comments/new.html.haml
+++ b/app/views/activity_comments/new.html.haml
@@ -6,9 +6,10 @@
       %h2.govuk-heading-l
         = t("page_content.comment.add_about_activity", activity: @activity.title)
 
-  .govuk-grid-row
-    .govuk-grid-column-full
-      = render partial: "reports/summary_short", locals: { report: ReportPresenter.new(@comment.report) }
+  - if @comment.report
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = render partial: "reports/summary_short", locals: { report: ReportPresenter.new(@comment.report) }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/config/locales/models/comment.en.yml
+++ b/config/locales/models/comment.en.yml
@@ -18,8 +18,9 @@ en:
       add_about_activity: Add a comment about %{activity}
       edit: Edit comment
       edit_about_activity: Edit comment about %{activity}
-      index_html: "This tab shows all the comments for this activity.<br>New comments can only be added whilst there is an active report."
-      index_level_b: "This tab shows all the comments for this activity."
+      index:
+        default: This tab shows all the comments for this activity.
+        only_when_reportable: New comments can only be added whilst there is an active report.
     tab_content:
       comments:
         heading: Comments

--- a/config/locales/models/comment.en.yml
+++ b/config/locales/models/comment.en.yml
@@ -19,6 +19,7 @@ en:
       edit: Edit comment
       edit_about_activity: Edit comment about %{activity}
       index_html: "This tab shows all the comments for this activity.<br>New comments can only be added whilst there is an active report."
+      index_level_b: "This tab shows all the comments for this activity."
     tab_content:
       comments:
         heading: Comments

--- a/spec/controllers/activity_comments_controller_spec.rb
+++ b/spec/controllers/activity_comments_controller_spec.rb
@@ -1,0 +1,279 @@
+require "rails_helper"
+
+RSpec.describe ActivityCommentsController do
+  let(:beis_user) { create(:beis_user) }
+  let(:partner_organisation_user) { create(:partner_organisation_user) }
+
+  let(:programme_activity) { create(:programme_activity) }
+
+  let(:project_activity) { create(:project_activity, organisation: partner_organisation_user.organisation) }
+  let!(:project_activity_report) { create(:report, :active, fund: project_activity.associated_fund, organisation: partner_organisation_user.organisation) }
+
+  let(:existing_programme_activity_comment) { create(:comment, commentable: programme_activity, owner: beis_user) }
+  let(:existing_project_activity_comment) { create(:comment, commentable: project_activity, owner: partner_organisation_user, report: project_activity_report) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  after { logout }
+
+  describe "#new" do
+    render_views
+
+    context "when the activity is a programme" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "shows the submit button" do
+          get :new, params: {activity_id: programme_activity.id}
+
+          expect(response.body).to include(t("default.button.submit"))
+        end
+      end
+
+      context "when signed in as a partner organisation user" do
+        let(:user) { partner_organisation_user }
+
+        it "responds with a 401" do
+          get :new, params: {activity_id: programme_activity.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "responds with a 401" do
+          get :new, params: {activity_id: project_activity.id, report_id: project_activity_report.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is the same as the activity's report" do
+        let(:user) { partner_organisation_user }
+
+        it "shows the submit button" do
+          get :new, params: {activity_id: project_activity.id, report_id: project_activity_report.id}
+
+          expect(response.body).to include(t("default.button.submit"))
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
+        let(:user) { create(:partner_organisation_user) }
+
+        it "responds with a 401" do
+          get :new, params: {activity_id: project_activity.id, report_id: project_activity_report.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    context "when the activity is a programme" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "creates the comment and redirects to organisation activity comments path" do
+          old_count = Comment.count
+
+          post_comment(activity_id: programme_activity.id, report_id: "")
+
+          expect(Comment.count).to eq(old_count + 1)
+          expect(response).to redirect_to(organisation_activity_comments_path(beis_user.organisation, programme_activity))
+        end
+      end
+
+      context "when signed in as a partner organisation user" do
+        let(:user) { partner_organisation_user }
+
+        it "responds with a 401" do
+          post_comment(activity_id: programme_activity.id, report_id: "")
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "responds with a 401" do
+          post_comment(activity_id: project_activity.id, report_id: project_activity_report.id)
+
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is the same as the activity's report" do
+        let(:user) { partner_organisation_user }
+
+        it "creates the comment and redirects to organisation activity comments path" do
+          old_count = Comment.count
+
+          post_comment(activity_id: project_activity.id, report_id: project_activity_report.id)
+
+          expect(Comment.count).to eq(old_count + 1)
+          expect(response).to redirect_to(organisation_activity_comments_path(partner_organisation_user.organisation, project_activity))
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
+        let(:user) { create(:partner_organisation_user) }
+
+        it "responds with a 401" do
+          post_comment(activity_id: project_activity.id, report_id: project_activity_report.id)
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
+
+  describe "#edit" do
+    render_views
+
+    context "when the activity is a programme" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "shows the submit button" do
+          get :edit, params: {activity_id: programme_activity.id, id: existing_programme_activity_comment.id}
+
+          expect(response.body).to include(t("default.button.submit"))
+        end
+      end
+
+      context "when signed in as a partner organisation user" do
+        let(:user) { partner_organisation_user }
+
+        it "responds with a 401" do
+          get :edit, params: {activity_id: programme_activity.id, id: existing_programme_activity_comment.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "responds with a 401" do
+          get :edit, params: {activity_id: project_activity.id, id: existing_project_activity_comment.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is the same as the activity's report" do
+        let(:user) { partner_organisation_user }
+
+        it "shows the submit button" do
+          get :edit, params: {activity_id: project_activity.id, id: existing_project_activity_comment.id}
+
+          expect(response.body).to include(t("default.button.submit"))
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
+        let(:user) { create(:partner_organisation_user) }
+
+        it "responds with a 401" do
+          get :edit, params: {activity_id: project_activity.id, id: existing_project_activity_comment.id}
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when the activity is a programme" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "updates the comment and redirects to organisation activity comments path" do
+          put_comment(comment_id: existing_programme_activity_comment.id, activity_id: programme_activity.id)
+
+          updated_comment = Comment.find(existing_programme_activity_comment.id)
+
+          expect(updated_comment.body).to eq(updated_comment_body)
+          expect(response).to redirect_to(organisation_activity_comments_path(beis_user.organisation, programme_activity))
+        end
+      end
+
+      context "when signed in as a partner organisation user" do
+        let(:user) { partner_organisation_user }
+
+        it "responds with a 401" do
+          put_comment(comment_id: existing_programme_activity_comment.id, activity_id: programme_activity.id)
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      context "when signed in as a BEIS user" do
+        let(:user) { beis_user }
+
+        it "responds with a 401" do
+          put_comment(comment_id: existing_project_activity_comment.id, activity_id: project_activity.id)
+
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is the same as the activity's report" do
+        let(:user) { partner_organisation_user }
+
+        it "updates the comment and redirects to organisation activity comments path" do
+          put_comment(comment_id: existing_project_activity_comment.id, activity_id: project_activity.id)
+
+          updated_comment = Comment.find(existing_project_activity_comment.id)
+
+          expect(updated_comment.body).to eq(updated_comment_body)
+          expect(response).to redirect_to(organisation_activity_comments_path(partner_organisation_user.organisation, project_activity))
+        end
+      end
+
+      context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
+        let(:user) { create(:partner_organisation_user) }
+
+        it "responds with a 401" do
+          put_comment(comment_id: existing_project_activity_comment.id, activity_id: project_activity.id)
+
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
+
+  def post_comment(activity_id:, report_id:)
+    post :create, params: {
+      activity_id: activity_id,
+      comment: {body: "Nihilism slips on a banana peel.", report_id: report_id}
+    }
+  end
+
+  def put_comment(comment_id:, activity_id:)
+    put :update, params: {
+      id: comment_id,
+      activity_id: activity_id,
+      comment: {body: updated_comment_body}
+    }
+  end
+
+  def updated_comment_body
+    "Abstraction set a treehouse on fire."
+  end
+end

--- a/spec/features/users_can_create_a_comment_spec.rb
+++ b/spec/features/users_can_create_a_comment_spec.rb
@@ -2,17 +2,18 @@ RSpec.describe "Users can create a comment" do
   let(:beis_user) { create(:beis_user) }
   let(:partner_org_user) { create(:partner_organisation_user) }
 
-  let(:activity) { create(:project_activity, organisation: partner_org_user.organisation) }
-  let(:actual) { create(:actual, report: report, activity: activity) }
-  let!(:report) { create(:report, :active, fund: activity.associated_fund, organisation: partner_org_user.organisation, financial_year: 2020, financial_quarter: 1) }
+  let(:project_activity) { create(:project_activity, organisation: partner_org_user.organisation) }
+  let!(:project_activity_report) { create(:report, :active, fund: project_activity.associated_fund, organisation: partner_org_user.organisation, financial_year: 2020, financial_quarter: 1) }
+
+  let(:programme_activity) { create(:programme_activity) }
 
   context "from the report variance tab" do
     context "when the activity has variance" do
       before do
-        variance_stub = instance_double(Activity::VarianceFetcher, activities: [activity], total: 0)
+        variance_stub = instance_double(Activity::VarianceFetcher, activities: [project_activity], total: 0)
 
         allow(Activity::VarianceFetcher).to receive(:new).and_return(variance_stub)
-        allow(activity).to receive(:variance_for_report_financial_quarter).with(report: report).and_return(100)
+        allow(project_activity).to receive(:variance_for_report_financial_quarter).with(report: project_activity_report).and_return(100)
       end
 
       context "when the user is a BEIS user" do
@@ -21,16 +22,16 @@ RSpec.describe "Users can create a comment" do
 
         context "when the report is editable" do
           scenario "the user cannot add a comment" do
-            visit report_path(report)
+            visit report_path(project_activity_report)
             click_on t("tabs.report.variance.heading")
             expect(page).not_to have_content t("table.body.report.add_comment")
           end
         end
 
         context "when the report is not editable" do
-          let(:report) { create(:report, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
+          let(:project_activity_report) { create(:report, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
           scenario "the user cannot add a comment" do
-            visit report_path(report)
+            visit report_path(project_activity_report)
             click_on t("tabs.report.variance.heading")
             expect(page).not_to have_content t("table.body.report.add_comment")
           end
@@ -44,7 +45,7 @@ RSpec.describe "Users can create a comment" do
         context "when the report is editable" do
           context "when there are no comments about this activity" do
             scenario "the user can add a comment" do
-              form = CommentForm.create(report: report)
+              form = CommentForm.create(report: project_activity_report)
 
               expect(form).to have_report_summary_information
               form.complete(comment: "This activity underspent")
@@ -57,25 +58,25 @@ RSpec.describe "Users can create a comment" do
               within ".activity_comments" do
                 expect(page).to have_content form.comment
                 expect(page).to have_content I18n.l(Date.today)
-                expect(page).to have_link "#{report.financial_quarter_and_year} #{report.description}"
+                expect(page).to have_link "#{project_activity_report.financial_quarter_and_year} #{project_activity_report.description}"
               end
             end
           end
         end
 
         context "when the report is not editable" do
-          let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
+          let(:project_activity_report) { create(:report, :approved, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
           scenario "the user cannot add a comment" do
-            visit report_path(report)
+            visit report_path(project_activity_report)
             click_on t("tabs.report.variance.heading")
             expect(page).not_to have_content t("table.body.report.add_comment")
           end
         end
 
         context "when the report is editable but does not belong to this user's organisation" do
-          let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: create(:partner_organisation)) }
+          let(:project_activity_report) { create(:report, :active, fund: project_activity.associated_fund, organisation: create(:partner_organisation)) }
           scenario "the user cannot add a comment" do
-            visit report_path(report)
+            visit report_path(project_activity_report)
             expect(page).to have_content t("page_title.errors.not_authorised")
           end
         end
@@ -88,23 +89,66 @@ RSpec.describe "Users can create a comment" do
       before { authenticate!(user: partner_org_user) }
       after { logout }
 
-      context "when the report is editable" do
+      context "for a project activity" do
+        context "when the report is editable" do
+          scenario "the user can create a comment" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).to have_css(".govuk-button")
+            click_on t("page_content.comment.add")
+            fill_in "comment[body]", with: "Amendments have been made"
+            click_button t("default.button.submit")
+            expect(page).to have_content "Amendments have been made"
+            expect(page).to have_content t("action.comment.create.success")
+          end
+        end
+
+        context "when the report is not editable" do
+          let(:project_activity_report) { create(:report, :approved, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
+          scenario "the user cannot create a comment" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("page_content.comment.add")
+          end
+        end
+      end
+
+      context "for a programme activity" do
+        scenario "the user cannot create a comment" do
+          visit organisation_activity_comments_path(beis_user.organisation, programme_activity)
+          expect(page).not_to have_content t("page_content.comment.add")
+        end
+      end
+    end
+
+    context "when the user is a BEIS user" do
+      before { authenticate!(user: beis_user) }
+      after { logout }
+
+      context "for a project activity" do
+        context "when the report is editable" do
+          scenario "the user cannot create a comment" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("page_content.comment.add")
+          end
+        end
+
+        context "when the report is not editable" do
+          let(:project_activity_report) { create(:report, :approved, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
+          scenario "the user cannot create a comment" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("page_content.comment.add")
+          end
+        end
+      end
+
+      context "for a programme activity" do
         scenario "the user can create a comment" do
-          visit organisation_activity_comments_path(activity.organisation, activity)
+          visit organisation_activity_comments_path(beis_user.organisation, programme_activity)
           expect(page).to have_css(".govuk-button")
           click_on t("page_content.comment.add")
           fill_in "comment[body]", with: "Amendments have been made"
           click_button t("default.button.submit")
           expect(page).to have_content "Amendments have been made"
           expect(page).to have_content t("action.comment.create.success")
-        end
-      end
-
-      context "when the report is not editable" do
-        let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
-        scenario "the user cannot create a comment" do
-          visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.add")
         end
       end
     end

--- a/spec/features/users_can_edit_a_comment_spec.rb
+++ b/spec/features/users_can_edit_a_comment_spec.rb
@@ -2,27 +2,43 @@ RSpec.describe "Users can edit a comment" do
   let(:beis_user) { create(:beis_user) }
   let(:partner_org_user) { create(:partner_organisation_user) }
 
-  let(:activity) { create(:project_activity, organisation: partner_org_user.organisation) }
-  let(:report) { create(:report, :active, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
-  let!(:comment) { create(:comment, commentable: activity, report_id: report.id, owner: partner_org_user) }
+  let(:project_activity) { create(:project_activity, organisation: partner_org_user.organisation) }
+  let!(:project_activity_report) { create(:report, :active, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
+  let!(:project_activity_comment) { create(:comment, commentable: project_activity, report_id: project_activity_report.id, owner: partner_org_user) }
+
+  let(:programme_activity) { create(:programme_activity) }
+  let!(:programme_activity_comment) { create(:comment, commentable: programme_activity, owner: beis_user) }
 
   context "editing a comment from the activity view" do
     context "when the user is a BEIS user" do
       before { authenticate!(user: beis_user) }
       after { logout }
 
-      context "when the report is editable" do
-        scenario "the user cannot edit comments" do
-          visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.edit")
+      context "for a project activity" do
+        context "when the report is editable" do
+          scenario "the user cannot edit comments" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("page_content.comment.edit")
+          end
+        end
+
+        context "when the report is not editable" do
+          let(:project_activity_report) { create(:report, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
+          scenario "the user cannot edit comments" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("page_content.comment.edit")
+          end
         end
       end
 
-      context "when the report is not editable" do
-        let(:report) { create(:report, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
-        scenario "the user cannot edit comments" do
-          visit organisation_activity_comments_path(activity.organisation, activity)
-          expect(page).not_to have_content t("page_content.comment.edit")
+      context "for a programme activity" do
+        scenario "the user can edit a comment" do
+          form = CommentForm.edit_from_activity_page(report: nil, comment: programme_activity_comment)
+
+          form.complete(comment: "Amendments have been made")
+
+          expect(page).to have_content t("action.comment.update.success")
+          expect(page).to have_content form.comment
         end
       end
     end
@@ -31,30 +47,39 @@ RSpec.describe "Users can edit a comment" do
       before { authenticate!(user: partner_org_user) }
       after { logout }
 
-      context "when the report is editable" do
-        scenario "the user can edit any comments left by users in the same organisation" do
-          form = CommentForm.edit_from_activity_page(report: report, comment: comment)
+      context "for a project activity" do
+        context "when the report is editable" do
+          scenario "the user can edit any comments left by users in the same organisation" do
+            form = CommentForm.edit_from_activity_page(report: project_activity_report, comment: project_activity_comment)
 
-          expect(form).to have_report_summary_information
-          form.complete(comment: "Amendments have been made")
+            expect(form).to have_report_summary_information
+            form.complete(comment: "Amendments have been made")
 
-          expect(page).to have_content t("action.comment.update.success")
-          expect(page).to have_content form.comment
+            expect(page).to have_content t("action.comment.update.success")
+            expect(page).to have_content form.comment
+          end
+
+          scenario "the user can edit comments on actuals belonging to the same organisation" do
+            actual = create(:actual, :with_comment, report: project_activity_report, parent_activity: project_activity)
+
+            visit organisation_activity_comments_path(project_activity_comment.commentable.organisation, project_activity_comment.commentable)
+
+            expect(page).to have_link("Edit", href: edit_activity_actual_path(project_activity, actual))
+          end
         end
 
-        scenario "the user can edit comments on actuals belonging to the same organisation" do
-          actual = create(:actual, :with_comment, report: report, parent_activity: activity)
-
-          visit organisation_activity_comments_path(comment.commentable.organisation, comment.commentable)
-
-          expect(page).to have_link("Edit", href: edit_activity_actual_path(activity, actual))
+        context "when the report is not editable" do
+          let(:project_activity_report) { create(:report, :approved, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
+          scenario "the user cannot edit any comments" do
+            visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+            expect(page).not_to have_content t("default.link.edit")
+          end
         end
       end
 
-      context "when the report is not editable" do
-        let(:report) { create(:report, :approved, fund: activity.associated_fund, organisation: partner_org_user.organisation) }
-        scenario "the user cannot edit any comments" do
-          visit organisation_activity_comments_path(activity.organisation, activity)
+      context "for a programme activity" do
+        scenario "the user cannot create a comment" do
+          visit organisation_activity_comments_path(beis_user.organisation, programme_activity)
           expect(page).not_to have_content t("default.link.edit")
         end
       end

--- a/spec/features/users_can_view_comments_spec.rb
+++ b/spec/features/users_can_view_comments_spec.rb
@@ -1,4 +1,14 @@
 RSpec.feature "Users can view comments on an activity page" do
+  let(:partner_organisation_user) { create(:partner_organisation_user) }
+  let(:beis_user) { create(:beis_user) }
+
+  let(:project_activity) { create(:project_activity, organisation: partner_organisation_user.organisation) }
+  let!(:project_activity_report) { create(:report, :active, fund: project_activity.associated_fund, organisation: partner_organisation_user.organisation) }
+  let!(:project_activity_comment) { create(:comment, commentable: project_activity, report: project_activity_report, owner: partner_organisation_user) }
+  let!(:project_activity_actual) { create(:actual, :with_comment, parent_activity: project_activity, report: project_activity_report) }
+  let!(:project_activity_adjustment) { create(:adjustment, parent_activity: project_activity, report: project_activity_report) }
+  let!(:project_activity_refund) { create(:refund, parent_activity: project_activity, report: project_activity_report) }
+
   before do
     authenticate!(user: user)
   end
@@ -6,43 +16,73 @@ RSpec.feature "Users can view comments on an activity page" do
   after { logout }
 
   context "when the user is a partner organisation user" do
-    let(:user) { create(:partner_organisation_user) }
+    let(:user) { partner_organisation_user }
 
-    scenario "they can view all comments associated with an activity" do
-      activity = create(:project_activity, organisation: user.organisation)
-      report = create(:report, :active, fund: activity.associated_fund, organisation: user.organisation)
+    scenario "they can see all comments associated with one of their organisation's project activities" do
+      expect_user_to_see_all_project_activity_comments
+    end
 
-      comment = create(:comment, commentable: activity, report: report, owner: user)
-      actual = create(:actual, :with_comment, parent_activity: activity, report: report)
-      adjustment = create(:adjustment, parent_activity: activity, report: report)
-      refund = create(:refund, parent_activity: activity, report: report)
+    scenario "they can see comments associated with programme activities for which they are the extending organisation" do
+      programme_activity = create(:programme_activity, extending_organisation: partner_organisation_user.organisation)
+      programme_activity_comment = create(:comment, commentable: programme_activity, report: nil, owner: beis_user)
+      visit organisation_activity_details_path(beis_user.organisation, programme_activity)
 
-      visit organisation_activity_details_path(user.organisation, activity)
       click_on t("tabs.activity.comments")
 
-      within "#comment_#{comment.id}" do
-        expect(page).to have_content comment.body
-        expect(page).to have_content report.description
+      within "#comment_#{programme_activity_comment.id}" do
+        expect(page).to have_content programme_activity_comment.body
         expect(page).to have_content "Comment"
       end
+    end
+  end
 
-      within "#comment_#{actual.comment.id}" do
-        expect(page).to have_content actual.comment.body
-        expect(page).to have_content report.description
-        expect(page).to have_content "Actual"
-      end
+  context "when the user is a BEIS user" do
+    let(:user) { beis_user }
 
-      within "#comment_#{adjustment.comment.id}" do
-        expect(page).to have_content adjustment.comment.body
-        expect(page).to have_content report.description
-        expect(page).to have_content "Adjustment"
-      end
+    scenario "they can view all comments associated with a project activity" do
+      expect_user_to_see_all_project_activity_comments
+    end
 
-      within "#comment_#{refund.comment.id}" do
-        expect(page).to have_content refund.comment.body
-        expect(page).to have_content report.description
-        expect(page).to have_content "Refund"
+    scenario "they can view comments associated with a programme activity" do
+      programme_activity = create(:programme_activity)
+      programme_activity_comment = create(:comment, commentable: programme_activity, report: nil, owner: user)
+      visit organisation_activity_details_path(user.organisation, programme_activity)
+
+      click_on t("tabs.activity.comments")
+
+      within "#comment_#{programme_activity_comment.id}" do
+        expect(page).to have_content programme_activity_comment.body
+        expect(page).to have_content "Comment"
       end
+    end
+  end
+
+  def expect_user_to_see_all_project_activity_comments
+    visit organisation_activity_details_path(partner_organisation_user.organisation, project_activity)
+    click_on t("tabs.activity.comments")
+
+    within "#comment_#{project_activity_comment.id}" do
+      expect(page).to have_content project_activity_comment.body
+      expect(page).to have_content project_activity_report.description
+      expect(page).to have_content "Comment"
+    end
+
+    within "#comment_#{project_activity_actual.comment.id}" do
+      expect(page).to have_content project_activity_actual.comment.body
+      expect(page).to have_content project_activity_report.description
+      expect(page).to have_content "Actual"
+    end
+
+    within "#comment_#{project_activity_adjustment.comment.id}" do
+      expect(page).to have_content project_activity_adjustment.comment.body
+      expect(page).to have_content project_activity_report.description
+      expect(page).to have_content "Adjustment"
+    end
+
+    within "#comment_#{project_activity_refund.comment.id}" do
+      expect(page).to have_content project_activity_refund.comment.body
+      expect(page).to have_content project_activity_report.description
+      expect(page).to have_content "Refund"
     end
   end
 end

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe ActivityHelper, type: :helper do
   let(:organisation) { create(:partner_organisation) }
+  let(:programme_activity) { create(:programme_activity) }
+  let(:project_activity) { create(:project_activity) }
+  let(:report) { create(:report) }
 
   describe "#step_is_complete_or_next?" do
     context "when the activity has passed the identification step" do
@@ -58,6 +61,132 @@ RSpec.describe ActivityHelper, type: :helper do
 
         expect(helper.link_to_activity_parent(parent: parent_activity, user: user)).to include organisation_activity_path(parent_activity.organisation, parent_activity)
         expect(helper.link_to_activity_parent(parent: parent_activity, user: user)).to include parent_activity.title
+      end
+    end
+  end
+
+  describe "#show_link_to_add_comment?" do
+    context "when activity is a programme" do
+      context "when user is authorised to add programme comments" do
+        before { authorise_creating_comments(commentable_type: :programme_activity, authorise: true) }
+
+        it "returns true" do
+          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to eq(true)
+        end
+      end
+
+      context "when user is unauthorised to add programme comments" do
+        before do
+          authorise_creating_comments(commentable_type: :programme_activity, authorise: false)
+          authorise_creating_comments(commentable_type: :project_activity, authorise: true)
+        end
+
+        it "returns false" do
+          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to eq(false)
+        end
+      end
+    end
+
+    context "when activity is a project" do
+      context "when user is authorised to add project comments" do
+        before do
+          authorise_creating_comments(commentable_type: :programme_activity, authorise: false)
+          authorise_creating_comments(commentable_type: :project_activity, authorise: true)
+        end
+
+        context "when a report exists" do
+          it "returns true" do
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to eq(true)
+          end
+        end
+
+        context "when a report does not exist" do
+          it "returns false" do
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to eq(false)
+          end
+        end
+      end
+
+      context "when user is unauthorised to add project comments" do
+        before do
+          authorise_creating_comments(commentable_type: :programme_activity, authorise: false)
+          authorise_creating_comments(commentable_type: :project_activity, authorise: false)
+        end
+
+        context "when a report exists" do
+          it "returns false" do
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to eq(false)
+          end
+        end
+
+        context "when a report does not exist" do
+          it "returns false" do
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#show_link_to_edit_comment?" do
+    context "when commentable is a programme activity" do
+      let(:existing_programme_activity_comment) { create(:comment, commentable: programme_activity, owner: create(:beis_user)) }
+
+      context "when user is authorised to edit programme comments" do
+        it "returns true" do
+          authorise_updating_comments(commentable_type: :programme_activity, authorise: true)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to eq(true)
+        end
+      end
+
+      context "when user is unauthorised to add programme comments" do
+        it "returns false" do
+          authorise_updating_comments(commentable_type: :programme_activity, authorise: false)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to eq(false)
+        end
+      end
+    end
+
+    context "when commentable is a project activity" do
+      let(:existing_project_activity_comment) { create(:comment, commentable: project_activity, owner: create(:partner_organisation_user), report: report) }
+
+      context "when user is authorised to add project comments" do
+        it "returns true" do
+          authorise_updating_comments(commentable_type: :project_activity, authorise: true)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to eq(true)
+        end
+      end
+
+      context "when user is unauthorised to add project comments" do
+        it "returns false" do
+          authorise_updating_comments(commentable_type: :project_activity, authorise: false)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to eq(false)
+        end
+      end
+    end
+
+    context "when commentable is not an activity" do
+      let(:actual) { create(:actual, parent_activity: project_activity) }
+      let(:existing_actual_comment) { create(:comment, commentable: actual, report: report) }
+
+      context "when user is authorised to add non-activity comments" do
+        it "returns true" do
+          authorise_updating_comments(commentable_type: :non_activity, authorise: true)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to eq(true)
+        end
+      end
+
+      context "when user is unauthorised to add non-activity comments" do
+        it "returns false" do
+          authorise_updating_comments(commentable_type: :non_activity, authorise: false)
+
+          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to eq(false)
+        end
       end
     end
   end
@@ -186,6 +315,39 @@ RSpec.describe ActivityHelper, type: :helper do
 
       it "returns false" do
         expect(can_download_as_xml?(activity: activity, user: user)).to eql(false)
+      end
+    end
+  end
+
+  def authorise_creating_comments(commentable_type:, authorise: true)
+    without_partial_double_verification do
+      case commentable_type
+      when :programme_activity
+        allow(view).to receive(:policy).with(:level_b).and_return(double(:level_b_policy, create_activity_comment?: authorise))
+      when :project_activity
+        allow(view).to receive(:policy).with([:activity, :comment]).and_return(double(:activity_policy, create?: authorise))
+      end
+    end
+  end
+
+  def authorise_updating_comments(commentable_type:, authorise: true)
+    without_partial_double_verification do
+      case commentable_type
+      when :programme_activity
+        allow(view)
+          .to receive(:policy)
+          .with(:level_b)
+          .and_return(double(:level_b_policy, update_activity_comment?: authorise))
+      when :project_activity
+        allow(view)
+          .to receive(:policy)
+          .with(array_including(instance_of(Activity), instance_of(Comment)))
+          .and_return(double(:activity_policy, update?: authorise))
+      when :non_activity
+        allow(view)
+          .to receive(:policy)
+          .with(array_including(anything, instance_of(Comment)))
+          .and_return(double(:activity_policy, update?: authorise))
       end
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,11 +4,30 @@ RSpec.describe Comment, type: :model do
   describe "associations" do
     it { should belong_to(:commentable) }
     it { should belong_to(:owner).class_name("User").optional(true) }
-    it { should belong_to(:report) }
   end
 
   describe "validations" do
     it { should validate_presence_of(:body) }
+  end
+
+  describe "report association/validation" do
+    context "when commentable is a programme activity" do
+      subject { build(:comment, commentable: build(:programme_activity)) }
+
+      it { should_not validate_presence_of(:report) }
+    end
+
+    context "when commentable is a project activity" do
+      subject { build(:comment) }
+
+      it { should validate_presence_of(:report) }
+    end
+
+    context "when commentable not an activity" do
+      subject { build(:comment, :with_refund) }
+
+      it { should validate_presence_of(:report) }
+    end
   end
 
   it { should validate_presence_of(:body) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe Comment, type: :model do
     end
   end
 
-  it { should validate_presence_of(:body) }
-
   it "should set the commentable type before creating the comment" do
     adjustment = create(:adjustment)
     adjustment_comment = create(:comment, commentable: adjustment)

--- a/spec/policies/level_b_policy_spec.rb
+++ b/spec/policies/level_b_policy_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe LevelBPolicy do
     it "permits all actions" do
       is_expected.to permit_action(:activity_upload)
       is_expected.to permit_action(:budget_upload)
+      is_expected.to permit_action(:create_activity_comment)
+      is_expected.to permit_action(:update_activity_comment)
     end
   end
 
@@ -18,6 +20,8 @@ RSpec.describe LevelBPolicy do
     it "forbids all actions" do
       is_expected.to forbid_action(:activity_upload)
       is_expected.to forbid_action(:budget_upload)
+      is_expected.to forbid_action(:create_activity_comment)
+      is_expected.to forbid_action(:update_activity_comment)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

This extends the activity comments functionality to allow BEIS users to add and edit comments at Level B

Partner organisations will be able to see comments on Level B activities, per client advice

## Screenshots of UI changes

### Before

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/40244233/195601140-e38459f7-b786-4ae9-a9e1-ff5d87a375ef.png">

### After

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/40244233/196757643-6fb1796d-f180-4e62-abfb-4862dcadbf22.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
