### PR TITLE
[2625] Add bare bones ISPF to the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1114,6 +1114,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Update seeds and create data migration for adding ISPF fund entity to the service
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120
 [release-119]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-118...release-119

--- a/db/data/20221019111441_add_ispf_level_a_activity.rb
+++ b/db/data/20221019111441_add_ispf_level_a_activity.rb
@@ -1,0 +1,33 @@
+# Run me with `rails runner db/data/20221019111441_add_ispf_level_a_activity.rb`
+
+# Add the top level (A) ISPF Activity (i.e. a fund-tier activity)
+
+beis = Organisation.service_owner
+
+description = <<~TXT.squish
+  ISPF exists to enable potential and foster prosperity, 
+  by funding research and innovation on the major themes of our time. 
+  By working with partners to support research excellence. 
+  By building the knowledge and technology of tomorrow. 
+  By complementing strong ties with countries that share our values. 
+  By helping researchers and innovators to cultivate connections, 
+  follow their curiosity and pioneer transformations internationally. 
+  For the good of the planet.
+TXT
+
+Activity.create!(
+  source_fund_code: 4,
+  roda_identifier: "ISPF",
+  title: "International Science Partnerships Fund",
+  organisation: beis,
+  level: "fund",
+  form_state: "complete",
+  fstc_applies: false,
+  delivery_partner_identifier: "ISPF",
+  description: description,
+  sector_category: "998",
+  sector: "99810",
+  programme_status: "spend_in_progress",
+  actual_start_date: Date.new(2022, 4, 1),
+  aid_type: "C01"
+)

--- a/db/seeds/activity.rb
+++ b/db/seeds/activity.rb
@@ -21,6 +21,13 @@ ooda_fund_params = FactoryBot.build(:fund_activity,
 
 _ooda_fund = Activity.find_or_create_by(ooda_fund_params)
 
+ispf_fund_params = FactoryBot.build(:fund_activity,
+  roda_identifier: "ISPF",
+  title: "International Science Partnerships Fund",
+  organisation: beis).attributes
+
+_ispf_fund = Activity.find_or_create_by(ispf_fund_params)
+
 partner_organisation = User.all.find(&:partner_organisation?).organisation
 
 first_programme_params = FactoryBot.build(:programme_activity,

--- a/spec/models/iati/xml_download_spec.rb
+++ b/spec/models/iati/xml_download_spec.rb
@@ -46,18 +46,18 @@ RSpec.describe Iati::XmlDownload do
       it "returns all XML downloads ordered by levels, then funds" do
         downloads = described_class.all_for_organisation(organisation)
 
-        expect(downloads.count).to eq(9)
+        expect(downloads.count).to eq(12)
 
         expect(downloads.map { |p| p.fund.short_name }).to eq(%w[
-          NF GCRF OODA
-          NF GCRF OODA
-          NF GCRF OODA
+          NF GCRF OODA ISPF
+          NF GCRF OODA ISPF
+          NF GCRF OODA ISPF
         ])
 
         expect(downloads.map(&:level)).to eq(%w[
-          programme programme programme
-          project project project
-          third_party_project third_party_project third_party_project
+          programme programme programme programme
+          project project project project
+          third_party_project third_party_project third_party_project third_party_project
         ])
         expect(downloads.map(&:organisation).uniq).to eq([organisation])
       end

--- a/vendor/data/codelists/BEIS/fund_types.yml
+++ b/vendor/data/codelists/BEIS/fund_types.yml
@@ -8,3 +8,6 @@ data:
   - code: 3
     name: Other ODA
     short_name: OODA
+  - code: 4
+    name: International Science Partnerships Fund
+    short_name: ISPF


### PR DESCRIPTION
## Changes in this PR

This is the first step on the journey to add ISPF to the service, adding:

- The ISPF fund type to the fund type codelists
- A local ISPF level A activity
- A data migration to create the actual Level A activity (this will need to be run manually on the deployed environment once ready to go)

Because of how we're currently looping over all funds, locally we can already see links for adding new activities (see screenshot).

I've opened this PR against a longer-running feature branch rather than `develop` until we get feature flagging sorted to be able to hide this data on a deployed environment.

## Screenshots of UI changes

### After

<img width="800" alt="image" src="https://user-images.githubusercontent.com/19826940/196742371-55611f68-17ce-4ed2-bb70-40b5e8ef6faf.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
