### PR TITLE
(2758) Add scripts for uploading approved reports to S3

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,0 +1,47 @@
+namespace :reports do
+  desc "Upload a single approved report to private S3 bucket"
+  task :upload_to_s3, [:requester_id, :report_id] => :environment do |_, args|
+    report_id = args[:report_id]
+    requester_id = args[:requester_id]
+
+    report = Report.find(report_id)
+    uploader = User.find(requester_id)
+
+    abort "Report #{report.id} has not been approved" unless report.approved?
+    abort "Report #{report.id} not found" if report.nil?
+    abort "User with id #{requester_id} not found" if uploader.nil?
+
+    sync_approved_at_with_updated_at(report)
+
+    puts "Queueing CSV upload for report with ID #{report.id}"
+    ReportExportUploaderJob.perform_later(requester_id: requester_id, report_id: report_id)
+    puts "Upload queued"
+  end
+
+  desc "Upload all approved reports for all reporting organisations to private S3 bucket"
+  task :upload_all_approved_reports_to_s3, [:requester_id] => :environment do |_, args|
+    requester_id = args[:requester_id]
+    uploader = User.find(requester_id)
+
+    abort "User with id #{requester_id} not found" if uploader.nil?
+
+    Organisation.reporters.each do |organisation|
+      puts "Queueing CSV upload for organisation #{organisation.name}"
+      non_uploaded_reports = organisation.reports.approved.where(export_filename: nil)
+      non_uploaded_reports.each do |report|
+        sync_approved_at_with_updated_at(report)
+
+        ReportExportUploaderJob.perform_later(requester_id: uploader.id, report_id: report.id)
+        print "."
+      end
+      puts "Uploads queued for organisation"
+    end
+  end
+
+  def sync_approved_at_with_updated_at(report)
+    return unless report.approved_at.nil?
+
+    report.approved_at = report.updated_at
+    report.save!
+  end
+end


### PR DESCRIPTION
## Changes in this PR

This adds:

- A script for uploading a single report to S3 - useful if a single one fails to upload for some reason and can be added as a support ticket.
- A script to upload all approved but not yet uploaded reports to S3 for all organisations.

## Next steps

- Run this on staging and confirm it works as expected, then production!

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
