### PR TITLE
(2733) Add the "None" option to the ISPF partner countries selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1143,6 +1143,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Enable activity linking for ISPF activities
 - ISPF activities can have multiple ISPF themes
 - ISPF activities can be tagged via the UI - tags can only be chosen from a BEIS-defined codelist
+- Allow users to designate an ISPF activity as having no ISPF partner countries
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-123...HEAD
 [release-123]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-122...release-123

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -107,6 +107,7 @@ class Activity < ApplicationRecord
   validates :aid_type, presence: true, on: :aid_type_step, if: :requires_aid_type?
   validates :ispf_themes, presence: true, on: :ispf_themes_step, if: :is_ispf_funded?
   validates :ispf_partner_countries, presence: true, on: :ispf_partner_countries_step, if: :is_ispf_funded?
+  validate :ispf_partner_countries_none_is_exclusive, on: :ispf_partner_countries_step, if: :is_ispf_funded?
   validates :policy_marker_gender, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_climate_change_adaptation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
   validates :policy_marker_climate_change_mitigation, presence: true, on: :policy_markers_step, if: :requires_policy_markers?
@@ -680,5 +681,11 @@ class Activity < ApplicationRecord
 
   def is_non_oda_project?
     is_project? && is_non_oda?
+  end
+
+  def ispf_partner_countries_none_is_exclusive
+    if ispf_partner_countries.include?("NONE") && ispf_partner_countries.size > 1
+      errors.add(:ispf_partner_countries, I18n.t("activerecord.errors.models.activity.attributes.ispf_partner_countries.none_exclusive"))
+    end
   end
 end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -532,6 +532,7 @@ en:
               blank: Select at least one ISPF theme
             ispf_partner_countries:
               blank: Select an ISPF partner country
+              none_exclusive: Selecting "None" is not valid when there are countries selected
             level:
               blank: Select the activity type
             objectives:

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -229,11 +229,11 @@ RSpec.describe CodelistHelper, type: :helper do
         it "returns the ODA partner country details in a hash" do
           options = helper.ispf_partner_country_options(is_oda: true)
 
-          expect(options.length).to eq(13)
+          expect(options.length).to eq(14)
           expect(options.first.code).to eq("BR")
           expect(options.first.name).to eq("Brazil")
-          expect(options.last.code).to eq("LDC")
-          expect(options.last.name).to eq "Least developed countries"
+          expect(options.last.code).to eq("NONE")
+          expect(options.last.name).to eq("None (exemption agreed)")
         end
       end
 
@@ -241,11 +241,11 @@ RSpec.describe CodelistHelper, type: :helper do
         it "returns the non-ODA partner country details in a hash" do
           options = helper.ispf_partner_country_options(is_oda: false)
 
-          expect(options.length).to eq(11)
+          expect(options.length).to eq(12)
           expect(options.first.code).to eq("CA")
           expect(options.first.name).to eq("Canada")
-          expect(options.last.code).to eq("US")
-          expect(options.last.name).to eq "USA"
+          expect(options.last.code).to eq("NONE")
+          expect(options.last.name).to eq("None (exemption agreed)")
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -626,6 +626,19 @@ RSpec.describe Activity, type: :model do
         it { is_expected.to_not validate_absence_of :parent }
       end
     end
+
+    context "for an ISPF activity" do
+      let(:activity) { build(:programme_activity, :ispf_funded) }
+
+      context "when the None option is chosen for ISPF partner countries" do
+        it "validates that no other countries are selected" do
+          activity.ispf_partner_countries = ["IN", "NONE"]
+
+          expect(activity.valid?).to eq(false)
+          expect(activity.errors[:ispf_partner_countries].first).to eq(t("activerecord.errors.models.activity.attributes.ispf_partner_countries.none_exclusive"))
+        end
+      end
+    end
   end
 
   describe "associations" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -855,12 +855,12 @@ RSpec.describe Activity, type: :model do
 
       expect(activity.has_extending_organisation?).to be true
     end
-  end
 
-  it "returns false if all extending_organisation fields are not present" do
-    activity = build(:project_activity, extending_organisation: nil)
+    it "returns false if all extending_organisation fields are not present" do
+      activity = build(:project_activity, extending_organisation: nil)
 
-    expect(activity.has_extending_organisation?).to be false
+      expect(activity.has_extending_organisation?).to be false
+    end
   end
 
   describe "#has_implementing_organisations?" do

--- a/spec/services/activity/import_level_b_spec.rb
+++ b/spec/services/activity/import_level_b_spec.rb
@@ -741,6 +741,25 @@ RSpec.describe Activity::Import do
           type: I18n.t("action.activity.type.ispf_oda")
         ))
       end
+
+      it "has an error if the upload contains None and some country codes" do
+        country_code = "BR"
+        none_country_code = "NONE"
+        codes = [country_code, none_country_code].join("|")
+        new_ispf_activity_attributes["ISPF partner countries"] = codes
+
+        expect { subject.import([new_ispf_activity_attributes]) }.to_not change { Activity.count }
+
+        expect(subject.created.count).to eq(0)
+        expect(subject.updated.count).to eq(0)
+
+        expect(subject.errors.count).to eq(1)
+        expect(subject.errors.first.csv_row).to eq(2)
+        expect(subject.errors.first.csv_column).to eq("ISPF partner countries")
+        expect(subject.errors.first.column).to eq(:ispf_partner_countries)
+        expect(subject.errors.first.value).to eq(codes)
+        expect(subject.errors.first.message).to eq(t("activerecord.errors.models.activity.attributes.ispf_partner_countries.none_exclusive"))
+      end
     end
 
     context "Linked activity RODA ID" do

--- a/vendor/data/codelists/BEIS/ispf_partner_countries.yml
+++ b/vendor/data/codelists/BEIS/ispf_partner_countries.yml
@@ -91,3 +91,7 @@ data:
     name: Least developed countries
     oda: true
     non_oda: false
+  - code: NONE
+    name: None (exemption agreed)
+    oda: true
+    non_oda: true


### PR DESCRIPTION
## Changes in this PR
- Allow users to designate an ISPF activity as having no ISPF partner countries

## Screenshots of UI changes
### After
![Screenshot 2022-12-12 at 17 04 49](https://user-images.githubusercontent.com/579522/207121707-1adca4f7-a927-44c5-8483-bae2633e6fd7.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
