### PR TITLE
WIP use accessible autocomplete for linking activities

### DIFF
--- a/app/assets/javascripts/accessibleAutocomplete.js
+++ b/app/assets/javascripts/accessibleAutocomplete.js
@@ -1,0 +1,36 @@
+// adapted from https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/d070006b2d68ba28e6b204d9efb9807c241c1eeb/app/assets/javascripts/autocomplete.js
+
+function rodaAccessibleAutocomplete () {
+  const selectElement = document.getElementById("activity-linked-activity-id-field")
+
+  if (selectElement) {
+    accessibleAutocomplete.enhanceSelectElement({
+      autoselect: false, // this was not present in simple original
+      defaultValue: '',
+      selectElement: selectElement,
+      showAllValues: true,
+      preserveNullOptions: true // this was false in simple original
+    })
+    
+    const autocompleteElement = selectElement.parentNode.getElementsByTagName('input')[0]
+    
+    resetSelectWhenDesynced(selectElement, autocompleteElement)
+  }
+}
+
+function resetSelectWhenDesynced (selectElement, autocompleteElement) {
+  // if the autocomplete element's value no longer matches the selected option
+  // in the select element, reset the select element - in particular, this
+  // avoids submitting the last selected value after clearing the input
+  // @see https://github.com/alphagov/accessible-autocomplete/issues/205
+
+  autocompleteElement.addEventListener('keyup', () => {
+    const optionSelectedInSelectElement = selectElement.querySelector('option:checked')
+
+    if (autocompleteElement.value !== optionSelectedInSelectElement.innerText) {
+      selectElement.value = ''
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', () => rodaAccessibleAutocomplete())

--- a/app/assets/javascripts/accessibleAutocomplete.js
+++ b/app/assets/javascripts/accessibleAutocomplete.js
@@ -15,6 +15,7 @@ function rodaAccessibleAutocomplete () {
     const autocompleteElement = selectElement.parentNode.getElementsByTagName('input')[0]
     
     resetSelectWhenDesynced(selectElement, autocompleteElement)
+    addClearButton(selectElement, autocompleteElement)
   }
 }
 
@@ -31,6 +32,48 @@ function resetSelectWhenDesynced (selectElement, autocompleteElement) {
       selectElement.value = ''
     }
   })
+}
+
+function addClearButton (selectElement, autocompleteElement) {
+  const autocompleteOuterWrapper = autocompleteElement.parentNode.parentNode
+
+  autocompleteOuterWrapper.className = 'autocomplete__outer-wrapper'
+
+  const clearButton = createClearButton(selectElement, autocompleteElement)
+
+  autocompleteOuterWrapper.append(clearButton)
+}
+
+function createClearButton (selectElement, autocompleteElement) {
+  const clearButton = document.createElement('button')
+
+  clearButton.type = 'button'
+  clearButton.innerText = 'X'
+  clearButton.ariaLabel = 'Clear selection'
+  clearButton.className = 'autocomplete__clear-button'
+
+  clearButton.addEventListener('click', () => {
+    resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+  })
+
+  clearButton.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+    }
+  })
+
+  return clearButton
+}
+
+function resetSelectAndAutocomplete (selectElement, autocompleteElement, clearButton) {
+  selectElement.value = ''
+  autocompleteElement.value = ''
+
+  autocompleteElement.click()
+  autocompleteElement.focus()
+  autocompleteElement.blur()
+
+  clearButton.focus()
 }
 
 document.addEventListener('DOMContentLoaded', () => rodaAccessibleAutocomplete())

--- a/app/assets/stylesheets/partials/_autocomplete.scss
+++ b/app/assets/stylesheets/partials/_autocomplete.scss
@@ -1,8 +1,17 @@
+// re: `z-index` on `.autocomplete__wrapper`
 // The styles for the dropdown arrow sets the z-index to -1 that seems to place
 // it behind the autocomplete, this may be a bug, but this is a workaround for
 // us, see: https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867
+
+.autocomplete__outer-wrapper {
+  display: flex;
+  align-items: start;
+}
+
 .autocomplete__wrapper {
-    z-index: 0;
+  flex: 1;
+  margin-right: 1.5rem;
+  z-index: 0;
 }
 
 // the autocomplete does not set a font, this only effects the autocomplete
@@ -11,4 +20,14 @@
 .autocomplete__input,
 .autocomplete__option {
   @include govuk-font($size: 19);
+}
+
+.autocomplete__clear-button {
+  @include govuk-font($size: 27, $weight: bold, $line-height: 0.8);
+
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-top: 0.5439375rem;
+  padding: 0;
 }

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -292,6 +292,10 @@ class ActivityPresenter < SimpleDelegator
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
 
+  def linkable_activity_select_label
+    "#{title} (#{roda_identifier})"
+  end
+
   private
 
   def translate(*args)

--- a/app/views/activity_forms/linked_activity.html.haml
+++ b/app/views/activity_forms/linked_activity.html.haml
@@ -1,4 +1,11 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset :linked_activity_id do
-    - @activity.linkable_activities.each do |activity|
-      = f.govuk_radio_button :linked_activity_id, activity.id, label: { text: "#{activity.roda_identifier} (#{activity.title})" }
+  - options = @activity.linkable_activities.map { |activity| ActivityPresenter.new(activity) }.unshift(OpenStruct.new(linkable_activity_select_label: "No linked activity", id: ""))
+
+  = f.govuk_collection_select :linked_activity_id,
+    options,
+    :id,
+    :linkable_activity_select_label,
+    options: { selected: f.object.linked_activity_id || options.first.id },
+    label: { text: "Linked activity", size: "xl", tag: "h1" }
+
+  = javascript_include_tag 'accessibleAutocomplete'

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,5 +69,8 @@ module Roda
 
     # serve dynamic error pages
     config.exceptions_app = routes
+
+    # JavaScript precompile
+    config.assets.precompile += ["accessibleAutocomplete.js"]
   end
 end


### PR DESCRIPTION
**Spike**

This adds accessible autocomplete to the activity linking form step

Wasn't sure where to put the options, since they don't really belong in the CodelistHelper

Currently if you use the form to change the linked activity, it will instead remove the link and set `has_linked_activity` to no, but maybe that's a quirk of how things are set up?

Played around with having a blank option equalling `nil`, which kind of works - it does the same as above, removing the link and setting `has_linked_activity` to no - but I haven't included this for now because it's difficult to differentiate nothing being selected and the blank `nil` option being selected. If we do go down this line, we should give `.autocomplete__option` a `min-height` of `1.5625rem` so that the blank option doesn't collapse to almost 0

Also, if you select something, empty out the input field, then click "continue" it will be as though the thing you initially selected is still selected, I think

If you have an option selected, you also need to know to clear it with your keyboard before you can see the full list again (although we might not want to show the full list ultimately anyway). Clicking in the input doesn't select all the text it's populated it with, so you need to Ctrl/Cmd + A and delete, or delete each character individually. It's not the most intuitive thing ever

I wonder if all these quirks are why this didn't end up getting used beyond the defunct (or renamed?) `country` field in #463. I think it could be viable, but it seems a little far from ideal

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
