### PR TITLE
(2766) Reflect adjustments/refunds in level C/D IATI export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1167,6 +1167,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Upload the report CSV to S3 when the report is approved
 - For approved reports, provide download of stored report CSV file instead of generating it from live data
 - Add page titles for home and activities pages (useful for Google Analytics reporting and accessibility); make page titles and headings consistent on activity form pages
+- Update level C/D IATI exports to provide a quarterly summary of all transactions combined (actuals, adjustments and refunds), not just actuals
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-126...HEAD
 [release-126]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-125...release-126

--- a/app/views/exports/organisations/show.xml.haml
+++ b/app/views/exports/organisations/show.xml.haml
@@ -2,5 +2,5 @@
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
 "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
-    = render partial: "shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.reportable_transactions_for_level, budgets: activity.budgets, forecasts: activity.reportable_forecasts_for_level, commitment: activity.commitment }
+    = render partial: "shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.net_spend_by_financial_quarter, budgets: activity.budgets, forecasts: activity.reportable_forecasts_for_level, commitment: activity.commitment }
 

--- a/spec/features/users_can_view_an_organisation_as_xml_spec.rb
+++ b/spec/features/users_can_view_an_organisation_as_xml_spec.rb
@@ -157,8 +157,8 @@ RSpec.feature "Users can view an organisation as XML" do
           visit iati_project_activities_exports_organisation_path(organisation, format: :xml, fund: "GCRF")
           xml = Nokogiri::XML::Document.parse(page.body)
 
-          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to match_array(["100.0", "150.0", "200.0"])
-          expect(xml.xpath("//iati-activity/transaction/transaction-date/@iso-date").map(&:text)).to eql(["2018-06-30", "2018-06-30", "2019-12-31"])
+          expect(xml.xpath("//iati-activity/transaction/value").map(&:text)).to match_array(["250.0", "200.0"])
+          expect(xml.xpath("//iati-activity/transaction/transaction-date/@iso-date").map(&:text)).to eql(["2018-06-30", "2019-12-31"])
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1739,60 +1739,61 @@ RSpec.describe Activity, type: :model do
       end
     end
 
-    describe "#reportable_transactions_for_level" do
+    describe "#net_spend_by_financial_quarter" do
       let(:organisation) { create(:partner_organisation) }
+      let(:programme) { create(:programme_activity, extending_organisation: organisation) }
+      let(:projects) { create_list(:project_activity, 2, parent: programme) }
+      let(:third_party_project) { create(:third_party_project_activity, parent: projects[0]) }
+
+      before do
+        create(:actual, value: 500, parent_activity: projects[0], financial_year: 2020, financial_quarter: 1)
+        create(:actual, value: 500, parent_activity: projects[1], financial_year: 2020, financial_quarter: 1)
+        create(:actual, value: 200, parent_activity: third_party_project, financial_year: 2020, financial_quarter: 1)
+
+        create(:actual, value: 1000, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
+
+        create(:actual, value: 1000, parent_activity: programme, financial_year: 2018, financial_quarter: 1)
+        create(:actual, value: 500, parent_activity: projects[0], financial_year: 2018, financial_quarter: 1)
+        create(:actual, value: 500, parent_activity: projects[1], financial_year: 2018, financial_quarter: 1)
+        create(:actual, value: 200, parent_activity: third_party_project, financial_year: 2018, financial_quarter: 1)
+      end
 
       context "when the activity is a programme" do
-        let(:programme) { create(:programme_activity, extending_organisation: organisation) }
-
-        before do
-          projects = create_list(:project_activity, 2, parent: programme)
-          third_party_project = create(:third_party_project_activity, parent: projects[0])
-
-          create(:actual, value: 500, parent_activity: projects[0], financial_year: 2020, financial_quarter: 1)
-          create(:actual, value: 500, parent_activity: projects[1], financial_year: 2020, financial_quarter: 1)
-          create(:actual, value: 200, parent_activity: third_party_project, financial_year: 2020, financial_quarter: 1)
-
-          create(:actual, value: 1000, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
-
-          create(:actual, value: 1000, parent_activity: programme, financial_year: 2018, financial_quarter: 1)
-          create(:actual, value: 500, parent_activity: projects[0], financial_year: 2018, financial_quarter: 1)
-          create(:actual, value: 500, parent_activity: projects[1], financial_year: 2018, financial_quarter: 1)
-          create(:actual, value: 200, parent_activity: third_party_project, financial_year: 2018, financial_quarter: 1)
-        end
-
         it "sums up the transactions of the activity and child activities by financial quarter" do
-          reportable_transactions = programme.reportable_transactions_for_level
-          expect(reportable_transactions.map(&:value)).to eql([1200, 1000, 2200])
-          expect(reportable_transactions.map(&:date)).to eql([FinancialQuarter.new(2020, 1).end_date, FinancialQuarter.new(2018, 2).end_date, FinancialQuarter.new(2018, 1).end_date])
-        end
-
-        it "accounts for refunds and adjustments" do
-          create(:refund, value: 500, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
-
-          expect(programme.reportable_transactions_for_level.second.value).to eq(500)
-
-          create(:adjustment, value: 50, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
-
-          expect(programme.reportable_transactions_for_level.second.value).to eq(550)
+          net_spend_by_financial_quarter = programme.net_spend_by_financial_quarter
+          expect(net_spend_by_financial_quarter.map(&:value)).to eq([1200, 1000, 2200])
+          expect(net_spend_by_financial_quarter.map(&:date)).to eq(
+            [
+              FinancialQuarter.new(2020, 1).end_date,
+              FinancialQuarter.new(2018, 2).end_date,
+              FinancialQuarter.new(2018, 1).end_date
+            ]
+          )
         end
       end
 
       context "when the activity is a project or third-party project" do
-        it "returns all the actuals with that activity only" do
-          project = create(:project_activity, :with_transparency_identifier, organisation: organisation)
-          third_party_project = create(:third_party_project_activity, parent: project, organisation: organisation)
+        it "sums up the transactions of the activity" do
+          projects.each { |project| expect(project.net_spend_by_financial_quarter.map(&:value)).to eq([500, 500]) }
 
-          project_actual_1 = create(:actual, value: 1000, parent_activity: project)
-          project_actual_2 = create(:actual, value: 1000, parent_activity: project)
-          project_actual_3 = create(:actual, value: 500, parent_activity: project)
-          project_actual_4 = create(:actual, value: 500, parent_activity: project)
+          expect(third_party_project.net_spend_by_financial_quarter.map(&:value)).to eq([200, 200])
 
-          third_party_project_actual = create(:actual, value: 500, parent_activity: third_party_project)
-
-          expect(project.reportable_transactions_for_level).to match_array([project_actual_1, project_actual_2, project_actual_3, project_actual_4])
-          expect(third_party_project.reportable_transactions_for_level).to match_array([third_party_project_actual])
+          [*projects, third_party_project].each do |activity|
+            expect(activity.net_spend_by_financial_quarter.map(&:date)).to eq(
+              [FinancialQuarter.new(2020, 1).end_date, FinancialQuarter.new(2018, 1).end_date]
+            )
+          end
         end
+      end
+
+      it "accounts for refunds and adjustments" do
+        create(:refund, value: 500, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
+
+        expect(programme.net_spend_by_financial_quarter.second.value).to eq(500)
+
+        create(:adjustment, value: 50, parent_activity: programme, financial_year: 2018, financial_quarter: 2)
+
+        expect(programme.net_spend_by_financial_quarter.second.value).to eq(550)
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

4f17df3 updated level B IATI exports to account for adjustments and refunds. This brings levels C and D in line. The only remaining difference between the level B and levels C and D is that at level B it included all descendents' transactions

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
