### PR TITLE
Upgrade parser to fix warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parser (3.1.2.1)
+    parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
     pry (0.14.1)


### PR DESCRIPTION
## Changes in this PR

In def189d, we fixed some warnings by upgrading `parser`. `parser` warnings have returned since the Ruby 3 upgrade, so this upgrades `parser` once more to remove the warnings

Example of warning:
```
warning: parser/current is loading parser/ruby30, which recognizes3.0.4-compliant syntax, but you are running 3.0.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
