### PR TITLE
(2699) Remove superflous arguments in `ActivityForm`

### DIFF
--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -198,7 +198,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       click_on t("form.button.activity.new_child", name: oda_activity.associated_fund.title)
 
       form = ActivityForm.new(activity: oda_activity, level: "programme", fund: "ispf")
-      form.complete!(is_oda: true)
+      form.complete!
 
       expect(page).to have_content(t("action.programme.create.success"))
 
@@ -231,7 +231,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       click_on t("form.button.activity.new_child", name: non_oda_activity.associated_fund.title)
 
       form = ActivityForm.new(activity: non_oda_activity, level: "programme", fund: "ispf")
-      form.complete!(is_oda: false)
+      form.complete!
 
       expect(page).to have_content(t("action.programme.create.success"))
 

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Users can create a project" do
         click_on t("action.activity.add_child")
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
-        form.complete!(is_oda: true)
+        form.complete!
 
         expect(page).to have_content t("action.project.create.success")
         expect(programme.child_activities.count).to eq 1
@@ -162,7 +162,7 @@ RSpec.feature "Users can create a project" do
         click_on t("action.activity.add_child")
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
-        form.complete!(is_oda: false)
+        form.complete!
 
         expect(page).to have_content t("action.project.create.success")
         expect(programme.child_activities.count).to eq 1

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -106,7 +106,7 @@ RSpec.feature "Users can create a third-party project" do
         click_on(t("action.activity.add_child"))
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
-        form.complete!(is_oda: true)
+        form.complete!
 
         expect(page).to have_content t("action.third_party_project.create.success")
         expect(project.child_activities.count).to eq 1
@@ -179,7 +179,7 @@ RSpec.feature "Users can create a third-party project" do
         click_on(t("action.activity.add_child"))
 
         form = ActivityForm.new(activity: activity, level: "project", fund: "ispf")
-        form.complete!(is_oda: false)
+        form.complete!
 
         expect(page).to have_content t("action.third_party_project.create.success")
         expect(project.child_activities.count).to eq 1

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -9,12 +9,12 @@ class ActivityForm
     @level = level
   end
 
-  def complete!(is_oda: nil)
-    if is_oda.nil?
+  def complete!
+    if @activity.is_oda.nil?
       return send("fill_in_#{fund}_#{level}_activity_form")
     end
 
-    send("fill_in_#{fund}_#{level}_activity_form", is_oda: is_oda)
+    send("fill_in_#{fund}_#{level}_activity_form")
   end
 
   def created_activity
@@ -130,18 +130,18 @@ class ActivityForm
     fill_in_named_contact
   end
 
-  def fill_in_ispf_programme_activity_form(is_oda:)
-    fill_in_is_oda_step(is_oda)
+  def fill_in_ispf_programme_activity_form
+    fill_in_is_oda_step
     fill_in_identifier_step
     fill_in_purpose_step
-    fill_in_objectives_step if is_oda
+    fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step
     fill_in_sector_step
     fill_in_programme_status
     fill_in_dates
     fill_in_ispf_partner_countries
 
-    if is_oda
+    if @activity.is_oda
       fill_in_benefitting_countries
       fill_in_gdi
       fill_in_aid_type
@@ -149,13 +149,13 @@ class ActivityForm
     end
 
     fill_in_ispf_theme
-    fill_in_oda_eligibility if is_oda
+    fill_in_oda_eligibility if @activity.is_oda
   end
 
-  def fill_in_ispf_project_activity_form(is_oda:)
+  def fill_in_ispf_project_activity_form
     fill_in_identifier_step
     fill_in_purpose_step
-    fill_in_objectives_step if is_oda
+    fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step
     fill_in_sector_step
     fill_in_call_details
@@ -164,7 +164,7 @@ class ActivityForm
     fill_in_dates
     fill_in_ispf_partner_countries
 
-    if is_oda
+    if @activity.is_oda
       fill_in_benefitting_countries
       fill_in_gdi
       fill_in_aid_type
@@ -174,7 +174,7 @@ class ActivityForm
 
     fill_in_ispf_theme
 
-    if is_oda
+    if @activity.is_oda
       fill_in_policy_markers
       fill_in_covid19_related
       fill_in_channel_of_delivery_code
@@ -185,9 +185,9 @@ class ActivityForm
     fill_in_named_contact
   end
 
-  def fill_in_is_oda_step(is_oda)
+  def fill_in_is_oda_step
     expect(page).to have_content I18n.t("form.legend.activity.is_oda")
-    find("input[value='#{is_oda}']", visible: :all).click
+    find("input[value='#{@activity.is_oda}']", visible: :all).click
     click_button I18n.t("form.button.activity.submit")
   end
 


### PR DESCRIPTION
## Changes in this PR

Previously `is_oda` was being passed into various methods in `ActivityForm`, however on initialisation we pass in the activity from which the `is_oda` value was always being taken. We can directly access this via the `@activity` instance method, so we don't need to pass in any of its attributes separately

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
