### PR TITLE
(2807) Fix organisation reports table for BEIS users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1198,6 +1198,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Remove heading for unpopulated organisation column in organisation reports table for BEIS users
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130
 [release-129]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-128...release-129

--- a/app/views/shared/reports/_grouped_table.html.haml
+++ b/app/views/shared/reports/_grouped_table.html.haml
@@ -2,7 +2,7 @@
   = render partial: "shared/reports/table_empty", locals: { type: type }
 - else
   %table.govuk-table
-    = render partial: "shared/reports/table_header", locals: { type: type }
+    = render partial: "shared/reports/table_header", locals: { type: type, show_organisation: current_user.service_owner? }
 
     %tbody.govuk-table__body
       - grouped_reports.each do |organisation, reports|

--- a/app/views/shared/reports/_table.html.haml
+++ b/app/views/shared/reports/_table.html.haml
@@ -2,9 +2,8 @@
   = render partial: "shared/reports/table_empty", locals: { type: type }
 - else
   %table.govuk-table
-    = render partial: "shared/reports/table_header", locals: { type: type }
+    = render partial: "shared/reports/table_header", locals: { type: type, show_organisation: false }
 
     %tbody.govuk-table__body
       - reports.each do |report|
         = render partial: "shared/reports/table_row", locals: { report: report, type: type }
-

--- a/app/views/shared/reports/_table_header.html.haml
+++ b/app/views/shared/reports/_table_header.html.haml
@@ -2,7 +2,7 @@
   = t("table.title.report.#{type}")
 %thead.govuk-table__head
   %tr.govuk-table__row
-    - if current_user.service_owner?
+    - if show_organisation
       %th.govuk-table__header
         = t("table.header.report.organisation")
     %th{class: "govuk-table__header govuk-!-width-one-quarter"}


### PR DESCRIPTION
## Changes in this PR

For BEIS users, the organisation reports table included a column heading of "Organisation", but there was no data for this column, meaning all data were offset one column from their headings

This makes it so that the organisation appears only for BEIS users at `/reports`, where the reports table covers multiple organisations. In all other cases - i.e. for PO users at `/reports` and for both PO and BEIS users at the organisation reports path - we leave the organisation out

---

The feature specs for viewing reports only seem to touch `/reports`, not `/organisations/:organisation_id/reports`, and don't appear to test column headings. Is it worth adding some tests for this, or is it too much detail for feature tests?

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/40244233/217254050-e59e1094-ef9f-45a5-ab4a-659b5a842955.png)

### After

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/40244233/217253980-44b0a3b7-64a0-4b11-9c6e-ef9339fe800d.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
