### PR TITLE
(2670) Add ISPF partner countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1130,6 +1130,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Exclude ISPF-related entities from exports when the feature flag is enabled
 - The first step for an ISPF programme is now choosing between ODA and Non-ODA
 - Add ISPF theme form step
+- Add ISPF partner countries form step
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -54,6 +54,8 @@ class ActivityFormsController < BaseController
       skip_step if @activity.partner_organisation_identifier.present?
     when :ispf_theme
       skip_step unless @activity.is_ispf_funded?
+    when :ispf_partner_countries
+      skip_step unless @activity.is_ispf_funded?
     end
 
     render_wizard

--- a/app/helpers/codelist_helper.rb
+++ b/app/helpers/codelist_helper.rb
@@ -139,6 +139,10 @@ module CodelistHelper
     Codelist.new(type: "ispf_theme", source: "beis").to_objects_with_description
   end
 
+  def ispf_partner_country_options(is_oda:)
+    Codelist.new(type: "ispf_partner_countries", source: "beis").to_partner_country_options(is_oda: is_oda)
+  end
+
   def gcrf_challenge_area_options
     data = Codelist.new(type: "gcrf_challenge_area", source: "beis")
     data.collect { |item|

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -52,6 +52,7 @@ class Activity < ApplicationRecord
     :call_present_step,
     :call_dates_step,
     :dates_step,
+    :ispf_partner_countries_step,
     :total_applications_and_awards_step,
     :programme_status_step,
     :country_partner_organisations_step,
@@ -99,6 +100,7 @@ class Activity < ApplicationRecord
   validates :sdg_1, presence: true, on: :sustainable_development_goals_step, if: :sdgs_apply?
   validates :aid_type, presence: true, on: :aid_type_step
   validates :ispf_theme, presence: true, on: :ispf_theme_step, if: :is_ispf_funded?
+  validates :ispf_partner_countries, presence: true, on: :ispf_partner_countries_step, if: :is_ispf_funded?
   validates :policy_marker_gender, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_climate_change_adaptation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_climate_change_mitigation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -22,6 +22,7 @@ class Activity < ApplicationRecord
     :programme_status,
     :country_partner_organisations,
     :dates,
+    :ispf_partner_countries,
     :benefitting_countries,
     :gdi,
     :aid_type,

--- a/app/models/codelist.rb
+++ b/app/models/codelist.rb
@@ -95,6 +95,20 @@ class Codelist
     }.compact.sort_by(&:name)
   end
 
+  def to_partner_country_options(is_oda:)
+    return [] if list.empty?
+
+    list.map do |item|
+      show_for_oda = item["oda"]
+      show_for_non_oda = item["non_oda"]
+
+      next if is_oda && !show_for_oda
+      next if !is_oda && !show_for_non_oda
+
+      OpenStruct.new(name: item["name"], code: item["code"])
+    end.compact
+  end
+
   def each
     list.map { |item| yield item }
   end

--- a/app/models/partner_country.rb
+++ b/app/models/partner_country.rb
@@ -1,0 +1,25 @@
+class PartnerCountry
+  include ActiveModel::Model
+  attr_accessor :name, :code, :oda, :non_oda
+
+  class << self
+    def all
+      @all ||= Codelist.new(type: "ispf_partner_countries", source: "beis").map { |country| new_from_hash(country) }
+    end
+
+    def find_by_code(code)
+      all.find { |country| country.code == code }
+    end
+
+    private
+
+    def new_from_hash(country)
+      new(
+        name: country["name"],
+        code: country["code"],
+        oda: country["oda"],
+        non_oda: country["non_oda"]
+      )
+    end
+  end
+end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -86,12 +86,12 @@ class ActivityPresenter < SimpleDelegator
 
   def intended_beneficiaries
     return if super.blank?
-    sentence_of_benefitting_countries(super)
+    sentence_of_countries(super, BenefittingCountry)
   end
 
   def benefitting_countries
     return if super.blank?
-    sentence_of_benefitting_countries(super)
+    sentence_of_countries(super, BenefittingCountry)
   end
 
   def benefitting_region
@@ -191,6 +191,11 @@ class ActivityPresenter < SimpleDelegator
     ispf_theme_options.select { |theme| theme.code == super }
       .map(&:description)
       .to_sentence
+  end
+
+  def ispf_partner_countries
+    return nil if super.blank?
+    sentence_of_countries(super, PartnerCountry)
   end
 
   def gcrf_challenge_area
@@ -293,12 +298,12 @@ class ActivityPresenter < SimpleDelegator
     I18n.t(*args)
   end
 
-  def sentence_of_benefitting_countries(country_code_list)
+  def sentence_of_countries(country_code_list, klass)
     return nil unless country_code_list.present?
-    benefitting_country_names = country_code_list.map { |country_code|
-      benefitting_country = BenefittingCountry.find_by_code(country_code)
-      benefitting_country.nil? ? translate("page_content.activity.unknown_country", code: country_code) : benefitting_country.name
+    country_names = country_code_list.map { |country_code|
+      country = klass.find_by_code(country_code)
+      country.nil? ? translate("page_content.activity.unknown_country", code: country_code) : country.name
     }
-    benefitting_country_names.to_sentence
+    country_names.to_sentence
   end
 end

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -79,6 +79,13 @@ class Activity
       activity.assign_attributes(gcrf_strategic_area: gcrf_strategic_area)
     end
 
+    def set_ispf_partner_countries
+      ispf_partner_countries = activity_params
+        .permit(ispf_partner_countries: [])
+        .fetch("ispf_partner_countries", []).reject(&:blank?)
+      activity.assign_attributes(ispf_partner_countries: ispf_partner_countries)
+    end
+
     def set_aid_type
       Activity::Inference.service.assign(activity, :aid_type, params_for("aid_type"))
     end

--- a/app/views/activity_forms/ispf_partner_countries.html.haml
+++ b/app/views/activity_forms/ispf_partner_countries.html.haml
@@ -1,0 +1,6 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_collection_check_boxes :ispf_partner_countries,
+    ispf_partner_country_options(is_oda: @activity.is_oda),
+    :code,
+    :name,
+    legend: { tag: 'h1', size: 'xl', text: t("form.legend.activity.ispf_partner_countries") }

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -216,6 +216,16 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :dates)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:planned_start_date)}"), activity_step_path(activity_presenter, :dates), t("activerecord.attributes.activity.actual_end_date"))
 
+  - if activity_presenter.is_ispf_funded?
+    .govuk-summary-list__row.ispf_partner_countries
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.ispf_partner_countries")
+      %dd.govuk-summary-list__value
+        = activity_presenter.ispf_partner_countries
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :ispf_partner_countries)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:ispf_partner_countries)}"), activity_step_path(activity_presenter, :ispf_partner_countries), t("activerecord.attributes.activity.ispf_partner_countries"))
+
   .govuk-summary-list__row.benefitting_countries
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.benefitting_countries")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -475,6 +475,7 @@ en:
         policy_marker_nutrition: Nutrition policy marker
         implementing_organisations: Implementing organisations
         ispf_theme: ISPF theme
+        ispf_partner_countries: ISPF partner countries
         tied_status_with_code: Tied status
         originating_report_id: Originating report identifier
         source_fund_code: Fund code

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -519,6 +519,8 @@ en:
               too_long: A maximum of 10 intended beneficiaries can be added
             ispf_theme:
               blank: Select an ISPF theme
+            ispf_partner_countries:
+              blank: Select an ISPF partner country
             level:
               blank: Select the activity type
             objectives:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -133,6 +133,7 @@ en:
         gdi: Is your activity affected by the Global Development Impact (GDI) policy?
         geography: Will the benefitting recipient be a region or country?
         ispf_theme: Which ISPF theme does this activity fall under?
+        ispf_partner_countries: Who are the ISPF partner countries?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
         objectives: What are the aims/objectives of this %{level}?
@@ -395,6 +396,7 @@ en:
         intended_beneficiaries: What are the intended beneficiaries?
         is_oda: Is this activity ODA or Non-ODA?
         ispf_theme: ISPF theme
+        ispf_partner_countries: ISPF partner countries
         level: Hierarchy level
         objectives: Aims/Objectives
         oda_eligibility: ODA eligibility

--- a/db/migrate/20221031155150_add_ispf_partner_countries_to_activities.rb
+++ b/db/migrate/20221031155150_add_ispf_partner_countries_to_activities.rb
@@ -1,0 +1,5 @@
+class AddIspfPartnerCountriesToActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :ispf_partner_countries, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_26_162057) do
+ActiveRecord::Schema.define(version: 2022_10_31_155150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2022_10_26_162057) do
     t.string "benefitting_countries", array: true
     t.boolean "is_oda"
     t.integer "ispf_theme"
+    t.string "ispf_partner_countries", array: true
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe ActivityFormsController do
         end
       end
 
+      context "ispf_partner_countries step" do
+        subject { get_step :ispf_partner_countries }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when it's an ISPF activity" do
+          let(:activity) { create(:programme_activity, :ispf_funded) }
+
+          it { is_expected.to render_current_step }
+        end
+      end
+
       context "collaboration_type" do
         subject { get_step :collaboration_type }
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     uk_po_named_contact { Faker::Name.name }
     fund_pillar { "0" }
     ispf_theme { 0 }
+    ispf_partner_countries { [""] }
 
     form_state { "complete" }
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -178,7 +178,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
         sdgs_apply: true,
         sdg_1: 5,
         is_oda: true,
-        ispf_theme: 1)
+        ispf_theme: 1,
+        ispf_partner_countries: ["IN"])
     end
 
     let!(:non_oda_activity) do
@@ -189,7 +190,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
         sdgs_apply: true,
         sdg_1: 5,
         is_oda: false,
-        ispf_theme: 1)
+        ispf_theme: 1,
+        ispf_partner_countries: ["IN"])
     end
 
     scenario "an ODA activity can be created" do
@@ -215,6 +217,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.planned_end_date).to eq(oda_activity.planned_end_date)
       expect(created_activity.actual_start_date).to eq(oda_activity.actual_start_date)
       expect(created_activity.actual_end_date).to eq(oda_activity.actual_end_date)
+      expect(created_activity.ispf_partner_countries).to match_array(oda_activity.ispf_partner_countries)
       expect(created_activity.benefitting_countries).to match_array(oda_activity.benefitting_countries)
       expect(created_activity.gdi).to eq(oda_activity.gdi)
       expect(created_activity.aid_type).to eq(oda_activity.aid_type)
@@ -249,6 +252,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.planned_end_date).to eq(non_oda_activity.planned_end_date)
       expect(created_activity.actual_start_date).to eq(non_oda_activity.actual_start_date)
       expect(created_activity.actual_end_date).to eq(non_oda_activity.actual_end_date)
+      expect(created_activity.ispf_partner_countries).to match_array(oda_activity.ispf_partner_countries)
       expect(created_activity.benefitting_countries).to match_array(non_oda_activity.benefitting_countries)
       expect(created_activity.gdi).to eq(non_oda_activity.gdi)
       expect(created_activity.aid_type).to eq(non_oda_activity.aid_type)

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -224,6 +224,32 @@ RSpec.describe CodelistHelper, type: :helper do
       end
     end
 
+    describe "#ispf_partner_country_options" do
+      context "when ODA" do
+        it "returns the ODA partner country details in a hash" do
+          options = helper.ispf_partner_country_options(is_oda: true)
+
+          expect(options.length).to eq(13)
+          expect(options.first.code).to eq("BR")
+          expect(options.first.name).to eq("Brazil")
+          expect(options.last.code).to eq("LDC")
+          expect(options.last.name).to eq "Least developed countries"
+        end
+      end
+
+      context "when non-ODA" do
+        it "returns the non-ODA partner country details in a hash" do
+          options = helper.ispf_partner_country_options(is_oda: false)
+
+          expect(options.length).to eq(11)
+          expect(options.first.code).to eq("CA")
+          expect(options.first.name).to eq("Canada")
+          expect(options.last.code).to eq("US")
+          expect(options.last.name).to eq "USA"
+        end
+      end
+    end
+
     describe "#channel_of_delivery_codes" do
       it "returns the list of items whose codes are allowed by BEIS" do
         expect(helper.channel_of_delivery_codes.size).to eql 32

--- a/spec/models/codelist_spec.rb
+++ b/spec/models/codelist_spec.rb
@@ -144,6 +144,30 @@ RSpec.describe Codelist do
     end
   end
 
+  describe "#to_partner_country_options" do
+    context "when ODA" do
+      it "formats the data from a codelist to an array of objects for use in govuk form builder" do
+        options = Codelist.new(type: "ispf_partner_countries", source: "beis").to_partner_country_options(is_oda: true)
+
+        expect(options).to include(
+          OpenStruct.new(name: "Brazil", code: "BR"),
+          OpenStruct.new(name: "Least developed countries", code: "LDC")
+        )
+      end
+    end
+
+    context "when non-ODA" do
+      it "formats the data from a codelist to an array of objects for use in govuk form builder" do
+        options = Codelist.new(type: "ispf_partner_countries", source: "beis").to_partner_country_options(is_oda: false)
+
+        expect(options).to include(
+          OpenStruct.new(name: "Canada", code: "CA"),
+          OpenStruct.new(name: "USA", code: "US")
+        )
+      end
+    end
+  end
+
   describe "#values_for" do
     let(:codelist) { Codelist.new(type: "aid_type") }
 

--- a/spec/models/codelist_spec.rb
+++ b/spec/models/codelist_spec.rb
@@ -144,6 +144,28 @@ RSpec.describe Codelist do
     end
   end
 
+  describe "#to_objects_with_categories" do
+    let(:active_sector) { OpenStruct.new(name: "Education policy and administrative management", code: "11110", category: "111") }
+    let(:inactive_sector) { OpenStruct.new(name: "Lower secondary education", code: "11321", category: "113") }
+
+    context "when withdrawn should not be included" do
+      it "formats the data from a codelist to an array of objects for use in govuk form builder, with categories" do
+        options = Codelist.new(type: "sector").to_objects_with_categories
+
+        expect(options).to include(active_sector)
+        expect(options).to_not include(inactive_sector)
+      end
+    end
+
+    context "when withdrawn should be included" do
+      it "formats the data from a codelist to an array of objects for use in govuk form builder, with categories" do
+        options = Codelist.new(type: "sector").to_objects_with_categories(include_withdrawn: true)
+
+        expect(options).to include(active_sector, inactive_sector)
+      end
+    end
+  end
+
   describe "#to_partner_country_options" do
     context "when ODA" do
       it "formats the data from a codelist to an array of objects for use in govuk form builder" do

--- a/spec/models/ispf_partner_country_spec.rb
+++ b/spec/models/ispf_partner_country_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+RSpec.describe PartnerCountry do
+  let(:countries) do
+    [
+      PartnerCountry.new(
+        code: "BR",
+        name: "Brazil",
+        oda: true,
+        non_oda: false
+      ),
+      PartnerCountry.new(
+        code: "CA",
+        name: "Canada",
+        oda: false,
+        non_oda: true
+      ),
+      PartnerCountry.new(
+        code: "CN",
+        name: "China",
+        oda: false,
+        non_oda: true
+      ),
+      PartnerCountry.new(
+        code: "EG",
+        name: "Egypt",
+        oda: true,
+        non_oda: false
+      ),
+      PartnerCountry.new(
+        code: "IN",
+        name: "India",
+        oda: true,
+        non_oda: true
+      )
+    ]
+  end
+
+  before do
+    allow(PartnerCountry).to receive(:all).and_return(countries)
+  end
+
+  describe ".all" do
+    it "includes all countries" do
+      expect(PartnerCountry.all).to match countries
+    end
+  end
+
+  describe ".find_by_code" do
+    context "when a country exists with the given code" do
+      let(:code) { "BR" }
+
+      it "returns a hash with the country's details" do
+        partner_country = PartnerCountry.find_by_code(code)
+
+        expect(partner_country.code).to eq("BR")
+        expect(partner_country.name).to eq("Brazil")
+        expect(partner_country.oda).to eq(true)
+        expect(partner_country.non_oda).to eq(false)
+      end
+    end
+
+    context "when a country does not exist with the given code" do
+      let(:code) { "ZZ" }
+
+      it "returns nil" do
+        expect(PartnerCountry.find_by_code(code)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -523,6 +523,24 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#ispf_partner_countries" do
+    it_behaves_like "a code translator", "ispf_partner_countries", {type: "ispf_partner_countries", source: "beis"}, "Array"
+
+    context "when there are partner countries" do
+      it "returns the locale value for the codes of the countries joined in sentence form" do
+        activity = build(:programme_activity, ispf_partner_countries: ["BR", "IN", "LDC"])
+        result = ActivityPresenter.new(activity).ispf_partner_countries
+        expect(result).to eq("Brazil, India, and Least developed countries")
+      end
+
+      it "handles unexpected country codes" do
+        activity = build(:programme_activity, ispf_partner_countries: ["ZZ"])
+        result = ActivityPresenter.new(activity).ispf_partner_countries
+        expect(result).to eq t("page_content.activity.unknown_country", code: "ZZ")
+      end
+    end
+  end
+
   describe "#gcrf_challenge_area" do
     it_behaves_like "a code translator", "gcrf_challenge_area", {type: "gcrf_challenge_area", source: "beis"}, "Integer"
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -139,6 +139,7 @@ class ActivityForm
     fill_in_sector_step
     fill_in_programme_status
     fill_in_dates
+    fill_in_ispf_partner_countries
     fill_in_benefitting_countries
     fill_in_gdi
     fill_in_aid_type
@@ -281,6 +282,12 @@ class ActivityForm
     fill_in "activity[actual_end_date(2i)]", with: activity.actual_end_date.month
     fill_in "activity[actual_end_date(1i)]", with: activity.actual_end_date.year
 
+    click_button I18n.t("form.button.activity.submit")
+  end
+
+  def fill_in_ispf_partner_countries
+    expect(page).to have_content I18n.t("form.legend.activity.ispf_partner_countries")
+    find("input[value='IN']").click
     click_button I18n.t("form.button.activity.submit")
   end
 

--- a/vendor/data/codelists/BEIS/ispf_partner_countries.yml
+++ b/vendor/data/codelists/BEIS/ispf_partner_countries.yml
@@ -1,0 +1,93 @@
+data:
+  - code: BR
+    name: Brazil
+    oda: true
+    non_oda: false
+  - code: CA
+    name: Canada
+    oda: false
+    non_oda: true
+  - code: CN
+    name: China
+    oda: false
+    non_oda: true
+  - code: EG
+    name: Egypt
+    oda: true
+    non_oda: false
+  - code: DE
+    name: Germany
+    oda: false
+    non_oda: true
+  - code: IN
+    name: India
+    oda: true
+    non_oda: true
+  - code: ID
+    name: Indonesia
+    oda: true
+    non_oda: false
+  - code: IL
+    name: Israel
+    oda: false
+    non_oda: true
+  - code: JP
+    name: Japan
+    oda: false
+    non_oda: true
+  - code: JO
+    name: Jordan
+    oda: true
+    non_oda: false
+  - code: KE
+    name: Kenya
+    oda: true
+    non_oda: false
+  - code: MY
+    name: Malaysia
+    oda: true
+    non_oda: false
+  - code: PH
+    name: Philippines
+    oda: true
+    non_oda: false
+  - code: SG
+    name: Singapore
+    oda: false
+    non_oda: true
+  - code: ZA
+    name: South Africa
+    oda: true
+    non_oda: false
+  - code: KR
+    name: South Korea
+    oda: false
+    non_oda: true
+  - code: CH
+    name: Switzerland
+    oda: false
+    non_oda: true
+  - code: TW
+    name: Taiwan
+    oda: false
+    non_oda: true
+  - code: TH
+    name: Thailand
+    oda: true
+    non_oda: false
+  - code: TR
+    name: Turkey
+    oda: true
+    non_oda: false
+  - code: US
+    name: USA
+    oda: false
+    non_oda: true
+  - code: VN
+    name: Vietnam
+    oda: true
+    non_oda: false
+  - code: LDC
+    name: Least developed countries
+    oda: true
+    non_oda: false


### PR DESCRIPTION
## Changes in this PR

Adds ISPF partner countries to the activities table/model, a PartnerCountry (non-Active Record) model, a form step for adding this when creating an activity, and a line in the activity details page (including an edit link)

## Screenshots of UI changes

### After

<img width="625" alt="image" src="https://user-images.githubusercontent.com/40244233/199249156-7f82d7a7-4499-4782-9bfa-f99296ab592d.png">

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/40244233/199249505-4a80ef34-8a63-47b5-9428-426023aabbe5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
