### PR TITLE
(2787) (2819) Successfully uploaded summary table fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1202,6 +1202,9 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Prevent child ODA activities being created on non-ODA parents and vice-versa via the bulk upload
 - Prefix imported non-ODA programmes "NODA-"
 - Prevent editing ODA type via the UI
+- Fix the display of successfully uploaded forecasts for the cases when:
+  - the original forecast is deleted
+  - the imported values were already in the report
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/services/forecast/import.rb
+++ b/app/services/forecast/import.rb
@@ -106,8 +106,10 @@ class Forecast
 
     def import_forecast(activity, financial_quarter, value, header:)
       return if value.blank?
+
       history = ForecastHistory.new(activity, user: @uploader, report: @report, **financial_quarter)
       history.set_value(value)
+      history.latest_entry
     rescue ConvertFinancialValue::Error
       @errors << Error.new(@current_index, header, value, I18n.t("importer.errors.forecast.non_numeric_value"))
     rescue Encoding::CompatibilityError

--- a/app/services/forecast_history.rb
+++ b/app/services/forecast_history.rb
@@ -129,9 +129,9 @@ class ForecastHistory
   def update_entry(entry, value)
     if value == 0 && entries.count == 1
       entry.destroy!
-    else
-      entry.update!(value: value)
+      return
     end
+    entry.update!(value: value)
     entry
   end
 

--- a/spec/services/forecast/import_spec.rb
+++ b/spec/services/forecast/import_spec.rb
@@ -53,6 +53,43 @@ RSpec.describe Forecast::Import do
         expect(importer.imported_forecasts).to eq([forecast, forecast])
       end
     end
+
+    context "importing into a specific report" do
+      let(:selected_report) { latest_report }
+      let(:reporter) { nil }
+
+      context "when the report already has some original forecasts" do
+        let :forecast_row do
+          {
+            "Activity RODA Identifier" => project.roda_identifier,
+            "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+            "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793",
+            "FC 2021/22 FY Q1 (Apr, May, Jun)" => "984150",
+            "FC 2021/22 FY Q2 (Jul, Aug, Sep)" => "206206"
+          }
+        end
+
+        before do
+          Forecast::Import.new(uploader: reporter, report: selected_report).import([forecast_row])
+        end
+
+        context "when replacing some existing values with zero" do
+          let(:updated_forecast_row) do
+            {
+              "Activity RODA Identifier" => project.roda_identifier,
+              "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "0",
+              "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "0"
+            }
+          end
+
+          it "does not include the deleted forecasts" do
+            importer.import([updated_forecast_row])
+
+            expect(importer.imported_forecasts).to eq([nil, nil])
+          end
+        end
+      end
+    end
   end
 
   describe "importing a row of forecasts" do

--- a/spec/services/forecast/import_spec.rb
+++ b/spec/services/forecast/import_spec.rb
@@ -31,25 +31,27 @@ RSpec.describe Forecast::Import do
   end
 
   describe "#imported_forecasts" do
-    let(:forecast) { double("forecast") }
+    context "a generic import" do
+      let(:forecast) { double("forecast") }
 
-    let :forecast_row do
-      {
-        "Activity RODA Identifier" => project.roda_identifier,
-        "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
-        "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793"
-      }
-    end
+      let :forecast_row do
+        {
+          "Activity RODA Identifier" => project.roda_identifier,
+          "FC 2020/21 FY Q3 (Oct, Nov, Dec)" => "200436",
+          "FC 2020/21 FY Q4 (Jan, Feb, Mar)" => "310793"
+        }
+      end
 
-    before do
-      forecast_history = instance_double(ForecastHistory, set_value: forecast)
-      allow(ForecastHistory).to receive(:new).and_return(forecast_history)
-    end
+      before do
+        forecast_history = instance_double(ForecastHistory, set_value: forecast)
+        allow(ForecastHistory).to receive(:new).and_return(forecast_history)
+      end
 
-    it "returns a list of forecasts" do
-      importer.import([forecast_row])
+      it "returns a list of forecasts" do
+        importer.import([forecast_row])
 
-      expect(importer.imported_forecasts).to eq([forecast, forecast])
+        expect(importer.imported_forecasts).to eq([forecast, forecast])
+      end
     end
   end
 

--- a/spec/services/forecast_history_spec.rb
+++ b/spec/services/forecast_history_spec.rb
@@ -202,18 +202,24 @@ RSpec.describe ForecastHistory do
         ])
       end
 
-      it "deletes an original entry with a zero value" do
-        history.set_value(0)
-
-        expect(history_entries).to eq([])
-      end
-
       it "does not create a historical event when the value is first set" do
         expect { history.set_value(20) }.to not_create_a_historical_event
       end
 
       it "returns a _Forecast_" do
         expect(history.set_value(20)).to be_a(Forecast)
+      end
+
+      context "when an original entry is set to zero" do
+        it "deletes the original entry" do
+          history.set_value(0)
+
+          expect(history_entries).to eq([])
+        end
+
+        it "returns nil" do
+          expect(history.set_value(0)).to be_nil
+        end
       end
     end
 
@@ -232,13 +238,19 @@ RSpec.describe ForecastHistory do
         ])
       end
 
-      it "adds a revision with a zero value" do
-        history.set_value(0)
+      context "with a zero value" do
+        it "adds a revision" do
+          history.set_value(0)
 
-        expect(history_entries).to eq([
-          ["original", 1, 2015, 10],
-          ["revised", 2, 2015, 0]
-        ])
+          expect(history_entries).to eq([
+            ["original", 1, 2015, 10],
+            ["revised", 2, 2015, 0]
+          ])
+        end
+
+        it "returns a _Forecast_" do
+          expect(history.set_value(0)).to be_a(Forecast)
+        end
       end
 
       it "adds a revision with a zero value when a forecast is deleted" do


### PR DESCRIPTION
## Changes in this PR
- Fix the display of successfully uploaded forecasts for the cases when:
  - the original forecast is deleted
  - the imported values were already in the report
 
## Screenshots of UI changes

### Before
#### Reuploading identical values resulted in an empty summary table
![Screenshot 2023-02-15 at 21 19 41](https://user-images.githubusercontent.com/579522/219450360-f7d6f9ec-d591-459f-a647-4c8931aca09f.png)

### After
#### Reuploading identical values results in them being listed and counted as part of the total uploaded
![Screenshot 2023-02-15 at 17 40 56](https://user-images.githubusercontent.com/579522/219450897-fbd57889-e25c-4037-9138-39ee20374cd0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
