### PR TITLE
Log out after specs that log in as a user

### DIFF
--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -13,6 +13,8 @@ def log_in_via_form(user, remember_me: false)
 end
 
 RSpec.feature "Users can sign in" do
+  after { logout }
+
   context "user does not have 2FA enabled" do
     scenario "successful sign in via header link" do
       # Given a user exists

--- a/spec/requests/activity_forms_spec.rb
+++ b/spec/requests/activity_forms_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Activity forms", type: :request do
     login_as(user)
   end
 
+  after { logout }
+
   let(:activity) { create(:project_activity, organisation: user.organisation, extending_organisation: user.organisation) }
   let!(:fund) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
 

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "XML Validation", type: :request do
     login_as(user)
   end
 
+  after { logout }
+
   context "the downloaded XML conforms to IATI standards" do
     before { allow_any_instance_of(IATIValidator::XML).to receive(:valid?).and_return(true) }
     it "allows the XML to be downloaded without let or hindrance" do


### PR DESCRIPTION
## Changes in this PR

As previously discovered[1], specs that log in a user have side effects on specs that rely on there being no logged in user for their initial state.

Fix a few more specs that didn’t log out after they were done.

[1] e31486980ac2a597534ee0e0c0abbfa0c84c350b

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
