### PR TITLE
Remove ineffective attempt at changing bucket

### DIFF
--- a/terraform/s3-export-download-bucket.tf
+++ b/terraform/s3-export-download-bucket.tf
@@ -6,9 +6,6 @@ resource "cloudfoundry_service_instance" "beis-roda-s3-export-download-bucket" {
   name         = "beis-roda-${var.environment}-s3-export-download-bucket"
   space        = cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.aws-s3-bucket.service_plans["default"]
-  json_params  = <<EOF
-  {"public_bucket":true}
-EOF
 }
 
 resource "cloudfoundry_service_instance" "beis-roda-s3-export-download-bucket-private" {


### PR DESCRIPTION
## Changes in this PR
The public bucket is already public, whether we send the `public_bucket` directive or not. However, sending the public directive when the bucket is already public results in an error at deploy:
`Error: Service broker error: Updating the S3 bucket is currently not supported`.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
