### PR TITLE
(2662) Use feature flag to hide ISPF reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1116,6 +1116,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Configure Rollout and Rollout UI gems to allow BEIS users to manage feature flags
 - Update seeds and create data migration for adding ISPF fund entity to the service
+- Hide ISPF reports when the ISPF feature flag is enabled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -40,6 +40,7 @@ class ReportsController < BaseController
 
     @report = Report.new
     @funds = Activity.fund
+    @funds = @funds.not_ispf if hide_ispf_for_user?(current_user)
 
     authorize @report
   end
@@ -51,6 +52,7 @@ class ReportsController < BaseController
     authorize @report
 
     @funds = Activity.fund
+    @funds = @funds.not_ispf if hide_ispf_for_user?(current_user)
 
     @report.assign_attributes(report_creatable_params.merge(state: "active"))
     if @report.valid?(:new)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -224,6 +224,8 @@ class Activity < ApplicationRecord
     where(programme_status: ["completed", "stopped", "cancelled"])
   }
 
+  scope :not_ispf, -> { where.not(source_fund_code: Fund.by_short_name("ISPF")) }
+
   def self.new_child(parent_activity:, partner_organisation:, &block)
     attributes = ActivityDefaults.new(
       parent_activity: parent_activity,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -64,6 +64,8 @@ class Report < ApplicationRecord
     where(fund_id: activity.associated_fund.id, organisation_id: activity.organisation_id)
   end
 
+  scope :not_ispf, -> { where.not(fund_id: Activity.by_roda_identifier("ISPF").id) }
+
   def self.editable_for_activity(activity)
     editable.for_activity(activity).first
   end

--- a/app/services/report/grouped_reports_fetcher.rb
+++ b/app/services/report/grouped_reports_fetcher.rb
@@ -1,11 +1,17 @@
 class Report
   class GroupedReportsFetcher
     def current
-      @current ||= fetch(Report.not_approved)
+      @current ||= fetch(reports.not_approved)
     end
 
     def approved
-      @approved ||= fetch(Report.approved)
+      @approved ||= fetch(reports.approved)
+    end
+
+    private def reports
+      return Report.not_ispf if hide_ispf_for_group?(:beis_users)
+
+      Report
     end
 
     private def fetch(relation)

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -15,6 +15,7 @@ class Report
     private
 
     def reports
+      return Report.where(organisation: organisation).not_ispf if hide_ispf_for_group?(:partner_organisation_users)
       Report.where(organisation: organisation)
     end
 

--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -13,3 +13,11 @@ end
 Rollout::UI.configure do
   instance { ROLLOUT }
 end
+
+def hide_ispf_for_group?(user_group)
+  ROLLOUT.get(:ispf_fund_in_stealth_mode).groups.include?(user_group)
+end
+
+def hide_ispf_for_user?(user)
+  ROLLOUT.active?(:ispf_fund_in_stealth_mode, user)
+end

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -82,6 +82,16 @@ FactoryBot.define do
           Activity.find_or_initialize_by(roda_identifier: "OODA")
         end
       end
+
+      trait :ispf do
+        roda_identifier { "ISPF" }
+        title { "International Science Partnerships Fund" }
+        source_fund_code { Fund.by_short_name("ISPF").id }
+
+        initialize_with do
+          Activity.find_or_initialize_by(roda_identifier: "ISPF")
+        end
+      end
     end
 
     factory :programme_activity do

--- a/spec/features/beis_users_can_create_a_report_spec.rb
+++ b/spec/features/beis_users_can_create_a_report_spec.rb
@@ -20,6 +20,20 @@ RSpec.feature "BEIS users can create a report" do
     and_the_report_is_active
   end
 
+  context "when the feature flag hiding ISPF is enabled for BEIS users" do
+    let!(:ispf_fund) { create(:fund_activity, :ispf) }
+
+    before do
+      allow(ROLLOUT).to receive(:active?).with(:ispf_fund_in_stealth_mode, beis_user).and_return(true)
+    end
+
+    scenario "they cannot create an ISPF report" do
+      given_i_am_a_logged_in_beis_user
+      when_i_am_on_the_new_report_page
+      then_i_cannot_choose_ispf_as_the_fund
+    end
+  end
+
   def given_i_am_a_logged_in_beis_user
     authenticate!(user: beis_user)
   end
@@ -45,5 +59,13 @@ RSpec.feature "BEIS users can create a report" do
       expect(page).to have_content("FQ3 2018-2019")
       expect(page).to have_content("Active")
     end
+  end
+
+  def when_i_am_on_the_new_report_page
+    visit new_report_path
+  end
+
+  def then_i_cannot_choose_ispf_as_the_fund
+    expect(page).not_to have_content("International Science Partnerships Fund")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,10 @@ RSpec.configure do |config|
   config.before(:each, type: :request) do
     host! "test.local"
   end
+
+  config.before(:each) do |example|
+    stub_const("ROLLOUT", Rollout.new(Redis.new)) unless example.metadata[:use_original_rollout]
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/rollout_spec.rb
+++ b/spec/requests/rollout_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Rollout UI", type: :request do
   before do
-    stub_const("ROLLOUT", Rollout.new(Redis.new))
     Rollout::UI.configure do
       instance { ROLLOUT }
     end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "Rollout" do
-  it "has two custom groups for BEIS users and PO users" do
+  it "has two custom groups for BEIS users and PO users", :use_original_rollout do
     expect(ROLLOUT.groups).to include(:beis_users, :partner_organisation_users)
   end
 
   context "a BEIS user" do
     let(:user) { build(:beis_user) }
 
-    it "is part of the beis_users group and not the partner_organisation_users group" do
+    it "is part of the beis_users group and not the partner_organisation_users group", :use_original_rollout do
       expect(ROLLOUT.active_in_group?(:beis_users, user)).to be true
       expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be false
     end
@@ -15,9 +15,29 @@ RSpec.describe "Rollout" do
   context "a partner organisation user" do
     let(:user) { build(:partner_organisation_user) }
 
-    it "is part of the partner_organisation_users group and not the beis_users group" do
+    it "is part of the partner_organisation_users group and not the beis_users group", :use_original_rollout do
       expect(ROLLOUT.active_in_group?(:beis_users, user)).to be false
       expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be true
+    end
+  end
+
+  describe "#hide_ispf_for_group?" do
+    it "provides a more readable interface to check if the feature is enabled for that group" do
+      mock_feature = double(:feature, groups: [:real_group])
+      allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(mock_feature)
+
+      expect(hide_ispf_for_group?(:real_group)).to be true
+      expect(hide_ispf_for_group?(:fake_group)).to be false
+    end
+  end
+
+  describe "#hide_ispf_for_user?" do
+    let(:user) { double(:user) }
+
+    it "provides a more readable interface to check if the feature is enabled for that user" do
+      expect(ROLLOUT).to receive(:active?).with(:ispf_fund_in_stealth_mode, user)
+
+      hide_ispf_for_user?(user)
     end
   end
 end

--- a/spec/services/report/grouped_reports_fetcher_spec.rb
+++ b/spec/services/report/grouped_reports_fetcher_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Report::GroupedReportsFetcher do
   let(:organisation1) { build(:partner_organisation) }
   let(:organisation2) { build(:partner_organisation) }
+  let(:subject) { described_class.new }
 
   describe "#approved" do
     it "returns approved reports grouped by organisation and sorted by organisation name" do
@@ -16,10 +17,30 @@ RSpec.describe Report::GroupedReportsFetcher do
       expect(approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(approved_relation_double)
       expect(approved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(approved_reports)
 
-      expect(described_class.new.approved).to eq({
+      expect(subject.approved).to eq({
         organisation1 => organisation1_approved_reports,
         organisation2 => organisation2_approved_reports
       })
+    end
+
+    context "when the feature flag hiding ISPF is enabled for BEIS users" do
+      before do
+        feature = double(:feature, groups: [:beis_users])
+        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
+      end
+
+      it "only returns approved non-ISPF reports" do
+        non_ispf_approved_reports = build_list(:report, 3, organisation: organisation1)
+        non_ispf_approved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_approved_reports)
+
+        expect(Report).to receive_message_chain(:not_ispf, :approved).and_return(non_ispf_approved_relation_double)
+        expect(non_ispf_approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_approved_relation_double)
+        expect(non_ispf_approved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(non_ispf_approved_reports)
+
+        expect(subject.approved).to eq({
+          organisation1 => non_ispf_approved_reports
+        })
+      end
     end
   end
 
@@ -35,10 +56,29 @@ RSpec.describe Report::GroupedReportsFetcher do
       expect(unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(unapproved_relation_double)
       expect(unapproved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(unapproved_reports)
 
-      expect(described_class.new.current).to eq({
+      expect(subject.current).to eq({
         organisation1 => organisation1_unapproved_reports,
         organisation2 => organisation2_unapproved_reports
       })
+    end
+
+    context "when the feature flag hiding ISPF is enabled for BEIS users" do
+      before do
+        feature = double(:feature, groups: [:beis_users])
+        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
+      end
+
+      it "only returns unapproved non-ISPF reports" do
+        non_ispf_unapproved_reports = build_list(:report, 2, organisation: organisation1)
+        non_ispf_unapproved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_unapproved_reports)
+        expect(non_ispf_unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_unapproved_relation_double)
+        expect(non_ispf_unapproved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(non_ispf_unapproved_reports)
+
+        expect(Report).to receive_message_chain(:not_ispf, :not_approved).and_return(non_ispf_unapproved_relation_double)
+        expect(subject.current).to eq({
+          organisation1 => non_ispf_unapproved_reports
+        })
+      end
     end
   end
 end

--- a/spec/services/report/organisation_reports_fetcher_spec.rb
+++ b/spec/services/report/organisation_reports_fetcher_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe Report::OrganisationReportsFetcher do
 
       expect(subject).to eq(approved_reports)
     end
+
+    context "when the feature flag hiding ISPF is enabled for partner organisation users" do
+      before do
+        feature = double(:feature, groups: [:partner_organisation_users])
+        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
+      end
+
+      it "only returns approved non-ISPF reports" do
+        non_ispf_approved_reports = build_list(:report, 3, :approved, organisation: organisation)
+
+        non_ispf_approved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_approved_reports)
+
+        expect(Report).to receive(:where).with(organisation: organisation).and_return(non_ispf_approved_relation_double)
+        expect(non_ispf_approved_relation_double).to receive_message_chain(:not_ispf, :approved).and_return(non_ispf_approved_relation_double)
+
+        expect(non_ispf_approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_approved_relation_double)
+        expect(non_ispf_approved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(non_ispf_approved_reports)
+
+        expect(subject).to eq(non_ispf_approved_reports)
+      end
+    end
   end
 
   describe "#current" do
@@ -38,6 +59,27 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(unapproved_reports)
 
       expect(subject).to eq(unapproved_reports)
+    end
+
+    context "when the feature flag hiding ISPF is enabled for partner organisation users" do
+      before do
+        feature = double(:feature, groups: [:partner_organisation_users])
+        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
+      end
+
+      it "only returns active unapproved non-ISPF reports for the organisation" do
+        non_ispf_unapproved_reports = build_list(:report, 2, :active, organisation: organisation)
+
+        non_ispf_unapproved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_unapproved_reports)
+
+        expect(Report).to receive(:where).with(organisation: organisation).and_return(non_ispf_unapproved_relation_double)
+        expect(non_ispf_unapproved_relation_double).to receive_message_chain(:not_ispf, :not_approved).and_return(non_ispf_unapproved_relation_double)
+
+        expect(non_ispf_unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_unapproved_relation_double)
+        expect(non_ispf_unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(non_ispf_unapproved_reports)
+
+        expect(subject).to eq(non_ispf_unapproved_reports)
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Hide ISPF reports when the ISPF feature flag is enabled

## Screenshots of UI changes

### Before
![Screenshot 2022-10-24 at 14 48 53](https://user-images.githubusercontent.com/579522/197542175-a3bd8e68-1782-48a1-a75b-f54b2f815962.png)
![Screenshot 2022-10-24 at 14 51 31](https://user-images.githubusercontent.com/579522/197542227-c0c36f63-1ed3-4bc2-9929-e6dc4b072446.png)

### After
![Screenshot 2022-10-24 at 14 49 38](https://user-images.githubusercontent.com/579522/197542276-2a181bc9-38c6-47dd-927b-9df959d7e6d7.png)
![Screenshot 2022-10-24 at 14 51 43](https://user-images.githubusercontent.com/579522/197542302-9042872a-1bab-4c4a-8b76-72684f2b10c9.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
