### PR TITLE
Only generate IATI identifiers for ODA activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1207,6 +1207,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - the imported values were already in the report
 - Omit legacy fields for ISPF activities on the "details" page.
 - Remove legacy fields from ISPF reports.
+- Only generate IATI identifiers for ODA activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -20,7 +20,7 @@ class ActivityDefaults
       source_fund_code: source_fund_code,
       roda_identifier: roda_identifier,
       transparency_identifier: transparency_identifier,
-      is_oda: is_oda.nil? ? parent_activity.is_oda : is_oda,
+      is_oda: is_oda?,
       organisation_id: organisation.id,
       extending_organisation_id: extending_organisation.id,
       originating_report_id: originating_report&.id,
@@ -30,6 +30,10 @@ class ActivityDefaults
   end
 
   private
+
+  def is_oda?
+    @is_oda.nil? ? @parent_activity.is_oda : @is_oda
+  end
 
   def service_owner
     @_service_owner ||= Organisation.service_owner
@@ -81,6 +85,8 @@ class ActivityDefaults
   end
 
   def transparency_identifier
+    return nil if is_oda? == false
+
     [
       Organisation::SERVICE_OWNER_IATI_REFERENCE,
       roda_identifier


### PR DESCRIPTION
## Changes in this PR
Currently, we generate an IATI identifier for all activities.

However, we have had some feedback that this is confusing, and the IATI
identifier should be absent for non-ODA activities in the CSV download.

Only generate IATI identifiers for ODA activities. Add some coverage for the
`is_oda` and `transparency_identifier` attributes of the activity defaults.

We don't have any ISPF activities in production, so there aren't any existing
identifiers that need to be hidden.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
