### PR TITLE
(2813) Add Sidekiq web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1190,6 +1190,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Default to 0, rather than `nil` in the rare case where a report has no actual value for an activity
 - Add QA completed report step in between review and approval
 - Optimise codelist-related logic with the aim of fixing IATI export timeout issues and providing speed gains more generally
+- Add Sidekiq web UI route
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...HEAD
 [release-128]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-127...release-128

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   devise_scope :user do
     devise_for :users, controllers: {sessions: "users/sessions"}
@@ -15,6 +17,7 @@ Rails.application.routes.draw do
   end
 
   mount Rollout::UI::Web.new => "/rollout", :constraints => ServiceOwnerConstraint
+  mount Sidekiq::Web => "/sidekiq", :constraints => ServiceOwnerConstraint
 
   scope module: "public" do
     get "health_check" => "base#health_check"


### PR DESCRIPTION
## Changes in this PR

Adds Sidekiq UI

This will allow us to view the result of scheduled jobs in the service more easily. This is particularly useful now we're about to run the report uploading script

This is accessible at `/sidekiq` but only for logged in "service owner" users.

## Screenshots of UI changes

### After

![image](https://user-images.githubusercontent.com/19826940/217219342-dd9f0380-633a-462c-8423-cf6cb77aa0d2.png)


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
