### PR TITLE
(2709) Upload reports to private S3 bucket on approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,6 +1177,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Upload the report CSV to S3 when the report is approved
+- For approved reports, provide download of stored report CSV file instead of generating it from live data
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1176,6 +1176,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Upload the report CSV to S3 when the report is approved
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128
 [release-127]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-126...release-127

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -35,6 +35,18 @@ class ReportsController < BaseController
     end
   end
 
+  def download
+    @report = Report.find(id)
+    authorize @report
+
+    report_csv = Export::S3Downloader.new(filename: @report.export_filename).download
+
+    response.headers["Content-Type"] = "text/csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{ERB::Util.url_encode(@report.export_filename)}"
+    response.stream.write(report_csv)
+    response.stream.close
+  end
+
   def new
     add_breadcrumb "Reports", :reports_path
 

--- a/app/controllers/reports_state_controller.rb
+++ b/app/controllers/reports_state_controller.rb
@@ -62,6 +62,7 @@ class ReportsStateController < BaseController
       Report::SendStateChangeEmails.new(report).send!
 
       if report.state == "approved"
+        report.update!(approved_at: Time.current)
         ReportExportUploaderJob.perform_later(requester_id: current_user.id, report_id: report.id)
       end
     end

--- a/app/controllers/reports_state_controller.rb
+++ b/app/controllers/reports_state_controller.rb
@@ -60,6 +60,10 @@ class ReportsStateController < BaseController
       report.update!(state: state)
 
       Report::SendStateChangeEmails.new(report).send!
+
+      if report.state == "approved"
+        ReportExportUploaderJob.perform_later(requester_id: current_user.id, report_id: report.id)
+      end
     end
 
     @report_presenter = ReportPresenter.new(report)

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,0 +1,7 @@
+module ReportHelper
+  def report_download_link(report)
+    return download_report_path(report) if report.export_filename
+
+    report_path(report, format: :csv)
+  end
+end

--- a/app/jobs/report_export_uploader_job.rb
+++ b/app/jobs/report_export_uploader_job.rb
@@ -1,0 +1,37 @@
+class ReportExportUploaderJob < ApplicationJob
+  require "csv"
+
+  def perform(requester_id:, report_id:)
+    requester = User.find(requester_id)
+    report = Report.find(report_id)
+
+    export = Export::Report.new(report: report)
+    upload = upload_csv_to_s3(file: save_tempfile(export), filename: export.filename)
+    report.export_filename = upload.timestamped_filename
+    report.save
+  rescue => error
+    log_error(error, requester)
+    DownloadLinkMailer.send_failure_notification(recipient: requester).deliver
+  end
+
+  def save_tempfile(export)
+    Tempfile.new.tap do |tmpfile|
+      CSV.open(tmpfile, "wb", {headers: true}) do |csv|
+        csv << export.headers
+        export.rows.each do |row|
+          csv << row
+        end
+      end
+    end
+  end
+
+  def upload_csv_to_s3(file:, filename:)
+    Export::S3Uploader.new(file: file, filename: filename, use_public_bucket: false).upload
+  end
+
+  def log_error(error, requester)
+    message = "#{error.message} for #{requester.email}"
+    Rails.logger.error(message)
+    Rollbar.log(:error, message, error)
+  end
+end

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -29,7 +29,7 @@ class SpendingBreakdownJob < ApplicationJob
   end
 
   def upload_csv_to_s3(file:, filename:)
-    Export::S3Uploader.new(file: file, filename: filename).upload
+    Export::S3Uploader.new(file: file, filename: filename, use_public_bucket: true).upload
   end
 
   def log_error(error, requester)

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -16,6 +16,18 @@ class ReportPresenter < SimpleDelegator
     I18n.l(super)
   end
 
+  def approved_at
+    return if super.blank?
+    I18n.l(super, {format: :detailed})
+  end
+
+  def uploaded_at
+    return nil if export_filename.nil?
+    uploaded_time_from_filename = Time.parse(export_filename[-18..-5])
+
+    I18n.l(uploaded_time_from_filename, {format: :detailed})
+  end
+
   def email_title
     return nil if financial_quarter_and_year.nil? || fund.nil? || organisation.nil?
     "#{financial_quarter_and_year} #{fund.roda_identifier} #{organisation.beis_organisation_reference}"

--- a/app/services/export/s3_downloader.rb
+++ b/app/services/export/s3_downloader.rb
@@ -1,0 +1,35 @@
+module Export
+  class S3DownloaderError < StandardError; end
+
+  class S3Downloader
+    def initialize(filename:)
+      @config = S3UploaderConfig.new(use_public_bucket: false)
+      @client = Aws::S3::Client.new(
+        region: config.region,
+        credentials: Aws::Credentials.new(
+          config.key_id,
+          config.secret_key
+        )
+      )
+      @filename = filename
+    end
+
+    def download
+      client.get_object(
+        bucket: config.bucket,
+        key: filename,
+        response_content_type: "text/csv"
+      ).body.read
+    rescue => error
+      raise_error(error.message)
+    end
+
+    private
+
+    attr_reader :config, :client, :filename
+
+    def raise_error(original_message = nil)
+      raise S3DownloaderError, [original_message, I18n.t("download.failure", filename: filename)].join(" ")
+    end
+  end
+end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -3,7 +3,7 @@ module Export
 
   class S3Uploader
     def initialize(file:, filename:)
-      @config = S3UploaderConfig.new
+      @config = S3UploaderConfig.new(use_public_bucket: true)
       @client = Aws::S3::Client.new(
         region: config.region,
         credentials: Aws::Credentials.new(

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -3,11 +3,12 @@ module Export
 
   class S3Uploader
     def initialize(file:, filename:)
+      @config = S3UploaderConfig.new
       @client = Aws::S3::Client.new(
-        region: S3UploaderConfig.region,
+        region: config.region,
         credentials: Aws::Credentials.new(
-          S3UploaderConfig.key_id,
-          S3UploaderConfig.secret_key
+          config.key_id,
+          config.secret_key
         )
       )
       @file = file
@@ -18,7 +19,7 @@ module Export
 
     def upload
       response = client.put_object(
-        bucket: S3UploaderConfig.bucket,
+        bucket: config.bucket,
         key: filename,
         body: file
       )
@@ -34,6 +35,8 @@ module Export
 
     private
 
+    attr_reader :config
+
     def timestamped_filename(name)
       pathname = Pathname.new(name)
       basename = pathname.basename(".*")
@@ -48,7 +51,7 @@ module Export
 
     def bucket
       resource = Aws::S3::Resource.new(client: client)
-      resource.bucket(S3UploaderConfig.bucket)
+      resource.bucket(config.bucket)
     end
   end
 end

--- a/app/services/export/s3_uploader.rb
+++ b/app/services/export/s3_uploader.rb
@@ -51,7 +51,7 @@ module Export
     end
 
     def raise_error(original_message = nil)
-      raise S3UploadError, [original_message, "Error uploading report #{filename}"].join(" ")
+      raise S3UploadError, [original_message, I18n.t("upload.failure", filename: filename)].join(" ")
     end
 
     def bucket

--- a/app/services/export/s3_uploader_config.rb
+++ b/app/services/export/s3_uploader_config.rb
@@ -1,5 +1,9 @@
 module Export
   class S3UploaderConfig
+    def initialize(use_public_bucket:)
+      @use_public_bucket = use_public_bucket
+    end
+
     def region
       credentials.fetch("aws_region")
     end
@@ -19,10 +23,18 @@ module Export
     def credentials
       JSON.parse(ENV.fetch("VCAP_SERVICES"))
         .fetch("aws-s3-bucket")
-        .find { |config| config.fetch("name").match?(/s3-export-download-bucket/) }
+        .find { |config| config.fetch("name").match?(bucket_name_regex) }
         .fetch("credentials")
     rescue KeyError, NoMethodError => _error
       raise "AWS S3 credentials not found"
+    end
+
+    private
+
+    attr_reader :use_public_bucket
+
+    def bucket_name_regex
+      use_public_bucket ? /s3-export-download-bucket$/ : /s3-export-download-bucket-private/
     end
   end
 end

--- a/app/services/export/s3_uploader_config.rb
+++ b/app/services/export/s3_uploader_config.rb
@@ -1,22 +1,22 @@
 module Export
   class S3UploaderConfig
-    def self.region
+    def region
       credentials.fetch("aws_region")
     end
 
-    def self.bucket
+    def bucket
       credentials.fetch("bucket_name")
     end
 
-    def self.key_id
+    def key_id
       credentials.fetch("aws_access_key_id")
     end
 
-    def self.secret_key
+    def secret_key
       credentials.fetch("aws_secret_access_key")
     end
 
-    def self.credentials
+    def credentials
       JSON.parse(ENV.fetch("VCAP_SERVICES"))
         .fetch("aws-s3-bucket")
         .find { |config| config.fetch("name").match?(/s3-export-download-bucket/) }

--- a/app/services/export/s3_uploader_config.rb
+++ b/app/services/export/s3_uploader_config.rb
@@ -20,6 +20,10 @@ module Export
       credentials.fetch("aws_secret_access_key")
     end
 
+    private
+
+    attr_reader :use_public_bucket
+
     def credentials
       JSON.parse(ENV.fetch("VCAP_SERVICES"))
         .fetch("aws-s3-bucket")
@@ -28,10 +32,6 @@ module Export
     rescue KeyError, NoMethodError => _error
       raise "AWS S3 credentials not found"
     end
-
-    private
-
-    attr_reader :use_public_bucket
 
     def bucket_name_regex
       use_public_bucket ? /s3-export-download-bucket$/ : /s3-export-download-bucket-private/

--- a/app/views/reports/_download.haml
+++ b/app/views/reports/_download.haml
@@ -5,4 +5,4 @@
     Download a CSV file to review offline. For guidance on reviewing and submitting your report, see the
     = link_to_new_tab " guidance in the help centre", "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005604902-Review-and-Submit-your-Data"
   .govuk-button-group
-    = link_to t("action.report.download.button"), report_path(report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+    = link_to t("action.report.download.button"), report_download_link(report_presenter), class: "govuk-button govuk-button--secondary"

--- a/app/views/reports/_summary.html.haml
+++ b/app/views/reports/_summary.html.haml
@@ -5,22 +5,39 @@
         = t("form.label.report.organisation")
       %dd.govuk-summary-list__value
         = @report_presenter.organisation.name
+
   - if @report_presenter.description.present?
     .govuk-summary-list__row
       %dt.govuk-summary-list__key
         = t("form.label.report.description")
       %dd.govuk-summary-list__value
         = @report_presenter.description
+
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("form.label.report.deadline")
     %dd.govuk-summary-list__value
       = @report_presenter.deadline
+
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("form.label.report.state")
     %dd.govuk-summary-list__value
       = @report_presenter.state
+
+  - if @report_presenter.approved?
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("form.label.report.approved_at")
+      %dd.govuk-summary-list__value
+        = @report_presenter.approved_at
+
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        = t("form.label.report.uploaded_at")
+      %dd.govuk-summary-list__value
+        = @report_presenter.uploaded_at
+
   - if current_user.partner_organisation?
     .govuk-summary-list__row
       %dt.govuk-summary-list__key

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -13,6 +13,7 @@ en:
   time:
     formats:
       default: "%Y-%m-%d"
+      detailed: "%Y-%m-%d %H:%M"
   default:
     button:
       download_as_xml: Download as XML

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -100,7 +100,7 @@ en:
     report:
       state:
         active: Active
-        approved: Approved
+        approved: Approved and locked
         awaiting_changes: Awaiting changes
         in_review: In review
         inactive: Inactive

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -183,6 +183,8 @@ en:
         subject: "%{environment_name}%{application_name} - A report is awaiting changes"
   download:
     failure: Error generating download for %{filename}
+  upload:
+    failure: Error uploading report %{filename}
   action:
     report:
       activate:

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -115,6 +115,7 @@ en:
   form:
     label:
       report:
+        approved_at: Approved at
         description: Report description
         fund: Fund (level A)
         organisation: Organisation
@@ -123,6 +124,7 @@ en:
         deadline: Deadline
         level_a_activity: Fund (level A)
         financial_quarter_and_year: Financial quarter
+        uploaded_at: Uploaded at
     legend:
       report:
         description: Reporting period

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -179,6 +179,8 @@ en:
           subject: "%{environment_name}%{application_name} - A report has been approved"
       awaiting_changes:
         subject: "%{environment_name}%{application_name} - A report is awaiting changes"
+  download:
+    failure: Error generating download for %{filename}
   action:
     report:
       activate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,9 @@ Rails.application.routes.draw do
   end
 
   resources :reports, only: [:new, :create, :show, :edit, :update, :index] do
+    member do
+      get "download"
+    end
     resource :state, only: [:edit, :update], controller: :reports_state
     get "variance" => "report_variance#show"
     get "forecasts" => "report_forecasts#show"

--- a/db/migrate/20230116171600_add_export_filename_to_report.rb
+++ b/db/migrate/20230116171600_add_export_filename_to_report.rb
@@ -1,0 +1,5 @@
+class AddExportFilenameToReport < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reports, :export_filename, :string
+  end
+end

--- a/db/migrate/20230116173500_add_approved_at_to_reports.rb
+++ b/db/migrate/20230116173500_add_approved_at_to_reports.rb
@@ -1,0 +1,5 @@
+class AddApprovedAtToReports < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reports, :approved_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -287,6 +287,7 @@ ActiveRecord::Schema.define(version: 2023_01_25_115632) do
     t.integer "financial_quarter"
     t.integer "financial_year"
     t.string "export_filename"
+    t.datetime "approved_at"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -286,6 +286,7 @@ ActiveRecord::Schema.define(version: 2023_01_25_115632) do
     t.date "deadline"
     t.integer "financial_quarter"
     t.integer "financial_year"
+    t.string "export_filename"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"

--- a/spec/features/users_can_approve_a_report_spec.rb
+++ b/spec/features/users_can_approve_a_report_spec.rb
@@ -1,26 +1,49 @@
 RSpec.feature "Users can approve reports" do
   context "signed in as a BEIS user" do
     let!(:beis_user) { create(:beis_user) }
-    let(:organisation) { create(:partner_organisation, users: create_list(:partner_organisation_user, 3)) }
+    let(:organisation) {
+      create(
+        :partner_organisation,
+        beis_organisation_reference: "AMS",
+        users: create_list(:partner_organisation_user, 3)
+      )
+    }
+    let(:uploader) { instance_double(Export::S3Uploader, upload: upload) }
+    let(:upload) do
+      OpenStruct.new(
+        url: "https://example.com/presigned_url",
+        timestamped_filename: "timestamped_filename.csv"
+      )
+    end
+
+    let(:tempfile) { double(:tempfile, tap: saved_temp_file) }
+    let(:saved_temp_file) { double(:saved_temp_file) }
 
     before do
       authenticate!(user: beis_user)
+
+      allow(Export::S3Uploader).to receive(:new).and_return(uploader)
+      allow(Tempfile).to receive(:new).and_return(tempfile)
     end
 
     after { logout }
 
     scenario "they can mark a report as approved" do
-      report = create(:report, state: :in_review, organisation: organisation)
+      # Given we have a report for FQ1 2023-2024 for AMS
+      report = create(:report, :for_gcrf, financial_quarter: 1, financial_year: 2023, state: :in_review, organisation: organisation)
 
+      # When we approve the report
       perform_enqueued_jobs do
         visit report_path(report)
         click_link t("action.report.approve.button")
         click_button t("action.report.approve.confirm.button")
       end
 
+      # Then we expect the report to be marked as approved
       expect(page).to have_content "approved"
       expect(report.reload.state).to eql "approved"
 
+      # And we expect the BEIS team and the partner org users to receive an "approved" email
       expect(ActionMailer::Base.deliveries.count).to eq(organisation.users.count + 1)
 
       expect(beis_user).to have_received_email.with_subject(t("mailer.report.approved.service_owner.subject", application_name: t("app.title"), environment_name: nil))
@@ -28,6 +51,11 @@ RSpec.feature "Users can approve reports" do
       organisation.users.each do |user|
         expect(user).to have_received_email.with_subject(t("mailer.report.approved.partner_organisation.subject", application_name: t("app.title"), environment_name: nil))
       end
+
+      # And we expect the report CSV to have been uploaded and associated with the report
+      expect(Export::S3Uploader).to have_received(:new).with(file: saved_temp_file, filename: "FQ1 2023-2024_GCRF_AMS_report.csv", use_public_bucket: false)
+      expect(uploader).to have_received(:upload)
+      expect(report.export_filename).to eq("timestamped_filename.csv")
     end
 
     context "when the report is already approved" do

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature "Users can view reports" do
 
     context "when the report has an export_filename" do
       scenario "the link to download the report is the download path instead of the show path" do
-        report = create(:report, :approved, export_filename: "exported_csv")
+        report = create(:report, :approved, export_filename: "FQ4 2020-2021_GCRF_BA_report-20230111184653.csv")
 
         visit reports_path
 
@@ -445,7 +445,7 @@ RSpec.feature "Users can view reports" do
 
     context "when the report has an export_filename" do
       scenario "the link to download the report is the download path instead of the show path" do
-        report = create(:report, :approved, export_filename: "exported_csv", organisation: partner_org_user.organisation)
+        report = create(:report, :approved, export_filename: "FQ4 2020-2021_GCRF_BA_report-20230111184653.csv", organisation: partner_org_user.organisation)
 
         visit reports_path
 

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature "Users can view reports" do
       end
     end
 
-    scenario "they see helpful guidance about and can download a CSV of their own report" do
+    scenario "they see helpful guidance about and can download a CSV of a report" do
       report = create(:report, :active)
 
       visit reports_path
@@ -164,6 +164,20 @@ RSpec.feature "Users can view reports" do
 
       expect(page.response_headers["Content-Type"]).to include("text/csv")
       expect(page.status_code).to eq 200
+    end
+
+    context "when the report has an export_filename" do
+      scenario "the link to download the report is the download path instead of the show path" do
+        report = create(:report, :approved, export_filename: "exported_csv")
+
+        visit reports_path
+
+        within "##{report.id}" do
+          click_on t("default.link.show")
+        end
+
+        expect(page).to have_link(t("action.report.download.button"), href: download_report_path(report))
+      end
     end
 
     context "if the report description is empty" do
@@ -426,6 +440,20 @@ RSpec.feature "Users can view reports" do
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
         expect(page.status_code).to eq 200
+      end
+    end
+
+    context "when the report has an export_filename" do
+      scenario "the link to download the report is the download path instead of the show path" do
+        report = create(:report, :approved, export_filename: "exported_csv", organisation: partner_org_user.organisation)
+
+        visit reports_path
+
+        within "##{report.id}" do
+          click_on t("default.link.show")
+        end
+
+        expect(page).to have_link(t("action.report.download.button"), href: download_report_path(report))
       end
     end
 

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ReportHelper, type: :helper do
+  describe "#report_download_link" do
+    context "when the report doesn't have an export_filename" do
+      let(:report) { create(:report) }
+
+      it "returns the report show path in CSV format" do
+        expect(helper.report_download_link(report)).to eq(report_path(report, format: :csv))
+      end
+    end
+
+    context "when the report has an export_filename" do
+      let(:report) { create(:report, export_filename: "exported_csv") }
+
+      it "returns the report download path" do
+        expect(helper.report_download_link(report)).to eq(download_report_path(report))
+      end
+    end
+  end
+end

--- a/spec/jobs/report_export_uploader_job_spec.rb
+++ b/spec/jobs/report_export_uploader_job_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe ReportExportUploaderJob, type: :job do
+  let(:requester) { double(:user, email: "roger@example.com") }
+  let(:report) { double(:report, save: true) }
+  let(:row1) { double("row1") }
+  let(:row2) { double("row1") }
+
+  let(:report_export) do
+    instance_double(
+      Export::Report,
+      filename: "export_1234.csv",
+      headers: %w[col1 col2],
+      rows: [row1, row2]
+    )
+  end
+  let(:tempfile) { double("tempfile") }
+  let(:csv) { double("csv", "<<" => true) }
+  let(:upload) do
+    OpenStruct.new(
+      url: "https://example.com/presigned_url",
+      timestamped_filename: "timestamped_filename.csv"
+    )
+  end
+  let(:uploader) { instance_double(Export::S3Uploader, upload: upload) }
+  let(:email) { double("email", deliver: double) }
+
+  describe "#perform" do
+    before do
+      allow(User).to receive(:find).and_return(requester)
+      allow(Report).to receive(:find).and_return(report)
+      allow(Export::Report).to receive(:new).and_return(report_export)
+      allow(Tempfile).to receive(:new).and_return(tempfile)
+      allow(CSV).to receive(:open).and_yield(csv)
+      allow(Export::S3Uploader).to receive(:new).and_return(uploader)
+      allow(DownloadLinkMailer).to receive(:send_link).and_return(email)
+      allow(report).to receive(:export_filename=)
+    end
+
+    it "asks the user object for the user with a given id" do
+      ReportExportUploaderJob.perform_now(requester_id: "user123", report_id: double)
+
+      expect(User).to have_received(:find).with("user123")
+    end
+
+    it "asks the report object for the report with a given id" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: "report123")
+
+      expect(Report).to have_received(:find).with("report123")
+    end
+
+    it "uses Export::Report to build the report CSV for the given report" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+      expect(Export::Report).to have_received(:new).with(report: report)
+    end
+
+    it "writes the report CSV to a 'tempfile'" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+      expect(CSV).to have_received(:open).with(tempfile, "wb", {headers: true})
+      expect(csv).to have_received(:<<).with(%w[col1 col2])
+      expect(csv).to have_received(:<<).with(row1)
+      expect(csv).to have_received(:<<).with(row2)
+    end
+
+    it "uploads the file to S3" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+      expect(Export::S3Uploader).to have_received(:new)
+        .with(
+          file: tempfile,
+          filename: "export_1234.csv",
+          use_public_bucket: false
+        )
+      expect(uploader).to have_received(:upload)
+    end
+
+    context "when the uploader raises an error" do
+      let(:error) { Export::S3UploadError.new("Error uploading filename-xyz") }
+
+      before do
+        allow(uploader).to receive(:upload).and_raise(error)
+        allow(Rails.logger).to receive(:error)
+        allow(Rollbar).to receive(:log)
+        allow(DownloadLinkMailer).to receive(:send_failure_notification).and_return(email)
+      end
+
+      it "logs the error, including the identity of the requester" do
+        ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+        expect(Rails.logger).to have_received(:error).with(
+          "Error uploading filename-xyz for roger@example.com"
+        )
+      end
+
+      it "records the error at Rollbar for exception handling and debugging" do
+        ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+        expect(Rollbar).to have_received(:log).with(
+          :error,
+          "Error uploading filename-xyz for roger@example.com",
+          error
+        )
+      end
+
+      it "does not re-raise the error as we don't wish to retry the job" do
+        expect {
+          ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+        }.not_to raise_error
+      end
+
+      it "sends the email notifying the requester of failure uploading the report" do
+        ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+        expect(DownloadLinkMailer)
+          .to have_received(:send_failure_notification)
+          .with(recipient: requester)
+        expect(email).to have_received(:deliver)
+      end
+    end
+
+    it "saves the uploaded filename in the report" do
+      ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
+
+      expect(report).to have_received(:export_filename=).with(upload.timestamped_filename)
+      expect(report).to have_received(:save)
+    end
+  end
+end

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -63,13 +63,14 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       expect(csv).to have_received(:<<).with(row2)
     end
 
-    it "uploads the file to S3" do
+    it "uploads the file to the public S3 bucket" do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 
       expect(Export::S3Uploader).to have_received(:new)
         .with(
           file: tempfile,
-          filename: "export_1234.csv"
+          filename: "export_1234.csv",
+          use_public_bucket: true
         )
       expect(uploader).to have_received(:upload)
     end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -39,6 +39,33 @@ RSpec.describe ReportPresenter do
     end
   end
 
+  describe "#approved_at" do
+    it "returns the formatted datetime for the Report's approval date" do
+      now = Time.now
+      report = build(:report, approved_at: now)
+      result = described_class.new(report).approved_at
+      expect(result).to eql I18n.l(now, {format: :detailed})
+    end
+  end
+
+  describe "#uploaded_at" do
+    context "when the report has an `export_filename`" do
+      it "parses the timestamp from the uploaded report's filename" do
+        report = build(:report, export_filename: "FQ4 2020-2021_GCRF_BA_report-20230111184653.csv")
+        result = described_class.new(report).uploaded_at
+        expect(result).to eql "2023-01-11 18:46"
+      end
+    end
+
+    context "when the report has no `export_filename`" do
+      it "returns nil" do
+        report = build(:report, export_filename: nil)
+        result = described_class.new(report).uploaded_at
+        expect(result).to be_nil
+      end
+    end
+  end
+
   context "generating filenames" do
     let(:report) {
       build(:report,

--- a/spec/services/export/s3_downloader_spec.rb
+++ b/spec/services/export/s3_downloader_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Export::S3Downloader do
+  let(:response_body) { double("response_body", read: double) }
+  let(:response) { double("response", body: response_body) }
+  let(:aws_credentials) { double("aws credentials") }
+  let(:aws_client) { instance_double(Aws::S3::Client, get_object: response) }
+
+  let(:s3_bucket) { double("s3 bucket") }
+  let(:s3_uploader_config) {
+    instance_double(
+      Export::S3UploaderConfig,
+      key_id: "key id",
+      secret_key: "secret key",
+      region: "region",
+      bucket: s3_bucket
+    )
+  }
+
+  let(:filename) { "Q1_report0101202312345.csv" }
+
+  subject {
+    Export::S3Downloader.new(filename: filename)
+  }
+
+  before do
+    allow(Aws::Credentials).to receive(:new).and_return(aws_credentials)
+    allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
+    allow(Export::S3UploaderConfig).to receive(:new).and_return(s3_uploader_config)
+  end
+
+  describe "#initialize" do
+    context "when instantiating the Aws::S3::Client" do
+      it "sets `credentials:` using an Aws::Credentials object" do
+        subject
+
+        expect(Aws::Credentials).to have_received(:new).with(
+          s3_uploader_config.key_id,
+          s3_uploader_config.secret_key
+        )
+        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+          credentials: aws_credentials
+        ))
+      end
+
+      it "sets `region:` using the region from the S3UploaderConfig" do
+        subject
+
+        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+          region: s3_uploader_config.region
+        ))
+      end
+    end
+  end
+
+  describe "#download" do
+    it "gets the specified report CSV from S3" do
+      subject.download
+
+      expect(aws_client).to have_received(:get_object).with(
+        bucket: s3_bucket,
+        key: filename,
+        response_content_type: "text/csv"
+      )
+      expect(response).to have_received(:body)
+      expect(response_body).to have_received(:read)
+    end
+
+    context "when something goes wrong with fetching the object from S3" do
+      before do
+        allow(aws_client).to receive(:get_object).and_raise("There has been a problem!")
+      end
+
+      it "re-raises the error, adding the filename for information" do
+        enriched_message = "There has been a problem! #{I18n.t("download.failure", filename: filename)}"
+        expect { subject.download }.to raise_error(Export::S3DownloaderError, enriched_message)
+      end
+    end
+  end
+end

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module Export
   RSpec.describe S3UploaderConfig do
-    subject(:config) { S3UploaderConfig.new }
+    subject(:config) { S3UploaderConfig.new(use_public_bucket: true) }
 
     context "when an expected credential is missing from VCAP_SERVICES" do
       around(:each) do |example|
@@ -97,9 +97,18 @@ module Export
           {
             "aws-s3-bucket":[
                 {
+                   "name": "beis-roda-staging-s3-export-download-bucket-private",
+                   "credentials":{
+                      "bucket_name":"private_exports_bucket",
+                      "aws_access_key_id":"KEY_ID",
+                      "aws_secret_access_key":"SECRET_KEY",
+                      "aws_region":"eu-west-2"
+                   }
+                },
+                {
                    "name": "beis-roda-staging-s3-export-download-bucket",
                    "credentials":{
-                      "bucket_name":"exports_bucket",
+                      "bucket_name":"public_exports_bucket",
                       "aws_access_key_id":"KEY_ID",
                       "aws_secret_access_key":"SECRET_KEY",
                       "aws_region":"eu-west-2"
@@ -109,10 +118,6 @@ module Export
           }
         JSON
         ClimateControl.modify(VCAP_SERVICES: vcap_services) { example.run }
-      end
-
-      it "returns the bucket_name" do
-        expect(config.bucket).to eq("exports_bucket")
       end
 
       it "returns the key_id" do
@@ -125,6 +130,24 @@ module Export
 
       it "returns the region" do
         expect(config.region).to eq("eu-west-2")
+      end
+
+      describe "#bucket" do
+        context "when initialized with `use_public_bucket: true`" do
+          subject(:config) { S3UploaderConfig.new(use_public_bucket: true) }
+
+          it "uses the public S3 bucket" do
+            expect(config.bucket).to eq("public_exports_bucket")
+          end
+        end
+
+        context "when initialized with `use_public_bucket: false`" do
+          subject(:config) { S3UploaderConfig.new(use_public_bucket: false) }
+
+          it "uses the private S3 bucket" do
+            expect(config.bucket).to eq("private_exports_bucket")
+          end
+        end
       end
     end
   end

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 module Export
   RSpec.describe S3UploaderConfig do
+    subject(:config) { S3UploaderConfig.new }
+
     context "when an expected credential is missing from VCAP_SERVICES" do
       around(:each) do |example|
         vcap_services = <<~JSON
@@ -22,7 +24,7 @@ module Export
       end
 
       it "raises a helpful error message" do
-        expect { S3UploaderConfig.region }.to raise_error(KeyError, /key not found: "aws_region"/)
+        expect { config.region }.to raise_error(KeyError, /key not found: "aws_region"/)
       end
     end
 
@@ -46,7 +48,7 @@ module Export
       end
 
       it "raises a helpful error message" do
-        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+        expect { config.region }.to raise_error(/AWS S3 credentials not found/)
       end
     end
 
@@ -70,7 +72,7 @@ module Export
       end
 
       it "raises a helpful error message" do
-        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+        expect { config.region }.to raise_error(/AWS S3 credentials not found/)
       end
     end
 
@@ -85,7 +87,7 @@ module Export
       end
 
       it "raises a helpful error message" do
-        expect { S3UploaderConfig.region }.to raise_error(/AWS S3 credentials not found/)
+        expect { config.region }.to raise_error(/AWS S3 credentials not found/)
       end
     end
 
@@ -110,19 +112,19 @@ module Export
       end
 
       it "returns the bucket_name" do
-        expect(S3UploaderConfig.bucket).to eq("exports_bucket")
+        expect(config.bucket).to eq("exports_bucket")
       end
 
       it "returns the key_id" do
-        expect(S3UploaderConfig.key_id).to eq("KEY_ID")
+        expect(config.key_id).to eq("KEY_ID")
       end
 
       it "returns the secret_key" do
-        expect(S3UploaderConfig.secret_key).to eq("SECRET_KEY")
+        expect(config.secret_key).to eq("SECRET_KEY")
       end
 
       it "returns the region" do
-        expect(S3UploaderConfig.region).to eq("eu-west-2")
+        expect(config.region).to eq("eu-west-2")
       end
     end
   end

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Export::S3Uploader do
       end
 
       it "re-raises the error, adding the filename for information" do
-        enriched_message = "There has been a problem! Error uploading report #{timestamped_filename}"
+        enriched_message = "There has been a problem! #{I18n.t("upload.failure", filename: timestamped_filename)}"
         expect { subject.upload }.to raise_error(Export::S3UploadError, enriched_message)
       end
     end

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -16,12 +16,6 @@ resource "cloudfoundry_app" "beis-roda-app" {
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-redis.id }
   service_binding { service_instance = cloudfoundry_service_instance.beis-roda-postgres.id }
   service_binding {
-    service_instance = cloudfoundry_service_instance.beis-roda-s3-export-download-bucket.id
-    params = {
-      "permissions" = "read-only"
-    }
-  }
-  service_binding {
     service_instance = cloudfoundry_service_instance.beis-roda-s3-export-download-bucket-private.id
     params = {
       "permissions" = "read-only"


### PR DESCRIPTION
## Changes in this PR

Uploads reports to a new private bucket on S3 when they're approved by the BEIS team, storing an `approved_at` datetime on the Report to display the date at which this happened to users.

We're doing this as reports have always been created with the most up-to-date data in the service at the point of clicking the "download" button. This meant the data for a report that was previously thought to approved (and closed for further editing) could be different if any future transactions were added that referred to that quarter, essentially changing historical data.

For any reports that haven't been approved yet, we pull them together with live data at the point of clicking the button, like we used to do.

## Screenshots of UI changes

### After

<img width="889" alt="image" src="https://user-images.githubusercontent.com/19826940/214602432-cb7d6ef7-2fb3-48e4-a061-654c97285eac.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
