### PR TITLE
[Support] Set default currency & transaction_type on Actuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1137,6 +1137,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove collaboration type, COVID-19-related and FSTC applies from UI user journeys for adding Level B ISPF activities
 - Remove non-ODA steps from new ISPF Level B non-ODA activity form
 - Allow programmes to be redacted from IATI
+- Set default values for currency and transaction type on Actual Transactions, output in IATI XML
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -16,9 +16,6 @@ class Adjustment < Transaction
   validates_associated :detail
   validate :ensure_correction_suits_adjustment
 
-  attribute :currency, :string, default: "GBP"
-  attribute :transaction_type, :string, default: Transaction::TRANSACTION_TYPE_DISBURSEMENT
-
   delegate :adjustment_type, to: :detail
 
   def adjustment_type=(variant)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -7,9 +7,6 @@ class Refund < Transaction
 
   validates_associated :comment
 
-  attribute :currency, :string, default: "GBP"
-  attribute :transaction_type, :string, default: Transaction::TRANSACTION_TYPE_DISBURSEMENT
-
   def value=(amount)
     big_decimal = begin
       BigDecimal(amount)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -17,6 +17,9 @@ class Transaction < ApplicationRecord
   validates :date, date_within_boundaries: true
   validates :financial_quarter, inclusion: {in: 1..4}
 
+  attribute :currency, :string, default: "GBP"
+  attribute :transaction_type, :string, default: Transaction::TRANSACTION_TYPE_DISBURSEMENT
+
   before_validation :set_financial_quarter_from_date
 
   scope :with_adjustment_details, -> { joins("LEFT OUTER JOIN adjustment_details ON transactions.id = adjustment_details.adjustment_id") }

--- a/db/data/20221108103513_backfill_missing_currencies_and_transaction_types.rb
+++ b/db/data/20221108103513_backfill_missing_currencies_and_transaction_types.rb
@@ -1,0 +1,33 @@
+# Run me with `rails runner db/data/20221108103513_backfill_missing_currencies_and_transaction_types.rb`
+
+# Transactions (actuals, refunds and adjustments) were being created with blank attributes:
+# - currency
+# - transaction_type
+#
+# This isn't causing an immediate problem, but they are "transactions" and so
+# ought to conform to te normal transaction behaviour.
+
+# This is adapted from db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb
+
+finder = Transaction.where(currency: nil, transaction_type: nil)
+
+puts "Setting currency and transaction_type on #{finder.count} transactions..."
+
+finder.each do |transaction|
+  transaction.update_columns(
+    transaction_type: Transaction::TRANSACTION_TYPE_DISBURSEMENT,
+    currency: "GBP"
+  )
+end
+
+puts "-> there are now #{finder.reload.count} transactions where currency and transaction_type are nil"
+
+finder = Transaction.where(currency: nil)
+
+puts "Setting currency on #{finder.count} transactions..."
+
+finder.each do |transaction|
+  transaction.update_columns(currency: "GBP")
+end
+
+puts "-> there are now #{finder.reload.count} transactions where currency is nil"

--- a/spec/models/actual_spec.rb
+++ b/spec/models/actual_spec.rb
@@ -24,4 +24,24 @@ RSpec.describe Actual do
       end
     end
   end
+
+  describe "Single table inheritance from Transaction" do
+    it "should inherit from the Transaction class " do
+      expect(Actual.ancestors).to include(Transaction)
+      expect(Actual.table_name).to eq("transactions")
+      expect(Actual.inheritance_column).to eq("type")
+    end
+
+    it "should have the _type_ of 'Actual'" do
+      expect(Actual.new.type).to eq("Actual")
+    end
+
+    it "should have the _transaction_type_ of '3' for 'Disbursement'" do
+      expect(Actual.new.transaction_type).to eq("3")
+    end
+
+    it "should have the _currency_ of 'GBP'" do
+      expect(Actual.new.currency).to eq("GBP")
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Sets default currency on all classes that inherit from `Transaction` (specifically to set this on `Actual`s).

Previously, this was only done for `Adjustment`s and `Refund`s, but `Actuals` are also a type of `Transaction` and are exported in IATI XML.

Because `Actual`s didn't have a default value for `currency`, this meant it was outputting XML tags with an empty string value e.g.

```
<transaction>
<transaction-type code="3"/>
<value currency="" value-date="2022-03-31">1000</value>
```

I'm not sure why the default value wasn't added for Actuals [here](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1383), it may have been an oversight, but as we export all `Transaction`-inheritors to the XML, I thought it would be safest to put the default values on the `Transaction` class itself so we don't forget this in future.

Although the `transaction_type` doesn't appear to be an issue for IATI XML (as far as I'm aware) it feels best to set this to the default value ("3") as this seems to be the only real value we set it to in the codebase.

We'll want to re-run the data migration to backfill these values: `db/data/20211004_backfill_missing_attrs_on_refunds_and_adjustments.rb` on production to fix this.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/200545500-3f57102d-c14f-434e-8ae9-be249794b062.png)

### After (after running backfilling script)

![image](https://user-images.githubusercontent.com/19826940/200547361-a1ea98c5-186e-41fd-bed0-c65bbbc2504f.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
- [ ] Run data migration script 
