### PR TITLE
(2740) Prevent editing `is_oda` via UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1195,12 +1195,13 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [release-130] 2023-02-13
 
 - Update Ruby to 3.0.5
-- Prefix imported non-ODA programmes "NODA-"
 
 ## [unreleased]
 
 - Remove heading for unpopulated organisation column in organisation reports table for BEIS users
 - Prevent child ODA activities being created on non-ODA parents and vice-versa via the bulk upload
+- Prefix imported non-ODA programmes "NODA-"
+- Prevent editing ODA type via the UI
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -594,7 +594,7 @@ class Activity < ApplicationRecord
   end
 
   def requires_is_oda?
-    programme? && is_ispf_funded?
+    programme? && is_ispf_funded? && is_oda.nil?
   end
 
   def requires_ispf_oda_partner_countries?

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -34,7 +34,7 @@
           = t("summary.label.activity.is_oda.#{activity_presenter.is_oda}")
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update? && activity_presenter.requires_is_oda?
-          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:is_oda)}"), activity_step_path(activity_presenter, :is_oda), t("activerecord.attributes.activity.is_oda"))
+          = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :is_oda), t("activerecord.attributes.activity.is_oda"))
 
   .govuk-summary-list__row.identifier
     %dt.govuk-summary-list__key

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2147,6 +2147,40 @@ RSpec.describe Activity, type: :model do
       end
     end
 
+    describe "#requires_is_oda?" do
+      context "when the activity is an ISPF-funded programme with no `is_oda` value set" do
+        let(:programme) { build(:programme_activity, :ispf_funded, is_oda: nil) }
+
+        it "returns true" do
+          expect(programme.requires_is_oda?).to eq(true)
+        end
+      end
+
+      context "when the activity is not ISPF-funded" do
+        let(:programme) { build(:programme_activity, :newton_funded) }
+
+        it "returns false" do
+          expect(programme.requires_is_oda?).to eq(false)
+        end
+      end
+
+      context "when the activity is not a programme" do
+        let(:project) { build(:project_activity, :ispf_funded) }
+
+        it "returns false" do
+          expect(project.requires_is_oda?).to eq(false)
+        end
+      end
+
+      context "when the activity already has a non-nil `is_oda` value" do
+        let(:programme) { build(:programme_activity, :ispf_funded, is_oda: true) }
+
+        it "returns false" do
+          expect(programme.requires_is_oda?).to eq(false)
+        end
+      end
+    end
+
     ["project", "third-party project"].each do |level|
       context "when activity is a #{level}" do
         let(:factory_name) { factory_name_by_activity_level(level) }


### PR DESCRIPTION
## Changes in this PR

This prevents the activity details tab from including a link to edit the `is_oda` field, while retaining the link to add this for ISPF activities where the field is `nil`

The card also mentioned preventing this via bulk upload, but we don't have an `is_oda` column in the bulk upload template - this is handled by separate templates uploaded via separate forms. We have measures in place to ensure we don't do anything when there's a mismatch between the ODA type of the template and the form, but in any case the importer's activity updater doesn't modify `is_oda`

## Screenshots of UI changes

### Before

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/40244233/217858327-e227d473-02a3-4061-bea9-32e165a35fee.png">

### After

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/40244233/217858263-db6a2d7a-8e0c-4430-9477-ac00c4041cd4.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
