### PR TITLE
(2686) Part 4: enable level D activity linking

### DIFF
--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,7 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded? && (@activity.programme? || @activity.project?)
+      skip_step unless @activity.is_ispf_funded?
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,6 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded?
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -621,8 +621,8 @@ class Activity < ApplicationRecord
   end
 
   def linkable_activities
-    return [] unless (programme? || project?) && is_ispf_funded?
-    return [] if project? && parent.linked_activity.nil?
+    return [] unless is_ispf_funded?
+    return [] if is_project? && parent.linked_activity.nil?
 
     if programme?
       parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -73,10 +73,11 @@ class ActivityPolicy < ApplicationPolicy
       return beis_user? && record.linked_child_activities.empty?
     end
 
-    if record.project?
-      return false unless editable_report?
+    if record.is_project?
+      return false unless editable_report? && record.linked_child_activities.empty?
       return beis_user? || partner_organisation_user? && record.organisation == user.organisation
     end
+
     false
   end
 

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -69,16 +69,16 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def update_linked_activity?
+    return unless record.is_ispf_funded?
+
     if record.programme?
       return beis_user? && record.linked_child_activities.empty?
     end
 
     if record.is_project?
       return false unless editable_report? && record.linked_child_activities.empty?
-      return beis_user? || partner_organisation_user? && record.organisation == user.organisation
+      beis_user? || partner_organisation_user? && record.organisation == user.organisation
     end
-
-    false
   end
 
   def destroy?

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -68,21 +68,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:programme_activity, :ispf_funded) }
+        context "when the linked activity is editable" do
+          let(:policy) { double(:policy) }
+
+          before do
+            allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
+          end
 
           it { is_expected.to render_current_step }
-
-          context "when the linked activity is not editable" do
-            let(:policy) { double(:policy) }
-
-            before do
-              allow(controller).to receive(:policy).and_return(policy)
-              allow(policy).to receive(:update_linked_activity?).and_return(false)
-            end
-
-            it { is_expected.to skip_to_next_step }
-          end
         end
       end
 
@@ -215,25 +209,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:project_activity, :ispf_funded, organisation: organisation) }
+        context "when the linked activity is editable" do
           let(:policy) { double(:policy) }
 
           before do
             allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
           end
 
-          context "and the linked activity is editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
-
-            it { is_expected.to render_current_step }
-          end
-
-          context "and the linked activity is not editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
-
-            it { is_expected.to skip_to_next_step }
-          end
+          it { is_expected.to render_current_step }
         end
       end
     end
@@ -261,25 +245,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:third_party_project_activity, :ispf_funded, organisation: organisation) }
+        context "when the linked activity is editable" do
           let(:policy) { double(:policy) }
 
           before do
             allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
           end
 
-          context "and the linked activity is editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
-
-            it { is_expected.to render_current_step }
-          end
-
-          context "and the linked activity is not editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
-
-            it { is_expected.to skip_to_next_step }
-          end
+          it { is_expected.to render_current_step }
         end
       end
     end

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -255,6 +255,33 @@ RSpec.describe ActivityFormsController do
           it { is_expected.to render_current_step }
         end
       end
+
+      context "linked_activity step" do
+        subject { get_step :linked_activity }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when it's an ISPF activity" do
+          let(:activity) { create(:third_party_project_activity, :ispf_funded, organisation: organisation) }
+          let(:policy) { double(:policy) }
+
+          before do
+            allow(controller).to receive(:policy).and_return(policy)
+          end
+
+          context "and the linked activity is editable" do
+            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
+
+            it { is_expected.to render_current_step }
+          end
+
+          context "and the linked activity is not editable" do
+            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
+
+            it { is_expected.to skip_to_next_step }
+          end
+        end
+      end
     end
   end
 

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -46,7 +46,13 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_child)
         is_expected.to permit_action(:create_transfer)
 
-        is_expected.to permit_action(:update_linked_activity)
+        is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "when it's an ISPF programme" do
+        let(:activity) { create(:programme_activity, :ispf_funded, organisation: user.organisation) }
+
+        it { is_expected.to permit_action(:update_linked_activity) }
       end
 
       context "and there is an active report" do
@@ -85,18 +91,26 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:update_linked_activity)
       end
 
-      context "and there is an active report for the project's organisation" do
-        let(:activity) { create(:project_activity, :with_report) }
+      context "and the project is ISPF-funded" do
+        let(:activity) { create(:project_activity, :ispf_funded) }
 
-        it "permits update_linked_activity" do
-          is_expected.to permit_action(:update_linked_activity)
+        it "forbids update_linked_activity" do
+          is_expected.to forbid_action(:update_linked_activity)
         end
 
-        context "when the project has child activities that are linked to other activities" do
-          before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+        context "and there is an active report for the project's organisation" do
+          let(:activity) { create(:project_activity, :ispf_funded, :with_report) }
 
-          it "forbids update_linked_activity" do
-            is_expected.to forbid_action(:update_linked_activity)
+          it "permits update_linked_activity" do
+            is_expected.to permit_action(:update_linked_activity)
+          end
+
+          context "when the project has child activities that are linked to other activities" do
+            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+            it "forbids update_linked_activity" do
+              is_expected.to forbid_action(:update_linked_activity)
+            end
           end
         end
       end
@@ -121,11 +135,19 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:update_linked_activity)
       end
 
-      context "and there is an active report for the project's organisation" do
-        let(:activity) { create(:third_party_project_activity, :with_report) }
+      context "when the activity is ISPF-funded" do
+        let(:activity) { create(:third_party_project_activity, :ispf_funded) }
 
-        it "permits update_linked_activity" do
-          is_expected.to permit_action(:update_linked_activity)
+        it "forbids update_linked_activity" do
+          is_expected.to forbid_action(:update_linked_activity)
+        end
+
+        context "and there is an active report for the project's organisation" do
+          let(:activity) { create(:third_party_project_activity, :ispf_funded, :with_report) }
+
+          it "permits update_linked_activity" do
+            is_expected.to permit_action(:update_linked_activity)
+          end
         end
       end
     end
@@ -262,7 +284,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy and redact_from_iati" do
+          it "only forbids destroy, redact_from_iati, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -275,13 +297,19 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
             is_expected.to permit_action(:create_adjustment)
-            is_expected.to permit_action(:update_linked_activity)
+            is_expected.to forbid_action(:update_linked_activity)
           end
 
-          context "when the activity has child activities that are linked to other activities" do
-            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+          context "when the activity is ISPF-funded" do
+            let(:activity) { create(:project_activity, :ispf_funded) }
 
-            it { is_expected.to forbid_action(:update_linked_activity) }
+            it { is_expected.to permit_action(:update_linked_activity) }
+
+            context "when the activity has child activities that are linked to other activities" do
+              before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+              it { is_expected.to forbid_action(:update_linked_activity) }
+            end
           end
         end
       end
@@ -334,7 +362,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, and create_child" do
+          it "only forbids destroy, redact_from_iati, create_child, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -346,7 +374,13 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
-            is_expected.to permit_action(:update_linked_activity)
+            is_expected.to forbid_action(:update_linked_activity)
+          end
+
+          context "when the activity is ISPF-funded" do
+            let(:activity) { create(:third_party_project_activity, :ispf_funded) }
+
+            it { is_expected.to permit_action(:update_linked_activity) }
           end
         end
       end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe ActivityPolicy do
         it "permits update_linked_activity" do
           is_expected.to permit_action(:update_linked_activity)
         end
+
+        context "when the project has child activities that are linked to other activities" do
+          before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+          it "forbids update_linked_activity" do
+            is_expected.to forbid_action(:update_linked_activity)
+          end
+        end
       end
     end
 
@@ -111,6 +119,14 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
         is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "and there is an active report for the project's organisation" do
+        let(:activity) { create(:third_party_project_activity, :with_report) }
+
+        it "permits update_linked_activity" do
+          is_expected.to permit_action(:update_linked_activity)
+        end
       end
     end
   end
@@ -261,6 +277,12 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_adjustment)
             is_expected.to permit_action(:update_linked_activity)
           end
+
+          context "when the activity has child activities that are linked to other activities" do
+            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+            it { is_expected.to forbid_action(:update_linked_activity) }
+          end
         end
       end
     end
@@ -312,7 +334,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, update_linked_activity, and create_child" do
+          it "only forbids destroy, redact_from_iati, and create_child" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -320,11 +342,11 @@ RSpec.describe ActivityPolicy do
 
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
-            is_expected.to forbid_action(:update_linked_activity)
 
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
+            is_expected.to permit_action(:update_linked_activity)
           end
         end
       end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -151,7 +151,7 @@ class ActivityForm
 
   def fill_in_ispf_project_activity_form
     fill_in_identifier_step
-    fill_in_linked_activity_step if @activity.project?
+    fill_in_linked_activity_step
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step


### PR DESCRIPTION
## Changes in this PR
- Enable linking third-party projects (AKA level C activities)

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
