### PR TITLE
(2738) Display ODA or Non-ODA for level C and D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1144,9 +1144,11 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - ISPF activities can have multiple ISPF themes
 - ISPF activities can be tagged via the UI - tags can only be chosen from a BEIS-defined codelist
 - Allow users to designate an ISPF activity as having no ISPF partner countries
-- Add report CSV download for ISPF activities
 
 ## [unreleased]
+
+- Add report CSV download for ISPF activities
+- Show ODA / Non-ODA on level C and D activities' details pages
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-124...HEAD
 [release-124]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-123...release-124

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -26,7 +26,7 @@
           = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :parent), t("activerecord.attributes.activity.parent").downcase)
 
   - if activity_presenter.requires_is_oda?
-    .govuk-summary-list__row.parent
+    .govuk-summary-list__row.is_oda
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.is_oda")
       %dd.govuk-summary-list__value

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -25,7 +25,7 @@
         - if policy(activity_presenter).update? && activity_presenter.level.present? && activity_presenter.parent.blank?
           = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :parent), t("activerecord.attributes.activity.parent").downcase)
 
-  - if activity_presenter.requires_is_oda?
+  - if activity_presenter.is_ispf_funded?
     .govuk-summary-list__row.is_oda
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.is_oda")
@@ -33,7 +33,7 @@
         - unless activity_presenter.is_oda.nil?
           = t("summary.label.activity.is_oda.#{activity_presenter.is_oda}")
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update?
+        - if policy(activity_presenter).update? && activity_presenter.requires_is_oda?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:is_oda)}"), activity_step_path(activity_presenter, :is_oda), t("activerecord.attributes.activity.is_oda"))
 
   .govuk-summary-list__row.identifier

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -177,6 +177,10 @@ RSpec.describe "shared/activities/_activity" do
       context "when the activity is ODA" do
         before { render }
 
+        it { is_expected.to show_basic_details }
+        it { is_expected.to show_project_details }
+        it { is_expected.to show_ispf_specific_details }
+
         it "shows ISPF ODA fields" do
           expect(rendered).to have_content(t("activerecord.attributes.activity.collaboration_type"))
           expect(rendered).to have_content(t("activerecord.attributes.activity.fstc_applies"))
@@ -191,6 +195,8 @@ RSpec.describe "shared/activities/_activity" do
           activity.update(ispf_themes: [1], ispf_partner_countries: ["IN"])
           render
         end
+
+        it { is_expected.to show_ispf_specific_details }
 
         it "doesn't show non-ODA ISPF fields" do
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.objectives"))
@@ -216,10 +222,6 @@ RSpec.describe "shared/activities/_activity" do
 
       context "and it doesn't have a linked activity" do
         before { render }
-
-        it { is_expected.to show_basic_details }
-        it { is_expected.to show_project_details }
-        it { is_expected.to show_ispf_specific_details }
 
         it "shows a link to add a linked activity" do
           expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -624,6 +624,7 @@ RSpec.describe "shared/activities/_activity" do
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_themes")
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_partner_countries")
       expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
+      expect(rendered).to have_css(".govuk-summary-list__row.is_oda") if activity_presenter.programme?
 
       expect(rendered).to have_content(activity_presenter.ispf_themes)
       expect(rendered).to have_content(activity_presenter.ispf_partner_countries)

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -186,6 +186,10 @@ RSpec.describe "shared/activities/_activity" do
           expect(rendered).to have_content(t("activerecord.attributes.activity.fstc_applies"))
           expect(rendered).to have_content(t("activerecord.attributes.activity.covid19_related"))
         end
+
+        it "doesn't allow editing the ODA / non-ODA field" do
+          expect(body.find(".is_oda .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+        end
       end
 
       context "when the activity is non-ODA" do
@@ -217,6 +221,10 @@ RSpec.describe "shared/activities/_activity" do
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.channel_of_delivery_code"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility_lead"))
+        end
+
+        it "doesn't allow editing the ODA / non-ODA field" do
+          expect(body.find(".is_oda .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
         end
       end
 
@@ -626,7 +634,7 @@ RSpec.describe "shared/activities/_activity" do
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_themes")
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_partner_countries")
       expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
-      expect(rendered).to have_css(".govuk-summary-list__row.is_oda") if activity_presenter.programme?
+      expect(rendered).to have_css(".govuk-summary-list__row.is_oda")
 
       expect(rendered).to have_content(activity_presenter.ispf_themes)
       expect(rendered).to have_content(activity_presenter.ispf_partner_countries)

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "shared/activities/_activity" do
 
         it { is_expected.to show_ispf_specific_details }
 
-        it "doesn't show non-ODA ISPF fields" do
+        it "doesn't show fields that are irrelevant to non-ODA ISPF activities" do
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.objectives"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.benefitting_countries"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.gdi"))


### PR DESCRIPTION
## Changes in this PR
- Show ODA / Non-ODA on level C and D activities' details pages

## Screenshots of UI changes
### After
![Screenshot 2022-12-12 at 19 44 08](https://user-images.githubusercontent.com/579522/207139397-7e3045c8-8f2a-4350-b6e0-3d5d3ccbff71.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
