### PR TITLE
(2707) Exclude non ODA from IATI exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1136,6 +1136,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [release-123] 2022-12-01
 
 - Add ISPF ODA and non-ODA activity bulk uploads - templates will only be visible when the ISPF feature flag is disabled
+- Filter non-ODA activities from IATI exports
 
 ## [unreleased]
 

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -1,16 +1,20 @@
 class FindProgrammeActivities
   include Pundit::Authorization
 
-  attr_accessor :organisation, :user, :fund_code
+  attr_accessor :organisation, :user, :fund_code, :include_ispf_non_oda_activities
 
-  def initialize(organisation:, user:, fund_code: nil)
+  def initialize(organisation:, user:, fund_code: nil, include_ispf_non_oda_activities: false)
     @organisation = organisation
     @user = user
     @fund_code = fund_code
+    @include_ispf_non_oda_activities = include_ispf_non_oda_activities
   end
 
   def call
-    programmes = ProgrammePolicy::Scope.new(user, Activity.programme)
+    is_oda = [nil, true]
+    is_oda << false if include_ispf_non_oda_activities
+
+    programmes = ProgrammePolicy::Scope.new(user, Activity.programme.where(is_oda: is_oda))
       .resolve
       .includes(
         :organisation,

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -1,16 +1,17 @@
 class FindThirdPartyProjectActivities
   include Pundit::Authorization
 
-  attr_accessor :organisation, :user, :fund_code
+  attr_accessor :organisation, :user, :fund_code, :include_ispf_non_oda_activities
 
-  def initialize(organisation:, user:, fund_code: nil)
+  def initialize(organisation:, user:, fund_code: nil, include_ispf_non_oda_activities: false)
     @organisation = organisation
     @user = user
     @fund_code = fund_code
+    @include_ispf_non_oda_activities = include_ispf_non_oda_activities
   end
 
   def call
-    third_party_projects = ThirdPartyProjectPolicy::Scope.new(user, projects_scope)
+    ThirdPartyProjectPolicy::Scope.new(user, projects_scope)
       .resolve
       .includes(
         :organisation,
@@ -21,17 +22,18 @@ class FindThirdPartyProjectActivities
         :commitment
       )
       .order("created_at ASC")
-
-    if organisation.service_owner?
-      third_party_projects.all
-    else
-      third_party_projects.where(organisation_id: organisation.id)
-    end
   end
 
   private
 
   def projects_scope
-    fund_code.nil? ? Activity.third_party_project : Activity.third_party_project.where(source_fund_code: fund_code)
+    is_oda = [nil, true]
+    is_oda << false if include_ispf_non_oda_activities
+
+    query_conditions = {is_oda: is_oda}
+    query_conditions[:source_fund_code] = fund_code if fund_code.present?
+    query_conditions[:organisation_id] = organisation.id if !organisation.service_owner?
+
+    Activity.third_party_project.where(query_conditions)
   end
 end

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -38,5 +38,43 @@ RSpec.describe FindProgrammeActivities do
         expect(result).not_to include programme_from_another_fund
       end
     end
+
+    context "including or excluding ISPF non-ODA activities" do
+      let!(:oda_programme) {
+        create(
+          :programme_activity,
+          :ispf_funded,
+          extending_organisation: other_organisation,
+          is_oda: true
+        )
+      }
+
+      let!(:non_oda_programme) {
+        create(
+          :programme_activity,
+          :ispf_funded,
+          extending_organisation: other_organisation,
+          is_oda: false
+        )
+      }
+
+      context "when `include_ispf_non_oda_activities` is not passed" do
+        it "includes only programmes with `is_oda` values of `true` or `nil`" do
+          result = described_class.new(organisation: other_organisation, user: user).call
+
+          expect(result).to match_array([extending_organisation_programme, oda_programme])
+          expect(result).not_to include(other_programme, non_oda_programme)
+        end
+      end
+
+      context "when `include_ispf_non_oda_activities` is passed as true" do
+        it "includes all programmes for the organisation" do
+          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
+
+          expect(result).to match_array([extending_organisation_programme, oda_programme, non_oda_programme])
+          expect(result).not_to include other_programme
+        end
+      end
+    end
   end
 end

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -22,6 +22,29 @@ RSpec.describe FindProjectActivities do
 
         expect(result).to match_array [fund_1_organisation_project, other_project]
       end
+
+      context "filtering by `include_ispf_non_oda_activities`" do
+        let!(:oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: true) }
+        let!(:non_oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: false) }
+
+        it "excludes ISPF non-ODA activities by default" do
+          result = described_class.new(organisation: service_owner, user: user).call
+
+          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, other_project, oda_project]
+        end
+
+        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
+          result = described_class.new(organisation: service_owner, user: user, include_ispf_non_oda_activities: true).call
+
+          expect(result).to match_array [
+            fund_1_organisation_project,
+            fund_2_organisation_project,
+            other_project,
+            oda_project,
+            non_oda_project
+          ]
+        end
+      end
     end
 
     context "when the organisation is not the service owner" do
@@ -35,6 +58,28 @@ RSpec.describe FindProjectActivities do
         result = described_class.new(organisation: other_organisation, user: user, fund_code: 1).call
 
         expect(result).to match_array [fund_1_organisation_project]
+      end
+
+      context "filtering by `include_ispf_non_oda_activities`" do
+        let!(:oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: true) }
+        let!(:non_oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: false) }
+
+        it "excludes ISPF non-ODA activities by default" do
+          result = described_class.new(organisation: other_organisation, user: user).call
+
+          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, oda_project]
+        end
+
+        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
+          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
+
+          expect(result).to match_array [
+            fund_1_organisation_project,
+            fund_2_organisation_project,
+            oda_project,
+            non_oda_project
+          ]
+        end
       end
     end
   end

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -22,6 +22,44 @@ RSpec.describe FindThirdPartyProjectActivities do
 
         expect(result).to match_array [fund_1_organisation_project, other_project]
       end
+
+      context "filtering by `include_ispf_non_oda_activities`" do
+        let!(:oda_project) {
+          create(
+            :third_party_project_activity,
+            :ispf_funded,
+            organisation: other_organisation,
+            is_oda: true
+          )
+        }
+
+        let!(:non_oda_project) {
+          create(
+            :third_party_project_activity,
+            :ispf_funded,
+            organisation: other_organisation,
+            is_oda: false
+          )
+        }
+
+        it "excludes ISPF non-ODA activities by default" do
+          result = described_class.new(organisation: service_owner, user: user).call
+
+          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, other_project, oda_project]
+        end
+
+        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
+          result = described_class.new(organisation: service_owner, user: user, include_ispf_non_oda_activities: true).call
+
+          expect(result).to match_array [
+            fund_1_organisation_project,
+            fund_2_organisation_project,
+            other_project,
+            oda_project,
+            non_oda_project
+          ]
+        end
+      end
     end
 
     context "when the organisation is not the service owner" do
@@ -35,6 +73,43 @@ RSpec.describe FindThirdPartyProjectActivities do
         result = described_class.new(organisation: other_organisation, user: user, fund_code: 1).call
 
         expect(result).to match_array [fund_1_organisation_project]
+      end
+
+      context "filtering by `include_ispf_non_oda_activities`" do
+        let!(:oda_project) {
+          create(
+            :third_party_project_activity,
+            :ispf_funded,
+            organisation: other_organisation,
+            is_oda: true
+          )
+        }
+
+        let!(:non_oda_project) {
+          create(
+            :third_party_project_activity,
+            :ispf_funded,
+            organisation: other_organisation,
+            is_oda: false
+          )
+        }
+
+        it "excludes ISPF non-ODA activities by default" do
+          result = described_class.new(organisation: other_organisation, user: user).call
+
+          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, oda_project]
+        end
+
+        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
+          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
+
+          expect(result).to match_array [
+            fund_1_organisation_project,
+            fund_2_organisation_project,
+            oda_project,
+            non_oda_project
+          ]
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

This filters out non-ODA activities from IATI exports

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
