### PR TITLE
(2642) Add new steps to the new activity form for Level C/D ODA ISPF activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1131,6 +1131,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - The first step for an ISPF programme is now choosing between ODA and Non-ODA
 - Add ISPF theme form step
 - Add ISPF partner countries form step
+- Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -19,6 +19,7 @@ class ActivityDefaults
       source_fund_code: source_fund_code,
       roda_identifier: roda_identifier,
       transparency_identifier: transparency_identifier,
+      is_oda: parent_activity.is_oda,
 
       organisation_id: organisation.id,
       extending_organisation_id: extending_organisation.id,

--- a/spec/services/activity_defaults_spec.rb
+++ b/spec/services/activity_defaults_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe ActivityDefaults do
   let(:project) { create(:project_activity, :gcrf_funded, parent: programme) }
   let(:third_party_project) { create(:third_party_project_activity, :gcrf_funded, parent: project) }
 
+  let(:ispf_oda_programme) { create(:programme_activity, :ispf_funded) }
+  let(:ispf_non_oda_programme) { create(:programme_activity, :ispf_funded, is_oda: false) }
+  let(:ispf_oda_project) { create(:project_activity, parent: ispf_oda_programme, is_oda: true) }
+  let(:ispf_non_oda_project) { create(:project_activity, parent: ispf_non_oda_programme, is_oda: false) }
+
   let!(:current_report) { create(:report, :active, organisation: partner_organisation, fund: fund) }
 
   before do
@@ -72,6 +77,10 @@ RSpec.describe ActivityDefaults do
       it "sets the transparency identifier" do
         expect(subject[:transparency_identifier]).to eq("#{Organisation::SERVICE_OWNER_IATI_REFERENCE}-#{subject[:roda_identifier]}")
       end
+
+      it "sets the is_oda attribute" do
+        expect(subject[:is_oda]).to be_nil
+      end
     end
 
     context "parent is a programme" do
@@ -119,6 +128,26 @@ RSpec.describe ActivityDefaults do
 
       it "sets the transparency identifier" do
         expect(subject[:transparency_identifier]).to eq("#{Organisation::SERVICE_OWNER_IATI_REFERENCE}-#{subject[:roda_identifier]}")
+      end
+
+      it "sets the is_oda attribute" do
+        expect(subject[:is_oda]).to be_nil
+      end
+
+      context "when the parent is an ISPF ODA programme" do
+        let(:parent_activity) { ispf_oda_programme }
+
+        it "sets the is_oda attribute to true" do
+          expect(subject[:is_oda]).to eq(true)
+        end
+      end
+
+      context "when the parent is an ISPF non-ODA programme" do
+        let(:parent_activity) { ispf_non_oda_programme }
+
+        it "sets the is_oda attribute to false" do
+          expect(subject[:is_oda]).to eq(false)
+        end
       end
     end
 
@@ -168,6 +197,26 @@ RSpec.describe ActivityDefaults do
 
       it "sets the transparency identifier" do
         expect(subject[:transparency_identifier]).to eq("#{Organisation::SERVICE_OWNER_IATI_REFERENCE}-#{subject[:roda_identifier]}")
+      end
+
+      it "sets the is_oda attribute" do
+        expect(subject[:is_oda]).to be_nil
+      end
+
+      context "when the parent is an ISPF ODA project" do
+        let(:parent_activity) { ispf_oda_project }
+
+        it "sets the is_oda attribute to true" do
+          expect(subject[:is_oda]).to eq(true)
+        end
+      end
+
+      context "when the parent is an ISPF non-ODA project" do
+        let(:parent_activity) { ispf_non_oda_project }
+
+        it "sets the is_oda attribute to false" do
+          expect(subject[:is_oda]).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

Activities now inherit the `is_oda` attribute from their parent, so Level C/D activities will have the same `is_oda` value as was set on their parent Level B activity, and therefore be shown the correct ODA countries on the ISPF partner countries step

Other than skipping the ODA/non-ODA step, everything else is as per the Level B ISPF user journey

Re: feature tests: `spec/features/users_can_create_a_project_level_activity_spec.rb` isn't as comprehensive as `spec/features/beis_users_can_create_a_programme_level_activity_spec.rb` in testing different funds and the form steps, but perhaps we should expand it?

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
