### PR TITLE
(2784) Remove `ispf_partner_countries` column

### DIFF
--- a/db/migrate/20230125115632_remove_ispf_partner_countries_from_activities.rb
+++ b/db/migrate/20230125115632_remove_ispf_partner_countries_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveIspfPartnerCountriesFromActivities < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :activities, :ispf_partner_countries, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_16_173500) do
+ActiveRecord::Schema.define(version: 2023_01_25_115632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -79,7 +79,6 @@ ActiveRecord::Schema.define(version: 2023_01_16_173500) do
     t.string "benefitting_countries", array: true
     t.boolean "is_oda"
     t.integer "ispf_themes", array: true
-    t.string "ispf_partner_countries", array: true
     t.uuid "linked_activity_id"
     t.integer "tags", array: true
     t.string "ispf_oda_partner_countries", array: true


### PR DESCRIPTION
## Changes in this PR

This is superseded by `ispf_oda_partner_countries` and `ispf_non_oda_partner_countries`, to which all staging and training data have already been migrated

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
