### PR TITLE
(2809) Prefix non-ODA programmes with NODA in import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1195,6 +1195,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [release-130] 2023-02-13
 
 - Update Ruby to 3.0.5
+- Prefix imported non-ODA programmes "NODA-"
 
 ## [unreleased]
 

--- a/app/services/activity/roda_identifier_generator.rb
+++ b/app/services/activity/roda_identifier_generator.rb
@@ -1,8 +1,9 @@
 class Activity
   class RodaIdentifierGenerator
-    def initialize(parent_activity:, extending_organisation:)
+    def initialize(parent_activity:, extending_organisation:, is_non_oda: false)
       @parent_activity = parent_activity
       @extending_organisation = extending_organisation
+      @is_non_oda = is_non_oda
     end
 
     def generate
@@ -16,11 +17,14 @@ class Activity
     private
 
     def programme_identifier
+      non_oda_prefix = @is_non_oda ? "NODA" : nil
+
       [
+        non_oda_prefix,
         parent_activity.roda_identifier,
         extending_organisation.beis_organisation_reference,
         component_identifier
-      ].join("-")
+      ].compact.join("-")
     end
 
     def project_identifier

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -75,7 +75,8 @@ class ActivityDefaults
   def generate_roda_identifier
     Activity::RodaIdentifierGenerator.new(
       parent_activity: parent_activity,
-      extending_organisation: extending_organisation
+      extending_organisation: extending_organisation,
+      is_non_oda: is_oda == false
     ).generate
   end
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -38,7 +38,8 @@ FactoryBot.define do
       if activity.roda_identifier.blank? && activity.parent.present?
         activity.roda_identifier = Activity::RodaIdentifierGenerator.new(
           parent_activity: activity.parent,
-          extending_organisation: activity.extending_organisation
+          extending_organisation: activity.extending_organisation,
+          is_non_oda: activity.is_oda == false
         ).generate
       end
     end

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -1387,6 +1387,46 @@ RSpec.describe Activity::Import do
         end
       end
     end
+
+    context "when it's a non-ODA programme" do
+      subject { described_class.new(uploader: uploader, partner_organisation: organisation, report: nil, is_oda: false) }
+
+      let(:fund_activity) { create(:fund_activity, :ispf) }
+      let(:ispf) { create(:fund_activity, :ispf) }
+
+      it "prefixes the RODA identifier with 'NODA'" do
+        allow(ActivityPolicy).to receive(:new).with(uploader, ispf).and_return(activity_policy_double)
+
+        new_non_oda_programme_attributes = {
+          "RODA ID" => new_activity_attributes["RODA ID"],
+          "Parent RODA ID" => ispf.roda_identifier,
+          "Linked activity RODA ID" => "",
+          "Transparency identifier" => new_activity_attributes["Transparency identifier"],
+          "Title" => new_activity_attributes["Title"],
+          "Description" => new_activity_attributes["Description"],
+          "Partner organisation identifier" => new_activity_attributes["Partner organisation identifier"],
+          "SDG 1" => new_activity_attributes["SDG 1"],
+          "SDG 2" => new_activity_attributes["SDG 2"],
+          "SDG 3" => new_activity_attributes["SDG 3"],
+          "Activity Status" => new_activity_attributes["Activity Status"],
+          "Planned start date" => new_activity_attributes["Planned start date"],
+          "Planned end date" => new_activity_attributes["Planned end date"],
+          "Actual start date" => new_activity_attributes["Actual start date"],
+          "Actual end date" => new_activity_attributes["Actual end date"],
+          "Sector" => new_activity_attributes["Sector"],
+          "ISPF themes" => "4",
+          "ISPF non-ODA partner countries" => "CA|US",
+          "Comments" => new_activity_attributes["Comments"],
+          "Tags" => ""
+        }
+
+        expect { subject.import([new_non_oda_programme_attributes]) }.to change { Activity.count }.by(1)
+
+        new_activity = Activity.order(:created_at).last
+
+        expect(new_activity.roda_identifier).to start_with("NODA-")
+      end
+    end
   end
 
   context "when updating and importing" do

--- a/spec/services/activity/roda_identifier_generator_spec.rb
+++ b/spec/services/activity/roda_identifier_generator_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Activity::RodaIdentifierGenerator do
   describe "#generate" do
-    let(:extending_organisation) { build(:partner_organisation) }
+    let(:extending_organisation) { build(:partner_organisation, beis_organisation_reference: "REF") }
 
     subject do
       described_class.new(
@@ -18,26 +18,26 @@ RSpec.describe Activity::RodaIdentifierGenerator do
     end
 
     context "when the parent activity is a fund" do
-      let(:parent_activity) { build(:fund_activity) }
+      let(:parent_activity) { build(:fund_activity, roda_identifier: "FUND") }
 
       it "generates a RODA identifier" do
-        expect(subject).to eq("#{parent_activity.roda_identifier}-#{extending_organisation.beis_organisation_reference}-3455ABC")
+        expect(subject).to eq("FUND-REF-3455ABC")
       end
     end
 
     context "when the parent activity is a programme" do
-      let(:parent_activity) { build(:programme_activity) }
+      let(:parent_activity) { build(:programme_activity, roda_identifier: "FUND-REF-PROG") }
 
       it "generates a RODA identifier" do
-        expect(subject).to eq("#{parent_activity.roda_identifier}-3455ABC")
+        expect(subject).to eq("FUND-REF-PROG-3455ABC")
       end
     end
 
     context "when the parent activity is a project" do
-      let(:parent_activity) { build(:project_activity) }
+      let(:parent_activity) { build(:project_activity, roda_identifier: "FUND-REF-PROG-3PP") }
 
       it "generates a RODA identifier" do
-        expect(subject).to eq("#{parent_activity.roda_identifier}-3455ABC")
+        expect(subject).to eq("FUND-REF-PROG-3PP-3455ABC")
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

The changes in 46e5f29 meant that non-ODA activities added via the UI are prefixed "NODA-". This change was implemented in the `ActivityUpdater` service, which is not touched when creating activities via the importer. Projects and third-party projects created via the importer would be prefixed "NODA-" through including their parent's identifier in their own, however new level B imported activities would not

This rectifies that by amending the RODA identifier generator to include "NODA-" when passed `is_non_oda: false` via
`ActivityDefaults#generate_roda_identifier` (or the activity factory)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
