### PR TITLE
(2819) Spike - imported forecasts post-upload

### DIFF
--- a/app/services/forecast/import.rb
+++ b/app/services/forecast/import.rb
@@ -106,8 +106,10 @@ class Forecast
 
     def import_forecast(activity, financial_quarter, value, header:)
       return if value.blank?
+
       history = ForecastHistory.new(activity, user: @uploader, report: @report, **financial_quarter)
       history.set_value(value)
+      history.latest_entry
     rescue ConvertFinancialValue::Error
       @errors << Error.new(@current_index, header, value, I18n.t("importer.errors.forecast.non_numeric_value"))
     rescue Encoding::CompatibilityError

--- a/app/services/forecast_history.rb
+++ b/app/services/forecast_history.rb
@@ -129,9 +129,9 @@ class ForecastHistory
   def update_entry(entry, value)
     if value == 0 && entries.count == 1
       entry.destroy!
-    else
-      entry.update!(value: value)
+      return
     end
+    entry.update!(value: value)
     entry
   end
 

--- a/spec/services/forecast_history_spec.rb
+++ b/spec/services/forecast_history_spec.rb
@@ -202,18 +202,24 @@ RSpec.describe ForecastHistory do
         ])
       end
 
-      it "deletes an original entry with a zero value" do
-        history.set_value(0)
-
-        expect(history_entries).to eq([])
-      end
-
       it "does not create a historical event when the value is first set" do
         expect { history.set_value(20) }.to not_create_a_historical_event
       end
 
       it "returns a _Forecast_" do
         expect(history.set_value(20)).to be_a(Forecast)
+      end
+
+      context "when an original entry is set to zero" do
+        it "deletes the original entry" do
+          history.set_value(0)
+
+          expect(history_entries).to eq([])
+        end
+
+        it "returns nil" do
+          expect(history.set_value(0)).to be_nil
+        end
       end
     end
 
@@ -232,13 +238,19 @@ RSpec.describe ForecastHistory do
         ])
       end
 
-      it "adds a revision with a zero value" do
-        history.set_value(0)
+      context "with a zero value" do
+        it "adds a revision" do
+          history.set_value(0)
 
-        expect(history_entries).to eq([
-          ["original", 1, 2015, 10],
-          ["revised", 2, 2015, 0]
-        ])
+          expect(history_entries).to eq([
+            ["original", 1, 2015, 10],
+            ["revised", 2, 2015, 0]
+          ])
+        end
+
+        it "returns a _Forecast_" do
+          expect(history.set_value(0)).to be_a(Forecast)
+        end
       end
 
       it "adds a revision with a zero value when a forecast is deleted" do


### PR DESCRIPTION
## Changes in this PR
- `ForecastHistory#set_value` returns `nil` when a forecast is deleted
- Imported forecasts list unchanged values if included in the uploaded CSV

## Screenshots of UI changes

An extreme edge case example of uploading a spreadsheet with one forecast with the same value as the existing forecast reported in the same report. Previously there would have been a successful message with an empty table:

### Before
![Screenshot 2023-02-15 at 21 19 41](https://user-images.githubusercontent.com/579522/219169004-a4fcc971-264f-4411-b874-943c0fc9f4a1.png)

After this PR the success table lists the forecast:

### After
![Screenshot 2023-02-15 at 17 40 56](https://user-images.githubusercontent.com/579522/219115152-3c6ea2ab-05a6-452f-97cf-98d5025f1947.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
