### PR TITLE
(2773) Report uploading emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1182,6 +1182,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - Show useful error when trying to remove the body from an existing comment
   - Show the RODA identifier when adding/editing a comment on an activity without a title
   - Include breadcrumbs when the form is re-rendered after failing to create/update a comment
+- Report approved emails sent to BEIS users include a reminder that the report is going to be uploaded
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1183,6 +1183,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - Show the RODA identifier when adding/editing a comment on an activity without a title
   - Include breadcrumbs when the form is re-rendered after failing to create/update a comment
 - Report approved emails sent to BEIS users include a reminder that the report is going to be uploaded
+- Send a notification email to the report approver if the report upload fails
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/app/jobs/report_export_uploader_job.rb
+++ b/app/jobs/report_export_uploader_job.rb
@@ -11,7 +11,7 @@ class ReportExportUploaderJob < ApplicationJob
     report.save
   rescue => error
     log_error(error, requester)
-    DownloadLinkMailer.send_failure_notification(recipient: requester).deliver
+    ReportMailer.with(report: report, user: requester).upload_failed.deliver
   end
 
   def save_tempfile(export)

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -59,7 +59,28 @@ class ReportMailer < ApplicationMailer
       subject: t("mailer.report.awaiting_changes.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
   end
 
+  def upload_failed
+    @report_presenter = ReportPresenter.new(params[:report])
+    @user = params[:user]
+    raise_unless_active_user
+    raise_unless_service_owner
+
+    view_mail(
+      ENV["NOTIFY_VIEW_TEMPLATE"],
+      to: @user.email,
+      subject: t(
+        "mailer.report.upload_failed.subject",
+        application_name: t("app.title"),
+        environment_name: environment_mailer_prefix
+      )
+    )
+  end
+
   private def raise_unless_active_user
     raise ArgumentError, "User must be active to receive report-related emails" unless @user.active
+  end
+
+  private def raise_unless_service_owner
+    raise ArgumentError, "User must be a service owner to receive report upload failure notification emails" unless @user.service_owner?
   end
 end

--- a/app/views/report_mailer/_approved_service_owner.text.erb
+++ b/app/views/report_mailer/_approved_service_owner.text.erb
@@ -5,3 +5,5 @@ A report has been approved.
 # What happens next?
 
 No further action is required.
+
+The CSV file for the approved and locked report is being uploaded. The user who approved the report will receive a notification if the upload is unsuccessful.

--- a/app/views/report_mailer/upload_failed.text.erb
+++ b/app/views/report_mailer/upload_failed.text.erb
@@ -1,0 +1,5 @@
+# There has been a problem
+
+There has been a problem uploading the CSV for the report <%= @report_presenter.email_title %>. The error has been logged and our team will investigate as soon as possible. If you have any additional context to add please create a support request using the link below.
+
+<%= render partial: "report_mailer/footer" %>

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -181,6 +181,8 @@ en:
           subject: "%{environment_name}%{application_name} - A report has been approved"
       awaiting_changes:
         subject: "%{environment_name}%{application_name} - A report is awaiting changes"
+      upload_failed:
+        subject: "%{environment_name}%{application_name} - Report upload failed"
   download:
     failure: Error generating download for %{filename}
   upload:

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       it "contains the expected body" do
         expect(mail.body).to include("A report has been approved.")
+        expect(mail.body).to include("The CSV file for the approved and locked report is being uploaded")
       end
 
       context "when the email is from the training site" do


### PR DESCRIPTION
## Changes in this PR
- Report approved emails sent to BEIS users include a reminder that the report is going to be uploaded
- Send notification email to report approver if report upload fails

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
