### PR TITLE
(2664) ISPF programmes cannot be created when the feature flag is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1117,6 +1117,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Configure Rollout and Rollout UI gems to allow BEIS users to manage feature flags
 - Update seeds and create data migration for adding ISPF fund entity to the service
 - Hide ISPF reports when the ISPF feature flag is enabled
+- ISPF programmes cannot be created when the feature flag is enabled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -18,6 +18,7 @@ class ActivitiesController < BaseController
       render "activities/index_beis"
     else
       @funds = Activity.fund.order(:title)
+      @funds = @funds.not_ispf if hide_ispf_for_group?(:beis_users)
       @grouped_activities = Activity::GroupedActivitiesFetcher.new(
         user: current_user,
         organisation: @organisation,

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -16,6 +16,7 @@ class Report
 
     def reports
       return Report.where(organisation: organisation).not_ispf if hide_ispf_for_group?(:partner_organisation_users)
+
       Report.where(organisation: organisation)
     end
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -168,6 +168,37 @@ RSpec.feature "BEIS users can create a programme level activity" do
     end
   end
 
+  context "when the source fund is ISPF" do
+    let(:identifier) { "a-fund-has-an-accountable-organisation" }
+    let!(:activity) do
+      build(:programme_activity,
+        parent: create(:fund_activity, :ispf),
+        partner_organisation_identifier: identifier,
+        benefitting_countries: ["AG", "HT"],
+        sdgs_apply: true,
+        sdg_1: 5)
+    end
+
+    scenario "an activity can be created" do
+      visit organisation_activities_path(partner_organisation)
+
+      expect(page).to have_button t("form.button.activity.new_child", name: activity.associated_fund.title)
+    end
+
+    context "and the feature flag hiding ISPF is enabled for BEIS users" do
+      before do
+        mock_feature = double(:feature, groups: [:beis_users])
+        allow(ROLLOUT).to receive(:get).and_return(mock_feature)
+      end
+
+      scenario "there is no link to create a programme" do
+        visit organisation_activities_path(partner_organisation)
+
+        expect(page).to_not have_button t("form.button.activity.new_child", name: activity.associated_fund.title)
+      end
+    end
+  end
+
   def expect_implementing_organisation_to_be_the_partner_organisation(
     activity:,
     organisation:


### PR DESCRIPTION
**NB** This PR builds upon #1834 

## Changes in this PR
- ISPF programmes cannot be created when the feature flag is enabled for BEIS users

## Screenshots of UI changes

### Before
![Screenshot 2022-10-24 at 15 38 34](https://user-images.githubusercontent.com/579522/197556581-eaff4f15-61d4-471f-9e96-10a2dc90bf38.png)

### After
![Screenshot 2022-10-24 at 15 38 49](https://user-images.githubusercontent.com/579522/197556613-94e66ed1-ca86-4d43-847a-7e19ae5a6b0e.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
