### PR TITLE
(2745) Show an error if the implem orgs are missing when uploading a level D ISPF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1156,6 +1156,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Show an error message if trying to upload a level D ISPF activity without an implementing organisation
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-125...HEAD
 [release-125]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-124...release-125
 [release-124]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-123...release-124

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -684,7 +684,7 @@ class Activity < ApplicationRecord
   end
 
   def ispf_partner_countries_none_is_exclusive
-    if ispf_partner_countries.include?("NONE") && ispf_partner_countries.size > 1
+    if ispf_partner_countries&.include?("NONE") && ispf_partner_countries.size > 1
       errors.add(:ispf_partner_countries, I18n.t("activerecord.errors.models.activity.attributes.ispf_partner_countries.none_exclusive"))
     end
   end

--- a/app/services/activity/import.rb
+++ b/app/services/activity/import.rb
@@ -6,6 +6,7 @@ class Activity
       end
 
       def csv_column
+        return "Implementing organisation names" if column == :implementing_organisation_id
         ACTIVITY_CSV_COLUMNS.dig(column, :heading) || column.to_s
       end
     }
@@ -271,6 +272,12 @@ class Activity
 
         if row["Comments"].present?
           @activity.comments.build(body: row["Comments"], report: @report, owner: @uploader, commentable: @activity)
+        end
+
+        if @activity.is_ispf_funded? && @activity.third_party_project? &&
+            row["Implementing organisation names"].to_s.strip.blank?
+          @errors[:implementing_organisation_names] = [row["Implementing organisation names"], I18n.t("activerecord.errors.models.activity.attributes.implementing_organisation_id.blank")]
+          return
         end
 
         return true if @activity.save(context: Activity::VALIDATION_STEPS)

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -526,6 +526,8 @@ en:
               invalid: Please enter a valid date
             gdi:
               blank: Select an option for GDI
+            implementing_organisation_id:
+              blank: ISPF third-party projects must have an implementing organisation
             intended_beneficiaries:
               blank: Select at least one intended beneficiary
               too_long: A maximum of 10 intended beneficiaries can be added


### PR DESCRIPTION
## Changes in this PR
- Show an error message if trying to upload a level D ISPF activity without an implementing organisation

Known limitations: this will not catch the attempt to *update* an existing activity and removing all the implementing organisations.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
