### PR TITLE
(2686) Enable linking ISPF ODA with non-ODA activities via the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1136,9 +1136,11 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [release-123] 2022-12-01
 
 - Add ISPF ODA and non-ODA activity bulk uploads - templates will only be visible when the ISPF feature flag is disabled
-- Filter non-ODA activities from IATI exports
 
 ## [unreleased]
+
+- Filter non-ODA activities from IATI exports
+- Enable activity linking for ISPF activities - manually via the user interface
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-123...HEAD
 [release-123]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-122...release-123

--- a/app/assets/stylesheets/partials/_autocomplete.scss
+++ b/app/assets/stylesheets/partials/_autocomplete.scss
@@ -1,8 +1,17 @@
+// re: `z-index` on `.autocomplete__wrapper`
 // The styles for the dropdown arrow sets the z-index to -1 that seems to place
 // it behind the autocomplete, this may be a bug, but this is a workaround for
 // us, see: https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867
+
+.autocomplete__outer-wrapper {
+  display: flex;
+  align-items: start;
+}
+
 .autocomplete__wrapper {
-    z-index: 0;
+  flex: 1;
+  margin-right: 1.5rem;
+  z-index: 0;
 }
 
 // the autocomplete does not set a font, this only effects the autocomplete
@@ -11,4 +20,14 @@
 .autocomplete__input,
 .autocomplete__option {
   @include govuk-font($size: 19);
+}
+
+.autocomplete__clear-button {
+  @include govuk-font($size: 27, $weight: bold, $line-height: 0.8);
+
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-top: 0.5439375rem;
+  padding: 0;
 }

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -7,11 +7,12 @@ class ActivityFormsController < BaseController
 
   def show
     @activity = Activity.find(activity_id)
-    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    @page_title = page_title(step)
+
     authorize @activity
 
     prepare_default_activity_trail(@activity, tab: "details")
-    add_breadcrumb t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}")), activity_step_path(@activity.id, step)
+    add_breadcrumb @page_title, activity_step_path(@activity.id, step)
 
     case step
     when :is_oda
@@ -19,6 +20,8 @@ class ActivityFormsController < BaseController
     when :identifier
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
+    when :linked_activity
+      skip_step unless @activity.is_ispf_funded? && @activity.programme?
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present
@@ -77,7 +80,8 @@ class ActivityFormsController < BaseController
 
   def update
     @activity = Activity.find(activity_id)
-    @page_title = t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    @page_title = page_title(step)
+
     authorize @activity
 
     updater = Activity::Updater.new(activity: @activity, params: params)
@@ -142,5 +146,13 @@ class ActivityFormsController < BaseController
   def assign_default_collaboration_type_value_if_nil
     # This allows us to pre-select a specific radio button on collaboration_type form step (value "Bilateral" in this case)
     @activity.collaboration_type = "1" if @activity.collaboration_type.nil?
+  end
+
+  def page_title(step)
+    if step == :linked_activity
+      @activity.is_oda ? t("page_title.activity_form.show.linked_non_oda_activity") : t("page_title.activity_form.show.linked_oda_activity")
+    else
+      t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
+    end
   end
 end

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,8 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded? && @activity.programme?
+      skip_step unless @activity.is_ispf_funded? && (@activity.programme? || @activity.project?)
+      skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -22,6 +22,7 @@ class ActivityFormsController < BaseController
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
       skip_step unless @activity.is_ispf_funded? && @activity.programme?
+      @options = linkable_activities_options(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present
@@ -154,5 +155,10 @@ class ActivityFormsController < BaseController
     else
       t("page_title.activity_form.show.#{step}", sector_category: t("activity.sector_category.#{@activity.sector_category}"), level: t("page_content.activity.level.#{@activity.level}"))
     end
+  end
+
+  def linkable_activities_options(activity)
+    activity.linkable_activities.map { |linkable_activity| ActivityPresenter.new(linkable_activity) }
+      .unshift(OpenStruct.new(linkable_activity_select_label: t("form.label.activity.no_linked_activity"), id: ""))
   end
 end

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,7 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded? && (@activity.programme? || @activity.project?)
+      skip_step unless @activity.is_ispf_funded?
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -21,7 +21,6 @@ class ActivityFormsController < BaseController
       @label_text = @activity.is_project? ? t("form.label.activity.partner_organisation_identifier") : t("form.label.activity.partner_organisation_identifier_level_b")
       skip_step if @activity.partner_organisation_identifier.present?
     when :linked_activity
-      skip_step unless @activity.is_ispf_funded?
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
     when :objectives

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,6 +18,7 @@
 import accessibleAutocomplete from "accessible-autocomplete"
 import Rails from "@rails/ujs"
 
+import rodaAccessibleAutocomplete from "../src/accessible-autocomplete"
 import cookieConsent from "../src/cookie-consent"
 import initTableTreeView from "../src/table-tree-view"
 import toggleProvidingOrgFields from "../src/toggle-providing-org-fields"

--- a/app/javascript/src/accessible-autocomplete.js
+++ b/app/javascript/src/accessible-autocomplete.js
@@ -1,0 +1,79 @@
+// adapted from https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/d070006b2d68ba28e6b204d9efb9807c241c1eeb/app/assets/javascripts/autocomplete.js
+
+function rodaAccessibleAutocomplete () {
+  const selectElement = document.getElementById("activity-linked-activity-id-field")
+
+  if (!selectElement) { return }
+
+  accessibleAutocomplete.enhanceSelectElement({
+    autoselect: true,
+    defaultValue: '',
+    selectElement: selectElement,
+    showAllValues: true,
+    preserveNullOptions: true
+  })
+
+  const autocompleteElement = selectElement.parentNode.getElementsByTagName('input')[0]
+
+  resetSelectWhenDesynced(selectElement, autocompleteElement)
+  addClearButton(selectElement, autocompleteElement)
+}
+
+function resetSelectWhenDesynced (selectElement, autocompleteElement) {
+  // if the autocomplete element's value no longer matches the selected option
+  // in the select element, reset the select element - in particular, this
+  // avoids submitting the last selected value after clearing the input
+  // @see https://github.com/alphagov/accessible-autocomplete/issues/205
+
+  autocompleteElement.addEventListener('keyup', () => {
+    const optionSelectedInSelectElement = selectElement.querySelector('option:checked')
+
+    if (autocompleteElement.value !== optionSelectedInSelectElement.innerText) {
+      selectElement.value = ''
+    }
+  })
+}
+
+function addClearButton (selectElement, autocompleteElement) {
+  const autocompleteOuterWrapper = autocompleteElement.parentNode.parentNode
+
+  autocompleteOuterWrapper.className = 'autocomplete__outer-wrapper'
+
+  const clearButton = createClearButton(selectElement, autocompleteElement)
+
+  autocompleteOuterWrapper.append(clearButton)
+}
+
+function createClearButton (selectElement, autocompleteElement) {
+  const clearButton = document.createElement('button')
+
+  clearButton.type = 'button'
+  clearButton.innerText = 'X'
+  clearButton.ariaLabel = 'Clear selection'
+  clearButton.className = 'autocomplete__clear-button'
+
+  clearButton.addEventListener('click', () => {
+    resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+  })
+
+  clearButton.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      resetSelectAndAutocomplete(selectElement, autocompleteElement, clearButton)
+    }
+  })
+
+  return clearButton
+}
+
+function resetSelectAndAutocomplete (selectElement, autocompleteElement, clearButton) {
+  selectElement.value = ''
+  autocompleteElement.value = ''
+
+  autocompleteElement.click()
+  autocompleteElement.focus()
+  autocompleteElement.blur()
+
+  clearButton.focus()
+}
+
+document.addEventListener('DOMContentLoaded', () => rodaAccessibleAutocomplete())

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -621,9 +621,14 @@ class Activity < ApplicationRecord
   end
 
   def linkable_activities
-    return [] unless programme? && is_ispf_funded?
+    return [] unless (programme? || project?) && is_ispf_funded?
+    return [] if project? && parent.linked_activity.nil?
 
-    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
+    if programme?
+      parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
+    else
+      parent.linked_activity.child_activities.where(linked_activity_id: [nil, id])
+    end
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -622,7 +622,7 @@ class Activity < ApplicationRecord
   def linkable_activities
     return [] unless programme? && is_ispf_funded?
 
-    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation)
+    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -171,6 +171,7 @@ class Activity < ApplicationRecord
     ->(activity) { unscope(:where).for_activity(activity).in_historical_order }
 
   belongs_to :linked_activity, optional: true, class_name: "Activity"
+  after_save :ensure_linked_activity_reciprocity
 
   enum level: {
     fund: "fund",
@@ -600,6 +601,22 @@ class Activity < ApplicationRecord
 
   def historic?
     programme_status.in?(["completed", "stopped", "cancelled"])
+  end
+
+  def ensure_linked_activity_reciprocity
+    return unless saved_change_to_attribute?(:linked_activity_id)
+
+    formerly_linked_activity_id = saved_change_to_attribute(:linked_activity_id).first
+    if formerly_linked_activity_id && (formerly_linked_activity = Activity.find_by(id: formerly_linked_activity_id)).present?
+      # we do not want to propagate this, because it would nullify self.linked_activity_id
+      formerly_linked_activity.update_columns(linked_activity_id: nil)
+    end
+
+    if linked_activity.present?
+      # we do want to propagate this change, in case the newly linked activity was previously linked to another
+      linked_activity.linked_activity = self
+      linked_activity.save
+    end
   end
 
   def self.hierarchically_grouped_projects

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -170,6 +170,8 @@ class Activity < ApplicationRecord
   has_many :reports,
     ->(activity) { unscope(:where).for_activity(activity).in_historical_order }
 
+  belongs_to :linked_activity, optional: true, class_name: "Activity"
+
   enum level: {
     fund: "fund",
     programme: "programme",

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -12,6 +12,7 @@ class Activity < ApplicationRecord
   FORM_STEPS = [
     :is_oda,
     :identifier,
+    :linked_activity,
     :purpose,
     :objectives,
     :sector_category,

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -619,6 +619,12 @@ class Activity < ApplicationRecord
     end
   end
 
+  def linkable_activities
+    return [] unless programme? && is_ispf_funded?
+
+    parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation)
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -621,8 +621,8 @@ class Activity < ApplicationRecord
   end
 
   def linkable_activities
-    return [] unless (programme? || project?) && is_ispf_funded?
-    return [] if project? && parent.linked_activity.nil?
+    return [] unless is_ispf_funded?
+    return [] if is_project? && parent.linked_activity.nil?
 
     if programme?
       parent.child_activities.where(is_oda: !is_oda, extending_organisation: extending_organisation, linked_activity_id: [nil, id])

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -631,6 +631,10 @@ class Activity < ApplicationRecord
     end
   end
 
+  def linked_child_activities
+    child_activities.where.not(linked_activity_id: nil)
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -68,6 +68,18 @@ class ActivityPolicy < ApplicationPolicy
     false
   end
 
+  def update_linked_activity?
+    if record.programme?
+      return beis_user? && record.linked_child_activities.empty?
+    end
+
+    if record.project?
+      return false unless editable_report?
+      return beis_user? || partner_organisation_user? && record.organisation == user.organisation
+    end
+    false
+  end
+
   def destroy?
     false
   end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -73,10 +73,11 @@ class ActivityPolicy < ApplicationPolicy
       return beis_user? && record.linked_child_activities.empty?
     end
 
-    if record.project?
-      return false unless editable_report?
+    if record.is_project?
+      return false unless editable_report? && record.linked_child_activities.empty?
       return beis_user? || partner_organisation_user? && record.organisation == user.organisation
     end
+
     false
   end
 

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -69,16 +69,16 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def update_linked_activity?
+    return unless record.is_ispf_funded?
+
     if record.programme?
       return beis_user? && record.linked_child_activities.empty?
     end
 
     if record.is_project?
       return false unless editable_report? && record.linked_child_activities.empty?
-      return beis_user? || partner_organisation_user? && record.organisation == user.organisation
+      beis_user? || partner_organisation_user? && record.organisation == user.organisation
     end
-
-    false
   end
 
   def destroy?

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -292,6 +292,10 @@ class ActivityPresenter < SimpleDelegator
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
 
+  def linkable_activity_select_label
+    "#{roda_identifier} (#{title})"
+  end
+
   private
 
   def translate(*args)

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -34,6 +34,10 @@ class Activity
       assign_attributes_for_step("partner_organisation_identifier")
     end
 
+    def set_linked_activity
+      activity.assign_attributes(linked_activity_id: params_for(:linked_activity_id))
+    end
+
     def set_purpose
       activity.assign_attributes(title: params_for("title"), description: params_for("description"))
     end

--- a/app/views/activity_forms/linked_activity.html.haml
+++ b/app/views/activity_forms/linked_activity.html.haml
@@ -1,0 +1,5 @@
+= render layout: "wrapper" do |f|
+  = f.govuk_radio_buttons_fieldset :linked_activity_id, legend: { text: @page_title } do
+    = f.govuk_radio_button :linked_activity_id, nil, label: { text: "None" }, hint: { text: "This activity isn't linked to another activity, or the activity to link to is not in RODA yet." }
+    - @activity.linkable_activities.each do |activity|
+      = f.govuk_radio_button :linked_activity_id, activity.id, label: { text: "#{activity.roda_identifier} (#{activity.title})" }

--- a/app/views/activity_forms/linked_activity.html.haml
+++ b/app/views/activity_forms/linked_activity.html.haml
@@ -1,5 +1,8 @@
 = render layout: "wrapper" do |f|
-  = f.govuk_radio_buttons_fieldset :linked_activity_id, legend: { text: @page_title } do
-    = f.govuk_radio_button :linked_activity_id, nil, label: { text: "None" }, hint: { text: "This activity isn't linked to another activity, or the activity to link to is not in RODA yet." }
-    - @activity.linkable_activities.each do |activity|
-      = f.govuk_radio_button :linked_activity_id, activity.id, label: { text: "#{activity.roda_identifier} (#{activity.title})" }
+  = f.govuk_collection_select :linked_activity_id,
+    @options,
+    :id,
+    :linkable_activity_select_label,
+    options: { selected: f.object.linked_activity_id || @options.first.id },
+    label: { text: @page_title, size: "xl", tag: "h1" },
+    hint: { text: t("form.hint.activity.linked_activity_guidance") }

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -67,7 +67,7 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update?
+        - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))
 
   .govuk-summary-list__row.title

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -59,6 +59,15 @@
       = activity_presenter.transparency_identifier
     %dd.govuk-summary-list__actions
 
+  - if activity_presenter.is_ispf_funded?
+    .govuk-summary-list__row.linked_activity
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.linked_activity")
+      %dd.govuk-summary-list__value
+        - if activity_presenter.linked_activity
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+      %dd.govuk-summary-list__actions
+
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.title")

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -67,6 +67,8 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update?
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))
 
   .govuk-summary-list__row.title
     %dt.govuk-summary-list__key

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -38,5 +38,5 @@
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update?
+        - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -29,3 +29,11 @@
       = t("activerecord.attributes.activity.partner_organisation_identifier")
     %dd.govuk-summary-list__value
       = activity_presenter.partner_organisation_identifier
+
+  - if activity_presenter.is_ispf_funded?
+    .govuk-summary-list__row.linked_activity
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.linked_activity")
+      %dd.govuk-summary-list__value
+        - if activity_presenter.linked_activity
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -37,3 +37,6 @@
       %dd.govuk-summary-list__value
         - if activity_presenter.linked_activity
           = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update?
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -5,30 +5,35 @@
         = t("activerecord.attributes.activity.partner_organisation")
       %dd.govuk-summary-list__value
         = activity_presenter.extending_organisation.name
+      %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.fund
     %dt.govuk-summary-list__key
       Fund
     %dd.govuk-summary-list__value
       = activity_presenter.source_fund.name
+    %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.programme_status
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.programme_status")
     %dd.govuk-summary-list__value
       = activity_presenter.programme_status
+    %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.roda_identifier
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.roda_identifier")
     %dd.govuk-summary-list__value
       = activity_presenter.roda_identifier
+    %dd.govuk-summary-list__actions
 
   .govuk-summary-list__row.identifier
     %dt.govuk-summary-list__key
       = t("activerecord.attributes.activity.partner_organisation_identifier")
     %dd.govuk-summary-list__value
       = activity_presenter.partner_organisation_identifier
+    %dd.govuk-summary-list__actions
 
   - if activity_presenter.is_ispf_funded?
     .govuk-summary-list__row.linked_activity

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -493,6 +493,7 @@ en:
         organisation: Organisation
         partner_organisation: Partner organisation
         is_oda: ODA or Non-ODA
+        linked_activity: Linked activity
     errors:
       models:
         activity:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -138,6 +138,7 @@ en:
         ispf_partner_countries: Who are the ISPF partner countries?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
+        linked_activity_id: What is the activity linked to this activity?
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility: Is this activity ODA eligible?
         parent: Select the parent activity
@@ -400,6 +401,8 @@ en:
         ispf_theme: ISPF theme
         ispf_partner_countries: ISPF partner countries
         level: Hierarchy level
+        linked_oda_activity: What is the ODA activity linked to this activity?
+        linked_non_oda_activity: What is the non-ODA activity linked to this activity?
         objectives: Aims/Objectives
         oda_eligibility: ODA eligibility
         oda_eligibility_lead: ODA eligibility lead

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -64,6 +64,7 @@ en:
         partner_organisation_identifier: Enter your unique identifier
         partner_organisation_identifier_level_b: Enter your unique identifier (optional)
         intended_beneficiaries: What are the intended beneficiaries?
+        no_linked_activity: No linked activity or the activity is not in RODA yet
         objectives: Aims/Objectives of the activity
         oda_eligibility:
           never_eligible: No - was never eligible
@@ -138,7 +139,6 @@ en:
         ispf_partner_countries: Who are the ISPF partner countries?
         intended_beneficiaries: What are the intended beneficiaries?
         level: Add new activity
-        linked_activity_id: What is the activity linked to this activity?
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility: Is this activity ODA eligible?
         parent: Select the parent activity
@@ -193,6 +193,7 @@ en:
         sector_category_html: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the %{link}
         title: A short title that explains the purpose of the %{level}. There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.
         description: There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.
+        linked_activity_guidance: If the activity you are trying to link does not appear in the selection, it's possible it is already linked to another activity.
         level: Select the type of activity
         level_step:
           fund: The amount of funding each partner organisation will receive

--- a/db/migrate/20221114173210_add_linked_activity_to_activities.rb
+++ b/db/migrate/20221114173210_add_linked_activity_to_activities.rb
@@ -1,0 +1,5 @@
+class AddLinkedActivityToActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :linked_activity_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_31_155150) do
+ActiveRecord::Schema.define(version: 2022_11_14_173210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2022_10_31_155150) do
     t.boolean "is_oda"
     t.integer "ispf_theme"
     t.string "ispf_partner_countries", array: true
+    t.uuid "linked_activity_id"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe ActivityFormsController do
         end
       end
 
+      context "linked_activity step" do
+        subject { get_step :linked_activity }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when it's an ISPF activity" do
+          let(:activity) { create(:programme_activity, :ispf_funded) }
+
+          it { is_expected.to render_current_step }
+        end
+      end
+
       context "collaboration_type" do
         subject { get_step :collaboration_type }
 

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -68,21 +68,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:programme_activity, :ispf_funded) }
+        context "when the linked activity is editable" do
+          let(:policy) { double(:policy) }
+
+          before do
+            allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
+          end
 
           it { is_expected.to render_current_step }
-
-          context "when the linked activity is not editable" do
-            let(:policy) { double(:policy) }
-
-            before do
-              allow(controller).to receive(:policy).and_return(policy)
-              allow(policy).to receive(:update_linked_activity?).and_return(false)
-            end
-
-            it { is_expected.to skip_to_next_step }
-          end
         end
       end
 
@@ -215,25 +209,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:project_activity, :ispf_funded, organisation: organisation) }
+        context "when the linked activity is editable" do
           let(:policy) { double(:policy) }
 
           before do
             allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
           end
 
-          context "and the linked activity is editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
-
-            it { is_expected.to render_current_step }
-          end
-
-          context "and the linked activity is not editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
-
-            it { is_expected.to skip_to_next_step }
-          end
+          it { is_expected.to render_current_step }
         end
       end
     end
@@ -261,25 +245,15 @@ RSpec.describe ActivityFormsController do
 
         it { is_expected.to skip_to_next_step }
 
-        context "when it's an ISPF activity" do
-          let(:activity) { create(:third_party_project_activity, :ispf_funded, organisation: organisation) }
+        context "when the linked activity is editable" do
           let(:policy) { double(:policy) }
 
           before do
             allow(controller).to receive(:policy).and_return(policy)
+            allow(policy).to receive(:update_linked_activity?).and_return(true)
           end
 
-          context "and the linked activity is editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
-
-            it { is_expected.to render_current_step }
-          end
-
-          context "and the linked activity is not editable" do
-            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
-
-            it { is_expected.to skip_to_next_step }
-          end
+          it { is_expected.to render_current_step }
         end
       end
     end

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -255,6 +255,33 @@ RSpec.describe ActivityFormsController do
           it { is_expected.to render_current_step }
         end
       end
+
+      context "linked_activity step" do
+        subject { get_step :linked_activity }
+
+        it { is_expected.to skip_to_next_step }
+
+        context "when it's an ISPF activity" do
+          let(:activity) { create(:third_party_project_activity, :ispf_funded, organisation: organisation) }
+          let(:policy) { double(:policy) }
+
+          before do
+            allow(controller).to receive(:policy).and_return(policy)
+          end
+
+          context "and the linked activity is editable" do
+            before { allow(policy).to receive(:update_linked_activity?).and_return(true) }
+
+            it { is_expected.to render_current_step }
+          end
+
+          context "and the linked activity is not editable" do
+            before { allow(policy).to receive(:update_linked_activity?).and_return(false) }
+
+            it { is_expected.to skip_to_next_step }
+          end
+        end
+      end
     end
   end
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -251,6 +251,26 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_theme).to eq(non_oda_activity.ispf_theme)
     end
 
+    scenario "a new non-ODA programme can be linked to an existing ODA programme" do
+      linked_oda_activity = create(:programme_activity, :ispf_funded, is_oda: true, extending_organisation: partner_organisation)
+      non_oda_activity.linked_activity = linked_oda_activity
+
+      visit organisation_activities_path(partner_organisation)
+
+      click_on t("form.button.activity.new_child", name: linked_oda_activity.associated_fund.title)
+
+      form = ActivityForm.new(activity: non_oda_activity, level: "programme", fund: "ispf")
+      form.complete!
+
+      expect(page).to have_content(t("action.programme.create.success"))
+
+      created_activity = form.created_activity
+
+      expect(created_activity.title).to eq(non_oda_activity.title)
+      expect(created_activity.is_oda).to eq(non_oda_activity.is_oda)
+      expect(created_activity.linked_activity).to eq(linked_oda_activity)
+    end
+
     context "and the feature flag hiding ISPF is enabled for BEIS users" do
       before do
         mock_feature = double(:feature, groups: [:beis_users])

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2271,7 +2271,7 @@ RSpec.describe Activity, type: :model do
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
         _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
-        _non_oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
+        _prelinked_non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(oda_programme.linkable_activities).to eq([non_oda_programme])
       end
@@ -2283,7 +2283,7 @@ RSpec.describe Activity, type: :model do
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
         _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
-        _oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
+        _prelinked_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(non_oda_programme.linkable_activities).to eq([oda_programme])
       end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2266,24 +2266,35 @@ RSpec.describe Activity, type: :model do
     end
 
     context "when the activity is an ODA ISPF programme" do
-      it "returns non-ODA ISPF programmes with the same PO as their extending organisation" do
+      it "returns unlinked non-ODA ISPF programmes with the same PO as their extending organisation" do
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
         _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+        _non_oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(oda_programme.linkable_activities).to eq([non_oda_programme])
       end
     end
 
     context "when the activity is a non-ODA ISPF programme" do
-      it "returns ODA ISPF programmes with the same PO as their extending organisation" do
+      it "returns unlinked ODA ISPF programmes with the same PO as their extending organisation" do
         non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
         oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
         _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
         _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+        _oda_programme_linked = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true, linked_activity: build(:programme_activity, :ispf_funded))
 
         expect(non_oda_programme.linkable_activities).to eq([oda_programme])
+      end
+    end
+
+    context "when the activity is already linked to another activity" do
+      it "includes the already linked activity" do
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false, linked_activity: oda_programme)
+
+        expect(oda_programme.reload.linkable_activities).to eq([non_oda_programme])
       end
     end
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2253,6 +2253,41 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#linkable_activities" do
+    let(:partner_organisation) { create(:partner_organisation) }
+
+    context "when the activity is a fund" do
+      it "returns an empty array" do
+        ispf = create(:fund_activity, :ispf)
+        create(:fund_activity)
+
+        expect(ispf.linkable_activities).to be_empty
+      end
+    end
+
+    context "when the activity is an ODA ISPF programme" do
+      it "returns non-ODA ISPF programmes with the same PO as their extending organisation" do
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
+        _other_po_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+        _other_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+
+        expect(oda_programme.linkable_activities).to eq([non_oda_programme])
+      end
+    end
+
+    context "when the activity is a non-ODA ISPF programme" do
+      it "returns ODA ISPF programmes with the same PO as their extending organisation" do
+        non_oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: false)
+        oda_programme = create(:programme_activity, :ispf_funded, extending_organisation: partner_organisation, is_oda: true)
+        _other_po_oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+        _other_non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+
+        expect(non_oda_programme.linkable_activities).to eq([oda_programme])
+      end
+    end
+  end
+
   def factory_name_by_activity_level(level)
     (level.underscore.parameterize(separator: "_") + "_activity").to_sym
   end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -46,7 +46,13 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_child)
         is_expected.to permit_action(:create_transfer)
 
-        is_expected.to permit_action(:update_linked_activity)
+        is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "when it's an ISPF programme" do
+        let(:activity) { create(:programme_activity, :ispf_funded, organisation: user.organisation) }
+
+        it { is_expected.to permit_action(:update_linked_activity) }
       end
 
       context "and there is an active report" do
@@ -85,18 +91,26 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:update_linked_activity)
       end
 
-      context "and there is an active report for the project's organisation" do
-        let(:activity) { create(:project_activity, :with_report) }
+      context "and the project is ISPF-funded" do
+        let(:activity) { create(:project_activity, :ispf_funded) }
 
-        it "permits update_linked_activity" do
-          is_expected.to permit_action(:update_linked_activity)
+        it "forbids update_linked_activity" do
+          is_expected.to forbid_action(:update_linked_activity)
         end
 
-        context "when the project has child activities that are linked to other activities" do
-          before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+        context "and there is an active report for the project's organisation" do
+          let(:activity) { create(:project_activity, :ispf_funded, :with_report) }
 
-          it "forbids update_linked_activity" do
-            is_expected.to forbid_action(:update_linked_activity)
+          it "permits update_linked_activity" do
+            is_expected.to permit_action(:update_linked_activity)
+          end
+
+          context "when the project has child activities that are linked to other activities" do
+            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+            it "forbids update_linked_activity" do
+              is_expected.to forbid_action(:update_linked_activity)
+            end
           end
         end
       end
@@ -121,11 +135,19 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:update_linked_activity)
       end
 
-      context "and there is an active report for the project's organisation" do
-        let(:activity) { create(:third_party_project_activity, :with_report) }
+      context "when the activity is ISPF-funded" do
+        let(:activity) { create(:third_party_project_activity, :ispf_funded) }
 
-        it "permits update_linked_activity" do
-          is_expected.to permit_action(:update_linked_activity)
+        it "forbids update_linked_activity" do
+          is_expected.to forbid_action(:update_linked_activity)
+        end
+
+        context "and there is an active report for the project's organisation" do
+          let(:activity) { create(:third_party_project_activity, :ispf_funded, :with_report) }
+
+          it "permits update_linked_activity" do
+            is_expected.to permit_action(:update_linked_activity)
+          end
         end
       end
     end
@@ -262,7 +284,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy and redact_from_iati" do
+          it "only forbids destroy, redact_from_iati, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -275,13 +297,19 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
             is_expected.to permit_action(:create_adjustment)
-            is_expected.to permit_action(:update_linked_activity)
+            is_expected.to forbid_action(:update_linked_activity)
           end
 
-          context "when the activity has child activities that are linked to other activities" do
-            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+          context "when the activity is ISPF-funded" do
+            let(:activity) { create(:project_activity, :ispf_funded) }
 
-            it { is_expected.to forbid_action(:update_linked_activity) }
+            it { is_expected.to permit_action(:update_linked_activity) }
+
+            context "when the activity has child activities that are linked to other activities" do
+              before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+              it { is_expected.to forbid_action(:update_linked_activity) }
+            end
           end
         end
       end
@@ -334,7 +362,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, and create_child" do
+          it "only forbids destroy, redact_from_iati, create_child, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -346,7 +374,13 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
-            is_expected.to permit_action(:update_linked_activity)
+            is_expected.to forbid_action(:update_linked_activity)
+          end
+
+          context "when the activity is ISPF-funded" do
+            let(:activity) { create(:third_party_project_activity, :ispf_funded) }
+
+            it { is_expected.to permit_action(:update_linked_activity) }
           end
         end
       end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe ActivityPolicy do
         it "permits update_linked_activity" do
           is_expected.to permit_action(:update_linked_activity)
         end
+
+        context "when the project has child activities that are linked to other activities" do
+          before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+          it "forbids update_linked_activity" do
+            is_expected.to forbid_action(:update_linked_activity)
+          end
+        end
       end
     end
 
@@ -111,6 +119,14 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
         is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "and there is an active report for the project's organisation" do
+        let(:activity) { create(:third_party_project_activity, :with_report) }
+
+        it "permits update_linked_activity" do
+          is_expected.to permit_action(:update_linked_activity)
+        end
       end
     end
   end
@@ -261,6 +277,12 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_adjustment)
             is_expected.to permit_action(:update_linked_activity)
           end
+
+          context "when the activity has child activities that are linked to other activities" do
+            before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+            it { is_expected.to forbid_action(:update_linked_activity) }
+          end
         end
       end
     end
@@ -312,7 +334,7 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, update_linked_activity, and create_child" do
+          it "only forbids destroy, redact_from_iati, and create_child" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -320,11 +342,11 @@ RSpec.describe ActivityPolicy do
 
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
-            is_expected.to forbid_action(:update_linked_activity)
 
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
+            is_expected.to permit_action(:update_linked_activity)
           end
         end
       end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to permit_action(:create_child)
         is_expected.to permit_action(:create_transfer)
+
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
 
@@ -43,6 +45,8 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to forbid_action(:create_child)
         is_expected.to permit_action(:create_transfer)
+
+        is_expected.to permit_action(:update_linked_activity)
       end
 
       context "and there is an active report" do
@@ -50,6 +54,14 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to permit_action(:create_refund) }
         it { is_expected.to forbid_action(:create_adjustment) }
+      end
+
+      context "when the activity has child activities that are linked to other activities" do
+        let(:activity) { create(:programme_activity, :ispf_funded) }
+
+        before { allow(activity).to receive(:linked_child_activities).and_return([double(:child_activity)]) }
+
+        it { is_expected.to forbid_action(:update_linked_activity) }
       end
     end
 
@@ -59,6 +71,7 @@ RSpec.describe ActivityPolicy do
       it "only permits show and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
+
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
 
@@ -69,6 +82,15 @@ RSpec.describe ActivityPolicy do
 
         is_expected.to forbid_action(:create_child)
         is_expected.to forbid_action(:create_transfer)
+        is_expected.to forbid_action(:update_linked_activity)
+      end
+
+      context "and there is an active report for the project's organisation" do
+        let(:activity) { create(:project_activity, :with_report) }
+
+        it "permits update_linked_activity" do
+          is_expected.to permit_action(:update_linked_activity)
+        end
       end
     end
 
@@ -88,6 +110,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_transfer)
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
   end
@@ -110,13 +133,14 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_transfer)
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
+        is_expected.to forbid_action(:update_linked_activity)
       end
     end
 
     context "when the activity is a programme" do
       let(:activity) { create(:programme_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -129,10 +153,11 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(extending_organisation: user.organisation)
         end
@@ -150,9 +175,10 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
@@ -162,6 +188,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
       end
@@ -170,7 +197,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -183,15 +210,16 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(organisation: user.organisation, extending_organisation: user.organisation)
         end
 
-        context "and there is no editable report for the users organisation" do
+        context "and there is no editable report for the user's organisation" do
           before do
             report.update(state: :approved)
           end
@@ -209,10 +237,11 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
@@ -230,6 +259,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
             is_expected.to permit_action(:create_adjustment)
+            is_expected.to permit_action(:update_linked_activity)
           end
         end
       end
@@ -238,7 +268,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      context "and the users organisation is not the extending organisation" do
+      context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
           is_expected.to forbid_action(:create)
@@ -251,15 +281,16 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_transfer)
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
+          is_expected.to forbid_action(:update_linked_activity)
         end
       end
 
-      context "and the users organisation is the extending organisation" do
+      context "and the user's organisation is the extending organisation" do
         before do
           activity.update(organisation: user.organisation, extending_organisation: user.organisation)
         end
 
-        context "and there is no editable report for the users organisation" do
+        context "and there is no editable report for the user's organisation" do
           it "only permits show" do
             is_expected.to permit_action(:show)
 
@@ -272,15 +303,16 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_child)
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
+            is_expected.to forbid_action(:update_linked_activity)
           end
         end
 
-        context "and there is an editable report for the users organisation" do
+        context "and there is an editable report for the user's organisation" do
           before do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, and create_child" do
+          it "only forbids destroy, redact_from_iati, update_linked_activity, and create_child" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
@@ -288,6 +320,7 @@ RSpec.describe ActivityPolicy do
 
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
+            is_expected.to forbid_action(:update_linked_activity)
 
             is_expected.to forbid_action(:create_child)
             is_expected.to permit_action(:create_transfer)

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -197,8 +197,11 @@ class ActivityForm
   end
 
   def fill_in_linked_activity_step
-    expect(page).to have_content I18n.t("form.legend.activity.linked_activity_id")
-    choose("activity[linked_activity_id]", option: activity.linked_activity_id) if activity.linked_activity_id.present?
+    expected_title = @activity.is_oda ? I18n.t("page_title.activity_form.show.linked_non_oda_activity") : I18n.t("page_title.activity_form.show.linked_oda_activity")
+    expect(page).to have_content expected_title
+    if activity.linked_activity.present?
+      select "#{activity.linked_activity.roda_identifier} (#{activity.linked_activity.title})", from: "activity[linked_activity_id]"
+    end
     click_button I18n.t("form.button.activity.submit")
   end
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -151,6 +151,7 @@ class ActivityForm
 
   def fill_in_ispf_project_activity_form
     fill_in_identifier_step
+    fill_in_linked_activity_step if @activity.project?
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -151,7 +151,7 @@ class ActivityForm
 
   def fill_in_ispf_project_activity_form
     fill_in_identifier_step
-    fill_in_linked_activity_step if @activity.project?
+    fill_in_linked_activity_step
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -129,6 +129,7 @@ class ActivityForm
   def fill_in_ispf_programme_activity_form
     fill_in_is_oda_step
     fill_in_identifier_step
+    fill_in_linked_activity_step
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step
@@ -192,6 +193,12 @@ class ActivityForm
     expect(page).to have_content I18n.t("form.label.activity.partner_organisation_identifier")
     expect(page).to have_content I18n.t("form.hint.activity.partner_organisation_identifier")
     fill_in "activity[partner_organisation_identifier]", with: activity.partner_organisation_identifier
+    click_button I18n.t("form.button.activity.submit")
+  end
+
+  def fill_in_linked_activity_step
+    expect(page).to have_content I18n.t("form.legend.activity.linked_activity_id")
+    choose("activity[linked_activity_id]", option: activity.linked_activity_id) if activity.linked_activity_id.present?
     click_button I18n.t("form.button.activity.submit")
   end
 

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "shared/activities/_activity" do
       allow(view).to receive(:edit_activity_redaction_path).and_return("This path isn't important")
       allow(view).to receive(:organisation_activity_path).and_return("This path isn't important")
     end
-
-    render
   end
 
   context "when the fund is GCRF" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :gcrf_funded) }
 
@@ -45,6 +45,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "when the fund is Newton" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :newton_funded, country_partner_organisations: country_partner_orgs) }
 
@@ -69,6 +71,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "when the fund is ISPF" do
+    before { render }
+
     context "when the activity is a programme activity" do
       let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"]) }
 
@@ -151,6 +155,8 @@ RSpec.describe "shared/activities/_activity" do
   end
 
   context "showing the publish to iati field" do
+    before { render }
+
     context "when redact_from_iati is false" do
       let(:policy_stub) { double("policy", update?: true, redact_from_iati?: false) }
 
@@ -169,6 +175,8 @@ RSpec.describe "shared/activities/_activity" do
 
     context "when the activity is a fund activity" do
       let(:activity) { build(:fund_activity, organisation: user.organisation) }
+
+      before { render }
 
       it "does not show the parent field" do
         expect(rendered).not_to have_content(t("activerecord.attributes.activity.parent"))
@@ -200,10 +208,45 @@ RSpec.describe "shared/activities/_activity" do
         end
       end
     end
+
+    context "when the activity is an ISPF programme" do
+      let(:activity) { build(:programme_activity, :ispf_funded) }
+
+      context "and it doesn't have a linked activity" do
+        before { render }
+
+        it "shows a link to add a linked activity" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+        end
+      end
+
+      context "and it has a linked activity" do
+        let!(:linked_prog) { create(:programme_activity, :ispf_funded, linked_activity: activity) }
+
+        before { render }
+
+        it "shows a link to edit the linked activity" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
+        end
+      end
+
+      context "when the programme has any child projects that are linked" do
+        let!(:linked_prog) { create(:programme_activity, :ispf_funded, linked_activity: activity) }
+        let!(:project) { create(:project_activity, parent: activity, linked_activity: create(:project_activity, parent: linked_prog)) }
+
+        before { render }
+
+        it "does not show an edit link for the linked programme" do
+          expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+        end
+      end
+    end
   end
 
-  context "when the activity is programme level activity" do
+  context "when the activity is a programme level activity" do
     let(:activity) { build(:programme_activity) }
+
+    before { render }
 
     it "does not show the Channel of delivery code field" do
       expect(rendered).to_not have_content(t("activerecord.attributes.activity.channel_of_delivery_code"))
@@ -214,6 +257,8 @@ RSpec.describe "shared/activities/_activity" do
 
   context "when the activity is a project level activity" do
     let(:activity) { build(:project_activity, organisation: user.organisation) }
+
+    before { render }
 
     it { is_expected.to_not show_the_edit_add_actions }
 
@@ -252,6 +297,8 @@ RSpec.describe "shared/activities/_activity" do
   describe "Benefitting region" do
     let(:activity) { build(:programme_activity, benefitting_countries: benefitting_countries) }
 
+    before { render }
+
     context "when the activity has benefitting countries" do
       subject { body.find(".benefitting_region") }
 
@@ -282,6 +329,8 @@ RSpec.describe "shared/activities/_activity" do
         )
       }
 
+      before { render }
+
       it "is shown at all times and has a helpful 'read only' label" do
         expect(body.find(".recipient_region .govuk-summary-list__value")).to have_content("Africa, regional")
         expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")
@@ -303,6 +352,8 @@ RSpec.describe "shared/activities/_activity" do
           intended_beneficiaries: []
         )
       }
+
+      before { render }
 
       it "is shown at all times and has a helpful 'read only' label" do
         expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe "shared/activities/_activity" do
         expect(rendered).not_to have_content(t("activerecord.attributes.activity.covid19_related"))
       end
 
+      context "when the programme has a linked programme" do
+        let(:linked_activity) { build(:programme_activity, :ispf_funded) }
+        let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], linked_activity: linked_activity) }
+
+        it "shows the linked programme" do
+          expect(rendered).to have_content(activity_presenter.linked_activity.title)
+        end
+      end
+
       context "when the activity is non-ODA" do
         let(:activity) { build(:programme_activity, :ispf_funded, ispf_theme: 1, ispf_partner_countries: ["IN"], is_oda: false) }
 
@@ -423,6 +432,7 @@ RSpec.describe "shared/activities/_activity" do
     match do |actual|
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_theme")
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_partner_countries")
+      expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
 
       expect(rendered).to have_content(activity_presenter.ispf_theme)
       expect(rendered).to have_content(activity_presenter.ispf_partner_countries)


### PR DESCRIPTION
## Changes in this PR
- Enable activity linking for ISPF activities - manually via the user interface

## Screenshots of UI changes

### After
![Screenshot 2022-11-28 at 13 39 49](https://user-images.githubusercontent.com/579522/205634454-8610c36a-7142-4320-b0a1-7d294927201f.png)

![Screenshot 2022-11-28 at 16 36 27](https://user-images.githubusercontent.com/579522/205634527-52364f60-367c-4119-821e-fe137522724b.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
