### PR TITLE
(2719) Hide ISPF level B templates with feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1137,6 +1137,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Add Level B ISPF ODA and non-ODA activity bulk uploads
 - Add Level C ISPF ODA activity bulk uploads
+- Hide the ISPF templates for level B bulk uploads when the ISPF feature flag is enabled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-122...HEAD
 [release-122]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-121...release-122

--- a/app/views/level_b/activities/uploads/new.html.haml
+++ b/app/views/level_b/activities/uploads/new.html.haml
@@ -10,8 +10,9 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = render partial: "fund_section", locals: { type: :ispf_oda }
-      = render partial: "fund_section", locals: { type: :ispf_non_oda }
+      - unless hide_ispf_for_group?(:beis_users)
+        = render partial: "fund_section", locals: { type: :ispf_oda }
+        = render partial: "fund_section", locals: { type: :ispf_non_oda }
       = render partial: "fund_section", locals: { type: :non_ispf }
 
   .govuk-grid-row

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -232,6 +232,20 @@ RSpec.feature "BEIS users can upload Level B activities" do
     end
   end
 
+  context "when the feature flag hiding ISPF is enabled for BEIS users" do
+    before do
+      mock_feature = double(:feature, groups: [:beis_users])
+      allow(ROLLOUT).to receive(:get).and_return(mock_feature)
+    end
+
+    it "does not show the ISPF template download links" do
+      visit new_organisation_level_b_activities_upload_path(organisation)
+
+      expect(page).to_not have_content("ISPF")
+      expect(page).to have_content("GCRF/NF/OODA")
+    end
+  end
+
   context "ISPF ODA" do
     scenario "downloading the CSV template" do
       click_link t("action.activity.download.link", type: t("action.activity.type.ispf_oda"))


### PR DESCRIPTION
## Changes in this PR
- Hide the ISPF templates for level B bulk uploads when the ISPF feature flag is enabled.

I considered renaming the non-ISPF templates when the feature flag is hiding ISPF, but decided against it. It's not technically wrong, even if it might seem odd to name the template when there is no other template to distinguish it from.

## Screenshots of UI changes

### Before
![Screenshot 2022-11-29 at 16 58 32](https://user-images.githubusercontent.com/579522/204597027-da893759-076c-4f79-b0c1-c1a473b35460.png)

### After
![Screenshot 2022-11-29 at 16 58 50](https://user-images.githubusercontent.com/579522/204597052-4c5da57b-7afb-46d1-9da9-f19841afd18f.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
