### PR TITLE
(2686) Part 2: Linking programmes through the UI

### DIFF
--- a/app/assets/stylesheets/partials/_autocomplete.scss
+++ b/app/assets/stylesheets/partials/_autocomplete.scss
@@ -1,8 +1,17 @@
+// re: `z-index` on `.autocomplete__wrapper`
 // The styles for the dropdown arrow sets the z-index to -1 that seems to place
 // it behind the autocomplete, this may be a bug, but this is a workaround for
 // us, see: https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867
+
+.autocomplete__outer-wrapper {
+  display: flex;
+  align-items: start;
+}
+
 .autocomplete__wrapper {
-    z-index: 0;
+  flex: 1;
+  margin-right: 1.5rem;
+  z-index: 0;
 }
 
 // the autocomplete does not set a font, this only effects the autocomplete
@@ -11,4 +20,14 @@
 .autocomplete__input,
 .autocomplete__option {
   @include govuk-font($size: 19);
+}
+
+.autocomplete__clear-button {
+  @include govuk-font($size: 27, $weight: bold, $line-height: 0.8);
+
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-top: 0.5439375rem;
+  padding: 0;
 }

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -7,11 +7,12 @@ class ActivityFormsController < BaseController
 
   def show
     @activity = Activity.find(activity_id)
-    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    @page_title = page_title(step)
+
     authorize @activity
 
     prepare_default_activity_trail(@activity, tab: "details")
-    add_breadcrumb t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}")), activity_step_path(@activity.id, step)
+    add_breadcrumb @page_title, activity_step_path(@activity.id, step)
 
     case step
     when :is_oda
@@ -19,6 +20,8 @@ class ActivityFormsController < BaseController
     when :identifier
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
+    when :linked_activity
+      skip_step unless @activity.is_ispf_funded? && @activity.programme?
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present
@@ -77,7 +80,8 @@ class ActivityFormsController < BaseController
 
   def update
     @activity = Activity.find(activity_id)
-    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    @page_title = page_title(step)
+
     authorize @activity
 
     updater = Activity::Updater.new(activity: @activity, params: params)
@@ -142,5 +146,13 @@ class ActivityFormsController < BaseController
   def assign_default_collaboration_type_value_if_nil
     # This allows us to pre-select a specific radio button on collaboration_type form step (value "Bilateral" in this case)
     @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
+  end
+
+  def page_title(step)
+    if step == :linked_activity
+      @activity.is_oda ? t("page_title.activity_form.show.linked_non_oda_activity") : t("page_title.activity_form.show.linked_oda_activity")
+    else
+      t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    end
   end
 end

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -22,6 +22,7 @@ class ActivityFormsController < BaseController
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
       skip_step unless @activity.is_ispf_funded? && @activity.programme?
+      @options = linkable_activities_options(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present
@@ -154,5 +155,10 @@ class ActivityFormsController < BaseController
     else
       t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
     end
+  end
+
+  def linkable_activities_options(activity)
+    activity.linkable_activities.map { |linkable_activity| ActivityPresenter.new(linkable_activity) }
+      .unshift(OpenStruct.new(linkable_activity_select_label: t("form.label.activity.no_linked_activity"), id: ""))
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,6 +18,7 @@
 import accessibleAutocomplete from "accessible-autocomplete"
 import Rails from "@rails/ujs"
 
+import rodaAccessibleAutocomplete from "../src/accessible-autocomplete"
 import cookieConsent from "../src/cookie-consent"
 import initTableTreeView from "../src/table-tree-view"
 import toggleProvidingOrgFields from "../src/toggle-providing-org-fields"

--- a/app/javascript/src/accessible-autocomplete.js
+++ b/app/javascript/src/accessible-autocomplete.js
@@ -1,0 +1,79 @@
+// adapted from https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/d070006b2d68ba28e6b204d9efb9807c241c1eeb/app/assets/javascripts/autocomplete.js
+
+function rodaAccessibleAutocomplete () {
+  const selectElement = document.getElementById("activity-linked-activity-id-field")
+
+  if (!selectElement) { return }
+
+  accessibleAutocomplete.enhanceSelectElement({
+    autoselect: true,
+    defaultValue: '',
+    selectElement: selectElement,
+    showAllValues: true,
+    preserveNullOptions: true
+  })
+
+  const autocompleteElement = selectElement.parentNode.getElementsByTagName('input')[0]
+
+  resetSelectWhenDesynced(selectElement, autocompleteElement)
+  addClearButton(selectElement, autocompleteElement)
+}
+
+function resetSelectWhenDesynced (selectElement, autocompleteElement) {
+  // if the autocomplete element's value no longer matches the selected option
+  // in the select element, reset the select element - in particular, this
+  // avoids submitting the last selected value after clearing the input
+  // @see https://github.com/alphagov/accessible-autocomplete/issues/205
+
+  autocompleteElement.addEventListener('keyup', () => {
+    const optionSelectedInSelectElement = selectElement.querySelector('option:checked')
+
+    if (autocompleteElement.value !== optionSelectedInSelectElement.innerText) {
+      selectElement.value = ''
+    }
+  })
+}
+
+function addClearButton (selectElement, autocompleteElement) {
+  const autocompleteOuterWrapper = autocompleteElement.parentNode.parentNode
+
+  autocompleteOuterWrapper.className = 'autocomplete__outer-wrapper'
+
+  const clearButton = createClearButton(selectElement, autocompleteElement)
+
+  autocompleteOuterWrapper.append(clearButton)
+}
+
+function createClearButton (selectElement, autocompleteElement) {
+  const clearButton = document.createElement('button')
+
+  clearButton.type = 'button'
+  clearButton.innerText = 'X'
+  clearButton.ariaLabel = 'Clear selection'
+  clearButton.className = 'autocomplete__clear-button'
+
+  clearButton.addEventListener('click', () => {
+    resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+  })
+
+  clearButton.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+    }
+  })
+
+  return clearButton
+}
+
+function resetSelectAndAutocomplete (selectElement, autocompleteElement, clearButton) {
+  selectElement.value = ''
+  autocompleteElement.value = ''
+
+  autocompleteElement.click()
+  autocompleteElement.focus()
+  autocompleteElement.blur()
+
+  clearButton.focus()
+}
+
+document.addEventListener('DOMContentLoaded', () => rodaAccessibleAutocomplete())

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -622,7 +622,7 @@ class Activity < ApplicationRecord
   def linkable_activities
     return [] unless programme? && is_ispf_funded?
 
-    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation)
+    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,6 +12,7 @@ class Activity < ApplicationRecord
   FORM_STEPS = [
     :is_oda,
     :identifier,
+    :linked_activity,
     :purpose,
     :objectives,
     :sector_category,

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -292,6 +292,10 @@ class ActivityPresenter < SimpleDelegator
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
 
+  def linkable_activity_select_label
+    "#{roda_identifier} (#{title})"
+  end
+
   private
 
   def translate(*args)

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -34,6 +34,10 @@ class Activity
       assign_attributes_for_step("partner_organisation_identifier")
     end
 
+    def set_linked_activity
+      activity.assign_attributes(linked_activity_id: params_for(:linked_activity_id))
+    end
+
     def set_purpose
       activity.assign_attributes(title: params_for("title"), description: params_for("description"))
     end

--- a/app/views/activity_forms/linked_activity.html.haml
+++ b/app/views/activity_forms/linked_activity.html.haml
@@ -1,0 +1,5 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_radio_buttons_fieldset :linked_activity_id, legend: { text: @page_title } do
+    = f.govuk_radio_button :linked_activity_id, nil, label: { text: "None" }, hint: { text: "This activity isn't linked to another activity, or the activity to link to is not in RODA yet." }
+    - @activity.linkable_activities.each do |activity|
+      = f.govuk_radio_button :linked_activity_id, activity.id, label: { text: "#{activity.roda_identifier} (#{activity.title})" }

--- a/app/views/activity_forms/linked_activity.html.haml
+++ b/app/views/activity_forms/linked_activity.html.haml
@@ -1,5 +1,8 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset :linked_activity_id, legend: { text: @page_title } do
-    = f.govuk_radio_button :linked_activity_id, nil, label: { text: "None" }, hint: { text: "This activity isn't linked to another activity, or the activity to link to is not in RODA yet." }
-    - @activity.linkable_activities.each do |activity|
-      = f.govuk_radio_button :linked_activity_id, activity.id, label: { text: "#{activity.roda_identifier} (#{activity.title})" }
+  = f.govuk_collection_select :linked_activity_id,
+    @options,
+    :id,
+    :linkable_activity_select_label,
+    options: { selected: f.object.linked_activity_id || @options.first.id },
+    label: { text: @page_title, size: "xl", tag: "h1" },
+    hint: { text: t("form.hint.activity.linked_activity_guidance") }

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -67,6 +67,8 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update?
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -37,3 +37,6 @@
       %dd.govuk-summary-list__value
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update?
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -138,6 +138,7 @@ en:
         ispf_partner_countries: Who are the ISPF partner countries?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
+        linked_activity_id: What is the activity linked to this activity?
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility: Is this activity ODA eligible?
         parent: Select the parent activity
@@ -401,6 +402,9 @@ en:
         ispf_theme: ISPF theme
         ispf_partner_countries: ISPF partner countries
         level: Hierarchy level
+        linked_activity: What is the activity linked to this activity?
+        linked_oda_activity: What is the ODA activity linked to this activity?
+        linked_non_oda_activity: What is the non-ODA activity linked to this activity?
         objectives: Aims/Objectives
         oda_eligibility: ODA eligibility
         oda_eligibility_lead: ODA eligibility lead

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -64,6 +64,7 @@ en:
         partner_organisation_identifier: Enter your unique identifier
         partner_organisation_identifier_level_b: Enter your unique identifier (optional)
         intended_beneficiaries: What are the intended beneficiaries?
+        no_linked_activity: No linked activity or the activity is not in RODA yet
         objectives: Aims/Objectives of the activity
         oda_eligibility:
           never_eligible: No - was never eligible
@@ -138,7 +139,6 @@ en:
         ispf_partner_countries: Who are the ISPF partner countries?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
-        linked_activity_id: What is the activity linked to this activity?
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility: Is this activity ODA eligible?
         parent: Select the parent activity
@@ -193,6 +193,7 @@ en:
         sector_category_html: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the %{link}
         title: A short title that explains the purpose of the %{level}. There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.
         description: There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.
+        linked_activity_guidance: If the activity you are trying to link does not appear in the selection, it's possible it is already linked to another activity.
         level: Select the type of activity
         level_step:
           fund: The amount of funding each partner organisation will receive

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe ActivityFormsController do
         end
       end
 
+      context "linked_activity step" do
+        subject { get_step :linked_activity }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when it's an ISPF activity" do
+          let(:activity) { create(:programme_activity, :ispf_funded) }
+
+          it { is_expected.to render_current_step }
+        end
+      end
+
       context "collaboration_type" do
         subject { get_step :collaboration_type }
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -251,6 +251,26 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_theme).to eq(non_oda_activity.ispf_theme)
     end
 
+    scenario "a new non-ODA programme can be linked to an existing ODA programme" do
+      linked_oda_activity = create(:programme_activity, :ispf_funded, is_oda: true, extending_organisation: partner_organisation)
+      non_oda_activity.linked_activity = linked_oda_activity
+
+      visit organisation_activities_path(partner_organisation)
+
+      click_on t("form.button.activity.new_child", name: linked_oda_activity.associated_fund.title)
+
+      form = ActivityForm.new(activity: non_oda_activity, level: "programme", fund: "ispf")
+      form.complete!
+
+      expect(page).to have_content(t("action.programme.create.success"))
+
+      created_activity = form.created_activity
+
+      expect(created_activity.title).to eq(non_oda_activity.title)
+      expect(created_activity.is_oda).to eq(non_oda_activity.is_oda)
+      expect(created_activity.linked_activity).to eq(linked_oda_activity)
+    end
+
     context "and the feature flag hiding ISPF is enabled for BEIS users" do
       before do
         mock_feature = double(:feature, groups: [:beis_users])

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2266,24 +2266,35 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when the activity is an ODA ISPF programme" do
-      it "returns non-ODA ISPF programmes with the same PO as their extending organisation" do
+      it "returns unlinked non-ODA ISPF programmes with the same PO as their extending organisation" do
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
         _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+        _non_oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(oda_programme.linkable_activities).to eq([non_oda_programme])
       end
     end
 
     context "when the activity is a non-ODA ISPF programme" do
-      it "returns ODA ISPF programmes with the same PO as their extending organisation" do
+      it "returns unlinked ODA ISPF programmes with the same PO as their extending organisation" do
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
         _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+        _oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(non_oda_programme.linkable_activities).to eq([oda_programme])
+      end
+    end
+
+    context "when the activity is already linked to another activity" do
+      it "includes the already linked activity" do
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: oda_programme)
+
+        expect(oda_programme.reload.linkable_activities).to eq([non_oda_programme])
       end
     end
   end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -197,8 +197,11 @@ class ActivityForm
   end
 
   def fill_in_linked_activity_step
-    expect(page).to have_content I18n.t("form.legend.activity.linked_activity_id")
-    choose("activity[linked_activity_id]", option: activity.linked_activity_id) if activity.linked_activity_id.present?
+    expected_title = @activity.is_oda ? I18n.t("page_title.activity_form.show.linked_non_oda_activity") : I18n.t("page_title.activity_form.show.linked_oda_activity")
+    expect(page).to have_content expected_title
+    if activity.linked_activity.present?
+      select "#{activity.linked_activity.roda_identifier} (#{activity.linked_activity.title})", from: "activity[linked_activity_id]"
+    end
     click_button I18n.t("form.button.activity.submit")
   end
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -129,6 +129,7 @@ class ActivityForm
   def fill_in_ispf_programme_activity_form
     fill_in_is_oda_step
     fill_in_identifier_step
+    fill_in_linked_activity_step
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step
@@ -192,6 +193,12 @@ class ActivityForm
     expect(page).to have_content I18n.t("form.label.activity.partner_organisation_identifier")
     expect(page).to have_content I18n.t("form.hint.activity.partner_organisation_identifier")
     fill_in "activity[partner_organisation_identifier]", with: activity.partner_organisation_identifier
+    click_button I18n.t("form.button.activity.submit")
+  end
+
+  def fill_in_linked_activity_step
+    expect(page).to have_content I18n.t("form.legend.activity.linked_activity_id")
+    choose("activity[linked_activity_id]", option: activity.linked_activity_id) if activity.linked_activity_id.present?
     click_button I18n.t("form.button.activity.submit")
   end
 


### PR DESCRIPTION
## Changes in this PR
- Enable ISPF programme activities (level B) to be linked through the UI
- Only programmes that are not already linked are selectable for linking

## Screenshots of UI changes

![Screenshot 2022-11-28 at 13 39 49](https://user-images.githubusercontent.com/579522/204293307-f1268c3f-60fe-4707-b22f-49e6ba3aa1ea.png)

![Screenshot 2022-11-28 at 13 40 08](https://user-images.githubusercontent.com/579522/204293356-aea0e5ee-7c47-4687-bff0-c812ab94d4a1.png)

![Screenshot 2022-11-24 at 14 23 00](https://user-images.githubusercontent.com/579522/203807059-983f754e-487e-4b4e-8fcf-18146e2917fe.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
