### PR TITLE
(2746) Clear sessions during training DB sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1213,6 +1213,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove ODA fields from the non-ODA CSV upload template.
 - Move the comments column to the end of all the CSV templates.
 - Make error messages clearer when importing actuals and refunds
+- Clear remember tokens during password reset step in the training database sync script
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1213,7 +1213,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove ODA fields from the non-ODA CSV upload template.
 - Move the comments column to the end of all the CSV templates.
 - Make error messages clearer when importing actuals and refunds
-- Clear remember tokens during password reset step in the training database sync script
+- Fix login issues after running the training database sync script by clearing remember tokens during password reset step and clearing sessions as an additional step
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/script/training_db_sync.rb
+++ b/script/training_db_sync.rb
@@ -93,6 +93,8 @@ class TrainingDbSync
               encrypted_otp_secret_iv: nil,
               encrypted_otp_secret_salt: nil
               )
+
+            user.forget_me!
           end
         end
       end

--- a/script/training_db_sync.rb
+++ b/script/training_db_sync.rb
@@ -21,6 +21,7 @@ class TrainingDbSync
     copy_data_to_destination
     load_source_data_to_destination
     force_password_reset_for_users
+    clear_sessions
     remove_temp_files
   end
 
@@ -111,6 +112,13 @@ class TrainingDbSync
     reset_cmd = %(cf ssh beis-roda-#{destination} -c 'cd /app; PATH=$PATH:/usr/local/bin bin/rails runner #{pw_reset_script}')
     Kernel.puts "Running pw reset script on #{destination} ==> #{reset_cmd}"
     CmdRunner.run(reset_cmd)
+  end
+
+  def clear_sessions
+    authenticate_to(destination)
+    cmd = %(cf ssh beis-roda-#{destination} -c 'cd /app; PATH=$PATH:/usr/local/bin bin/rails sessions:delete_all')
+    Kernel.puts "Clearing sessions from #{destination} ==> #{cmd}"
+    CmdRunner.run(cmd)
   end
 
   def remove_temp_files


### PR DESCRIPTION
**Note:** we weren't able to reproduce the error after playing around with the training DB sync script, so we've reverted this to draft for now. We can revisit it if and when the login issues reapper

## Changes in this PR

Hopefully a fix for the login issues after running the training DB sync

Shall we try testing this before merging, if the timing (for a training data refresh) is okay with BEIS?

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/40244233/216377021-b520a077-8d6b-4208-9d4a-8e2102eb3c23.png)

### After

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/40244233/216377098-f144217a-6c89-451e-8de7-04c5dac11212.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
