### PR TITLE
(2782) Fix invalid comment update and other edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1178,6 +1178,10 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Upload the report CSV to S3 when the report is approved
 - For approved reports, provide download of stored report CSV file instead of generating it from live data
+- Fix/improve various commenting edge cases:
+  - Show useful error when trying to remove the body from an existing comment
+  - Show the RODA identifier when adding/editing a comment on an activity without a title
+  - Include breadcrumbs when the form is re-rendered after failing to create/update a comment
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/app/controllers/activity_comments_controller.rb
+++ b/app/controllers/activity_comments_controller.rb
@@ -71,6 +71,7 @@ class ActivityCommentsController < BaseController
       flash[:notice] = t("action.comment.update.success")
       redirect_to organisation_activity_comments_path(@comment.commentable.organisation, @comment.commentable)
     else
+      @activity = Activity.find(@comment.commentable_id)
       render :edit
     end
   end

--- a/app/controllers/activity_comments_controller.rb
+++ b/app/controllers/activity_comments_controller.rb
@@ -9,14 +9,12 @@ class ActivityCommentsController < BaseController
     if @activity.programme?
       @comment = @activity.comments.new
       authorize :level_b, :create_activity_comment?
-      prepare_default_activity_trail(@activity, tab: "comments")
     else
       @comment = @activity.comments.new(report_id: report_id)
       authorize @comment, policy_class: Activity::CommentPolicy
-      prepare_default_report_variance_trail(@comment.report)
     end
 
-    add_breadcrumb t("breadcrumb.comment.new"), new_activity_comment_path(@activity)
+    prepare_new_trail_and_breadcrumb
   end
 
   def create
@@ -36,6 +34,7 @@ class ActivityCommentsController < BaseController
       flash[:notice] = t("action.comment.create.success")
       redirect_to organisation_activity_comments_path(@activity.organisation, @activity)
     else
+      prepare_new_trail_and_breadcrumb
       render :new
     end
   end
@@ -52,8 +51,7 @@ class ActivityCommentsController < BaseController
       authorize @comment, policy_class: Activity::CommentPolicy
     end
 
-    prepare_default_activity_trail(@activity, tab: "comments")
-    add_breadcrumb t("breadcrumb.comment.edit"), edit_activity_comment_path(@activity, @comment)
+    prepare_edit_trail_and_breadcrumb
   end
 
   def update
@@ -72,6 +70,7 @@ class ActivityCommentsController < BaseController
       redirect_to organisation_activity_comments_path(@comment.commentable.organisation, @comment.commentable)
     else
       @activity = Activity.find(@comment.commentable_id)
+      prepare_edit_trail_and_breadcrumb
       render :edit
     end
   end
@@ -92,5 +91,20 @@ class ActivityCommentsController < BaseController
 
   def comment_params
     params.require(:comment).permit(:body, :report_id)
+  end
+
+  def prepare_new_trail_and_breadcrumb
+    if @activity.programme?
+      prepare_default_activity_trail(@activity, tab: "comments")
+    else
+      prepare_default_report_variance_trail(@comment.report)
+    end
+
+    add_breadcrumb t("breadcrumb.comment.new"), new_activity_comment_path(@activity)
+  end
+
+  def prepare_edit_trail_and_breadcrumb
+    prepare_default_activity_trail(@activity, tab: "comments")
+    add_breadcrumb t("breadcrumb.comment.edit"), edit_activity_comment_path(@activity, @comment)
   end
 end

--- a/app/views/activity_comments/edit.html.haml
+++ b/app/views/activity_comments/edit.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-l
-        = t("page_content.comment.edit_about_activity", activity: @activity.title)
+        = t("page_content.comment.edit_about_activity", activity: @activity.title || @activity.roda_identifier)
 
   - if @comment.report
     .govuk-grid-row

--- a/app/views/activity_comments/new.html.haml
+++ b/app/views/activity_comments/new.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       %h2.govuk-heading-l
-        = t("page_content.comment.add_about_activity", activity: @activity.title)
+        = t("page_content.comment.add_about_activity", activity: @activity.title || @activity.roda_identifier)
 
   - if @comment.report
     .govuk-grid-row

--- a/config/locales/models/comment.en.yml
+++ b/config/locales/models/comment.en.yml
@@ -16,7 +16,6 @@ en:
     comment:
       add: Add a comment
       add_about_activity: Add a comment about %{activity}
-      edit: Edit comment
       edit_about_activity: Edit comment about %{activity}
       index:
         default: This tab shows all the comments for this activity.

--- a/spec/controllers/activity_comments_controller_spec.rb
+++ b/spec/controllers/activity_comments_controller_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe ActivityCommentsController do
   end
 
   describe "#create" do
+    render_views
+
+    context "when the comment body is empty" do
+      let(:user) { partner_organisation_user }
+
+      it "doesn't create the comment and shows an error" do
+        expect {
+          post :create, params: {
+            activity_id: project_activity.id,
+            comment: {body: "", report_id: project_activity_report.id}
+          }
+        }.not_to change { Comment.count }
+
+        expect(response.body).to include(CGI.escapeHTML(t("activerecord.errors.messages.blank", attribute: "Body")))
+      end
+    end
+
     context "when the activity is a programme" do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }

--- a/spec/controllers/activity_comments_controller_spec.rb
+++ b/spec/controllers/activity_comments_controller_spec.rb
@@ -197,6 +197,24 @@ RSpec.describe ActivityCommentsController do
   end
 
   describe "#update" do
+    render_views
+
+    context "when the comment body is empty" do
+      let(:user) { partner_organisation_user }
+
+      it "doesn't update the comment and shows an error" do
+        expect {
+          put :update, params: {
+            id: existing_project_activity_comment.id,
+            activity_id: project_activity.id,
+            comment: {body: ""}
+          }
+        }.not_to change { existing_programme_activity_comment.body }
+
+        expect(response.body).to include(CGI.escapeHTML(t("activerecord.errors.messages.blank", attribute: "Body")))
+      end
+    end
+
     context "when the activity is a programme" do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }

--- a/spec/features/users_can_create_a_comment_spec.rb
+++ b/spec/features/users_can_create_a_comment_spec.rb
@@ -85,6 +85,21 @@ RSpec.describe "Users can create a comment" do
   end
 
   context "from the activity comments tab" do
+    context "when the activity has no title" do
+      it "provides the RODA ID of the activity being commented on" do
+        authenticate!(user: partner_org_user)
+
+        project_activity.update(form_state: "purpose", title: nil)
+
+        visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+        click_on t("page_content.comment.add")
+
+        expect(page).to have_content project_activity.roda_identifier
+
+        logout
+      end
+    end
+
     context "when the user is a partner organisation user" do
       before { authenticate!(user: partner_org_user) }
       after { logout }

--- a/spec/features/users_can_create_a_comment_spec.rb
+++ b/spec/features/users_can_create_a_comment_spec.rb
@@ -168,4 +168,43 @@ RSpec.describe "Users can create a comment" do
       end
     end
   end
+
+  context "when the form is rendered via the new action" do
+    it "includes breadcrumbs" do
+      authenticate!(user: partner_org_user)
+
+      visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+      click_on t("default.link.add")
+
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content("Home")
+        expect(page).to have_content("Current Reports")
+        expect(page).to have_content(t("page_title.report.show", report_fund: project_activity_report.fund.source_fund.name, report_financial_quarter: project_activity_report.financial_quarter_and_year))
+      end
+    end
+  end
+
+  context "when the form is rendered via the create action due to the comment body being empty" do
+    before do
+      authenticate!(user: partner_org_user)
+
+      visit organisation_activity_comments_path(project_activity.organisation, project_activity)
+      click_on t("default.link.add")
+      click_button t("default.button.submit")
+    end
+
+    after { logout }
+
+    it "includes breadcrumbs" do
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content("Home")
+        expect(page).to have_content("Current Reports")
+        expect(page).to have_content(t("page_title.report.show", report_fund: project_activity_report.fund.source_fund.name, report_financial_quarter: project_activity_report.financial_quarter_and_year))
+      end
+    end
+
+    it "displays an error message" do
+      expect(page).to have_content(t("activerecord.errors.messages.blank", attribute: "Body"))
+    end
+  end
 end

--- a/spec/features/users_can_edit_a_comment_spec.rb
+++ b/spec/features/users_can_edit_a_comment_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe "Users can edit a comment" do
   let!(:programme_activity_comment) { create(:comment, commentable: programme_activity, owner: beis_user) }
 
   context "editing a comment from the activity view" do
+    context "when the activity has no title" do
+      it "provides the RODA ID of the activity being commented on" do
+        authenticate!(user: beis_user)
+
+        programme_activity.update(form_state: "purpose", title: nil)
+
+        visit organisation_activity_comments_path(programme_activity.organisation, programme_activity)
+        click_on t("default.link.edit")
+
+        expect(page).to have_content programme_activity.roda_identifier
+
+        logout
+      end
+    end
+
     context "when the user is a BEIS user" do
       before { authenticate!(user: beis_user) }
       after { logout }

--- a/spec/features/users_can_edit_a_comment_spec.rb
+++ b/spec/features/users_can_edit_a_comment_spec.rb
@@ -100,4 +100,44 @@ RSpec.describe "Users can edit a comment" do
       end
     end
   end
+
+  context "when the form is rendered via the edit action" do
+    it "includes breadcrumbs" do
+      authenticate!(user: beis_user)
+
+      visit organisation_activity_comments_path(programme_activity.organisation, programme_activity)
+      click_on t("default.link.edit")
+
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content("Home")
+        expect(page).to have_content(programme_activity.parent.title)
+        expect(page).to have_content(programme_activity.title)
+      end
+    end
+  end
+
+  context "when the form is rendered via the update action due to the comment body being empty" do
+    before do
+      authenticate!(user: beis_user)
+
+      visit organisation_activity_comments_path(programme_activity.organisation, programme_activity)
+      click_on t("default.link.edit")
+      fill_in "comment[body]", with: ""
+      click_button t("default.button.submit")
+    end
+
+    after { logout }
+
+    it "includes breadcrumbs" do
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content("Home")
+        expect(page).to have_content(programme_activity.parent.title)
+        expect(page).to have_content(programme_activity.title)
+      end
+    end
+
+    it "displays an error message" do
+      expect(page).to have_content(t("activerecord.errors.messages.blank", attribute: "Body"))
+    end
+  end
 end

--- a/spec/features/users_can_edit_a_comment_spec.rb
+++ b/spec/features/users_can_edit_a_comment_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Users can edit a comment" do
         context "when the report is editable" do
           scenario "the user cannot edit comments" do
             visit organisation_activity_comments_path(project_activity.organisation, project_activity)
-            expect(page).not_to have_content t("page_content.comment.edit")
+            expect(page).not_to have_content t("default.link.edit")
           end
         end
 
@@ -41,7 +41,7 @@ RSpec.describe "Users can edit a comment" do
           let(:project_activity_report) { create(:report, fund: project_activity.associated_fund, organisation: partner_org_user.organisation) }
           scenario "the user cannot edit comments" do
             visit organisation_activity_comments_path(project_activity.organisation, project_activity)
-            expect(page).not_to have_content t("page_content.comment.edit")
+            expect(page).not_to have_content t("default.link.edit")
           end
         end
       end


### PR DESCRIPTION
## Changes in this PR

Previously:
- If when editing a comment, you submit the form with no body, an error would show up due to a missing instance variable
- Tests were missing for this in both the `update` and `create` controller actions (but the latter didn't cause an error)
- When an activity had no title, the heading when adding/editing comments was confusing: "Add a comment about"/"Edit comment about"
- Some comment tests were checking for the absence of the wrong translation
- If a create/update failed, the breadcrumbs would be lost when re-rendering the form

This fixes all of the above

## Screenshots of UI changes

### Before

<img width="1455" alt="image" src="https://user-images.githubusercontent.com/40244233/214613715-01ad62b8-5573-4990-ba84-84591762eb5f.png">

### After

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/40244233/214613612-8b66060e-8778-4e1c-bbfb-daf351e5f61d.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
