### PR TITLE
(2786) Fix `rows_for_last_financial_quarter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1187,6 +1187,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - The latest generated spending breakdown CSVs can be downloaded from the Exports page
 - Spending breakdown email notification has a link to the Exports page instead of a direct download link
 - Spending breakdown exports use a private S3 bucket
+- Default to 0, rather than `nil` in the rare case where a report has no actual value for an activity
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/app/models/export/activity_actuals_columns.rb
+++ b/app/models/export/activity_actuals_columns.rb
@@ -37,7 +37,7 @@ class Export::ActivityActualsColumns
   end
 
   def rows_for_last_financial_quarter
-    rows.each_with_object({}) { |(key, values), obj| obj[key] = values.last }
+    rows.each_with_object({}) { |(key, values), obj| obj[key] = values.last || 0 }
   end
 
   private

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -128,6 +128,21 @@ RSpec.describe Export::ActivityActualsColumns do
         expect(value_for_activity).to eq BigDecimal("300")
         expect(last_column_data.count).to eq 5
       end
+
+      context "if, unexpectedly, there is no value for that report quarter" do
+        let(:activity) { create(:project_activity) }
+        subject {
+          described_class.new(activities: [activity], include_breakdown: breakdown, report: report)
+        }
+
+        it "returns zero and not nil" do
+          last_column_data = subject.rows_for_last_financial_quarter
+          value_for_activity = last_column_data.fetch(activity.id)
+
+          expect(value_for_activity).to eq 0
+          expect(value_for_activity).not_to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

A while back, we added protection to `rows_for_first_financial_quarter` to prevent it trying to convert `nil` values to BigDecimals when there weren't any found.

Although [the PR](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1482) in which that was added suggests that there should always be a value for the last row of actuals, on Staging, at least, this doesn't appear to be the case.

Although the above may be due to slightly wonky, possibly invalid data on Staging, this error caused a report (with ID
b45c5b36-e502-4406-ac66-8a51321a177c) to fail being uploaded to S3 (particularly, when calling `Export::Report#rows`. We'd like to make sure this doesn't happen on Production.

## Next steps

- [ ] Run the report upload job on staging and make sure all succeeds
- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
