### PR TITLE
Remove unnecessary conditional in ActivityForm

### DIFF
--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -10,10 +10,6 @@ class ActivityForm
   end
 
   def complete!
-    if @activity.is_oda.nil?
-      return send("fill_in_#{fund}_#{level}_activity_form")
-    end
-
     send("fill_in_#{fund}_#{level}_activity_form")
   end
 


### PR DESCRIPTION
## Changes in this PR

Removes unnecessary conditional in ActivityForm which was originally needed as we were passing in an argument to `send` to read from an `Activity`. It looks like we forgot to update this after removing that parameter from the method signature.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
