### PR TITLE
(2666) Exclude ISPF activities from search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1119,6 +1119,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Hide ISPF reports when the ISPF feature flag is enabled
 - ISPF programmes cannot be created when the feature flag is enabled
 - ISPF activities are not shown to users when the feature flag is enabled
+- ISPF activities are not shown in search results when the feature flag is enabled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -33,9 +33,9 @@ class ActivitySearch
 
   def activities
     @_activities ||= if @user.service_owner?
-      Activity.all
+      hide_ispf_for_user?(@user) ? Activity.not_ispf : Activity.all
     else
-      Activity.where(extending_organisation: @user.organisation)
+      hide_ispf_for_user?(@user) ? Activity.not_ispf.where(extending_organisation: @user.organisation) : Activity.where(extending_organisation: @user.organisation)
     end
   end
 end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe ActivitySearch do
         expect(activity_search.results).to match_array [alice_third_party_project, bob_project]
       end
     end
+
+    context "when the feature flag hiding ISPF is enabled" do
+      let!(:ispf_fund) { create(:fund_activity, :ispf) }
+      let!(:ispf_programme) { create(:programme_activity, :ispf_funded, title: "ISPF programme") }
+      let(:query) { "ISPF" }
+
+      before do
+        allow(ROLLOUT).to receive(:active?).and_return(true)
+      end
+
+      describe "searching for ISPF activities" do
+        it "returns nothing" do
+          expect(activity_search.results).to be_empty
+        end
+      end
+    end
   end
 
   context "for partner organisations" do
@@ -184,6 +200,22 @@ RSpec.describe ActivitySearch do
 
       it "returns the matching activities" do
         expect(activity_search.results).to match_array [alice_third_party_project]
+      end
+    end
+
+    context "when the feature flag hiding ISPF is enabled" do
+      let!(:ispf_fund) { create(:fund_activity, :ispf) }
+      let!(:ispf_programme) { create(:programme_activity, :ispf_funded, title: "ISPF programme", extending_organisation: alice.organisation) }
+      let(:query) { "ISPF" }
+
+      before do
+        allow(ROLLOUT).to receive(:active?).and_return(true)
+      end
+
+      describe "searching for ISPF activities" do
+        it "returns nothing" do
+          expect(activity_search.results).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
- ISPF activities are not shown in search results when the feature flag is enabled

## Screenshots of UI changes

### Before
![Screenshot 2022-10-25 at 15 20 14](https://user-images.githubusercontent.com/579522/197799945-921c60a7-0e3c-4fdf-845d-29cd8551ba62.png)

### After
![Screenshot 2022-10-25 at 15 20 27](https://user-images.githubusercontent.com/579522/197799981-70bb3158-b272-40a8-96f5-2c888d271cd5.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
