### PR TITLE
(2677) Add Level B comments to budget exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1117,6 +1117,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Configure Rollout and Rollout UI gems to allow BEIS users to manage feature flags
 - Allow comments on Level B activities from BEIS users
 - Add comments column to Level B activities bulk upload template
+- Add Level B activity comments to budget exports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1118,6 +1118,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Allow comments on Level B activities from BEIS users
 - Add comments column to Level B activities bulk upload template
 - Add Level B activity comments to budget exports
+- Strip leading/trailing whitespace and line breaks from comments in reports and exports
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...HEAD
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,5 @@
+module CommentsHelper
+  def comments_formatted_for_csv(comments)
+    comments.pluck(:body).map(&:strip).join("|")
+  end
+end

--- a/app/models/export/activity_comments_column.rb
+++ b/app/models/export/activity_comments_column.rb
@@ -1,4 +1,6 @@
 class Export::ActivityCommentsColumn
+  include CommentsHelper
+
   def initialize(activities:, report:)
     @activities = activities
     @report = report
@@ -14,11 +16,5 @@ class Export::ActivityCommentsColumn
     @activities.map { |activity|
       [activity.id, comments_formatted_for_csv(activity.comments_for_report(report_id: @report.id))]
     }.to_h
-  end
-
-  private
-
-  def comments_formatted_for_csv(comments)
-    comments.pluck(:body).join("|")
   end
 end

--- a/app/services/budget/export.rb
+++ b/app/services/budget/export.rb
@@ -1,5 +1,7 @@
 class Budget
   class Export
+    include CommentsHelper
+
     HEADERS = [
       "RODA identifier",
       "Partner organisation identifier",
@@ -56,10 +58,6 @@ class Budget
         activity.title,
         activity.programme? ? comments_formatted_for_csv(activity.comments) : ""
       ]
-    end
-
-    def comments_formatted_for_csv(comments)
-      comments.pluck(:body).map(&:strip).join("|")
     end
 
     def budget_data(budgets)

--- a/app/services/budget/export.rb
+++ b/app/services/budget/export.rb
@@ -5,7 +5,8 @@ class Budget
       "Partner organisation identifier",
       "Partner organisation",
       "Level",
-      "Title"
+      "Title",
+      "Level B activity comments"
     ]
 
     def initialize(source_fund:, organisation: nil)
@@ -52,8 +53,13 @@ class Budget
         activity.partner_organisation_identifier,
         activity.extending_organisation&.name,
         I18n.t("table.body.activity.level.#{activity.level}"),
-        activity.title
+        activity.title,
+        activity.programme? ? comments_formatted_for_csv(activity.comments) : ""
       ]
+    end
+
+    def comments_formatted_for_csv(comments)
+      comments.pluck(:body).map(&:strip).join("|")
     end
 
     def budget_data(budgets)

--- a/spec/features/beis_users_can_download_exports_spec.rb
+++ b/spec/features/beis_users_can_download_exports_spec.rb
@@ -1,6 +1,8 @@
 RSpec.feature "BEIS users can download exports" do
+  let(:beis_user) { create(:beis_user) }
+
   before do
-    authenticate! user: create(:beis_user)
+    authenticate! user: beis_user
   end
   after { logout }
 
@@ -147,12 +149,17 @@ RSpec.feature "BEIS users can download exports" do
 
     report = create(:report)
 
+    programme = create(:programme_activity, extending_organisation: partner_organisation)
     project = create(:project_activity, :newton_funded, extending_organisation: partner_organisation)
+
+    create(:budget, financial_year: 2021, value: 1000, parent_activity: programme, report: nil)
 
     create(:budget, financial_year: 2018, value: 100, parent_activity: project, report: report)
     create(:budget, financial_year: 2019, value: 80, parent_activity: project, report: report)
     create(:budget, financial_year: 2020, value: 75, parent_activity: project, report: report)
     create(:budget, financial_year: 2021, value: 20, parent_activity: project, report: report)
+
+    programme_comment = create(:comment, commentable: programme, owner: beis_user, body: "I am a programme comment")
 
     visit exports_path
     click_link partner_organisation.name
@@ -160,15 +167,28 @@ RSpec.feature "BEIS users can download exports" do
 
     document = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
 
-    expect(document.size).to eq(1)
+    expect(document.size).to eq(2)
 
     expect(document).to match_array([
+      {
+        "RODA identifier" => programme.roda_identifier,
+        "Partner organisation identifier" => programme.partner_organisation_identifier,
+        "Partner organisation" => programme.extending_organisation.name,
+        "Level" => "Programme (level B)",
+        "Title" => programme.title,
+        "Level B activity comments" => programme_comment.body,
+        "2018-2019" => "0.00",
+        "2019-2020" => "0.00",
+        "2020-2021" => "0.00",
+        "2021-2022" => "1000.00"
+      },
       {
         "RODA identifier" => project.roda_identifier,
         "Partner organisation identifier" => project.partner_organisation_identifier,
         "Partner organisation" => partner_organisation.name,
         "Level" => "Project (level C)",
         "Title" => project.title,
+        "Level B activity comments" => "",
         "2018-2019" => "100.00",
         "2019-2020" => "80.00",
         "2020-2021" => "75.00",
@@ -186,6 +206,8 @@ RSpec.feature "BEIS users can download exports" do
     project1 = create(:project_activity, :newton_funded, extending_organisation: partner_organisation1, parent: programme)
     project2 = create(:project_activity, :newton_funded, extending_organisation: partner_organisation2, parent: programme)
 
+    create(:budget, financial_year: 2021, value: 1000, parent_activity: programme, report: nil)
+
     create(:budget, financial_year: 2018, value: 100, parent_activity: project1, report: report)
     create(:budget, financial_year: 2019, value: 80, parent_activity: project1, report: report)
     create(:budget, financial_year: 2021, value: 20, parent_activity: project1, report: report)
@@ -196,20 +218,36 @@ RSpec.feature "BEIS users can download exports" do
     create(:budget, financial_year: 2021, value: 20, parent_activity: project2, report: report)
     create(:budget, financial_year: 2021, value: 60, parent_activity: project2, report: report)
 
+    programme_comment_1 = create(:comment, commentable: programme, owner: beis_user, body: "I like big budgets and I cannot lie")
+    programme_comment_2 = create(:comment, commentable: programme, owner: beis_user, body: "The chief budgerigar asked if we could budge over this budget")
+
     visit exports_path
     click_link "Download Budgets for Newton Fund"
 
     document = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
 
-    expect(document.size).to eq(3)
+    expect(document.size).to eq(4)
 
     expect(document).to match_array([
+      {
+        "RODA identifier" => programme.roda_identifier,
+        "Partner organisation identifier" => programme.partner_organisation_identifier,
+        "Partner organisation" => programme.extending_organisation.name,
+        "Level" => "Programme (level B)",
+        "Title" => programme.title,
+        "Level B activity comments" => [programme_comment_1, programme_comment_2].map(&:body).join("|"),
+        "2018-2019" => "0.00",
+        "2019-2020" => "0.00",
+        "2020-2021" => "0.00",
+        "2021-2022" => "1000.00"
+      },
       {
         "RODA identifier" => project1.roda_identifier,
         "Partner organisation identifier" => project1.partner_organisation_identifier,
         "Partner organisation" => partner_organisation1.name,
         "Level" => "Project (level C)",
         "Title" => project1.title,
+        "Level B activity comments" => "",
         "2018-2019" => "100.00",
         "2019-2020" => "80.00",
         "2020-2021" => "0.00",
@@ -221,6 +259,7 @@ RSpec.feature "BEIS users can download exports" do
         "Partner organisation" => partner_organisation2.name,
         "Level" => "Project (level C)",
         "Title" => project2.title,
+        "Level B activity comments" => "",
         "2018-2019" => "100.00",
         "2019-2020" => "80.00",
         "2020-2021" => "75.00",
@@ -232,6 +271,7 @@ RSpec.feature "BEIS users can download exports" do
         "Partner organisation" => partner_organisation2.name,
         "Level" => "Project (level C)",
         "Title" => project2.title,
+        "Level B activity comments" => "",
         "2018-2019" => "0.00",
         "2019-2020" => "0.00",
         "2020-2021" => "0.00",

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe CommentsHelper, type: :helper do
+  let(:comment_clean) { create(:comment, body: "Nice") }
+  let(:comment_breaks) { create(:comment, body: "\rThis is a comment. It has some line breaks at both ends\n") }
+  let(:comment_spaces) { create(:comment, body: " This is a comment with leading and trailing spaces    ") }
+  let(:comments) { [comment_clean, comment_breaks, comment_spaces] }
+
+  describe "#comments_formatted_for_csv" do
+    context "when passed multiple comments" do
+      it "returns the comment bodies trimmed and joined by a pipe" do
+        expect(helper.comments_formatted_for_csv(comments)).to eq(
+          "Nice|This is a comment. It has some line breaks at both ends|This is a comment with leading and trailing spaces"
+        )
+      end
+    end
+
+    context "when passed a single comment" do
+      context "when the comment body has no leading/trailing spaces or line breaks" do
+        it "returns the comment body unchanged" do
+          expect(helper.comments_formatted_for_csv([comment_clean])).to eq("Nice")
+        end
+      end
+
+      context "when the comment has leading/trailing line breaks" do
+        it "returns the comment body with leading/trailing line breaks removed" do
+          expect(helper.comments_formatted_for_csv([comment_breaks])).to eq("This is a comment. It has some line breaks at both ends")
+        end
+      end
+
+      context "when the comment has leading/trailing spaces" do
+        it "returns the comment body with leading/trailing spaces trimmed" do
+          expect(helper.comments_formatted_for_csv([comment_spaces])).to eq("This is a comment with leading and trailing spaces")
+        end
+      end
+    end
+
+    context "when passed no comments" do
+      it "returns an empty string" do
+        expect(helper.comments_formatted_for_csv([])).to eq("")
+      end
+    end
+  end
+end

--- a/spec/services/budget/export_spec.rb
+++ b/spec/services/budget/export_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Budget::Export do
               activity1.extending_organisation.name,
               "Project (level C)",
               activity1.title,
+              "",
               "100.00",
               "80.00",
               "0.00",
@@ -104,6 +105,7 @@ RSpec.describe Budget::Export do
               activity1.extending_organisation.name,
               "Project (level C)",
               activity1.title,
+              "",
               "-20.00",
               "0.00",
               "0.00",
@@ -115,6 +117,7 @@ RSpec.describe Budget::Export do
               activity2.extending_organisation.name,
               "Project (level C)",
               activity2.title,
+              "",
               "100.00",
               "80.00",
               "75.00",
@@ -126,12 +129,36 @@ RSpec.describe Budget::Export do
               activity2.extending_organisation.name,
               "Project (level C)",
               activity2.title,
+              "",
               "0.00",
               "0.00",
               "25.00",
               "0.00"
             ]
           ])
+        end
+
+        context "when there's a Level B activity with a budget and comments" do
+          let(:programme_activity) { build(:programme_activity, budgets: programme_activity_budgets) }
+          let(:programme_activity_budgets) { [build(:budget, financial_year: 2018, value: 1000)] }
+          let!(:programme_activity_comment_1) { create(:comment, commentable: programme_activity, owner: build(:beis_user), body: "Budgets, budgets, budgets") }
+          let!(:programme_activity_comment_2) { create(:comment, commentable: programme_activity, owner: build(:beis_user), body: "Excellent budgeting") }
+
+          let(:activities) { [programme_activity] }
+
+          it "returns the budget and pipe-separated comments for the activity" do
+            expect(subject.rows).to match_array([
+              [
+                programme_activity.roda_identifier,
+                programme_activity.partner_organisation_identifier,
+                programme_activity.extending_organisation.name,
+                "Programme (level B)",
+                programme_activity.title,
+                "Budgets, budgets, budgets|Excellent budgeting",
+                "1000.00"
+              ]
+            ])
+          end
         end
 
         context "when there are no budgets present" do


### PR DESCRIPTION
## Changes in this PR

This adds Level B activity comments to the budget exports in a new column. There is no demand for comments for other levels in budget exports at present

I've extended one test to include a programme activity with two comments (since it already created a programme activity), but not the test above it (`downloading budgets for a partner organisation`) - is it worth doing this?

For the `export_spec`, I've updated the `#activity` tests. I notice that the private methods don't have tests - is this standard? I haven't added tests for `#activity_comments` for now

## Screenshots of UI changes

### Before

<img width="456" alt="image" src="https://user-images.githubusercontent.com/40244233/197862504-89645864-0632-46f6-b450-01b08eca07a7.png">

### After

<img width="526" alt="image" src="https://user-images.githubusercontent.com/40244233/197862473-0c93a227-65c7-4de4-a2ea-3e8cf8fa445c.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
