### PR TITLE
Bind private bucket to worker

### DIFF
--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -21,6 +21,12 @@ resource "cloudfoundry_app" "beis-roda-worker" {
       "permissions" = "read-write"
     }
   }
+  service_binding {
+    service_instance = cloudfoundry_service_instance.beis-roda-s3-export-download-bucket-private.id
+    params = {
+      "permissions" = "read-write"
+    }
+  }
   service_binding { service_instance = cloudfoundry_user_provided_service.papertrail.id }
   environment = {
     "RAILS_LOG_TO_STDOUT"              = "true"


### PR DESCRIPTION
## Changes in this PR

Bind private bucket to worker

The worker is used for uploading files to S3, while the app is used to download them. We forgot to bind the private bucket to the worker on our previous attempts to upload reports, so we're unable to upload to S3.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
