### PR TITLE
(2815) Remove sentence from report approved confirmation

### DIFF
--- a/app/views/reports_state/approve/complete.html.haml
+++ b/app/views/reports_state/approve/complete.html.haml
@@ -15,6 +15,3 @@
 
       %p.govuk-body
         If any updates are required to the data in this report, they will have to be made in the current active report (see RODA User Manual).
-
-      %p.govuk-body
-        Please notify the Service Manager and ODA PMO Finance Lead that the report has been approved. The Service Manager will then activate the new reports and notify Partner Organisations by email.


### PR DESCRIPTION
## Changes in this PR

As requested by BEIS, this removes a sentence that's fairly redundant, given who approved reports within the organisation

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/40244233/217306414-e6dff59e-de2e-4e6e-bd7f-2800f9952f52.png)

### After

<img width="772" alt="image" src="https://user-images.githubusercontent.com/40244233/217306359-e716629d-bbd7-45f8-979c-aecb28e7262b.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
