### PR TITLE
(2764) Remove unused report filename generation method

### DIFF
--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -21,10 +21,6 @@ class ReportPresenter < SimpleDelegator
     "#{financial_quarter_and_year} #{fund.roda_identifier} #{organisation.beis_organisation_reference}"
   end
 
-  def filename_for_report_download
-    filename(purpose: "report")
-  end
-
   def filename_for_activities_template(is_oda:)
     filename(purpose: "activities_upload", is_oda: is_oda)
   end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -49,14 +49,6 @@ RSpec.describe ReportPresenter do
         description: "My report")
     }
 
-    describe "#filename_for_report_download" do
-      it "returns the URL-encoded filename for the downloadable report" do
-        result = described_class.new(report).filename_for_report_download
-
-        expect(result).to eql "FQ1 2020-2021-GCRF-BOR-report.csv"
-      end
-    end
-
     describe "#filename_for_activities_template" do
       context "non-ISPF" do
         it "returns the URL-encoded filename for the activities template CSV dowload" do


### PR DESCRIPTION
## Changes in this PR

Removes unused report filename generation method.  

This was used for generating the filename for the legacy CSV, which was removed in #5bf495 (#1948)

I originally thought it would make sense to use the `ReportPresenter`'s method here, rather than the having the `Export:Report` class  have its own report generation method, but the other Export classes `Budget` and `ExternalIncome` have their own filename generation classes so it made sense to keep consistency across the three Export classes here.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
