### PR TITLE
Skip Pundit’s policy scope verification on index

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,6 +7,8 @@ class ReportsController < BaseController
   include StreamCsvDownload
   include Reports::Breadcrumbed
 
+  after_action :skip_policy_scope, only: [:index]
+
   def index
     add_breadcrumb "Reports", :reports_path
 


### PR DESCRIPTION
## Changes in this PR

In our base controller, we use Pundit’s mechanism for alerting us if we forget to authorize any controller actions. Collective controller actions such as index are checked for the use of `policy_scope`.

The reports index doesn’t call the policy scope, so we see this error in our server logs:
`Pundit::PolicyScopingNotPerformedError (ReportsController)`

We can skip the policy scope check, because permissions are checked against the user’s organisation.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
