### PR TITLE
Fix db-restore and set OTP

### DIFF
--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -3,7 +3,7 @@ administrator = User.find_or_initialize_by(
   email: "roda@dxw.com"
 )
 partner_org_user = User.find_or_initialize_by(
-  name: "artner Org User",
+  name: "Partner Org User",
   email: "roda+dp@dxw.com"
 )
 

--- a/db/seeds/development_users.rb
+++ b/db/seeds/development_users.rb
@@ -7,13 +7,13 @@ partner_org_user = User.find_or_initialize_by(
   email: "roda+dp@dxw.com"
 )
 
-administrator.password = "LlEeTtMmEeIiNn!1"
-partner_org_user.password = "LlEeTtMmEeIiNn!1"
-
 beis = Organisation.service_owner
-administrator.organisation = beis
-administrator.save!
-
 other_organisation = Organisation.find_by(role: :partner_organisation)
-partner_org_user.organisation = other_organisation
-partner_org_user.save!
+
+[
+  {user: administrator, organisation: beis},
+  {user: partner_org_user, organisation: other_organisation}
+].each do |hash|
+  hash[:user].update(password: "LlEeTtMmEeIiNn!1", otp_required_for_login: false, organisation: hash[:organisation])
+  hash[:user].save!
+end

--- a/script/db-restore
+++ b/script/db-restore
@@ -78,7 +78,7 @@ if [ "$delete_data" == "y" ]; then
     pg_restore -d roda-development --no-owner --clean "$filename" || true
 
     echo "==> Removing extraneous Postgres extensions..."
-    psql -d roda-development -c 'DROP EXTENSION IF EXISTS citext; DROP EXTENSION IF EXISTS postgis; DROP EXTENSION IF EXISTS "uuid-ossp";'
+    psql -d roda-development -c 'DROP EXTENSION IF EXISTS citext; DROP EXTENSION IF EXISTS postgis CASCADE; DROP EXTENSION IF EXISTS "uuid-ossp";'
 
     echo "==> Setting database environment..."
     bundle exec rails db:environment:set RAILS_ENV=development


### PR DESCRIPTION
## Changes in this PR

- Fixes `db-restore` error and typo
- Integrates setting `otp_required_for_login` into local development user seeds, removing the need for devs to do this manually every time they sync with production data

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
