### PR TITLE
(2692) Update UI user journey for adding Level B ISPF non-ODA activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1134,7 +1134,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
 - Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one
 - Add ISPF Level C/D UI user journeys for adding activities
-- Remove collaboration type and FSTC applies from UI user journeys for adding Level B ISPF activities
+- Remove collaboration type, COVID-19-related and FSTC applies from UI user journeys for adding Level B ISPF activities
+- Remove non-ODA steps from new ISPF Level B non-ODA activity form
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -44,7 +44,7 @@ class ActivityFormsController < BaseController
       skip_step unless Activity::Inference.service.editable?(@activity, :collaboration_type)
       assign_default_collaboration_type_value_if_nil
     when :sustainable_development_goals
-      skip_step if @activity.fund? || @activity.is_non_oda_project?
+      skip_step if @activity.fund? || @activity.is_non_oda?
     when :ispf_theme
       skip_step unless @activity.is_ispf_funded?
     when :fund_pillar

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -492,7 +492,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_objectives?
-    !fund? && !is_non_oda_project?
+    !fund? && !is_non_oda?
   end
 
   def requires_call_dates?
@@ -500,23 +500,26 @@ class Activity < ApplicationRecord
   end
 
   def requires_benefitting_countries?
-    !is_non_oda_project?
+    !is_non_oda?
   end
 
   def requires_gdi?
-    !fund? && !is_non_oda_project?
+    !fund? && !is_non_oda?
   end
 
   def requires_aid_type?
-    !is_non_oda_project?
+    !is_non_oda?
   end
 
   def requires_covid19_related?
-    !is_non_oda_project?
+    [
+      programme? && is_ispf_funded?,
+      is_non_oda_project?
+    ].none?
   end
 
   def requires_oda_eligibility?
-    !is_non_oda_project?
+    !is_non_oda?
   end
 
   def requires_oda_eligibility_lead?
@@ -566,8 +569,8 @@ class Activity < ApplicationRecord
     !fund? && source_fund.present? && source_fund.ispf?
   end
 
-  def is_non_oda_project?
-    is_project? && is_non_oda?
+  def is_non_oda?
+    is_oda == false
   end
 
   def requires_is_oda?
@@ -629,7 +632,7 @@ class Activity < ApplicationRecord
     end
   end
 
-  def is_non_oda?
-    is_oda == false
+  def is_non_oda_project?
+    is_project? && is_non_oda?
   end
 end

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -187,8 +187,6 @@ RSpec.feature "BEIS users can create a programme level activity" do
         parent: create(:fund_activity, :ispf),
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
-        sdgs_apply: true,
-        sdg_1: 5,
         is_oda: false,
         ispf_theme: 1,
         ispf_partner_countries: ["IN"])
@@ -224,7 +222,6 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_theme).to eq(oda_activity.ispf_theme)
       expect(created_activity.sdgs_apply).to eq(oda_activity.sdgs_apply)
       expect(created_activity.sdg_1).to eq(oda_activity.sdg_1)
-      expect(created_activity.covid19_related).to eq(oda_activity.covid19_related)
       expect(created_activity.oda_eligibility).to eq(oda_activity.oda_eligibility)
     end
 
@@ -243,7 +240,6 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.title).to eq(non_oda_activity.title)
       expect(created_activity.is_oda).to eq(non_oda_activity.is_oda)
       expect(created_activity.description).to eq(non_oda_activity.description)
-      expect(created_activity.objectives).to eq(non_oda_activity.objectives)
       expect(created_activity.sector_category).to eq(non_oda_activity.sector_category)
       expect(created_activity.sector).to eq(non_oda_activity.sector)
       expect(created_activity.programme_status).to eq(non_oda_activity.programme_status)
@@ -252,14 +248,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.actual_start_date).to eq(non_oda_activity.actual_start_date)
       expect(created_activity.actual_end_date).to eq(non_oda_activity.actual_end_date)
       expect(created_activity.ispf_partner_countries).to match_array(oda_activity.ispf_partner_countries)
-      expect(created_activity.benefitting_countries).to match_array(non_oda_activity.benefitting_countries)
-      expect(created_activity.gdi).to eq(non_oda_activity.gdi)
-      expect(created_activity.aid_type).to eq(non_oda_activity.aid_type)
       expect(created_activity.ispf_theme).to eq(non_oda_activity.ispf_theme)
-      expect(created_activity.sdgs_apply).to eq(non_oda_activity.sdgs_apply)
-      expect(created_activity.sdg_1).to eq(non_oda_activity.sdg_1)
-      expect(created_activity.covid19_related).to eq(non_oda_activity.covid19_related)
-      expect(created_activity.oda_eligibility).to eq(non_oda_activity.oda_eligibility)
     end
 
     context "and the feature flag hiding ISPF is enabled for BEIS users" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1825,10 +1825,28 @@ RSpec.describe Activity, type: :model do
       end
 
       context "when activity is a programme" do
-        let(:activity) { build(:programme_activity) }
+        context "when is_oda is nil" do
+          let(:activity) { build(:programme_activity, :newton_funded) }
 
-        it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is true" do
+          let(:activity) { build(:programme_activity, :ispf_funded) }
+
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is false" do
+          let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
+
+          it "returns false" do
+            expect(activity.send(method.to_sym)).to eq(false)
+          end
         end
       end
 
@@ -1867,7 +1885,6 @@ RSpec.describe Activity, type: :model do
   %w[
     requires_benefitting_countries?
     requires_aid_type?
-    requires_covid19_related?
     requires_oda_eligibility?
   ].each do |method|
     describe "##{method}" do
@@ -1880,10 +1897,28 @@ RSpec.describe Activity, type: :model do
       end
 
       context "when activity is a programme" do
-        let(:activity) { build(:programme_activity) }
+        context "when is_oda is nil" do
+          let(:activity) { build(:programme_activity, :newton_funded) }
 
-        it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is true" do
+          let(:activity) { build(:programme_activity, :ispf_funded) }
+
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is false" do
+          let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
+
+          it "returns false" do
+            expect(activity.send(method.to_sym)).to eq(false)
+          end
         end
       end
 
@@ -1969,6 +2004,74 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  %w[requires_covid19_related? requires_fstc_applies?].each do |method|
+    describe "##{method}" do
+      context "when activity is a fund" do
+        let(:activity) { build(:fund_activity) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+    end
+
+    context "when activity is a programme" do
+      context "when Newton-funded" do
+        let(:activity) { build(:programme_activity, :newton_funded) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+
+      context "when GCRF-funded" do
+        let(:activity) { build(:programme_activity, :gcrf_funded) }
+
+        it "returns true" do
+          expect(activity.send(method.to_sym)).to eq(true)
+        end
+      end
+
+      context "when ISPF-funded" do
+        let(:activity) { build(:programme_activity, :ispf_funded) }
+
+        it "returns false" do
+          expect(activity.send(method.to_sym)).to eq(false)
+        end
+      end
+    end
+
+    ["project", "third-party project"].each do |level|
+      context "when activity is a #{level}" do
+        let(:factory_name) { factory_name_by_activity_level(level) }
+
+        context "when is_oda is nil" do
+          let(:activity) { build(factory_name, :newton_funded) }
+
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is true" do
+          let(:activity) { build(factory_name, :ispf_funded) }
+
+          it "returns true" do
+            expect(activity.send(method.to_sym)).to eq(true)
+          end
+        end
+
+        context "when is_oda is false" do
+          let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
+
+          it "returns false" do
+            expect(activity.send(method.to_sym)).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
   describe "#requires_collaboration_type?" do
     context "when activity is a fund" do
       let(:activity) { build(:fund_activity) }
@@ -2035,37 +2138,37 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#requires_fstc_applies?" do
+  describe "#is_non_oda?" do
     context "when activity is a fund" do
       let(:activity) { build(:fund_activity) }
 
-      it "returns true" do
-        expect(activity.requires_fstc_applies?).to eq(true)
+      it "returns false" do
+        expect(activity.is_non_oda?).to eq(false)
       end
     end
 
     context "when activity is a programme" do
-      context "when Newton-funded" do
+      context "when is_oda is nil" do
         let(:activity) { build(:programme_activity, :newton_funded) }
 
-        it "returns true" do
-          expect(activity.requires_fstc_applies?).to eq(true)
+        it "returns false" do
+          expect(activity.is_non_oda?).to eq(false)
         end
       end
 
-      context "when GCRF-funded" do
-        let(:activity) { build(:programme_activity, :gcrf_funded) }
-
-        it "returns true" do
-          expect(activity.requires_fstc_applies?).to eq(true)
-        end
-      end
-
-      context "when ISPF-funded" do
+      context "when is_oda is true" do
         let(:activity) { build(:programme_activity, :ispf_funded) }
 
         it "returns false" do
-          expect(activity.requires_fstc_applies?).to eq(false)
+          expect(activity.is_non_oda?).to eq(false)
+        end
+      end
+
+      context "when is_oda is false" do
+        let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
+
+        it "returns true" do
+          expect(activity.is_non_oda?).to eq(true)
         end
       end
     end
@@ -2077,56 +2180,8 @@ RSpec.describe Activity, type: :model do
         context "when is_oda is nil" do
           let(:activity) { build(factory_name, :newton_funded) }
 
-          it "returns true" do
-            expect(activity.requires_fstc_applies?).to eq(true)
-          end
-        end
-
-        context "when is_oda is true" do
-          let(:activity) { build(factory_name, :ispf_funded) }
-
-          it "returns true" do
-            expect(activity.requires_fstc_applies?).to eq(true)
-          end
-        end
-
-        context "when is_oda is false" do
-          let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
-
           it "returns false" do
-            expect(activity.requires_fstc_applies?).to eq(false)
-          end
-        end
-      end
-    end
-  end
-
-  describe "#is_non_oda_project?" do
-    context "when activity is a fund" do
-      let(:activity) { build(:fund_activity) }
-
-      it "returns false" do
-        expect(activity.is_non_oda_project?).to eq(false)
-      end
-    end
-
-    context "when activity is a programme" do
-      let(:activity) { build(:programme_activity) }
-
-      it "returns false" do
-        expect(activity.is_non_oda_project?).to eq(false)
-      end
-    end
-
-    ["project", "third-party project"].each do |level|
-      context "when activity is a #{level}" do
-        let(:factory_name) { factory_name_by_activity_level(level) }
-
-        context "when is_oda is nil" do
-          let(:activity) { build(factory_name, :newton_funded) }
-
-          it "returns false" do
-            expect(activity.is_non_oda_project?).to eq(false)
+            expect(activity.is_non_oda?).to eq(false)
           end
         end
 
@@ -2134,7 +2189,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded) }
 
           it "returns false" do
-            expect(activity.is_non_oda_project?).to eq(false)
+            expect(activity.is_non_oda?).to eq(false)
           end
         end
 
@@ -2142,7 +2197,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
           it "returns true" do
-            expect(activity.is_non_oda_project?).to eq(true)
+            expect(activity.is_non_oda?).to eq(true)
           end
         end
       end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -134,19 +134,22 @@ class ActivityForm
     fill_in_is_oda_step(is_oda)
     fill_in_identifier_step
     fill_in_purpose_step
-    fill_in_objectives_step
+    fill_in_objectives_step if is_oda
     fill_in_sector_category_step
     fill_in_sector_step
     fill_in_programme_status
     fill_in_dates
     fill_in_ispf_partner_countries
-    fill_in_benefitting_countries
-    fill_in_gdi
-    fill_in_aid_type
-    fill_in_sdgs_apply
+
+    if is_oda
+      fill_in_benefitting_countries
+      fill_in_gdi
+      fill_in_aid_type
+      fill_in_sdgs_apply
+    end
+
     fill_in_ispf_theme
-    fill_in_covid19_related
-    fill_in_oda_eligibility
+    fill_in_oda_eligibility if is_oda
   end
 
   def fill_in_ispf_project_activity_form(is_oda:)


### PR DESCRIPTION
## Changes in this PR

This skips various form steps for Level B ISPF non-ODA activities

`is_non_oda_project?` is now only used in the `Activity` class, so it's shifted to a private method and its tests have been removed

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
