### PR TITLE
(2800) Don't upload reports with no financial year or financial quarter

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -8,6 +8,9 @@ namespace :reports do
     uploader = User.find(requester_id)
 
     abort "Report #{report.id} has not been approved" unless report.approved?
+    unless report.financial_year.present? && report.financial_quarter.present?
+      abort "Report #{report.id} has no financial year or quarter"
+    end
     abort "Report #{report.id} not found" if report.nil?
     abort "User with id #{requester_id} not found" if uploader.nil?
 
@@ -27,7 +30,13 @@ namespace :reports do
 
     Organisation.reporters.each do |organisation|
       puts "Queueing CSV upload for organisation #{organisation.name}"
-      non_uploaded_reports = organisation.reports.approved.where(export_filename: nil)
+      non_uploaded_reports =
+        organisation
+          .reports
+          .approved
+          .where(export_filename: nil)
+          .where.not("financial_year IS NULL OR financial_quarter IS NULL")
+
       non_uploaded_reports.each do |report|
         sync_approved_at_with_updated_at(report)
 

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -7,11 +7,11 @@ namespace :reports do
     report = Report.find(report_id)
     uploader = User.find(requester_id)
 
+    abort "Report #{report_id} not found" if report.nil?
     abort "Report #{report.id} has not been approved" unless report.approved?
     unless report.financial_year.present? && report.financial_quarter.present?
       abort "Report #{report.id} has no financial year or quarter"
     end
-    abort "Report #{report.id} not found" if report.nil?
     abort "User with id #{requester_id} not found" if uploader.nil?
 
     sync_approved_at_with_updated_at(report)


### PR DESCRIPTION
## Changes in this PR

This tweaks the approved Report-uploading Rake task to ignore reports with a `nil` value for `financial_year` or `financial_quarter` as these fail validations when we try to call `#rows` on them when creating the CSV file. 

We don't actually offer a CSV file for these kinds of reports, which were created from historical data from before RODA existed.

I've tested this locally with 2 organisations after fetching prod data, and all seems to be working as expected.

## Next steps

Run this on staging

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
