### PR TITLE
Fix documentation query

### DIFF
--- a/doc/deleting-things-from-production.md
+++ b/doc/deleting-things-from-production.md
@@ -12,7 +12,7 @@ You will need the database ID of each activity, often we'll be given the activit
 RODA identifier, so you first need to locate the database ID on the Rails console:
 
 ```ruby
-activity = Activity.by_roda_identifier("REPLACE-ME").pluck(:id)
+activity = Activity.by_roda_identifier("REPLACE-ME").id
 ```
 
 Then run the task, setting the activity database ID as the ID environment


### PR DESCRIPTION
## Changes in this PR
Tiny change - Fix documentation query

Pluck doesn't work on single records, we can access `id` directly instead.
