### PR TITLE
(2550) Add QA completed report state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1188,6 +1188,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Spending breakdown email notification has a link to the Exports page instead of a direct download link
 - Spending breakdown exports use a private S3 bucket
 - Default to 0, rather than `nil` in the rare case where a report has no actual value for an activity
+- Add QA completed report step in between review and approval
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/app/controllers/reports_state_controller.rb
+++ b/app/controllers/reports_state_controller.rb
@@ -8,6 +8,7 @@ class ReportsStateController < BaseController
     "submitted" => "submit",
     "in_review" => "review",
     "awaiting_changes" => "request_changes",
+    "qa_completed" => "mark_qa_completed",
     "approved" => "approve"
   }
 
@@ -18,6 +19,8 @@ class ReportsStateController < BaseController
     when "submitted"
       show_state_change_confirmation(:review)
     when "in_review"
+      params[:request_changes] ? show_state_change_confirmation(:request_changes) : show_state_change_confirmation(:mark_qa_completed)
+    when "qa_completed"
       params[:request_changes] ? show_state_change_confirmation(:request_changes) : show_state_change_confirmation(:approve)
     when "awaiting_changes"
       show_state_change_confirmation(:submit)

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -29,6 +29,17 @@ class ReportMailer < ApplicationMailer
     end
   end
 
+  def qa_completed
+    @report_presenter = ReportPresenter.new(params[:report])
+    @user = params[:user]
+    raise_unless_active_user
+    raise_unless_service_owner(message: "User must be a service owner to receive email notification of reports being marked as QA completed")
+
+    view_mail(ENV["NOTIFY_VIEW_TEMPLATE"],
+      to: @user.email,
+      subject: t("mailer.report.qa_completed.subject", application_name: t("app.title"), environment_name: environment_mailer_prefix))
+  end
+
   def approved
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
@@ -63,7 +74,7 @@ class ReportMailer < ApplicationMailer
     @report_presenter = ReportPresenter.new(params[:report])
     @user = params[:user]
     raise_unless_active_user
-    raise_unless_service_owner
+    raise_unless_service_owner(message: "User must be a service owner to receive report upload failure notification emails")
 
     view_mail(
       ENV["NOTIFY_VIEW_TEMPLATE"],
@@ -76,11 +87,13 @@ class ReportMailer < ApplicationMailer
     )
   end
 
-  private def raise_unless_active_user
+  private
+
+  def raise_unless_active_user
     raise ArgumentError, "User must be active to receive report-related emails" unless @user.active
   end
 
-  private def raise_unless_service_owner
-    raise ArgumentError, "User must be a service owner to receive report upload failure notification emails" unless @user.service_owner?
+  def raise_unless_service_owner(message:)
+    raise ArgumentError, message unless @user.service_owner?
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -29,6 +29,7 @@ class Report < ApplicationRecord
     submitted: "submitted",
     in_review: "in_review",
     awaiting_changes: "awaiting_changes",
+    qa_completed: "qa_completed",
     approved: "approved"
   }
 

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -37,6 +37,8 @@ class ReportPolicy < ApplicationPolicy
       beis_user?
     when "awaiting_changes"
       partner_organisation_user? && record.organisation == user.organisation
+    when "qa_completed"
+      beis_user?
     when "approved"
       false
     end
@@ -68,11 +70,15 @@ class ReportPolicy < ApplicationPolicy
   end
 
   def request_changes?
+    return change_state? if %w[in_review qa_completed].include?(record.state)
+  end
+
+  def mark_qa_completed?
     return change_state? if record.state == "in_review"
   end
 
   def approve?
-    return change_state? if record.state == "in_review"
+    return change_state? if record.state == "qa_completed"
   end
 
   class Scope < Scope

--- a/app/services/report/send_state_change_emails.rb
+++ b/app/services/report/send_state_change_emails.rb
@@ -14,6 +14,8 @@ class Report
         send_submitted
       when "awaiting_changes"
         send_awaiting_changes
+      when "qa_completed"
+        send_qa_completed
       when "approved"
         send_approved
       end
@@ -31,6 +33,10 @@ class Report
 
     def send_awaiting_changes
       send_mail_to_users(:awaiting_changes)
+    end
+
+    def send_qa_completed
+      send_mail_to_users(:qa_completed, service_owners)
     end
 
     def send_approved

--- a/app/views/report_mailer/qa_completed.text.erb
+++ b/app/views/report_mailer/qa_completed.text.erb
@@ -1,0 +1,11 @@
+A report has been marked as QA completed.
+
+<%= render partial: "report" %>
+
+# What happens next?
+
+The report will need to be approved by the Service Manager and ODA PMO Finance Lead.
+
+If you require any updates prior to the report being approved, please notify the Service Manager or ODA PMO Finance Lead.
+
+<%= render partial: "footer" %>

--- a/app/views/reports/_actions.html.haml
+++ b/app/views/reports/_actions.html.haml
@@ -9,6 +9,8 @@
     - if policy(@report_presenter).request_changes?
       = link_to t("action.report.request_changes.button"), edit_report_state_path(@report_presenter, request_changes: true), class: "govuk-button govuk-!-margin-left-4"
 
+    - if policy(@report_presenter).mark_qa_completed?
+      = link_to t("action.report.mark_qa_completed.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"
 
     - if policy(@report_presenter).approve?
       = link_to t("action.report.approve.button"), edit_report_state_path(@report_presenter), class: "govuk-button govuk-!-margin-left-4"

--- a/app/views/reports_state/mark_qa_completed/complete.html.haml
+++ b/app/views/reports_state/mark_qa_completed/complete.html.haml
@@ -1,0 +1,20 @@
+= content_for :page_title_prefix, t("page_title.report.mark_qa_completed.complete", report_organisation: @report.organisation.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          = t("action.report.mark_qa_completed.complete.title", report_organisation: @report.organisation.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %h2.govuk-heading-m
+        What happens next
+
+      %p.govuk-body
+        This report is now marked as QA completed, ready for approval by the Service Manager and ODA PMO Finance Lead.
+
+      %p.govuk-body
+        If any further updates are required before the report is approved this quarter, please notify the Service Manager or ODA PMO Finance Lead.
+
+      %p.govuk-body
+        Please notify the Service Manager and ODA PMO Finance Lead that the report has been marked as QA completed.

--- a/app/views/reports_state/mark_qa_completed/confirm.html.haml
+++ b/app/views/reports_state/mark_qa_completed/confirm.html.haml
@@ -1,0 +1,14 @@
+= content_for :page_title_prefix, t("page_title.report.mark_qa_completed.confirm", report_organisation: @report.organisation.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_title.report.mark_qa_completed.confirm", report_organisation: @report.organisation.name, report_financial_quarter: @report_presenter.financial_quarter_and_year)
+
+      %p.govuk-body
+        By marking this report as QA completed you are confirming all QA checks have been completed and the report is ready to be sent to BEIS for approval.
+
+      = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
+        = hidden_field_tag :state, "qa_completed"
+        = f.govuk_submit t("action.report.mark_qa_completed.confirm.button")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -104,14 +104,16 @@ en:
         awaiting_changes: Awaiting changes
         in_review: In review
         inactive: Inactive
+        qa_completed: QA completed
         submitted: Submitted
       can_edit:
         active: Yes, data can be added/edited
+        approved: N/A
         awaiting_changes: Yes, data can be revised
         in_review: No, report is in review with BEIS
-        submitted: No, report has been submitted to BEIS
         inactive: No, the report needs to be activated by BEIS
-        approved: N/A
+        qa_completed: No, report is in review with BEIS
+        submitted: No, report has been submitted to BEIS
   form:
     label:
       report:
@@ -151,6 +153,9 @@ en:
       request_changes:
         confirm: Confirm you want to request changes for %{report_financial_quarter} %{report_organisation} report
         complete: This report is now awaiting changes
+      mark_qa_completed:
+        confirm: Confirm you want to mark the %{report_organisation} %{report_financial_quarter} report as QA completed
+        complete: This report is marked as QA completed
       approve:
         confirm: Confirm approval of %{report_organisation} %{report_financial_quarter} report
         complete: This report is approved
@@ -228,6 +233,13 @@ en:
         complete:
           title: "%{report_financial_quarter} %{report_organisation} report is now awaiting changes"
         failure: Report could not be moved to awaiting changes
+      mark_qa_completed:
+        complete:
+          title: "%{report_financial_quarter} report for %{report_organisation} marked as QA completed"
+        button: Mark as completed
+        confirm:
+          button: Confirm
+        failure: Report could not be marked as QA completed
       approve:
         complete:
           title: "%{report_financial_quarter} report for %{report_organisation} approved"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -179,6 +179,8 @@ en:
           subject: "%{environment_name}%{application_name} - Your report has been submitted"
         service_owner:
           subject: "%{environment_name}%{application_name} - A partner organisation has submitted a report"
+      qa_completed:
+        subject: "%{environment_name}%{application_name} - QA has been completed on a report"
       approved:
         partner_organisation:
           subject: "%{environment_name}%{application_name} - Your report has been approved"

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -21,10 +21,6 @@ en:
         can_edit: Can edit?
     body:
       report:
-        action:
-          edit: Edit
-          activate: Activate
-          in_review: Mark as in review
         no_current_reports:
           You have no current reports. Once active, any new reports will appear here. You can view approved reports in the Approved tab.
         no_approved_reports:

--- a/spec/features/users_can_approve_a_report_spec.rb
+++ b/spec/features/users_can_approve_a_report_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Users can approve reports" do
 
     scenario "they can mark a report as approved" do
       # Given we have a report for FQ1 2023-2024 for AMS
-      report = create(:report, :for_gcrf, financial_quarter: 1, financial_year: 2023, state: :in_review, organisation: organisation)
+      report = create(:report, :for_gcrf, financial_quarter: 1, financial_year: 2023, state: :qa_completed, organisation: organisation)
 
       # When we approve the report
       perform_enqueued_jobs do

--- a/spec/features/users_can_mark_a_report_as_qa_completed_spec.rb
+++ b/spec/features/users_can_mark_a_report_as_qa_completed_spec.rb
@@ -1,0 +1,44 @@
+RSpec.feature "Users can mark reports as QA completed" do
+  context "signed in as a BEIS user" do
+    let!(:beis_user) { create(:beis_user) }
+
+    before { authenticate!(user: beis_user) }
+    after { logout }
+
+    scenario "they can mark a report as QA completed" do
+      report = create(:report, state: :in_review)
+
+      visit report_path(report)
+      click_link t("action.report.mark_qa_completed.button")
+      click_button t("action.report.mark_qa_completed.confirm.button")
+
+      expect(page).to have_content "QA completed"
+      expect(report.reload.state).to eql "qa_completed"
+    end
+
+    context "when the report is already marked as QA completed" do
+      scenario "it cannot be marked as QA completed" do
+        report = create(:report, state: :qa_completed)
+
+        visit report_path(report)
+
+        expect(page).not_to have_link t("action.report.mark_qa_completed.button")
+      end
+    end
+  end
+
+  context "signed in as a partner organisation user" do
+    let(:partner_org_user) { create(:partner_organisation_user) }
+
+    before { authenticate!(user: partner_org_user) }
+    after { logout }
+
+    scenario "they cannot mark a report as QA completed" do
+      report = create(:report, state: :in_review, organisation: partner_org_user.organisation)
+
+      visit report_path(report)
+
+      expect(page).not_to have_link t("action.report.mark_qa_completed.button")
+    end
+  end
+end

--- a/spec/features/users_can_mark_a_report_in_review_spec.rb
+++ b/spec/features/users_can_mark_a_report_in_review_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Users can move reports into review" do
       report = create(:report, state: :submitted)
 
       visit report_path(report)
-      click_link t("table.body.report.action.in_review")
+      click_link t("action.report.in_review.button")
       click_button t("action.report.in_review.confirm.button")
 
       expect(page).to have_content "in review"
@@ -25,7 +25,7 @@ RSpec.feature "Users can move reports into review" do
 
         visit report_path(report)
 
-        expect(page).not_to have_link t("table.body.report.action.in_review")
+        expect(page).not_to have_link t("action.report.in_review.button")
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.feature "Users can move reports into review" do
 
       visit report_path(report)
 
-      expect(page).not_to have_link t("table.body.report.action.in_review")
+      expect(page).not_to have_link t("action.report.in_review.button")
 
       visit edit_report_state_path(report)
 

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:change_state)
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
-        is_expected.to forbid_action(:request_changes)
         is_expected.to forbid_action(:review)
+        is_expected.to forbid_action(:request_changes)
+        is_expected.to forbid_action(:mark_qa_completed)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
       end
@@ -42,6 +43,7 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
         is_expected.to forbid_action(:request_changes)
+        is_expected.to forbid_action(:mark_qa_completed)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
         is_expected.to forbid_action(:upload_history)
@@ -54,11 +56,12 @@ RSpec.describe ReportPolicy do
       it "controls actions as expected" do
         is_expected.to permit_action(:change_state)
         is_expected.to permit_action(:request_changes)
-        is_expected.to permit_action(:approve)
+        is_expected.to permit_action(:mark_qa_completed)
 
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
         is_expected.to forbid_action(:review)
+        is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
         is_expected.to forbid_action(:upload_history)
       end
@@ -68,15 +71,33 @@ RSpec.describe ReportPolicy do
       before { report.update(state: :awaiting_changes) }
 
       it "controls actions as expected" do
+        is_expected.to permit_action(:upload_history)
+
         is_expected.to forbid_action(:change_state)
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
-        is_expected.to forbid_action(:request_changes)
         is_expected.to forbid_action(:review)
+        is_expected.to forbid_action(:request_changes)
+        is_expected.to forbid_action(:mark_qa_completed)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
+      end
+    end
 
-        is_expected.to permit_action(:upload_history)
+    context "when the report is marked as QA completed" do
+      before { report.update(state: :qa_completed) }
+
+      it "controls actions as expected" do
+        is_expected.to permit_action(:change_state)
+        is_expected.to permit_action(:request_changes)
+        is_expected.to permit_action(:approve)
+
+        is_expected.to forbid_action(:activate)
+        is_expected.to forbid_action(:submit)
+        is_expected.to forbid_action(:review)
+        is_expected.to forbid_action(:mark_qa_completed)
+        is_expected.to forbid_action(:upload)
+        is_expected.to forbid_action(:upload_history)
       end
     end
 
@@ -87,8 +108,9 @@ RSpec.describe ReportPolicy do
         is_expected.to forbid_action(:change_state)
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
-        is_expected.to forbid_action(:request_changes)
         is_expected.to forbid_action(:review)
+        is_expected.to forbid_action(:request_changes)
+        is_expected.to forbid_action(:mark_qa_completed)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
         is_expected.to forbid_action(:upload_history)
@@ -111,19 +133,20 @@ RSpec.describe ReportPolicy do
       let(:report) { create(:report) }
 
       it "controls actions as expected" do
-        is_expected.to forbid_action(:update)
+        is_expected.to permit_action(:index)
+
         is_expected.to forbid_action(:create)
-        is_expected.to forbid_action(:change_state)
+        is_expected.to forbid_action(:update)
         is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:change_state)
         is_expected.to forbid_action(:activate)
         is_expected.to forbid_action(:submit)
         is_expected.to forbid_action(:review)
         is_expected.to forbid_action(:request_changes)
+        is_expected.to forbid_action(:mark_qa_completed)
         is_expected.to forbid_action(:approve)
         is_expected.to forbid_action(:upload)
         is_expected.to forbid_action(:upload_history)
-
-        is_expected.to permit_action(:index)
       end
     end
 
@@ -134,17 +157,17 @@ RSpec.describe ReportPolicy do
         before { report.update(state: :active) }
 
         it "controls actions as expected" do
-          is_expected.to forbid_action(:create)
-
           is_expected.to permit_action(:show)
           is_expected.to permit_action(:download)
           is_expected.to permit_action(:change_state)
           is_expected.to permit_action(:submit)
           is_expected.to permit_action(:upload)
 
+          is_expected.to forbid_action(:create)
           is_expected.to forbid_action(:activate)
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
+          is_expected.to forbid_action(:mark_qa_completed)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload_history)
         end
@@ -162,6 +185,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:submit)
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
+          is_expected.to forbid_action(:mark_qa_completed)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
           is_expected.to forbid_action(:upload_history)
@@ -180,6 +204,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:submit)
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
+          is_expected.to forbid_action(:mark_qa_completed)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
           is_expected.to forbid_action(:upload_history)
@@ -199,6 +224,7 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:activate)
           is_expected.to forbid_action(:review)
           is_expected.to forbid_action(:request_changes)
+          is_expected.to forbid_action(:mark_qa_completed)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload_history)
         end
@@ -214,8 +240,9 @@ RSpec.describe ReportPolicy do
           is_expected.to forbid_action(:change_state)
           is_expected.to forbid_action(:activate)
           is_expected.to forbid_action(:submit)
-          is_expected.to forbid_action(:request_changes)
           is_expected.to forbid_action(:review)
+          is_expected.to forbid_action(:request_changes)
+          is_expected.to forbid_action(:mark_qa_completed)
           is_expected.to forbid_action(:approve)
           is_expected.to forbid_action(:upload)
           is_expected.to forbid_action(:upload_history)

--- a/spec/services/report/send_state_change_emails_spec.rb
+++ b/spec/services/report/send_state_change_emails_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Report::SendStateChangeEmails do
     end
   end
 
+  context "when the state is QA completed" do
+    let(:state) { "qa_completed" }
+
+    it "sends the QA completed emails to the active service owners" do
+      expect { subject.send! }.to have_enqueued_mail(ReportMailer, :qa_completed).exactly(service_owners.count).times
+
+      perform_enqueued_jobs
+
+      expect(recipients).to match_array(service_owners.pluck(:email))
+    end
+  end
+
   context "when the state is approved" do
     let(:state) { "approved" }
 


### PR DESCRIPTION
## Changes in this PR

Adds a QA completed step between in review and approved. When in review, users can now either request changes or mark the report as QA completed. When QA completed, they can request changes or approve the report

## Screenshots of UI changes

### Before

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/40244233/215807515-419fcb43-aca9-45d2-8bdd-527f59774eda.png">

### After

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/40244233/215807397-20674f42-9019-4b0f-9214-90b49cfc1e67.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
