### PR TITLE
[2831b] Refactor Commitment model and importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1223,6 +1223,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 ## [unreleased]
 
+- Update Commitment-importing script to infer `transaction_date` value from Activity values
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -3,15 +3,10 @@ class Commitment < ApplicationRecord
 
   belongs_to :activity
 
-  validates :value, :financial_quarter, :financial_year, presence: true
+  validates :value, presence: true
   validates :value, numericality: {
     greater_than: 0,
     less_than_or_equal_to: 99_999_999_999.00
   }
-  validates :financial_quarter, inclusion: {in: 1..4}
-  validates :financial_year, numericality: {
-    greater_than_or_equal_to: 2000,
-    less_than_or_equal_to: 3000,
-    only_integer: true
-  }
+  validates :transaction_date, presence: true
 end

--- a/app/presenters/commitment_presenter.rb
+++ b/app/presenters/commitment_presenter.rb
@@ -2,4 +2,8 @@ class CommitmentPresenter < SimpleDelegator
   def value
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
+
+  def transaction_date
+    I18n.l(super)
+  end
 end

--- a/app/services/commitment/import.rb
+++ b/app/services/commitment/import.rb
@@ -11,9 +11,7 @@ class Commitment
 
     VALID_HEADERS = [
       "RODA identifier",
-      "Commitment value",
-      "Financial quarter",
-      "Financial year"
+      "Commitment value"
     ]
 
     attr_reader :errors, :imported, :user
@@ -117,20 +115,20 @@ class Commitment
         @row.field("Commitment value")
       end
 
-      def financial_quarter
-        @row.field("Financial quarter")
-      end
+      def transaction_date
+        activity = Activity.find(activity_id)
 
-      def financial_year
-        @row.field("Financial year")
+        return activity.planned_start_date if activity.planned_start_date
+        return activity.actual_start_date if activity.actual_start_date
+
+        activity.created_at.to_date
       end
 
       def set_commitment
         commitment = Commitment.new(
           activity_id: activity_id,
           value: value,
-          financial_quarter: financial_quarter,
-          financial_year: financial_year
+          transaction_date: transaction_date
         )
         if commitment.valid?
           commitment.save

--- a/app/views/shared/commitment/_table.html.haml
+++ b/app/views/shared/commitment/_table.html.haml
@@ -10,5 +10,5 @@
 
   %tbody.govuk-table__body
     %tr.govuk-table__row
-      %td.govuk-table__cell= commitment.financial_quarter_and_year
+      %td.govuk-table__cell= commitment.transaction_date
       %td.govuk-table__cell= commitment.value

--- a/app/views/shared/xml/_commitment.xml.haml
+++ b/app/views/shared/xml/_commitment.xml.haml
@@ -1,4 +1,4 @@
 %transaction
   %transaction-type{"code" => 2}
-  %transaction-date{"iso-date" => commitment.first_day_of_financial_period}
-  %value{"value-date" => commitment.first_day_of_financial_period}=commitment.value
+  %transaction-date{"iso-date" => commitment.transaction_date}
+  %value{"value-date" => commitment.transaction_date}=commitment.value

--- a/db/migrate/20230301135404_remove_financial_year_and_financial_quarter_from_commitments.rb
+++ b/db/migrate/20230301135404_remove_financial_year_and_financial_quarter_from_commitments.rb
@@ -1,0 +1,5 @@
+class RemoveFinancialYearAndFinancialQuarterFromCommitments < ActiveRecord::Migration[6.1]
+  def change
+    remove_columns :commitments, :financial_year, :financial_quarter
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_27_114720) do
+ActiveRecord::Schema.define(version: 2023_03_01_135404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -145,8 +145,6 @@ ActiveRecord::Schema.define(version: 2023_02_27_114720) do
     t.uuid "activity_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "financial_quarter"
-    t.integer "financial_year"
     t.date "transaction_date"
     t.index ["activity_id"], name: "index_commitments_on_activity_id", unique: true
   end

--- a/doc/import-commitments.md
+++ b/doc/import-commitments.md
@@ -11,8 +11,8 @@ Commitments are imported by the `commitments:import` rake task.
 You will need a csv of valid commitments provided by BEIS:
 
 ```csv
-RODA identifier,Commitment value,Financial quarter,Financial year
-RODA-ID,100000,1,2021
+RODA identifier,Commitment value,Transaction date
+RODA-ID,100000,2023-01-02
 ```
 
 The header fields are case sensitive.

--- a/spec/factories/commitment.rb
+++ b/spec/factories/commitment.rb
@@ -2,8 +2,6 @@ FactoryBot.define do
   factory :commitment do
     association :activity, factory: :programme_activity
     value { BigDecimal("120.45") }
-    financial_quarter { 1 }
-    financial_year { 2021 }
     transaction_date { Date.today }
   end
 end

--- a/spec/factories/commitment.rb
+++ b/spec/factories/commitment.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     value { BigDecimal("120.45") }
     financial_quarter { 1 }
     financial_year { 2021 }
+    transaction_date { Date.today }
   end
 end

--- a/spec/features/users_can_view_commitment_values_spec.rb
+++ b/spec/features/users_can_view_commitment_values_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can view commitment values" do
       expect(page).to have_content "Commitment"
       expect(page).to have_css("table#commitment")
       expect(page).to have_content presenter.value
-      expect(page).to have_content presenter.financial_quarter_and_year
+      expect(page).to have_content presenter.transaction_date
     end
   end
 

--- a/spec/fixtures/csv/commitments/invalid.csv
+++ b/spec/fixtures/csv/commitments/invalid.csv
@@ -1,3 +1,3 @@
-RODA identifier,Commitment value,Financial quarter,Financial year
-RODA-ID,-100,1,
-UNKNOWN-RODA-ID,100,1,2021
+RODA identifier,Commitment value
+RODA-ID,-100
+UNKNOWN-RODA-ID,100,

--- a/spec/fixtures/csv/commitments/valid.csv
+++ b/spec/fixtures/csv/commitments/valid.csv
@@ -1,2 +1,2 @@
-RODA identifier,Commitment value,Financial quarter,Financial year
-RODA-ID,200,1,2021
+RODA identifier,Commitment value
+RODA-ID,200

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe Commitment do
     should validate_numericality_of(:value).is_greater_than(0)
     should validate_numericality_of(:value).is_less_than_or_equal_to(99_999_999_999.00)
 
-    should validate_presence_of(:financial_quarter)
-    should validate_inclusion_of(:financial_quarter).in_array((1..4).to_a)
-
-    should validate_presence_of(:financial_year)
-    should validate_numericality_of(:financial_year).only_integer
-    should validate_numericality_of(:financial_year).is_greater_than_or_equal_to(2_000)
-    should validate_numericality_of(:financial_year).is_less_than_or_equal_to(3_000)
+    should validate_presence_of(:transaction_date)
   end
 end

--- a/spec/presenters/commitment_presenter_spec.rb
+++ b/spec/presenters/commitment_presenter_spec.rb
@@ -5,4 +5,12 @@ RSpec.describe CommitmentPresenter do
       expect(described_class.new(commitment).value).to eq("£100,000.00")
     end
   end
+
+  describe "#transaction_date" do
+    it "returns a human readable date" do
+      commitment = build(:commitment, transaction_date: Date.parse("2023-02-20"))
+      result = described_class.new(commitment).transaction_date
+      expect(result).to eq("20 Feb 2023")
+    end
+  end
 end

--- a/spec/presenters/commitment_presenter_spec.rb
+++ b/spec/presenters/commitment_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe CommitmentPresenter do
   describe "#value" do
     it "returns the value to two decimal places with a currency symbol" do
-      commitment = Commitment.new(value: 100_000)
+      commitment = build(:commitment, value: 100_000)
       expect(described_class.new(commitment).value).to eq("£100,000.00")
     end
   end

--- a/spec/views/shared/xml/commitment_spec.rb
+++ b/spec/views/shared/xml/commitment_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "shared/xml/commitment" do
 
     it "has the transation date" do
       expect(subject.at("transaction/transaction-date/@iso-date").text)
-        .to eq l(commitment.first_day_of_financial_period, format: :iati)
+        .to eq l(commitment.transaction_date, format: :iati)
     end
 
     it "has the value and attributes" do
       expect(subject.at("transaction/value").text)
         .to eq commitment.value.to_s
       expect(subject.at("transaction/value/@value-date").text)
-        .to eq l(commitment.first_day_of_financial_period, format: :iati)
+        .to eq l(commitment.transaction_date, format: :iati)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

*Part 2 of 2*: Updates references to Financial Year & Financial Quarter to use new `transaction_date` field once it's been populated by the script introduced in #2047.

This PR refactors a few aspects of the Commitment model and the script used to import them:

- Updates the Commitment importer so no date fields are required. The `transaction_date` will be inferred from an Activity's `planned_start_date` if it exists, then the `actual_start_date`. If neither is present for any reason (as appears to be the case with some of our data despite validations), we fall back on the date the activity was created.
- Uses the new `transaction_date` field to display the Commitment figure on an Activity's financial details tab (see screenshot)
- Removes `financial_year` and `financial_quarter` from commitments

## Screenshots of UI changes

### Before

<img width="1283" alt="Screenshot 2023-02-20 at 15 40 20" src="https://user-images.githubusercontent.com/19826940/220170494-a6c4613f-f70f-4cf3-9517-76ddb7714720.png">

### After

![image](https://user-images.githubusercontent.com/19826940/220170463-b8c4f8e7-125e-4689-ade2-bec4b658a608.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
