### PR TITLE
(2456) Require implementing org for ISPF level D activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1139,6 +1139,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Allow programmes to be redacted from IATI
 - Set default values for currency and transaction type on Actual Transactions, output in IATI XML
 - Remove reference to "ODA activities" in activity status descriptions
+- Require ISPF third-party projects (level D) to have at least one implementing organisation set through the new activity journey
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -67,6 +67,9 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.requires_oda_eligibility_lead?
     when :uk_po_named_contact
       skip_step unless @activity.is_project?
+    when :implementing_organisation
+      skip_step unless @activity.requires_implementing_organisation?
+      @implementing_organisations = Organisation.active.sorted_by_name
     end
 
     render_wizard
@@ -80,8 +83,15 @@ class ActivityFormsController < BaseController
     updater = Activity::Updater.new(activity: @activity, params: params)
     updater.update(step)
 
-    if step == :dates && @activity.errors.present?
-      render_step :dates
+    if @activity.errors.present?
+      case step
+      when :dates
+        render_step :dates
+      when :implementing_organisation
+        @implementing_organisations = Organisation.active.sorted_by_name
+        render_step :implementing_organisation
+      end
+
       return
     end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -38,7 +38,8 @@ class Activity < ApplicationRecord
     :channel_of_delivery_code,
     :oda_eligibility,
     :oda_eligibility_lead,
-    :uk_po_named_contact
+    :uk_po_named_contact,
+    :implementing_organisation
   ]
 
   VALIDATION_STEPS = [
@@ -69,7 +70,8 @@ class Activity < ApplicationRecord
     :channel_of_delivery_code_step,
     :oda_eligibility_step,
     :oda_eligibility_lead_step,
-    :uk_po_named_contact_step
+    :uk_po_named_contact_step,
+    :implementing_organisation_step
   ]
 
   FORM_STATE_VALIDATION_LIST = FORM_STEPS.map(&:to_s).push("complete")
@@ -77,6 +79,8 @@ class Activity < ApplicationRecord
   before_validation :strip_control_characters_from_fields!
 
   strip_attributes only: [:partner_organisation_identifier]
+
+  attr_reader :implementing_organisation_id
 
   validates :level, presence: true
   validates :parent, absence: true, if: proc { |activity| activity.fund? }
@@ -579,6 +583,10 @@ class Activity < ApplicationRecord
 
   def requires_country_partner_organisations?
     is_newton_funded? && programme?
+  end
+
+  def requires_implementing_organisation?
+    third_party_project? && is_ispf_funded? && !has_implementing_organisations?
   end
 
   def iati_status

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -118,6 +118,19 @@ class Activity
       end
     end
 
+    def set_implementing_organisation
+      implementing_organisation = Organisation.find(params_for(:implementing_organisation_id))
+      org_participation = OrgParticipation.find_or_initialize_by(
+        activity: activity,
+        organisation: implementing_organisation
+      )
+      return if org_participation.persisted?
+
+      unless org_participation.save
+        activity.errors.add(:implementing_organisation_id, org_participation.errors.full_messages.first)
+      end
+    end
+
     def assign_attributes_for_step(step)
       activity.assign_attributes({step => params_for(step)})
     end

--- a/app/views/activity_forms/implementing_organisation.html.haml
+++ b/app/views/activity_forms/implementing_organisation.html.haml
@@ -1,0 +1,10 @@
+= render layout: "wrapper" do |f|
+  %h1.govuk-heading-xl= @page_title
+
+  = f.govuk_error_summary
+  = f.govuk_collection_select :implementing_organisation_id,
+    @implementing_organisations,
+    :id,
+    :name,
+    label: { text: t("form.label.implementing_organisation"), tag: :p, size: 'm' },
+    hint: { text: t("form.guidance_html", link: support_email_link).html_safe }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -393,6 +393,7 @@ en:
         gdi: GDI
         geography: Will the benefitting recipient be a region or country?
         identifier: Enter your unique identifier
+        implementing_organisation: Select an implementing organisation
         intended_beneficiaries: What are the intended beneficiaries?
         is_oda: Is this activity ODA or Non-ODA?
         ispf_theme: ISPF theme

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -156,6 +156,36 @@ RSpec.describe ActivityFormsController do
           it { is_expected.to skip_to_next_step }
         end
       end
+
+      context "implementing_organisation step" do
+        subject { get_step :implementing_organisation }
+
+        context "when the activity is GCRF funded" do
+          let(:activity) { create(:third_party_project_activity, :gcrf_funded, organisation: organisation) }
+
+          it "completes the activity without rendering the step" do
+            expect(activity.form_state).to eq("complete")
+          end
+        end
+
+        context "when the project is ISPF funded" do
+          let(:activity) { create(:third_party_project_activity, :ispf_funded, organisation: organisation) }
+
+          context "and doesn't have any implementing organisations set" do
+            before do
+              activity.implementing_organisations = []
+            end
+
+            it { is_expected.to render_current_step }
+          end
+
+          context "and it already has at least one implementing organisation set" do
+            it "completes the activity without rendering the step" do
+              expect(activity.form_state).to eq("complete")
+            end
+          end
+        end
+      end
     end
 
     context "when editing a third-party project" do

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -231,7 +231,7 @@ FactoryBot.define do
       trait :ispf_funded do
         source_fund_code { Fund.by_short_name("ISPF").id }
         is_oda { true }
-        parent factory: [:programme_activity, :ispf_funded]
+        parent factory: [:project_activity, :ispf_funded]
       end
 
       after(:create) do |project, _evaluator|

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "Users can create a project" do
-  context "when they are a delivery parther" do
+  context "when they are a delivery partner" do
     let(:user) { create(:partner_organisation_user) }
     before { authenticate!(user: user) }
     after { logout }

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -89,6 +89,8 @@ RSpec.feature "Users can create a third-party project" do
 
         _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
 
+        implementing_organisation = create(:implementing_organisation)
+
         activity = build(:third_party_project_activity,
           parent: project,
           is_oda: true,
@@ -96,7 +98,8 @@ RSpec.feature "Users can create a third-party project" do
           benefitting_countries: ["AG", "HT"],
           sdgs_apply: true,
           sdg_1: 5,
-          ispf_theme: 1)
+          ispf_theme: 1,
+          implementing_organisations: [implementing_organisation])
 
         visit activities_path
 
@@ -148,7 +151,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
         expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
-        expect(created_activity.implementing_organisations).to be_none
+        expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
       end
 
       scenario "a new third party project can be added to an ISPF non-ODA project" do
@@ -162,6 +165,8 @@ RSpec.feature "Users can create a third-party project" do
 
         _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
 
+        implementing_organisation = create(:implementing_organisation)
+
         activity = build(:third_party_project_activity,
           parent: project,
           is_oda: false,
@@ -169,7 +174,8 @@ RSpec.feature "Users can create a third-party project" do
           benefitting_countries: ["AG", "HT"],
           sdgs_apply: true,
           sdg_1: 5,
-          ispf_theme: 1)
+          ispf_theme: 1,
+          implementing_organisations: [implementing_organisation])
 
         visit activities_path
 
@@ -202,7 +208,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.ispf_partner_countries).to match_array(activity.ispf_partner_countries)
         expect(created_activity.ispf_theme).to eq(activity.ispf_theme)
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
-        expect(created_activity.implementing_organisations).to be_none
+        expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
       end
 
       context "without an editable report" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -863,7 +863,7 @@ RSpec.describe Activity, type: :model do
     expect(activity.has_extending_organisation?).to be false
   end
 
-  describe "#has_implementing_organisation?" do
+  describe "#has_implementing_organisations?" do
     it "returns true when there is one or more implementing organisations" do
       activity = create(:project_activity_with_implementing_organisations)
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -179,6 +179,7 @@ class ActivityForm
     end
 
     fill_in_named_contact
+    fill_in_implementing_organisation if @activity.third_party_project?
   end
 
   def fill_in_is_oda_step
@@ -434,6 +435,12 @@ class ActivityForm
     expect(page).to have_content I18n.t("form.label.activity.oda_eligibility_lead")
     expect(page).to have_content I18n.t("form.hint.activity.oda_eligibility_lead")
     fill_in "activity[oda_eligibility_lead]", with: activity.oda_eligibility_lead
+    click_button I18n.t("form.button.activity.submit")
+  end
+
+  def fill_in_implementing_organisation
+    expect(page).to have_content I18n.t("page_title.activity_form.show.implementing_organisation")
+    select(activity.implementing_organisations.first.name, from: I18n.t("form.label.implementing_organisation"))
     click_button I18n.t("form.button.activity.submit")
   end
 


### PR DESCRIPTION
## Changes in this PR
- Require ISPF third-party projects (level D) to have at least one implementing organisation set through the new activity journey

## Screenshots of UI changes

### After
![Screenshot 2022-11-02 at 18 32 51](https://user-images.githubusercontent.com/579522/199573263-52034e42-98f4-4d7c-a980-fe1023dcd61b.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
