### PR TITLE
(2665) Hide ISPF activities from home page and org page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1118,6 +1118,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Update seeds and create data migration for adding ISPF fund entity to the service
 - Hide ISPF reports when the ISPF feature flag is enabled
 - ISPF programmes cannot be created when the feature flag is enabled
+- ISPF activities are not shown to users when the feature flag is enabled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/services/activity/grouped_activities_fetcher.rb
+++ b/app/services/activity/grouped_activities_fetcher.rb
@@ -4,6 +4,7 @@ class Activity
       @organisation = organisation
       @scope = scope
       @activities = ActivityPolicy::Scope.new(user, Activity).resolve
+      @activities = @activities.not_ispf if hide_ispf_for_user?(user)
     end
 
     def call

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -125,6 +125,13 @@ FactoryBot.define do
         end
       end
 
+      trait :ispf_funded do
+        source_fund_code { Fund.by_short_name("ISPF").id }
+        parent do
+          Activity.fund.find_by(source_fund_code: Fund.by_short_name("ISPF").id) || create(:fund_activity, :ispf)
+        end
+      end
+
       after(:create) do |programme, _evaluator|
         programme.implementing_organisations << programme.organisation
         programme.reload

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -189,6 +189,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       before do
         mock_feature = double(:feature, groups: [:beis_users])
         allow(ROLLOUT).to receive(:get).and_return(mock_feature)
+        allow(ROLLOUT).to receive(:active?).and_return(true)
       end
 
       scenario "there is no link to create a programme" do


### PR DESCRIPTION
**NB** This PR builds upon #1835 

## Changes in this PR
- ISPF activities are not shown to users when the feature flag is enabled

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
