### PR TITLE
Use single quotes in password reset script

### DIFF
--- a/script/training_db_sync.rb
+++ b/script/training_db_sync.rb
@@ -106,7 +106,7 @@ class TrainingDbSync
     Kernel.puts "Copying pw reset script to #{destination} ==> #{copy_cmd}"
     CmdRunner.run(copy_cmd)
 
-    reset_cmd = %(cf ssh beis-roda-#{destination} -c "cd /app; PATH=$PATH:/usr/local/bin bin/rails runner #{pw_reset_script}")
+    reset_cmd = %(cf ssh beis-roda-#{destination} -c 'cd /app; PATH=$PATH:/usr/local/bin bin/rails runner #{pw_reset_script}')
     Kernel.puts "Running pw reset script on #{destination} ==> #{reset_cmd}"
     CmdRunner.run(reset_cmd)
   end


### PR DESCRIPTION
## Changes in this PR

When running the training database sync script, the password reset method was failing silently in the `force_password_reset_for_users` method

In the process of working on dc87872 (#1803), we provided a command to be run remotely using `-c` and single quotes. In the end, the commit used double quotes, but we've now found the single quotes are necessary to make this script run successfully on certain machines

For future reference, we were able to debug this by running the script on the server: we attempted to run the script normally, but with the method call that removes temp files (and all other irrelevant methods) commented out, then ssh-ed onto the server and ran it manually

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
