### PR TITLE
(2694) Do not allow removing the last implementing org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1132,6 +1132,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add ISPF theme form step
 - Add ISPF partner countries form step
 - Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
+- Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/controllers/implementing_organisations_controller.rb
+++ b/app/controllers/implementing_organisations_controller.rb
@@ -1,14 +1,15 @@
 class ImplementingOrganisationsController < BaseController
   def new
     @activity = Activity.find(params[:activity_id])
-    authorize @activity
+    authorize @activity, :edit?
+
     @implementing_organisations = Organisation.active.sorted_by_name
     @implementing_organisation = Organisation.new
   end
 
   def create
     @activity = Activity.find(params[:activity_id])
-    authorize @activity
+    authorize @activity, :edit?
 
     org_participation = associate_implementing_organisation
 

--- a/app/views/activities/details.html.haml
+++ b/app/views/activities/details.html.haml
@@ -28,4 +28,4 @@
           = render partial: "shared/activities/activity", locals: { activity_presenter: @activity }
 
           - if @activity.project? || @activity.third_party_project?
-            = render partial: "shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisation_presenters: @implementing_organisation_presenters }
+            = render partial: "shared/activities/implementing_organisations", locals: { activity: @activity, implementing_organisations: @implementing_organisation_presenters }

--- a/app/views/shared/activities/_implementing_organisations.html.haml
+++ b/app/views/shared/activities/_implementing_organisations.html.haml
@@ -6,5 +6,5 @@
     - if policy(activity).edit?
       = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(activity), class: "govuk-button")
 
-    - if activity.implementing_organisations.present?
-      = render partial: "shared/implementing_organisations/table", locals: { activity: activity, implementing_organisations: @implementing_organisation_presenters }
+    - if implementing_organisations.present?
+      = render partial: "shared/implementing_organisations/table", locals: { activity: activity, implementing_organisations: implementing_organisations }

--- a/app/views/shared/activities/_implementing_organisations.html.haml
+++ b/app/views/shared/activities/_implementing_organisations.html.haml
@@ -3,8 +3,8 @@
     %h2.govuk-heading-m
       = t("page_content.activity.implementing_organisation.heading")
 
-    - if policy(@activity).edit?
-      = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(@activity), class: "govuk-button")
+    - if policy(activity).edit?
+      = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(activity), class: "govuk-button")
 
-    - if @activity.implementing_organisations.present?
-      = render partial: "shared/implementing_organisations/table", locals: { implementing_organisations: @implementing_organisation_presenters }
+    - if activity.implementing_organisations.present?
+      = render partial: "shared/implementing_organisations/table", locals: { activity: activity, implementing_organisations: @implementing_organisation_presenters }

--- a/app/views/shared/activities/_implementing_organisations.html.haml
+++ b/app/views/shared/activities/_implementing_organisations.html.haml
@@ -3,9 +3,8 @@
     %h2.govuk-heading-m
       = t("page_content.activity.implementing_organisation.heading")
 
-    - if policy(:project).create?
+    - if policy(@activity).edit?
       = link_to(t("page_content.activity.implementing_organisation.button.new"), new_activity_implementing_organisation_path(@activity), class: "govuk-button")
 
     - if @activity.implementing_organisations.present?
       = render partial: "shared/implementing_organisations/table", locals: { implementing_organisations: @implementing_organisation_presenters }
-

--- a/app/views/shared/implementing_organisations/_table.html.haml
+++ b/app/views/shared/implementing_organisations/_table.html.haml
@@ -19,10 +19,13 @@
         %td.govuk-table__cell= organisation.iati_reference
         %td.govuk-table__cell
           - if policy(activity).edit?
-            = form_with(scope: :implementing_organisation, model: organisation, url: activity_implementing_organisation_path(activity, organisation), method: :delete) do |f|
-              = f.hidden_field :organisation_id, value: organisation.id
-              %button.govuk-button.govuk-button--secondary{ name: "delete" }
-                = t("action.implementing_organisation.delete.button")
+            - if !activity.is_ispf_funded? || implementing_organisations.size > 1
+              = form_with(scope: :implementing_organisation, model: organisation, url: activity_implementing_organisation_path(activity, organisation), method: :delete) do |f|
+                = f.hidden_field :organisation_id, value: organisation.id
+                %button.govuk-button.govuk-button--secondary{ name: "delete" }
+                  = t("action.implementing_organisation.delete.button")
+            - else
+              = "You cannot remove the last implementing organisation. Please add another implementing organisation before removing this one."
           - else
             %span.govuk-visually-hidden
               = t("table.cell.default.no_actions_available")

--- a/app/views/shared/implementing_organisations/_table.html.haml
+++ b/app/views/shared/implementing_organisations/_table.html.haml
@@ -18,8 +18,8 @@
         %td.govuk-table__cell= organisation.organisation_type
         %td.govuk-table__cell= organisation.iati_reference
         %td.govuk-table__cell
-          - if policy(@activity).edit?
-            = form_with(scope: :implementing_organisation, model: organisation, url: activity_implementing_organisation_path(@activity, organisation), method: :delete) do |f|
+          - if policy(activity).edit?
+            = form_with(scope: :implementing_organisation, model: organisation, url: activity_implementing_organisation_path(activity, organisation), method: :delete) do |f|
               = f.hidden_field :organisation_id, value: organisation.id
               %button.govuk-button.govuk-button--secondary{ name: "delete" }
                 = t("action.implementing_organisation.delete.button")

--- a/app/views/shared/implementing_organisations/_table.html.haml
+++ b/app/views/shared/implementing_organisations/_table.html.haml
@@ -18,7 +18,7 @@
         %td.govuk-table__cell= organisation.organisation_type
         %td.govuk-table__cell= organisation.iati_reference
         %td.govuk-table__cell
-          - if policy(:project).edit?
+          - if policy(@activity).edit?
             = form_with(scope: :implementing_organisation, model: organisation, url: activity_implementing_organisation_path(@activity, organisation), method: :delete) do |f|
               = f.hidden_field :organisation_id, value: organisation.id
               %button.govuk-button.govuk-button--secondary{ name: "delete" }

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -187,6 +187,11 @@ FactoryBot.define do
         source_fund_code { Fund.by_short_name("GCRF").id }
         parent factory: [:programme_activity, :gcrf_funded]
       end
+
+      trait :ispf_funded do
+        source_fund_code { Fund.by_short_name("ISPF").id }
+        parent factory: [:programme_activity, :ispf_funded]
+      end
     end
 
     factory :third_party_project_activity do

--- a/spec/features/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/users_can_manage_implementing_organisations_spec.rb
@@ -108,6 +108,30 @@ RSpec.feature "Users can manage the implementing organisations" do
       when_i_delete_the_second_implementing_org
       then_i_see_only_the_first_org_associated_with_the_project
     end
+
+    context "when the activity is ISPF" do
+      let(:project) { create(:project_activity, :ispf_funded, organisation: partner_organisation) }
+      let!(:report) { create(:report, :active, organisation: partner_organisation, fund: project.associated_fund) }
+
+      scenario "they cannot remove the last implementing organisation" do
+        def given_the_project_has_one_implementing_org
+          project.implementing_organisations = [implementing_org]
+        end
+
+        def when_i_go_to_the_details_page
+          visit organisation_activity_details_path(project.organisation, project)
+        end
+
+        def then_i_cannot_remove_the_implementing_org
+          expect(page).to_not have_button("Remove")
+          expect(page).to have_content("You cannot remove the last implementing organisation")
+        end
+
+        given_the_project_has_one_implementing_org
+        when_i_go_to_the_details_page
+        then_i_cannot_remove_the_implementing_org
+      end
+    end
   end
 
   context "when they are signed in as a BEIS user" do

--- a/spec/features/users_can_view_an_activitys_details_spec.rb
+++ b/spec/features/users_can_view_an_activitys_details_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view an activity's details" do
         expect(page).to have_content "Details"
       end
       expect(page).to have_content activity.title
-      expect(page).to have_link t("page_content.activity.implementing_organisation.button.new")
+      expect(page).to have_content t("page_content.activity.implementing_organisation.heading")
     end
 
     scenario "activities have human readable date format" do


### PR DESCRIPTION
## Changes in this PR
- Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one

## Screenshots of UI changes

### Before
![Screenshot 2022-11-03 at 17 30 53](https://user-images.githubusercontent.com/579522/199793127-7658d365-be57-490e-8e7a-6ae59bc615a6.png)

### After
![Screenshot 2022-11-03 at 17 29 45](https://user-images.githubusercontent.com/579522/199792996-bd55fc8e-ca92-415e-8cb9-e9920b8bcf8e.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
