### PR TITLE
(2743) Decorate activity importer implementing organisation error

### DIFF
--- a/app/services/activity/import.rb
+++ b/app/services/activity/import.rb
@@ -6,7 +6,10 @@ class Activity
       end
 
       def csv_column
-        return "Implementing organisation names" if column == :implementing_organisation_id
+        if [:implementing_organisation_id, :implementing_org_participations].include?(column)
+          return "Implementing organisation names"
+        end
+
         ACTIVITY_CSV_COLUMNS.dig(column, :heading) || column.to_s
       end
     }

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -465,6 +465,8 @@ en:
               invalid: Please enter a valid date
             gdi:
               blank: Select an option for GDI
+            implementing_org_participations:
+              invalid: Invalid implementing organisation name(s)
             implementing_organisation_id:
               blank: ISPF third-party projects must have an implementing organisation
             intended_beneficiaries:


### PR DESCRIPTION
## Changes in this PR

## Screenshots of UI changes

When there was an error with `implementing_org_participations` when importing activities, the column would be represented in snake case. This decorates the error so that it says "Implementing organisation names" instead

We may want to improve the error message at a later time - it currently says "Implementing org participations is invalid" (a default attribute error), which may be confusing to users

### Before

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/40244233/214570505-ac99efda-19bd-41a3-b09e-0c24a694d574.png">

### After

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/40244233/214587834-b85b2e6b-4465-4191-9e29-c0a55430e37d.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
