### PR TITLE
(2686) Part 1: Link ODA and non-ODA ISPF programmes

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -171,6 +171,7 @@ class Activity < ApplicationRecord
     ->(activity) { unscope(:where).for_activity(activity).in_historical_order }
 
   belongs_to :linked_activity, optional: true, class_name: "Activity"
+  after_save :ensure_linked_activity_reciprocity
 
   enum level: {
     fund: "fund",
@@ -600,6 +601,22 @@ class Activity < ApplicationRecord
 
   def historic?
     programme_status.in?(["completed", "stopped", "cancelled"])
+  end
+
+  def ensure_linked_activity_reciprocity
+    return unless saved_change_to_attribute?(:linked_activity_id)
+
+    formerly_linked_activity_id = saved_change_to_attribute(:linked_activity_id).first
+    if formerly_linked_activity_id && (formerly_linked_activity = Activity.find_by(id: formerly_linked_activity_id)).present?
+      # we do not want to propagate this, because it would nullify self.linked_activity_id
+      formerly_linked_activity.update_columns(linked_activity_id: nil)
+    end
+
+    if linked_activity.present?
+      # we do want to propagate this change, in case the newly linked activity was previously linked to another
+      linked_activity.linked_activity = self
+      linked_activity.save
+    end
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -170,6 +170,8 @@ class Activity < ApplicationRecord
   has_many :reports,
     ->(activity) { unscope(:where).for_activity(activity).in_historical_order }
 
+  belongs_to :linked_activity, optional: true, class_name: "Activity"
+
   enum level: {
     fund: "fund",
     programme: "programme",

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -619,6 +619,12 @@ class Activity < ApplicationRecord
     end
   end
 
+  def linkable_activities
+    return [] unless programme? && is_ispf_funded?
+
+    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation)
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -59,6 +59,15 @@
       = activity_presenter.transparency_identifier
     %dd.govuk-summary-list__actions
 
+  - if activity_presenter.is_ispf_funded?
+    .govuk-summary-list__row.linked_activity
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.linked_activity")
+      %dd.govuk-summary-list__value
+        - if activity_presenter.linked_activity
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+      %dd.govuk-summary-list__actions
+
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.title")

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -29,3 +29,11 @@
       = t("activerecord.attributes.activity.partner_organisation_identifier")
     %dd.govuk-summary-list__value
       = activity_presenter.partner_organisation_identifier
+
+  - if activity_presenter.is_ispf_funded?
+    .govuk-summary-list__row.linked_activity
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.linked_activity")
+      %dd.govuk-summary-list__value
+        - if activity_presenter.linked_activity
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -494,6 +494,7 @@ en:
         organisation: Organisation
         partner_organisation: Partner organisation
         is_oda: ODA or Non-ODA
+        linked_activity: Linked activity
     errors:
       models:
         activity:

--- a/db/migrate/20221114173210_add_linked_activity_to_activities.rb
+++ b/db/migrate/20221114173210_add_linked_activity_to_activities.rb
@@ -1,0 +1,5 @@
+class AddLinkedActivityToActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :linked_activity_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_31_155150) do
+ActiveRecord::Schema.define(version: 2022_11_14_173210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2022_10_31_155150) do
     t.boolean "is_oda"
     t.integer "ispf_theme"
     t.string "ispf_partner_countries", array: true
+    t.uuid "linked_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2253,6 +2253,41 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#linkable_activities" do
+    let(:partner_organisation) { create(:partner_organisation) }
+
+    context "when the activity is a fund" do
+      it "returns an empty array" do
+        ispf = create(:fund_activity, :ispf)
+        create(:fund_activity)
+
+        expect(ispf.linkable_activities).to be_empty
+      end
+    end
+
+    context "when the activity is an ODA ISPF programme" do
+      it "returns non-ODA ISPF programmes with the same PO as their extending organisation" do
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
+        _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+        _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+
+        expect(oda_programme.linkable_activities).to eq([non_oda_programme])
+      end
+    end
+
+    context "when the activity is a non-ODA ISPF programme" do
+      it "returns ODA ISPF programmes with the same PO as their extending organisation" do
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+        _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+
+        expect(non_oda_programme.linkable_activities).to eq([oda_programme])
+      end
+    end
+  end
+
   def factory_name_by_activity_level(level)
     (level.underscore.parameterize(separator: "_") + "_activity").to_sym
   end

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe "shared/activities/_activity" do
         expect(rendered).not_to have_content(t("activerecord.attributes.activity.covid19_related"))
       end
 
+      context "when the programme has a linked programme" do
+        let(:linked_activity) { build(:programme_activity, :ispf_funded) }
+        let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], linked_activity: linked_activity) }
+
+        it "shows the linked programme" do
+          expect(rendered).to have_content(activity_presenter.linked_activity.title)
+        end
+      end
+
       context "when the activity is non-ODA" do
         let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], is_oda: false) }
 
@@ -423,6 +432,7 @@ RSpec.describe "shared/activities/_activity" do
     match do |actual|
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_theme")
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_partner_countries")
+      expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
 
       expect(rendered).to have_content(activity_presenter.ispf_theme)
       expect(rendered).to have_content(activity_presenter.ispf_partner_countries)


### PR DESCRIPTION
## Changes in this PR
- Adds back-end activity linking
- Defines what programmes are linkable to a given programme (current definition: same level, same PO, opposite ODA type)
- Visualising of existing links

## Screenshots of UI changes

### Activity summary

![Screenshot 2022-11-23 at 15 45 02](https://user-images.githubusercontent.com/579522/203591287-5d228291-e97c-4cd2-8563-7f331baf1f14.png)

### Activity details
![Screenshot 2022-11-23 at 15 45 10](https://user-images.githubusercontent.com/579522/203591358-ba5fa73b-385a-4a5b-87c3-b874342fa509.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
