### PR TITLE
(2779) Update links to organisation activities path

### DIFF
--- a/app/views/shared/activities/tree_view/_table_tabbed.html.haml
+++ b/app/views/shared/activities/tree_view/_table_tabbed.html.haml
@@ -32,4 +32,4 @@
                       - third_party_projects.each do |third_party_project|
                         = render partial: "shared/activities/tree_view/row", locals: { activity: third_party_project, parent: project, is_parent: false }
 
-              = link_to "View all activities", activities_path(organisation_id: current_user.organisation.id), class: "govuk-body govuk-link"
+              = link_to t("table.actions.activity.view_all_activities"), organisation_activities_path(organisation_id: current_user.organisation.id), class: "govuk-body govuk-link"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -223,6 +223,7 @@ en:
     actions:
       activity:
         view_activities: View activities
+        view_all_activities: View all activities
   filters:
     activity:
       title: Filter activities

--- a/spec/features/users_can_view_activities_spec.rb
+++ b/spec/features/users_can_view_activities_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view activities" do
     after { logout }
 
     scenario "they can see and navigate current partner organisation activities", js: true do
-      visit activities_path(organisation_id: organisation.id)
+      visit organisation_activities_path(organisation_id: organisation.id)
 
       expect(page).to have_content t("page_title.activity.index")
 
@@ -68,7 +68,7 @@ RSpec.feature "Users can view activities" do
       other_programme = create(:programme_activity, extending_organisation: create(:partner_organisation))
       other_project = create(:project_activity, organisation: create(:partner_organisation))
 
-      visit activities_path(organisation_id: organisation.id)
+      visit organisation_activities_path(organisation_id: organisation.id)
 
       expect(page).to_not have_content(other_programme.title)
       expect(page).to_not have_content(other_project.title)
@@ -115,7 +115,7 @@ RSpec.feature "Users can view activities" do
       let(:user) { create(:beis_user) }
 
       scenario "does not see ISPF activities" do
-        visit activities_path(organisation_id: organisation.id)
+        visit organisation_activities_path(organisation_id: organisation.id)
 
         expect(page).not_to have_content("International Science Partnerships Fund")
         expect(page).not_to have_content(ispf_programme.title)
@@ -127,7 +127,7 @@ RSpec.feature "Users can view activities" do
       let(:user) { create(:partner_organisation_user, organisation: organisation) }
 
       scenario "does not see ISPF activities on their organisation page" do
-        visit activities_path(organisation_id: organisation.id)
+        visit organisation_activities_path(organisation_id: organisation.id)
 
         expect(page).not_to have_content("International Science Partnerships Fund")
         expect(page).not_to have_content(ispf_programme.title)


### PR DESCRIPTION
## Changes in this PR

The paths `/organisations/:organisation_id/activities` and `/activities?organisation_id=:organisation_id` are both served by the `activities#index` controller action and pass in the same params. For Google Analytics, it's better for such shows to use the same path. This updates the single use of the latter path to the former

It also updates the small number of specs using its path helper, and moves the link's text into a translation

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
