### PR TITLE
(2693) Hide fields from activity details based on `requires_X?` methods

### DIFF
--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -78,7 +78,7 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :purpose)
         = a11y_action_link(I18n.t("default.link.#{activity_presenter.call_to_action(:description)}"), activity_step_path(activity_presenter, :purpose), I18n.t("activerecord.attributes.activity.description").downcase)
 
-  - unless activity_presenter.fund?
+  - if activity_presenter.requires_objectives?
     .govuk-summary-list__row.objectives
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.objectives")
@@ -226,21 +226,22 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :ispf_partner_countries)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:ispf_partner_countries)}"), activity_step_path(activity_presenter, :ispf_partner_countries), t("activerecord.attributes.activity.ispf_partner_countries"))
 
-  .govuk-summary-list__row.benefitting_countries
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.benefitting_countries")
-    %dd.govuk-summary-list__value
-      = activity_presenter.benefitting_countries
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :benefitting_countries)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("activerecord.attributes.activity.benefitting_countries"))
+  - if activity_presenter.requires_benefitting_countries?
+    .govuk-summary-list__row.benefitting_countries
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.benefitting_countries")
+      %dd.govuk-summary-list__value
+        = activity_presenter.benefitting_countries
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :benefitting_countries)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("activerecord.attributes.activity.benefitting_countries"))
 
-  .govuk-summary-list__row.benefitting_region
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.benefitting_region")
-    %dd.govuk-summary-list__value
-      = activity_presenter.benefitting_region
-    %dd.govuk-summary-list__actions
+    .govuk-summary-list__row.benefitting_region
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.benefitting_region")
+      %dd.govuk-summary-list__value
+        = activity_presenter.benefitting_region
+      %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.recipient_region
     %dt.govuk-summary-list__key
@@ -263,14 +264,15 @@
       = activity_presenter.intended_beneficiaries
     %dd.govuk-summary-list__actions
 
-  .govuk-summary-list__row.gdi
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.gdi")
-    %dd.govuk-summary-list__value
-      = activity_presenter.gdi
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gdi)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gdi)}"), activity_step_path(activity_presenter, :gdi), t("activerecord.attributes.activity.gdi"))
+  - if activity_presenter.requires_gdi?
+    .govuk-summary-list__row.gdi
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.gdi")
+      %dd.govuk-summary-list__value
+        = activity_presenter.gdi
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gdi)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gdi)}"), activity_step_path(activity_presenter, :gdi), t("activerecord.attributes.activity.gdi"))
 
   - if activity_presenter.is_gcrf_funded?
     .govuk-summary-list__row.gcrf_strategic_area
@@ -292,7 +294,7 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :gcrf_challenge_area)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:gcrf_challenge_area)}"), activity_step_path(activity_presenter, :gcrf_challenge_area), t("activerecord.attributes.activity.gcrf_challenge_area"))
 
-  - unless activity_presenter.fund?
+  - if activity_presenter.requires_collaboration_type?
     .govuk-summary-list__row.collaboration_type
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.collaboration_type")
@@ -302,7 +304,7 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :collaboration_type) && Activity::Inference.service.editable?(activity_presenter, :collaboration_type)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:collaboration_type)}"), activity_step_path(activity_presenter, :collaboration_type), t("activerecord.attributes.activity.collaboration_type"))
 
-  - unless activity_presenter.fund?
+  - unless activity_presenter.fund? || activity_presenter.is_non_oda?
     .govuk-summary-list__row.sustainable_development_goals
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.sustainable_development_goals")
@@ -333,26 +335,28 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fund_pillar)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:fund_pillar)}"), activity_step_path(activity_presenter, :fund_pillar), t("activerecord.attributes.activity.fund_pillar"))
 
-  .govuk-summary-list__row.aid_type
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.aid_type")
-    %dd.govuk-summary-list__value
-      = activity_presenter.aid_type
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("activerecord.attributes.activity.aid_type"))
+  - if activity_presenter.requires_aid_type?
+    .govuk-summary-list__row.aid_type
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.aid_type")
+      %dd.govuk-summary-list__value
+        = activity_presenter.aid_type
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :aid_type)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:aid_type)}"), activity_step_path(activity_presenter, :aid_type), t("activerecord.attributes.activity.aid_type"))
 
-  .govuk-summary-list__row.fstc_applies
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.fstc_applies")
-    %dd.govuk-summary-list__value
-      - unless activity_presenter.fstc_applies.to_s.blank?
-        = t("summary.label.activity.fstc_applies.#{activity_presenter.fstc_applies}")
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fstc_applies) && Activity::Inference.service.editable?(activity_presenter, :fstc_applies)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:fstc_applies)}"), activity_step_path(activity_presenter, :fstc_applies), t("activerecord.attributes.activity.fstc_applies"))
+  - if activity_presenter.requires_fstc_applies?
+    .govuk-summary-list__row.fstc_applies
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.fstc_applies")
+      %dd.govuk-summary-list__value
+        - unless activity_presenter.fstc_applies.to_s.blank?
+          = t("summary.label.activity.fstc_applies.#{activity_presenter.fstc_applies}")
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :fstc_applies) && Activity::Inference.service.editable?(activity_presenter, :fstc_applies)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:fstc_applies)}"), activity_step_path(activity_presenter, :fstc_applies), t("activerecord.attributes.activity.fstc_applies"))
 
-  - if activity_presenter.project? || activity_presenter.third_party_project?
+  - if activity_presenter.requires_policy_markers?
     .govuk-summary-list__row.policy_marker_gender
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.policy_marker_gender")
@@ -425,16 +429,17 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :policy_markers)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:policy_marker_nutrition)}"), activity_step_path(activity_presenter, :policy_markers, anchor: "nutrition"), t("activerecord.attributes.activity.policy_marker_nutrition"))
 
-  .govuk-summary-list__row.covid19_related
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.covid19_related")
-    %dd.govuk-summary-list__value
-      = activity_presenter.covid19_related
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :covid19_related)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:covid19_related)}"), activity_step_path(activity_presenter, :covid19_related), t("activerecord.attributes.activity.covid19_related"))
+  - if activity_presenter.requires_covid19_related?
+    .govuk-summary-list__row.covid19_related
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.covid19_related")
+      %dd.govuk-summary-list__value
+        = activity_presenter.covid19_related
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :covid19_related)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:covid19_related)}"), activity_step_path(activity_presenter, :covid19_related), t("activerecord.attributes.activity.covid19_related"))
 
-  - if activity_presenter.is_project?
+  - if activity_presenter.requires_channel_of_delivery_code?
     .govuk-summary-list__row.channel_of_delivery_code
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.channel_of_delivery_code")
@@ -444,16 +449,17 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :channel_of_delivery_code) && Activity::Inference.service.editable?(activity_presenter, :channel_of_delivery_code)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:channel_of_delivery_code)}"), activity_step_path(activity_presenter, :channel_of_delivery_code), t("activerecord.attributes.activity.channel_of_delivery_code"))
 
-  .govuk-summary-list__row.oda_eligibility
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.oda_eligibility")
-    %dd.govuk-summary-list__value
-      = activity_presenter.oda_eligibility
-    %dd.govuk-summary-list__actions
-      - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :oda_eligibility)
-        = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:oda_eligibility)}"), activity_step_path(activity_presenter, :oda_eligibility), t("activerecord.attributes.activity.oda_eligibility"))
+  - if activity_presenter.requires_oda_eligibility?
+    .govuk-summary-list__row.oda_eligibility
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.oda_eligibility")
+      %dd.govuk-summary-list__value
+        = activity_presenter.oda_eligibility
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :oda_eligibility)
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:oda_eligibility)}"), activity_step_path(activity_presenter, :oda_eligibility), t("activerecord.attributes.activity.oda_eligibility"))
 
-  - if activity_presenter.is_project?
+  - if activity_presenter.requires_oda_eligibility_lead?
     .govuk-summary-list__row.oda_eligibility_lead
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.oda_eligibility_lead")
@@ -462,7 +468,6 @@
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :oda_eligibility_lead)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:oda_eligibility_lead)}"), activity_step_path(activity_presenter, :oda_eligibility_lead), t("activerecord.attributes.activity.oda_eligibility_lead"))
-
 
   - if policy(activity_presenter).redact_from_iati?
     .govuk-summary-list__row.publish_to_iati

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "shared/activities/_activity" do
 
     it { is_expected.to_not show_the_edit_add_actions }
 
-    context "and the policy allows a user to upate" do
+    context "and the policy allows a user to update" do
       let(:policy_stub) { double("policy", update?: true, redact_from_iati?: false) }
 
       it { is_expected.to show_the_edit_add_actions }

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "shared/activities/_activity" do
     render
   end
 
-  context "With a GCRF fund" do
+  context "when the fund is GCRF" do
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :gcrf_funded) }
 
@@ -44,7 +44,7 @@ RSpec.describe "shared/activities/_activity" do
     end
   end
 
-  context "With a Newton fund" do
+  context "when the fund is Newton" do
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :newton_funded, country_partner_organisations: country_partner_orgs) }
 
@@ -65,6 +65,79 @@ RSpec.describe "shared/activities/_activity" do
       it { is_expected.to show_basic_details }
       it { is_expected.to show_project_details }
       it { is_expected.to show_newton_specific_details }
+    end
+  end
+
+  context "when the fund is ISPF" do
+    context "when the activity is a programme activity" do
+      let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"]) }
+
+      it { is_expected.to show_basic_details }
+      it { is_expected.to show_ispf_specific_details }
+
+      it "doesn't show fields irrelevant to all ISPF programmes" do
+        expect(rendered).not_to have_content(t("activerecord.attributes.activity.collaboration_type"))
+        expect(rendered).not_to have_content(t("activerecord.attributes.activity.fstc_applies"))
+        expect(rendered).not_to have_content(t("activerecord.attributes.activity.covid19_related"))
+      end
+
+      context "when the activity is non-ODA" do
+        let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], is_oda: false) }
+
+        it "doesn't show fields irrelevant to ISPF non-ODA programmes" do
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.objectives"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.benefitting_countries"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.gdi"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.sustainable_development_goals"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.aid_type"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility"))
+        end
+      end
+    end
+
+    ["project", "third-party project"].each do |level|
+      context "when the activity is a #{level} activity" do
+        factory_name = (level.underscore.parameterize(separator: "_") + "_activity").to_sym
+
+        let(:activity) { build(factory_name, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"]) }
+
+        it { is_expected.to show_basic_details }
+        it { is_expected.to show_project_details }
+        it { is_expected.to show_ispf_specific_details }
+
+        context "when the activity is ODA" do
+          it "shows fields specific to ISPF ODA #{level}s" do
+            expect(rendered).to have_content(t("activerecord.attributes.activity.collaboration_type"))
+            expect(rendered).to have_content(t("activerecord.attributes.activity.fstc_applies"))
+            expect(rendered).to have_content(t("activerecord.attributes.activity.covid19_related"))
+          end
+        end
+
+        context "when the activity is non-ODA" do
+          let(:activity) { build(factory_name, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], is_oda: false) }
+
+          it "doesn't show fields irrelevant to ISPF non-ODA #{level}s" do
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.objectives"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.benefitting_countries"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.gdi"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.collaboration_type"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.sustainable_development_goals"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.aid_type"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.fstc_applies"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_gender"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_climate_change_adaptation"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_climate_change_mitigation"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_biodiversity"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_desertification"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_disability"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.policy_marker_disaster_risk_reduction"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.covid19_related"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.channel_of_delivery_code"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility"))
+            expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility_lead"))
+          end
+        end
+      end
     end
   end
 
@@ -343,6 +416,20 @@ RSpec.describe "shared/activities/_activity" do
 
     description do
       "show GCRF activity specific details for an activity"
+    end
+  end
+
+  RSpec::Matchers.define :show_ispf_specific_details do
+    match do |actual|
+      expect(rendered).to have_css(".govuk-summary-list__row.ispf_theme")
+      expect(rendered).to have_css(".govuk-summary-list__row.ispf_partner_countries")
+
+      expect(rendered).to have_content(activity_presenter.ispf_theme)
+      expect(rendered).to have_content(activity_presenter.ispf_partner_countries)
+    end
+
+    description do
+      "show ISPF activity specific details for an activity"
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

This uses all the new and existing `requires_X?` instance methods in the `Activity` class to determine whether to show fields in the activity details tab/page. One or two of these were already being used, while on some other fields the old logic of the `requires_X?` method was simply being replicated in the view - this brings the logic up to date and keeps the code DRY

It also updates the logic for displaying SDGs, however this does not use a `requires_X?` method. Since the validation of `sdg_1` is based on `sdgs_apply?` rather than a `requires_X?` method, the logic as to whether to skip this form step and show it in the view are kept separate/plain to avoid confusion about the difference between `sdgs_apply?` and `requires_sdgs?`

## Screenshots of UI changes

Example is non-ODA, which has the most changes

### Before

https://user-images.githubusercontent.com/40244233/200399448-d8961d61-73c3-44d0-9888-c8bdb64ff397.mov

### After

https://user-images.githubusercontent.com/40244233/200397516-5144a2c1-5a36-40e6-a90a-a8911f3de2f5.mov

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
