### PR TITLE
(2747) Fix level B IATI export figures and inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1159,6 +1159,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Show an error message if trying to upload a level D ISPF activity without an implementing organisation
 - Remove legacy report CSV generator
 - Switch to using JSbundling and CSSbundling instead of now-deprecated Webpacker for our assets
+- Fix exclusion from IATI of redacted programmes - an earlier change allowed programmes to be flagged for exclusion, but missed some code required for actually excluding them
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-125...HEAD
 [release-125]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-124...release-125

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1160,6 +1160,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove legacy report CSV generator
 - Switch to using JSbundling and CSSbundling instead of now-deprecated Webpacker for our assets
 - Fix exclusion from IATI of redacted programmes - an earlier change allowed programmes to be flagged for exclusion, but missed some code required for actually excluding them
+- Update programme-level IATI exports to provide a quarterly summary of all transactions combined (actuals, adjustments and refunds), not just actuals
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-125...HEAD
 [release-125]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-124...release-125

--- a/app/controllers/exports/organisations_controller.rb
+++ b/app/controllers/exports/organisations_controller.rb
@@ -73,7 +73,7 @@ class Exports::OrganisationsController < BaseController
       organisation: @organisation,
       user: current_user,
       fund_code: fund_code
-    ).call
+    ).call.publishable_to_iati
 
     render_xml
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -334,9 +334,9 @@ class Activity < ApplicationRecord
     model.where(parent_activity_id: activity_ids)
   end
 
-  def reportable_actuals_for_level
+  def reportable_transactions_for_level
     if programme?
-      spend_by_financial_quarter(own_and_descendants_associates(Actual).order("date DESC"))
+      spend_by_financial_quarter(own_and_descendants_associates(Transaction).order("date DESC"))
     else
       actuals.order("date DESC")
     end

--- a/app/views/exports/organisations/show.xml.haml
+++ b/app/views/exports/organisations/show.xml.haml
@@ -2,5 +2,5 @@
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
-    = render partial: "shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_actuals_for_level, budgets: activity.budgets, forecasts: activity.reportable_forecasts_for_level, commitment: activity.commitment }
+    = render partial: "shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_transactions_for_level, budgets: activity.budgets, forecasts: activity.reportable_forecasts_for_level, commitment: activity.commitment }
 

--- a/spec/controllers/exports/organisations_controller_spec.rb
+++ b/spec/controllers/exports/organisations_controller_spec.rb
@@ -207,8 +207,9 @@ RSpec.describe Exports::OrganisationsController do
     describe "#programme_activities" do
       before do
         @activities = double("ActiveRecord::Relation")
-        @find_programme_activities_stub = double("FindProgrammeActivities", call: @activities)
+        @find_programme_activities_stub = double("FindProgrammeActivities", publishable_to_iati: @activities)
         allow(FindProgrammeActivities).to receive(:new).and_return(@find_programme_activities_stub)
+        allow(@find_programme_activities_stub).to receive(:call).and_return(@find_programme_activities_stub)
 
         get :programme_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml, skip_validation: 1}
       end
@@ -220,6 +221,7 @@ RSpec.describe Exports::OrganisationsController do
 
         expect(FindProgrammeActivities).to have_received(:new).with(organisation: organisation, user: user, fund_code: fund.id)
         expect(@find_programme_activities_stub).to have_received(:call)
+        expect(@find_programme_activities_stub).to have_received(:publishable_to_iati)
       end
     end
 


### PR DESCRIPTION
## Changes in this PR

- 2747: fixes the transactions reported in level B IATI exports so that they reflect a quarterly sum of actuals minus adjustments and refunds (not just actuals)
- 2706: fixes redaction of programmes from IATI exports, adding a scope query that was missed from #1870

Debugged and checked using the example from the ticket: the activity with RODA ID `NF-BRNIF`. The figures are now in line with the report CSV, which is the same as the spending breakdown except for FQ3 2021-2022

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
