### PR TITLE
(2736) Prefix all non-ODA identifiers with “NODA”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1172,6 +1172,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Allow ISPF non-ODA partner countries on ODA activities
 - Change "Vietnam" to "Viet Nam" in ISPF ODA partner countries
+- Prefix the RODA identifiers of all non-ODA activities with "NODA-"
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...HEAD
 [release-127]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-126...release-127

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -30,6 +30,13 @@ class Activity
       activity.assign_attributes(programme_status: DEFAULT_PROGRAMME_STATUS_FOR_FUNDS)
     end
 
+    def set_is_oda
+      if params_for("is_oda") == "false"
+        activity.assign_attributes(roda_identifier: "NODA-#{activity.roda_identifier}")
+      end
+      assign_attributes_for_step("is_oda")
+    end
+
     def set_identifier
       assign_attributes_for_step("partner_organisation_identifier")
     end

--- a/doc/activity-identifiers.md
+++ b/doc/activity-identifiers.md
@@ -66,6 +66,10 @@ The RODA identifier also includes the fund code (level A activity code), this is
 achieved by adding these two values to the identifier for top level activities
 (level B).
 
+With the launch of ISPF, which will include non-ODA activities, the rules for the
+RODA identifiers of such activities have been expanded to include the addition of
+the prefix "NODA", to make it easier to distinguish non-ODA activities at a glance.
+
 ## RODA Identifier (legacy version <= Q1 2021-2022)
 
 The identifier by which RODA knows an activity, and should be regarded as the

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -358,6 +358,16 @@ RSpec.describe ActivityFormsController do
       end
     end
 
+    context "when setting non-ODA on a programme" do
+      let(:activity) { programme }
+
+      it "updates the RODA identifier to start with 'NODA'" do
+        put_step(:is_oda, {is_oda: false})
+
+        expect(programme.reload.roda_identifier).to start_with("NODA-")
+      end
+    end
+
     context "when the activity is invalid" do
       before do
         allow(Activity).to receive(:find).and_return(activity)


### PR DESCRIPTION
## Changes in this PR
- Prefix the RODA identifiers of all non-ODA activities with "NODA-"

## Screenshots of UI changes

### Before

### After
![Screenshot 2023-01-19 at 19 17 18](https://user-images.githubusercontent.com/579522/213539284-30a7785d-ed2d-4e71-b604-8281f3fa88c6.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
