### PR TITLE
(2700) Remove reference to "ODA activities" in activity status descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1138,6 +1138,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove non-ODA steps from new ISPF Level B non-ODA activity form
 - Allow programmes to be redacted from IATI
 - Set default values for currency and transaction type on Actual Transactions, output in IATI XML
+- Remove reference to "ODA activities" in activity status descriptions
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe CodelistHelper, type: :helper do
         expect(options.length).to eq 12
         expect(options.first.value).to eq "delivery"
         expect(options.first.label).to eq "Delivery"
-        expect(options.first.description).to eq "Activities related to delivery of ODA activities only"
+        expect(options.first.description).to eq "Activities related to delivery costs"
         expect(options.last.value).to eq "paused"
         expect(options.last.label).to eq "Paused"
         expect(options.last.description).to eq "Activity has been temporarily suspended. No spend should take place while this status is in use"

--- a/vendor/data/codelists/BEIS/programme_status.yml
+++ b/vendor/data/codelists/BEIS/programme_status.yml
@@ -2,7 +2,7 @@
 data:
   - code: 1
     name: Delivery
-    description: Activities related to delivery of ODA activities only
+    description: Activities related to delivery costs
     iati_status_code: 2
   - code: 2
     name: Planned


### PR DESCRIPTION
## Changes in this PR

Change “Activities related to delivery of ODA activities only” to “Activities related to delivery costs” on the Activity Status form step, now that this could refer to ISPF non-ODA activities

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/40244233/200565977-b2c0fa0a-403f-4471-9337-e517bedbf860.png)

### After

<img width="732" alt="image" src="https://user-images.githubusercontent.com/40244233/200565956-90a2166a-8e1d-4426-af68-86a7e3b1007f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
