### PR TITLE
(2706) Allow redacting programmes from IATI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1136,6 +1136,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add ISPF Level C/D UI user journeys for adding activities
 - Remove collaboration type, COVID-19-related and FSTC applies from UI user journeys for adding Level B ISPF activities
 - Remove non-ODA steps from new ISPF Level B non-ODA activity form
+- Allow programmes to be redacted from IATI
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -63,7 +63,7 @@ class ActivityPolicy < ApplicationPolicy
 
   def redact_from_iati?
     if beis_user?
-      return true if record.project? || record.third_party_project?
+      return true unless record.fund?
     end
     false
   end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:update)
 
         is_expected.to forbid_action(:destroy)
-        is_expected.to forbid_action(:redact_from_iati)
+        is_expected.to permit_action(:redact_from_iati)
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
 


### PR DESCRIPTION
## Changes in this PR

Previously redacting activities from IATI was only allowed to be done by BEIS users at Levels C/D. The client has indicated that it would also be useful to be able to do this at Level B, so this makes that possible

## Screenshots of UI changes

### Before

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/40244233/200600159-cdfd9726-ff65-44fe-8668-7bc97f1c04d8.png">

### After

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/40244233/200600055-dc9138c2-a0f1-41c2-b83a-df0314f083e5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
