### PR TITLE
(2820) Fix incorrectly-passed CSV arguments

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -25,6 +25,16 @@ VCAP_SERVICES='{
             "aws_region":"eu-west-2",
             "deploy_env":""
          }
+      },
+      {
+         "name":"beis-roda-test-s3-export-download-bucket-private",
+         "credentials":{
+            "bucket_name":"paas-s3-broker-test-lon-id",
+            "aws_access_key_id":"KEY_ID",
+            "aws_secret_access_key":"SECRET",
+            "aws_region":"eu-west-2",
+            "deploy_env":""
+         }
       }
    ]
 }'

--- a/app/jobs/report_export_uploader_job.rb
+++ b/app/jobs/report_export_uploader_job.rb
@@ -16,7 +16,7 @@ class ReportExportUploaderJob < ApplicationJob
 
   def save_tempfile(export)
     Tempfile.new.tap do |tmpfile|
-      CSV.open(tmpfile, "wb", {headers: true}) do |csv|
+      CSV.open(tmpfile, "wb", headers: true) do |csv|
         csv << export.headers
         export.rows.each do |row|
           csv << row

--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -23,7 +23,7 @@ class SpendingBreakdownJob < ApplicationJob
 
   def save_tempfile(export)
     Tempfile.new.tap do |tmpfile|
-      CSV.open(tmpfile, "wb", {headers: true}) do |csv|
+      CSV.open(tmpfile, "wb", headers: true) do |csv|
         csv << export.headers
         export.rows.each do |row|
           csv << row

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -93,6 +93,7 @@ Rails.application.configure do
     Bullet.add_safelist type: :unused_eager_loading, class_name: "Activity", association: :implementing_org_participations
     Bullet.add_safelist type: :unused_eager_loading, class_name: "OrgParticipation", association: :organisation
     Bullet.add_safelist type: :unused_eager_loading, class_name: "Comment", association: :owner
+    Aws.config.update(stub_responses: true)
   end
 
   config.hosts = [

--- a/spec/features/users_can_export_spending_breakdown_spec.rb
+++ b/spec/features/users_can_export_spending_breakdown_spec.rb
@@ -7,18 +7,25 @@ RSpec.feature "Users can export spending breakdown" do
     end
     after { logout }
 
-    scenario "they can request a spending breakdown export for all organisations" do
+    scenario "they can request, then download a spending breakdown export for all organisations" do
       visit exports_path
       click_link "Request Spending breakdown for Newton Fund"
+
+      perform_enqueued_jobs
 
       export_in_progress_msg =
         "The requested spending breakdown for Newton Fund is being prepared. " \
         "We will send a download link to beis@example.com when it is ready."
 
       expect(page).to have_content(export_in_progress_msg)
+
+      visit exports_path
+      newton_fund_id = Fund.by_short_name("NF").id
+
+      expect(page).to have_link("Download Spending breakdown for Newton Fund", href: spending_breakdown_download_export_path(newton_fund_id))
     end
 
-    context "when a fund has an uploaded spending breakdown" do
+    context "when a fund already has an uploaded spending breakdown" do
       let(:newton_fund) { Fund.by_short_name("NF").activity }
 
       before do

--- a/spec/jobs/report_export_uploader_job_spec.rb
+++ b/spec/jobs/report_export_uploader_job_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ReportExportUploaderJob, type: :job do
     it "writes the report CSV to a 'tempfile'" do
       ReportExportUploaderJob.perform_now(requester_id: double, report_id: double)
 
-      expect(CSV).to have_received(:open).with(tempfile, "wb", {headers: true})
+      expect(CSV).to have_received(:open).with(tempfile, "wb", headers: true)
       expect(csv).to have_received(:<<).with(%w[col1 col2])
       expect(csv).to have_received(:<<).with(row1)
       expect(csv).to have_received(:<<).with(row2)

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SpendingBreakdownJob, type: :job do
     it "writes the breakdown to a 'tempfile'" do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 
-      expect(CSV).to have_received(:open).with(tempfile, "wb", {headers: true})
+      expect(CSV).to have_received(:open).with(tempfile, "wb", headers: true)
       expect(csv).to have_received(:<<).with(%w[col1 col2])
       expect(csv).to have_received(:<<).with(row1)
       expect(csv).to have_received(:<<).with(row2)


### PR DESCRIPTION
## Changes in this PR

These are a couple of spots we missed when upgrading to Ruby 3, as the language has now changed the way it handles keyword arguments.

I've updated the feature tests here to use less mocking so we can check the result of the methods that are actually called, so that this will hopefully be caught in future. I've mocked responses to S3 in the test environment here too.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
