### PR TITLE
Update changelog for release 122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1120,28 +1120,23 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add Level B activity comments to budget exports
 - Strip leading/trailing whitespace and line breaks from comments in reports and exports
 
-## [unreleased]
+## [release-122] 2022-11-09
 
 - Update seeds and create data migration for adding ISPF fund entity to the service
-- Hide ISPF reports when the ISPF feature flag is enabled
-- ISPF programmes cannot be created when the feature flag is enabled
-- ISPF activities are not shown to users when the feature flag is enabled
-- ISPF activities are not shown in search results when the feature flag is enabled
-- Exclude ISPF-related entities from exports when the feature flag is enabled
-- The first step for an ISPF programme is now choosing between ODA and Non-ODA
-- Add ISPF theme form step
-- Add ISPF partner countries form step
+- Add ISPF Level B UI user journeys for adding activities
+- Add ISPF Level C/D UI user journeys for adding activities
 - Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
 - Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one
-- Add ISPF Level C/D UI user journeys for adding activities
-- Remove collaboration type, COVID-19-related and FSTC applies from UI user journeys for adding Level B ISPF activities
-- Remove non-ODA steps from new ISPF Level B non-ODA activity form
+- Require ISPF third-party projects (level D) to have at least one implementing organisation set through the new activity journey
+- Hide ISPF-facing functionality in the service and exports when the feature flag is enabled
 - Allow programmes to be redacted from IATI
 - Set default values for currency and transaction type on Actual Transactions, output in IATI XML
 - Remove reference to "ODA activities" in activity status descriptions
-- Require ISPF third-party projects (level D) to have at least one implementing organisation set through the new activity journey
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...HEAD
+## [unreleased]
+
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-122...HEAD
+[release-122]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...release-122
 [release-121]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-120...release-121
 [release-120]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-119...release-120
 [release-119]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-118...release-119


### PR DESCRIPTION
(Tidies up the changelog, as I felt it was a bit too granular.)

- Update seeds and create data migration for adding ISPF fund entity to the service
- Add ISPF Level B UI user journeys for adding activities
- Add ISPF Level C/D UI user journeys for adding activities
- Inherit `is_oda` from the parent activity - Level C/D ISPF activities will therefore be ODA or non-ODA based on the (grand)parent Level B activity
- Do not allow removing the implementing organisation from a level C or D ISPF activity if it is the only one
- Require ISPF third-party projects (level D) to have at least one implementing organisation set through the new activity journey
- Hide ISPF-facing functionality in the service and exports when the feature flag is enabled
- Allow programmes to be redacted from IATI
- Set default values for currency and transaction type on Actual Transactions, output in IATI XML
- Remove reference to "ODA activities" in activity status descriptions

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
