### PR TITLE
(2686) Part 3: Enable linking projects (level C activities)

### DIFF
--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,8 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded? && @activity.programme?
+      skip_step unless @activity.is_ispf_funded? && (@activity.programme? || @activity.project?)
+      skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -621,9 +621,14 @@ class Activity < ApplicationRecord
   end
 
   def linkable_activities
-    return [] unless programme? && is_ispf_funded?
+    return [] unless (programme? || project?) && is_ispf_funded?
+    return [] if project? && parent.linked_activity.nil?
 
-    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
+    if programme?
+      parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
+    else
+      parent.linked_activity.child_activities.where(linked_activity_id: [nil, id])
+    end
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -631,6 +631,10 @@ class Activity < ApplicationRecord
     end
   end
 
+  def linked_child_activities
+    child_activities.where.not(linked_activity_id: nil)
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -68,6 +68,18 @@ class ActivityPolicy < ApplicationPolicy
     false
   end
 
+  def update_linked_activity?
+    if record.programme?
+      return beis_user? && record.linked_child_activities.empty?
+    end
+
+    if record.project?
+      return false unless editable_report?
+      return beis_user? || partner_organisation_user? && record.organisation == user.organisation
+    end
+    false
+  end
+
   def destroy?
     false
   end

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -67,7 +67,7 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update?
+        - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))
 
   .govuk-summary-list__row.title

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -38,5 +38,5 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update?
+        - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -403,7 +403,6 @@ en:
         ispf_theme: ISPF theme
         ispf_partner_countries: ISPF partner countries
         level: Hierarchy level
-        linked_activity: What is the activity linked to this activity?
         linked_oda_activity: What is the ODA activity linked to this activity?
         linked_non_oda_activity: What is the non-ODA activity linked to this activity?
         objectives: Aims/Objectives

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2271,7 +2271,7 @@ RSpec.describe Activity, type: :model do
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
         _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
-        _non_oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
+        _prelinked_non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(oda_programme.linkable_activities).to eq([non_oda_programme])
       end
@@ -2283,7 +2283,7 @@ RSpec.describe Activity, type: :model do
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
         _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
-        _oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
+        _prelinked_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(non_oda_programme.linkable_activities).to eq([oda_programme])
       end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to permit_action(:create_child)
         is_expected.to permit_action(:create_transfer)
+
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
 
@@ -43,6 +45,8 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to forbid_action(:create_child)
         is_expected.to permit_action(:create_transfer)
+
+        is_expected.to permit_action(:update_linked_activity)
       end
 
       context "and there is an active report" do
@@ -50,6 +54,14 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to permit_action(:create_refund) }
         it { is_expected.to forbid_action(:create_adjustment) }
+      end
+
+      context "when the activity has child activities that are linked to other activities" do
+        let(:activity) { create(:programme_activity, :ispf_funded) }
+
+        before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+        it { is_expected.to forbid_action(:update_linked_activity) }
       end
     end
 
@@ -59,6 +71,7 @@ RSpec.describe ActivityPolicy do
       it "only permits show and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
+
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
 
@@ -69,6 +82,15 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to forbid_action(:create_child)
         is_expected.to forbid_action(:create_transfer)
+        is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "and there is an active report for the project's organisation" do
+        let(:activity) { create(:project_activity, :with_report) }
+
+        it "permits update_linked_activity" do
+          is_expected.to permit_action(:update_linked_activity)
+        end
       end
     end
 
@@ -88,6 +110,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_transfer)
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
   end
@@ -110,13 +133,14 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_transfer)
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -129,10 +153,11 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(extending_organisation: user.organisation)
         end
@@ -150,9 +175,10 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
@@ -162,6 +188,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
       end
@@ -170,7 +197,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -183,15 +210,16 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(organisation: user.organisation, extending_organisation: user.organisation)
         end
 
-        context "and there is no editable report for the users organisation" do
+        context "and there is no editable report for the user's organisation" do
           before do
             report.update(state: :approved)
           end
@@ -209,10 +237,11 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
@@ -230,6 +259,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
             is_expected.to permit_action(:create_adjustment)
+            is_expected.to permit_action(:update_linked_activity)
           end
         end
       end
@@ -238,7 +268,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -251,15 +281,16 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(organisation: user.organisation, extending_organisation: user.organisation)
         end
 
-        context "and there is no editable report for the users organisation" do
+        context "and there is no editable report for the user's organisation" do
           it "only permits show" do
             is_expected.to permit_action(:show)
 
@@ -272,15 +303,16 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_child)
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, and create_child" do
+          it "only forbids destroy, redact_from_iati, update_linked_activity, and create_child" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -288,6 +320,7 @@ RSpec.describe ActivityPolicy do
 
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
+            is_expected.to forbid_action(:update_linked_activity)
 
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -151,6 +151,7 @@ class ActivityForm
 
   def fill_in_ispf_project_activity_form
     fill_in_identifier_step
+    fill_in_linked_activity_step if @activity.project?
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "shared/activities/_activity" do
       allow(view).to receive(:edit_activity_redaction_path).and_return("This path isn't important")
       allow(view).to receive(:organisation_activity_path).and_return("This path isn't important")
     end
-
-    render
   end
 
   context "when the fund is GCRF" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :gcrf_funded) }
 
@@ -45,6 +45,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "when the fund is Newton" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :newton_funded, country_partner_organisations: country_partner_orgs) }
 
@@ -69,6 +71,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "when the fund is ISPF" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"]) }
 
@@ -151,6 +155,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "showing the publish to iati field" do
+    before { render }
+
     context "when redact_from_iati is false" do
       let(:policy_stub) { double("policy", update?: true, redact_from_iati?: false) }
 
@@ -169,6 +175,8 @@ RSpec.describe "shared/activities/_activity" do
 
     context "when the activity is a fund activity" do
       let(:activity) { build(:fund_activity, organisation: user.organisation) }
+
+      before { render }
 
       it "does not show the parent field" do
         expect(rendered).not_to have_content(t("activerecord.attributes.activity.parent"))
@@ -200,10 +208,45 @@ RSpec.describe "shared/activities/_activity" do
         end
       end
     end
+
+    context "when the activity is an ISPF programme" do
+      let(:activity) { build(:programme_activity, :ispf_funded) }
+
+      context "and it doesn't have a linked activity" do
+        before { render }
+
+        it "shows a link to add a linked activity" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+        end
+      end
+
+      context "and it has a linked activity" do
+        let!(:linked_prog) { create(:programme_activity, :ispf_funded, linked_activity: activity) }
+
+        before { render }
+
+        it "shows a link to edit the linked activity" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
+        end
+      end
+
+      context "when the programme has any child projects that are linked" do
+        let!(:linked_prog) { create(:programme_activity, :ispf_funded, linked_activity: activity) }
+        let!(:project) { create(:project_activity, parent: activity, linked_activity: create(:project_activity, parent: linked_prog)) }
+
+        before { render }
+
+        it "does not show an edit link for the linked programme" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+        end
+      end
+    end
   end
 
-  context "when the activity is programme level activity" do
+  context "when the activity is a programme level activity" do
     let(:activity) { build(:programme_activity) }
+
+    before { render }
 
     it "does not show the Channel of delivery code field" do
       expect(rendered).to_not have_content(t("activerecord.attributes.activity.channel_of_delivery_code"))
@@ -214,6 +257,8 @@ RSpec.describe "shared/activities/_activity" do
 
   context "when the activity is a project level activity" do
     let(:activity) { build(:project_activity, organisation: user.organisation) }
+
+    before { render }
 
     it { is_expected.to_not show_the_edit_add_actions }
 
@@ -252,6 +297,8 @@ RSpec.describe "shared/activities/_activity" do
   describe "Benefitting region" do
     let(:activity) { build(:programme_activity, benefitting_countries: benefitting_countries) }
 
+    before { render }
+
     context "when the activity has benefitting countries" do
       subject { body.find(".benefitting_region") }
 
@@ -282,6 +329,8 @@ RSpec.describe "shared/activities/_activity" do
         )
       }
 
+      before { render }
+
       it "is shown at all times and has a helpful 'read only' label" do
         expect(body.find(".recipient_region .govuk-summary-list__value")).to have_content("Africa, regional")
         expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")
@@ -303,6 +352,8 @@ RSpec.describe "shared/activities/_activity" do
           intended_beneficiaries: []
         )
       }
+
+      before { render }
 
       it "is shown at all times and has a helpful 'read only' label" do
         expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")


### PR DESCRIPTION
## Changes in this PR
- Projects that are children of linked programmes can be linked
- Programmes with linked children cannot have their linked activity edited

## Screenshots of UI changes

![Screenshot 2022-11-28 at 16 36 27](https://user-images.githubusercontent.com/579522/204331852-98dca788-6615-45be-8d12-32222ecc42bd.png)

![Screenshot 2022-11-28 at 16 36 44](https://user-images.githubusercontent.com/579522/204331870-43f1df81-3f92-4f8d-905b-c474b046d8a5.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
