### PR TITLE
(2643) Add Level C/D non-ODA ISPF form journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1133,6 +1133,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add ISPF partner countries form step
 - Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
 - Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one
+- Add ISPF Level C/D UI user journeys for adding activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -40,7 +40,7 @@ class ActivityFormsController < BaseController
     when :aid_type
       skip_step unless @activity.requires_aid_type?
     when :collaboration_type
-      skip_step if @activity.fund?
+      skip_step unless @activity.requires_collaboration_type?
       skip_step unless Activity::Inference.service.editable?(@activity, :collaboration_type)
       assign_default_collaboration_type_value_if_nil
     when :sustainable_development_goals

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -58,6 +58,8 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.is_ispf_funded?
     when :benefitting_countries
       skip_step unless @activity.requires_benefitting_countries?
+    when :gdi
+      skip_step unless @activity.requires_gdi?
     end
 
     render_wizard

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -17,7 +17,7 @@ class ActivityFormsController < BaseController
     when :is_oda
       skip_step unless @activity.requires_is_oda?
     when :objectives
-      skip_step if @activity.fund?
+      skip_step unless @activity.requires_objectives?
     when :programme_status
       skip_step if @activity.fund?
     when :country_partner_organisations

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -56,6 +56,8 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.is_ispf_funded?
     when :ispf_partner_countries
       skip_step unless @activity.is_ispf_funded?
+    when :benefitting_countries
+      skip_step unless @activity.requires_benefitting_countries?
     end
 
     render_wizard

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -58,7 +58,7 @@ class ActivityFormsController < BaseController
     when :gcrf_challenge_area, :gcrf_strategic_area
       skip_step unless @activity.is_gcrf_funded?
     when :channel_of_delivery_code
-      skip_step unless @activity.is_project?
+      skip_step unless @activity.requires_channel_of_delivery_code?
       skip_step unless Activity::Inference.service.editable?(@activity, :channel_of_delivery_code)
     when :oda_eligibility
       skip_step unless @activity.requires_oda_eligibility?

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -43,8 +43,10 @@ class ActivityFormsController < BaseController
     when :channel_of_delivery_code
       skip_step unless @activity.is_project?
       skip_step unless Activity::Inference.service.editable?(@activity, :channel_of_delivery_code)
+    when :oda_eligibility
+      skip_step unless @activity.requires_oda_eligibility?
     when :oda_eligibility_lead
-      skip_step unless @activity.is_project?
+      skip_step unless @activity.requires_oda_eligibility_lead?
     when :uk_po_named_contact
       skip_step unless @activity.is_project?
     when :fstc_applies

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -16,30 +16,47 @@ class ActivityFormsController < BaseController
     case step
     when :is_oda
       skip_step unless @activity.requires_is_oda?
+    when :identifier
+      @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
+      skip_step if @activity.partner_organisation_identifier.present?
     when :objectives
       skip_step unless @activity.requires_objectives?
-    when :programme_status
-      skip_step if @activity.fund?
-    when :country_partner_organisations
-      skip_step unless @activity.is_newton_funded?
     when :call_present
       skip_step unless @activity.requires_call_dates?
     when :call_dates
       skip_step unless @activity.call_present?
     when :total_applications_and_awards
       skip_step unless @activity.call_present?
+    when :programme_status
+      skip_step if @activity.fund?
+    when :country_partner_organisations
+      skip_step unless @activity.is_newton_funded?
+    when :ispf_partner_countries
+      skip_step unless @activity.is_ispf_funded?
+    when :benefitting_countries
+      skip_step unless @activity.requires_benefitting_countries?
+    when :gdi
+      skip_step unless @activity.requires_gdi?
+    when :aid_type
+      skip_step unless @activity.requires_aid_type?
     when :collaboration_type
       skip_step if @activity.fund?
       skip_step unless Activity::Inference.service.editable?(@activity, :collaboration_type)
       assign_default_collaboration_type_value_if_nil
-    when :policy_markers
-      skip_step unless @activity.requires_policy_markers?
     when :sustainable_development_goals
       skip_step if @activity.fund? || @activity.is_non_oda_project?
-    when :gcrf_challenge_area, :gcrf_strategic_area
-      skip_step unless @activity.is_gcrf_funded?
+    when :ispf_theme
+      skip_step unless @activity.is_ispf_funded?
     when :fund_pillar
       skip_step unless @activity.is_newton_funded?
+    when :fstc_applies
+      skip_step unless Activity::Inference.service.editable?(@activity, :fstc_applies)
+    when :policy_markers
+      skip_step unless @activity.requires_policy_markers?
+    when :covid19_related
+      skip_step unless @activity.requires_covid19_related?
+    when :gcrf_challenge_area, :gcrf_strategic_area
+      skip_step unless @activity.is_gcrf_funded?
     when :channel_of_delivery_code
       skip_step unless @activity.is_project?
       skip_step unless Activity::Inference.service.editable?(@activity, :channel_of_delivery_code)
@@ -49,23 +66,6 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.requires_oda_eligibility_lead?
     when :uk_po_named_contact
       skip_step unless @activity.is_project?
-    when :fstc_applies
-      skip_step unless Activity::Inference.service.editable?(@activity, :fstc_applies)
-    when :identifier
-      @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
-      skip_step if @activity.partner_organisation_identifier.present?
-    when :ispf_theme
-      skip_step unless @activity.is_ispf_funded?
-    when :ispf_partner_countries
-      skip_step unless @activity.is_ispf_funded?
-    when :benefitting_countries
-      skip_step unless @activity.requires_benefitting_countries?
-    when :gdi
-      skip_step unless @activity.requires_gdi?
-    when :aid_type
-      skip_step unless @activity.requires_aid_type?
-    when :covid19_related
-      skip_step unless @activity.requires_covid19_related?
     end
 
     render_wizard

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -62,6 +62,8 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.requires_gdi?
     when :aid_type
       skip_step unless @activity.requires_aid_type?
+    when :covid19_related
+      skip_step unless @activity.requires_covid19_related?
     end
 
     render_wizard

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -60,6 +60,8 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.requires_benefitting_countries?
     when :gdi
       skip_step unless @activity.requires_gdi?
+    when :aid_type
+      skip_step unless @activity.requires_aid_type?
     end
 
     render_wizard

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -35,7 +35,7 @@ class ActivityFormsController < BaseController
     when :policy_markers
       skip_step unless @activity.is_project?
     when :sustainable_development_goals
-      skip_step if @activity.fund?
+      skip_step if @activity.fund? || @activity.is_non_oda_project?
     when :gcrf_challenge_area, :gcrf_strategic_area
       skip_step unless @activity.is_gcrf_funded?
     when :fund_pillar

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -50,6 +50,7 @@ class ActivityFormsController < BaseController
     when :fund_pillar
       skip_step unless @activity.is_newton_funded?
     when :fstc_applies
+      skip_step unless @activity.requires_fstc_applies?
       skip_step unless Activity::Inference.service.editable?(@activity, :fstc_applies)
     when :policy_markers
       skip_step unless @activity.requires_policy_markers?

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -33,7 +33,7 @@ class ActivityFormsController < BaseController
       skip_step unless Activity::Inference.service.editable?(@activity, :collaboration_type)
       assign_default_collaboration_type_value_if_nil
     when :policy_markers
-      skip_step unless @activity.is_project?
+      skip_step unless @activity.requires_policy_markers?
     when :sustainable_development_goals
       skip_step if @activity.fund? || @activity.is_non_oda_project?
     when :gcrf_challenge_area, :gcrf_strategic_area

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -92,7 +92,7 @@ class Activity < ApplicationRecord
   validates :total_awards, presence: true, on: :total_applications_and_awards_step, if: :call_present?
   validates :programme_status, presence: true, on: :programme_status_step
   validates :country_partner_organisations, presence: true, on: :country_partner_organisations_step, if: :requires_country_partner_organisations?
-  validates :gdi, presence: true, on: :gdi_step, unless: proc { |activity| activity.fund? }
+  validates :gdi, presence: true, on: :gdi_step, if: :requires_gdi?
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
   validates :covid19_related, presence: true, on: :covid19_related_step
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
@@ -507,6 +507,10 @@ class Activity < ApplicationRecord
 
   def requires_benefitting_countries?
     !is_non_oda_project?
+  end
+
+  def requires_gdi?
+    !fund? && !is_non_oda_project?
   end
 
   def comments_for_report(report_id:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -505,6 +505,10 @@ class Activity < ApplicationRecord
     is_project?
   end
 
+  def requires_benefitting_countries?
+    !is_non_oda_project?
+  end
+
   def comments_for_report(report_id:)
     comments_on_self_and_transactions.where(report_id: report_id)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -526,7 +526,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_policy_markers?
-    is_project?
+    is_project? && !is_non_oda?
   end
 
   def is_project?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -111,8 +111,8 @@ class Activity < ApplicationRecord
   validates :policy_marker_nutrition, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :gcrf_challenge_area, presence: true, on: :gcrf_challenge_area_step, if: :is_gcrf_funded?
   validates :gcrf_strategic_area, presence: true, length: {maximum: 2}, on: :gcrf_strategic_area_step, if: :is_gcrf_funded?
-  validates :oda_eligibility, presence: true, on: :oda_eligibility_step
-  validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :is_project?
+  validates :oda_eligibility, presence: true, on: :oda_eligibility_step, if: :requires_oda_eligibility?
+  validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :requires_oda_eligibility_lead?
   validates :uk_po_named_contact, presence: true, on: :uk_po_named_contact_step, if: :is_project?
   validates_with ChannelOfDeliveryCodeValidator, on: :channel_of_delivery_code_step, if: :is_project?
 
@@ -519,6 +519,14 @@ class Activity < ApplicationRecord
 
   def requires_covid19_related?
     !is_non_oda_project?
+  end
+
+  def requires_oda_eligibility?
+    !is_non_oda_project?
+  end
+
+  def requires_oda_eligibility_lead?
+    is_project? && !is_non_oda?
   end
 
   def comments_for_report(report_id:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -84,7 +84,7 @@ class Activity < ApplicationRecord
   validates_with OrganisationValidator
   validates :partner_organisation_identifier, presence: true, on: :identifier_step, if: :is_project?
   validates :title, :description, presence: true, on: :purpose_step
-  validates :objectives, presence: true, on: :objectives_step, unless: proc { |activity| activity.fund? }
+  validates :objectives, presence: true, on: :objectives_step, if: :requires_objectives?
   validates :sector_category, presence: true, on: :sector_category_step
   validates :sector, presence: true, on: :sector_step
   validates :call_present, inclusion: {in: [true, false]}, on: :call_present_step, if: :requires_call_dates?
@@ -497,6 +497,10 @@ class Activity < ApplicationRecord
     ForecastOverview.new(self).latest_values
   end
 
+  def requires_objectives?
+    !fund? && !is_non_oda_project?
+  end
+
   def requires_call_dates?
     is_project?
   end
@@ -527,6 +531,14 @@ class Activity < ApplicationRecord
 
   def is_ispf_funded?
     !fund? && source_fund.present? && source_fund.ispf?
+  end
+
+  def is_non_oda?
+    is_oda == false
+  end
+
+  def is_non_oda_project?
+    is_project? && is_non_oda?
   end
 
   def requires_is_oda?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -114,7 +114,7 @@ class Activity < ApplicationRecord
   validates :oda_eligibility, presence: true, on: :oda_eligibility_step, if: :requires_oda_eligibility?
   validates :oda_eligibility_lead, presence: true, on: :oda_eligibility_lead_step, if: :requires_oda_eligibility_lead?
   validates :uk_po_named_contact, presence: true, on: :uk_po_named_contact_step, if: :is_project?
-  validates_with ChannelOfDeliveryCodeValidator, on: :channel_of_delivery_code_step, if: :is_project?
+  validates_with ChannelOfDeliveryCodeValidator, on: :channel_of_delivery_code_step, if: :requires_channel_of_delivery_code?
 
   validates :partner_organisation_identifier, uniqueness: {scope: :parent_id}, allow_nil: true
   validates :roda_identifier, uniqueness: true, allow_nil: true
@@ -535,6 +535,10 @@ class Activity < ApplicationRecord
 
   def requires_collaboration_type?
     !fund? && !is_non_oda_project?
+  end
+
+  def requires_channel_of_delivery_code?
+    is_project? && !is_non_oda?
   end
 
   def requires_policy_markers?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -98,7 +98,7 @@ class Activity < ApplicationRecord
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :fund_pillar, presence: true, on: :fund_pillar_step, if: :is_newton_funded?
   validates :sdg_1, presence: true, on: :sustainable_development_goals_step, if: :sdgs_apply?
-  validates :aid_type, presence: true, on: :aid_type_step
+  validates :aid_type, presence: true, on: :aid_type_step, if: :requires_aid_type?
   validates :ispf_theme, presence: true, on: :ispf_theme_step, if: :is_ispf_funded?
   validates :ispf_partner_countries, presence: true, on: :ispf_partner_countries_step, if: :is_ispf_funded?
   validates :policy_marker_gender, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
@@ -511,6 +511,10 @@ class Activity < ApplicationRecord
 
   def requires_gdi?
     !fund? && !is_non_oda_project?
+  end
+
+  def requires_aid_type?
+    !is_non_oda_project?
   end
 
   def comments_for_report(report_id:)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -93,7 +93,7 @@ class Activity < ApplicationRecord
   validates :programme_status, presence: true, on: :programme_status_step
   validates :country_partner_organisations, presence: true, on: :country_partner_organisations_step, if: :requires_country_partner_organisations?
   validates :gdi, presence: true, on: :gdi_step, if: :requires_gdi?
-  validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
+  validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step, if: :requires_fstc_applies?
   validates :covid19_related, presence: true, on: :covid19_related_step, if: :requires_covid19_related?
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :fund_pillar, presence: true, on: :fund_pillar_step, if: :is_newton_funded?
@@ -539,6 +539,10 @@ class Activity < ApplicationRecord
 
   def requires_channel_of_delivery_code?
     is_project? && !is_non_oda?
+  end
+
+  def requires_fstc_applies?
+    !is_non_oda_project?
   end
 
   def requires_policy_markers?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -94,7 +94,7 @@ class Activity < ApplicationRecord
   validates :country_partner_organisations, presence: true, on: :country_partner_organisations_step, if: :requires_country_partner_organisations?
   validates :gdi, presence: true, on: :gdi_step, if: :requires_gdi?
   validates :fstc_applies, inclusion: {in: [true, false]}, on: :fstc_applies_step
-  validates :covid19_related, presence: true, on: :covid19_related_step
+  validates :covid19_related, presence: true, on: :covid19_related_step, if: :requires_covid19_related?
   validates :collaboration_type, presence: true, on: :collaboration_type_step, if: :requires_collaboration_type?
   validates :fund_pillar, presence: true, on: :fund_pillar_step, if: :is_newton_funded?
   validates :sdg_1, presence: true, on: :sustainable_development_goals_step, if: :sdgs_apply?
@@ -514,6 +514,10 @@ class Activity < ApplicationRecord
   end
 
   def requires_aid_type?
+    !is_non_oda_project?
+  end
+
+  def requires_covid19_related?
     !is_non_oda_project?
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -534,7 +534,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_collaboration_type?
-    !fund?
+    !fund? && !is_non_oda_project?
   end
 
   def requires_policy_markers?

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -190,6 +190,7 @@ FactoryBot.define do
 
       trait :ispf_funded do
         source_fund_code { Fund.by_short_name("ISPF").id }
+        is_oda { true }
         parent factory: [:programme_activity, :ispf_funded]
       end
     end
@@ -225,6 +226,12 @@ FactoryBot.define do
       trait :gcrf_funded do
         source_fund_code { Fund.by_short_name("GCRF").id }
         parent factory: [:project_activity, :gcrf_funded]
+      end
+
+      trait :ispf_funded do
+        source_fund_code { Fund.by_short_name("ISPF").id }
+        is_oda { true }
+        parent factory: [:programme_activity, :ispf_funded]
       end
 
       after(:create) do |project, _evaluator|

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -77,6 +77,121 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.implementing_organisations).to be_none
       end
 
+      scenario "a new project can be added to an ISPF ODA programme" do
+        programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation)
+        report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
+        activity = build(:project_activity,
+          parent: programme,
+          is_oda: true,
+          ispf_partner_countries: ["IN"],
+          benefitting_countries: ["AG", "HT"],
+          sdgs_apply: true,
+          sdg_1: 5,
+          ispf_theme: 1)
+
+        visit activities_path
+        click_on programme.title
+        click_on t("tabs.activity.children")
+        click_on t("action.activity.add_child")
+
+        form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
+        form.complete!(is_oda: true)
+
+        expect(page).to have_content t("action.project.create.success")
+        expect(programme.child_activities.count).to eq 1
+
+        created_activity = form.created_activity
+
+        expect(created_activity).to eq(programme.child_activities.last)
+
+        # our new direct association between activity and report
+        expect(created_activity.originating_report).to eq(report)
+        expect(report.new_activities).to eq([created_activity])
+
+        expect(created_activity.organisation).to eq(user.organisation)
+        expect(created_activity.is_oda).to eq(activity.is_oda)
+        expect(created_activity.title).to eq(activity.title)
+        expect(created_activity.description).to eq(activity.description)
+        expect(created_activity.objectives).to eq(activity.objectives)
+        expect(created_activity.sector_category).to eq(activity.sector_category)
+        expect(created_activity.sector).to eq(activity.sector)
+        expect(created_activity.programme_status).to eq(activity.programme_status)
+        expect(created_activity.planned_start_date).to eq(activity.planned_start_date)
+        expect(created_activity.planned_end_date).to eq(activity.planned_end_date)
+        expect(created_activity.actual_start_date).to eq(activity.actual_start_date)
+        expect(created_activity.actual_end_date).to eq(activity.actual_end_date)
+        expect(created_activity.ispf_partner_countries).to match_array(activity.ispf_partner_countries)
+        expect(created_activity.benefitting_countries).to match_array(activity.benefitting_countries)
+        expect(created_activity.gdi).to eq(activity.gdi)
+        expect(created_activity.aid_type).to eq(activity.aid_type)
+        expect(created_activity.collaboration_type).to eq(activity.collaboration_type)
+        expect(created_activity.sdgs_apply).to eq(activity.sdgs_apply)
+        expect(created_activity.sdg_1).to eq(activity.sdg_1)
+        expect(created_activity.ispf_theme).to eq(activity.ispf_theme)
+        expect(created_activity.policy_marker_gender).to eq(activity.policy_marker_gender)
+        expect(created_activity.policy_marker_climate_change_adaptation).to eq(activity.policy_marker_climate_change_adaptation)
+        expect(created_activity.policy_marker_climate_change_mitigation).to eq(activity.policy_marker_climate_change_mitigation)
+        expect(created_activity.policy_marker_biodiversity).to eq(activity.policy_marker_biodiversity)
+        expect(created_activity.policy_marker_desertification).to eq(activity.policy_marker_desertification)
+        expect(created_activity.policy_marker_disability).to eq(activity.policy_marker_disability)
+        expect(created_activity.policy_marker_disaster_risk_reduction).to eq(activity.policy_marker_disaster_risk_reduction)
+        expect(created_activity.policy_marker_nutrition).to eq(activity.policy_marker_nutrition)
+        expect(created_activity.covid19_related).to eq(activity.covid19_related)
+        expect(created_activity.channel_of_delivery_code).to eq(activity.channel_of_delivery_code)
+        expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
+        expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
+        expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
+        expect(created_activity.implementing_organisations).to be_none
+      end
+
+      scenario "a new project can be added to an ISPF non-ODA programme" do
+        programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation, is_oda: false)
+        report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
+        activity = build(:project_activity,
+          parent: programme,
+          is_oda: false,
+          ispf_partner_countries: ["IN"],
+          benefitting_countries: ["AG", "HT"],
+          sdgs_apply: true,
+          sdg_1: 5,
+          ispf_theme: 1)
+
+        visit activities_path
+        click_on programme.title
+        click_on t("tabs.activity.children")
+        click_on t("action.activity.add_child")
+
+        form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
+        form.complete!(is_oda: false)
+
+        expect(page).to have_content t("action.project.create.success")
+        expect(programme.child_activities.count).to eq 1
+
+        created_activity = form.created_activity
+
+        expect(created_activity).to eq(programme.child_activities.last)
+
+        # our new direct association between activity and report
+        expect(created_activity.originating_report).to eq(report)
+        expect(report.new_activities).to eq([created_activity])
+
+        expect(created_activity.organisation).to eq(user.organisation)
+        expect(created_activity.is_oda).to eq(activity.is_oda)
+        expect(created_activity.title).to eq(activity.title)
+        expect(created_activity.description).to eq(activity.description)
+        expect(created_activity.sector_category).to eq(activity.sector_category)
+        expect(created_activity.sector).to eq(activity.sector)
+        expect(created_activity.programme_status).to eq(activity.programme_status)
+        expect(created_activity.planned_start_date).to eq(activity.planned_start_date)
+        expect(created_activity.planned_end_date).to eq(activity.planned_end_date)
+        expect(created_activity.actual_start_date).to eq(activity.actual_start_date)
+        expect(created_activity.actual_end_date).to eq(activity.actual_end_date)
+        expect(created_activity.ispf_partner_countries).to match_array(activity.ispf_partner_countries)
+        expect(created_activity.ispf_theme).to eq(activity.ispf_theme)
+        expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
+        expect(created_activity.implementing_organisations).to be_none
+      end
+
       scenario "can create a new child activity for a given programme" do
         gcrf = create(:fund_activity, :gcrf)
         programme = create(:programme_activity, parent: gcrf, extending_organisation: user.organisation)

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -78,6 +78,133 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
       end
 
+      scenario "a new third party project can be added to an ISPF ODA project" do
+        programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation)
+
+        project = create(:project_activity, :ispf_funded,
+          organisation: user.organisation,
+          extending_organisation: user.organisation,
+          parent: programme,
+          is_oda: true)
+
+        _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
+
+        activity = build(:third_party_project_activity,
+          parent: project,
+          is_oda: true,
+          ispf_partner_countries: ["IN"],
+          benefitting_countries: ["AG", "HT"],
+          sdgs_apply: true,
+          sdg_1: 5,
+          ispf_theme: 1)
+
+        visit activities_path
+
+        click_on(project.title)
+        click_on t("tabs.activity.children")
+
+        click_on(t("action.activity.add_child"))
+
+        form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
+        form.complete!(is_oda: true)
+
+        expect(page).to have_content t("action.third_party_project.create.success")
+        expect(project.child_activities.count).to eq 1
+
+        created_activity = form.created_activity
+
+        expect(created_activity).to eq(project.child_activities.last)
+
+        expect(created_activity.organisation).to eq(user.organisation)
+        expect(created_activity.is_oda).to eq(activity.is_oda)
+        expect(created_activity.title).to eq(activity.title)
+        expect(created_activity.description).to eq(activity.description)
+        expect(created_activity.objectives).to eq(activity.objectives)
+        expect(created_activity.sector_category).to eq(activity.sector_category)
+        expect(created_activity.sector).to eq(activity.sector)
+        expect(created_activity.programme_status).to eq(activity.programme_status)
+        expect(created_activity.planned_start_date).to eq(activity.planned_start_date)
+        expect(created_activity.planned_end_date).to eq(activity.planned_end_date)
+        expect(created_activity.actual_start_date).to eq(activity.actual_start_date)
+        expect(created_activity.actual_end_date).to eq(activity.actual_end_date)
+        expect(created_activity.ispf_partner_countries).to match_array(activity.ispf_partner_countries)
+        expect(created_activity.benefitting_countries).to match_array(activity.benefitting_countries)
+        expect(created_activity.gdi).to eq(activity.gdi)
+        expect(created_activity.aid_type).to eq(activity.aid_type)
+        expect(created_activity.collaboration_type).to eq(activity.collaboration_type)
+        expect(created_activity.sdgs_apply).to eq(activity.sdgs_apply)
+        expect(created_activity.sdg_1).to eq(activity.sdg_1)
+        expect(created_activity.ispf_theme).to eq(activity.ispf_theme)
+        expect(created_activity.policy_marker_gender).to eq(activity.policy_marker_gender)
+        expect(created_activity.policy_marker_climate_change_adaptation).to eq(activity.policy_marker_climate_change_adaptation)
+        expect(created_activity.policy_marker_climate_change_mitigation).to eq(activity.policy_marker_climate_change_mitigation)
+        expect(created_activity.policy_marker_biodiversity).to eq(activity.policy_marker_biodiversity)
+        expect(created_activity.policy_marker_desertification).to eq(activity.policy_marker_desertification)
+        expect(created_activity.policy_marker_disability).to eq(activity.policy_marker_disability)
+        expect(created_activity.policy_marker_disaster_risk_reduction).to eq(activity.policy_marker_disaster_risk_reduction)
+        expect(created_activity.policy_marker_nutrition).to eq(activity.policy_marker_nutrition)
+        expect(created_activity.covid19_related).to eq(activity.covid19_related)
+        expect(created_activity.channel_of_delivery_code).to eq(activity.channel_of_delivery_code)
+        expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
+        expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
+        expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
+        expect(created_activity.implementing_organisations).to be_none
+      end
+
+      scenario "a new third party project can be added to an ISPF non-ODA project" do
+        programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation, is_oda: false)
+
+        project = create(:project_activity, :ispf_funded,
+          organisation: user.organisation,
+          extending_organisation: user.organisation,
+          parent: programme,
+          is_oda: false)
+
+        _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
+
+        activity = build(:third_party_project_activity,
+          parent: project,
+          is_oda: false,
+          ispf_partner_countries: ["IN"],
+          benefitting_countries: ["AG", "HT"],
+          sdgs_apply: true,
+          sdg_1: 5,
+          ispf_theme: 1)
+
+        visit activities_path
+
+        click_on(project.title)
+        click_on t("tabs.activity.children")
+
+        click_on(t("action.activity.add_child"))
+
+        form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
+        form.complete!(is_oda: false)
+
+        expect(page).to have_content t("action.third_party_project.create.success")
+        expect(project.child_activities.count).to eq 1
+
+        created_activity = form.created_activity
+
+        expect(created_activity).to eq(project.child_activities.last)
+
+        expect(created_activity.organisation).to eq(user.organisation)
+        expect(created_activity.is_oda).to eq(activity.is_oda)
+        expect(created_activity.title).to eq(activity.title)
+        expect(created_activity.description).to eq(activity.description)
+        expect(created_activity.sector_category).to eq(activity.sector_category)
+        expect(created_activity.sector).to eq(activity.sector)
+        expect(created_activity.programme_status).to eq(activity.programme_status)
+        expect(created_activity.planned_start_date).to eq(activity.planned_start_date)
+        expect(created_activity.planned_end_date).to eq(activity.planned_end_date)
+        expect(created_activity.actual_start_date).to eq(activity.actual_start_date)
+        expect(created_activity.actual_end_date).to eq(activity.actual_end_date)
+        expect(created_activity.ispf_partner_countries).to match_array(activity.ispf_partner_countries)
+        expect(created_activity.ispf_theme).to eq(activity.ispf_theme)
+        expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
+        expect(created_activity.implementing_organisations).to be_none
+      end
+
       context "without an editable report" do
         scenario "a new third party project cannot be added" do
           programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1813,4 +1813,212 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  %w[requires_objectives? requires_gdi? requires_collaboration_type?].each do |method|
+    describe "##{method}" do
+      context "when activity is a fund" do
+        let(:activity) { build(:fund_activity) }
+
+        it "returns false" do
+          expect(activity.send(method.to_sym)).to eq(false)
+        end
+      end
+
+      context "when activity is a programme" do
+        let(:activity) { build(:programme_activity) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+
+      ["project", "third-party project"].each do |level|
+        context "when activity is a #{level}" do
+          let(:factory_name) { factory_name_by_activity_level(level) }
+
+          context "when is_oda is nil" do
+            let(:activity) { build(factory_name, :newton_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is true" do
+            let(:activity) { build(factory_name, :ispf_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is false" do
+            let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
+
+            it "returns false" do
+              expect(activity.send(method.to_sym)).to eq(false)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  %w[
+    requires_benefitting_countries?
+    requires_aid_type?
+    requires_covid19_related?
+    requires_oda_eligibility?
+    requires_fstc_applies?
+  ].each do |method|
+    describe "##{method}" do
+      context "when activity is a fund" do
+        let(:activity) { build(:fund_activity) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+
+      context "when activity is a programme" do
+        let(:activity) { build(:programme_activity) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+
+      ["project", "third-party project"].each do |level|
+        context "when activity is a #{level}" do
+          let(:factory_name) { factory_name_by_activity_level(level) }
+
+          context "when is_oda is nil" do
+            let(:activity) { build(factory_name, :newton_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is true" do
+            let(:activity) { build(factory_name, :ispf_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is false" do
+            let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
+
+            it "returns false" do
+              expect(activity.send(method.to_sym)).to eq(false)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  %w[requires_oda_eligibility_lead? requires_channel_of_delivery_code? requires_policy_markers?].each do |method|
+    describe "##{method}" do
+      context "when activity is a fund" do
+        let(:activity) { build(:fund_activity) }
+
+        it "returns false" do
+          expect(activity.send(method.to_sym)).to eq(false)
+        end
+      end
+
+      context "when activity is a programme" do
+        let(:activity) { build(:programme_activity) }
+
+        it "returns false" do
+          expect(activity.send(method.to_sym)).to eq(false)
+        end
+      end
+
+      ["project", "third-party project"].each do |level|
+        context "when activity is a #{level}" do
+          let(:factory_name) { factory_name_by_activity_level(level) }
+
+          context "when is_oda is nil" do
+            let(:activity) { build(factory_name, :newton_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is true" do
+            let(:activity) { build(factory_name, :ispf_funded) }
+
+            it "returns true" do
+              expect(activity.send(method.to_sym)).to eq(true)
+            end
+          end
+
+          context "when is_oda is false" do
+            let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
+
+            it "returns false" do
+              expect(activity.send(method.to_sym)).to eq(false)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#is_non_oda_project?" do
+    context "when activity is a fund" do
+      let(:activity) { build(:fund_activity) }
+
+      it "returns false" do
+        expect(activity.send(:is_non_oda_project?)).to eq(false)
+      end
+    end
+
+    context "when activity is a programme" do
+      let(:activity) { build(:programme_activity) }
+
+      it "returns false" do
+        expect(activity.send(:is_non_oda_project?)).to eq(false)
+      end
+    end
+
+    ["project", "third-party project"].each do |level|
+      context "when activity is a #{level}" do
+        let(:factory_name) { factory_name_by_activity_level(level) }
+
+        context "when is_oda is nil" do
+          let(:activity) { build(factory_name, :newton_funded) }
+
+          it "returns false" do
+            expect(activity.send(:is_non_oda_project?)).to eq(false)
+          end
+        end
+
+        context "when is_oda is true" do
+          let(:activity) { build(factory_name, :ispf_funded) }
+
+          it "returns false" do
+            expect(activity.send(:is_non_oda_project?)).to eq(false)
+          end
+        end
+
+        context "when is_oda is false" do
+          let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
+
+          it "returns true" do
+            expect(activity.send(:is_non_oda_project?)).to eq(true)
+          end
+        end
+      end
+    end
+  end
+
+  def factory_name_by_activity_level(level)
+    (level.underscore.parameterize(separator: "_") + "_activity").to_sym
+  end
 end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -150,6 +150,39 @@ class ActivityForm
     fill_in_oda_eligibility
   end
 
+  def fill_in_ispf_project_activity_form(is_oda:)
+    fill_in_identifier_step
+    fill_in_purpose_step
+    fill_in_objectives_step if is_oda
+    fill_in_sector_category_step
+    fill_in_sector_step
+    fill_in_call_details
+    fill_in_call_applications
+    fill_in_programme_status
+    fill_in_dates
+    fill_in_ispf_partner_countries
+
+    if is_oda
+      fill_in_benefitting_countries
+      fill_in_gdi
+      fill_in_aid_type
+      fill_in_collaboration_type
+      fill_in_sdgs_apply
+    end
+
+    fill_in_ispf_theme
+
+    if is_oda
+      fill_in_policy_markers
+      fill_in_covid19_related
+      fill_in_channel_of_delivery_code
+      fill_in_oda_eligibility
+      fill_in_oda_eligibility_lead
+    end
+
+    fill_in_named_contact
+  end
+
   def fill_in_is_oda_step(is_oda)
     expect(page).to have_content I18n.t("form.legend.activity.is_oda")
     find("input[value='#{is_oda}']", visible: :all).click


### PR DESCRIPTION
## Changes in this PR

- Adds Level C/D non-ODA ISPF form journey
- Adds feature tests covering both ODA and non-ODA ISPF Level C/D UI user journeys
- Adds unit tests for the public methods added to `Activity` - coverage here is still not incomplete, though

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
