### PR TITLE
(2741) Fix call to action text for Benefitting countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1149,6 +1149,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Add report CSV download for ISPF activities
 - Show ODA / Non-ODA on level C and D activities' details pages
+- Fix call to action link text for Benefitting countries to correctly change from Add to Edit when applicable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-124...HEAD
 [release-124]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-123...release-124

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -245,7 +245,7 @@
         = activity_presenter.benefitting_countries
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :benefitting_countries)
-          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:intended_beneficiaries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("activerecord.attributes.activity.benefitting_countries"))
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:benefitting_countries)}"), activity_step_path(activity_presenter, :benefitting_countries), t("activerecord.attributes.activity.benefitting_countries"))
 
     .govuk-summary-list__row.benefitting_region
       %dt.govuk-summary-list__key


### PR DESCRIPTION
## Changes in this PR
- Fix call to action link text for Benefitting countries to correctly change from Add to Edit when applicable

## Screenshots of UI changes

### Before
![Screenshot 2022-12-13 at 13 51 47](https://user-images.githubusercontent.com/579522/207381141-0f8a68bd-2eb9-45ba-8366-448c586237da.png)

### After
![Screenshot 2022-12-13 at 15 44 31](https://user-images.githubusercontent.com/579522/207381188-590ccd7b-4f95-44bd-8995-6aed3210d676.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
