### PR TITLE
(2777) Spending breakdown download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1185,6 +1185,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Report approved emails sent to BEIS users include a reminder that the report is going to be uploaded
 - Send a notification email to the report approver if the report upload fails
 - The latest generated spending breakdown CSVs can be downloaded from the Exports page
+- Spending breakdown email notification has a link to the Exports page instead of a direct download link
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1186,6 +1186,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Send a notification email to the report approver if the report upload fails
 - The latest generated spending breakdown CSVs can be downloaded from the Exports page
 - Spending breakdown email notification has a link to the Exports page instead of a direct download link
+- Spending breakdown exports use a private S3 bucket
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1184,6 +1184,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - Include breadcrumbs when the form is re-rendered after failing to create/update a comment
 - Report approved emails sent to BEIS users include a reminder that the report is going to be uploaded
 - Send a notification email to the report approver if the report upload fails
+- The latest generated spending breakdown CSVs can be downloaded from the Exports page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -50,6 +50,8 @@ class ExportsController < BaseController
   def spending_breakdown
     authorize :export, :show_external_income?
 
+    add_breadcrumb t("breadcrumbs.export.index"), :exports_path
+
     SpendingBreakdownJob.perform_later(
       requester_id: current_user.id,
       fund_id: params[:fund_id]

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -64,4 +64,18 @@ class ExportsController < BaseController
 
     render :export_in_progress
   end
+
+  def spending_breakdown_download
+    authorize :export, :show_external_income?
+
+    fund = Fund.new(params[:id])
+    fund_activity = fund.activity
+
+    spending_breakdown_csv = Export::S3Downloader.new(filename: fund_activity.spending_breakdown_filename).download
+
+    response.headers["Content-Type"] = "text/csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(fund_activity.spending_breakdown_filename)}"
+    response.stream.write(spending_breakdown_csv)
+    response.stream.close
+  end
 end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -14,7 +14,6 @@ class SpendingBreakdownJob < ApplicationJob
 
     DownloadLinkMailer.send_link(
       recipient: requester,
-      file_url: upload.url,
       file_name: upload.timestamped_filename
     ).deliver
   rescue => error

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -33,7 +33,7 @@ class SpendingBreakdownJob < ApplicationJob
   end
 
   def upload_csv_to_s3(file:, filename:)
-    Export::S3Uploader.new(file: file, filename: filename, use_public_bucket: true).upload
+    Export::S3Uploader.new(file: file, filename: filename, use_public_bucket: false).upload
   end
 
   def log_error(error, requester)

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -1,7 +1,7 @@
 class DownloadLinkMailer < ApplicationMailer
-  def send_link(recipient:, file_url:, file_name:)
-    @file_url = file_url
+  def send_link(recipient:, file_name:)
     @file_name = file_name
+    @file_url = exports_url
 
     view_mail(
       ENV["NOTIFY_VIEW_TEMPLATE"],

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -653,6 +653,12 @@ class Activity < ApplicationRecord
     child_activities.where.not(linked_activity_id: nil)
   end
 
+  def spending_breakdown_generated_at
+    return unless spending_breakdown_filename
+
+    Time.parse(spending_breakdown_filename[-18..-5])
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/views/download_link_mailer/send_link.text.erb
+++ b/app/views/download_link_mailer/send_link.text.erb
@@ -4,6 +4,6 @@
 
 <%= @file_url %>
 
-If you experience any difficulties downloading your export, please let us know. Please include the download link and the export's filename in your report.
+If you experience any difficulties downloading your export, please let us know. Please include the export's filename in your report.
 
 <%= render partial: "report_mailer/footer" %>

--- a/app/views/exports/index.html.haml
+++ b/app/views/exports/index.html.haml
@@ -42,7 +42,13 @@
               %td.govuk-table__cell
                 CSV
               %td.govuk-table__cell
-                = a11y_action_link("Request", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+                - if fund.activity.spending_breakdown_filename
+                  = a11y_action_link("Download", spending_breakdown_download_export_path(fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+                  = "(last generated at #{l(fund.activity.spending_breakdown_generated_at, format: :detailed)})"
+                  %br
+                  = a11y_action_link("Request new", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+                - else
+                  = a11y_action_link("Request", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
       %h1.govuk-heading-m
         = t("page_content.export.organisations.title")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,9 @@ Rails.application.routes.draw do
     get "external_income", on: :collection
     get "budgets", on: :collection
     get "spending_breakdown", on: :collection
+    member do
+      get "spending_breakdown_download"
+    end
   end
 
   namespace :exports do

--- a/db/migrate/20230118131413_add_spending_breakdown_filename_to_activities.rb
+++ b/db/migrate/20230118131413_add_spending_breakdown_filename_to_activities.rb
@@ -1,0 +1,5 @@
+class AddSpendingBreakdownFilenameToActivities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :spending_breakdown_filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2023_01_25_115632) do
     t.integer "tags", array: true
     t.string "ispf_oda_partner_countries", array: true
     t.string "ispf_non_oda_partner_countries", array: true
+    t.string "spending_breakdown_filename"
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/features/beis_users_can_download_exports_spec.rb
+++ b/spec/features/beis_users_can_download_exports_spec.rb
@@ -2,6 +2,7 @@ RSpec.feature "BEIS users can download exports" do
   let(:beis_user) { create(:beis_user) }
 
   before do
+    Fund.all.each { |fund| create(:fund_activity, source_fund_code: fund.id, roda_identifier: fund.short_name) }
     authenticate! user: beis_user
   end
   after { logout }

--- a/spec/jobs/report_export_uploader_job_spec.rb
+++ b/spec/jobs/report_export_uploader_job_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe ReportExportUploaderJob, type: :job do
       expect(uploader).to have_received(:upload)
     end
 
+    it "saves the uploaded filename in the report" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+      expect(report).to have_received(:export_filename=).with(upload.timestamped_filename)
+      expect(report).to have_received(:save)
+    end
+
     context "when the uploader raises an error" do
       let(:error) { Export::S3UploadError.new("Error uploading filename-xyz") }
 
@@ -117,13 +124,6 @@ RSpec.describe ReportExportUploaderJob, type: :job do
 
         expect(email).to have_received(:deliver)
       end
-    end
-
-    it "saves the uploaded filename in the report" do
-      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
-
-      expect(report).to have_received(:export_filename=).with(upload.timestamped_filename)
-      expect(report).to have_received(:save)
     end
   end
 end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -134,12 +134,11 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       end
     end
 
-    it "emails a download link to the requesting user" do
+    it "emails the requesting user to let them know the download is ready" do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 
       expect(DownloadLinkMailer).to have_received(:send_link).with(
         recipient: requester,
-        file_url: "https://example.com/presigned_url",
         file_name: "timestamped_filename.csv"
       )
       expect(email).to have_received(:deliver)

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SpendingBreakdownJob, type: :job do
         .with(
           file: tempfile,
           filename: "export_1234.csv",
-          use_public_bucket: true
+          use_public_bucket: false
         )
       expect(uploader).to have_received(:upload)
     end

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
     let(:mail) do
       DownloadLinkMailer.send_link(
         recipient: user,
-        file_url: "https://roda.example.com/abc123",
         file_name: "spending_breakdown.csv"
       )
     end
@@ -18,8 +17,8 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
       )
     end
 
-    it "includes the given url as a link to download the export" do
-      expect(mail.body).to include("https://roda.example.com/abc123")
+    it "includes the url to the exports page" do
+      expect(mail.body).to include(exports_url)
     end
 
     it "sends the email to the given recipient" do
@@ -36,8 +35,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
     it "includes a request for info in the event of a problem" do
       expect(mail.body).to include(
         "If you experience any difficulties downloading your export, " \
-        "please let us know. Please include the download link and " \
-        "the export's filename in your report."
+        "please let us know. Please include the export's filename in your report."
       )
     end
 

--- a/spec/mailers/previews/download_link_mailer_preview.rb
+++ b/spec/mailers/previews/download_link_mailer_preview.rb
@@ -4,7 +4,6 @@ class DownloadLinkMailerPreview < ActionMailer::Preview
   def send_link
     DownloadLinkMailer.send_link(
       recipient: FactoryBot.build(:beis_user, email: "beis@example.com"),
-      file_url: "https://roda.example.com/abc123",
       file_name: "spending_breakdown.csv"
     )
   end


### PR DESCRIPTION
## Changes in this PR
- The latest generated spending breakdown CSVs can be downloaded from the Exports page
- Spending breakdown email notification has a link to the Exports page instead of a direct download link
- Spending breakdown exports use a private S3 bucket

## Screenshots of UI changes

### Before

### After
![Screenshot 2023-01-30 at 15 13 11](https://user-images.githubusercontent.com/579522/215567646-5cfcb7f9-de83-4226-a1eb-bf94ee728006.png)
![Screenshot 2023-01-18 at 13 34 26](https://user-images.githubusercontent.com/579522/213474817-537e5b87-9dfe-441b-93ac-16d105a4228e.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
