### PR TITLE
(2801) Hide SID truncation note on non-ODA activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1208,6 +1208,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Omit legacy fields for ISPF activities on the "details" page.
 - Remove legacy fields from ISPF reports.
 - Only generate IATI identifiers for ODA activities
+- Remove reference to truncating data published to Statistics in International Development for non-ODA activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -22,6 +22,8 @@ class ActivityFormsController < BaseController
     when :linked_activity
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
+    when :purpose
+      @activity_presenter = ActivityPresenter.new(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -5,6 +5,18 @@ class ActivityPresenter < SimpleDelegator
   include ActivityHelper
   include CountryHelper
 
+  def title_hint
+    hint = I18n.t("form.hint.activity.title", level: I18n.t("page_content.activity.level.#{to_model.level}"))
+    hint += " #{I18n.t("form.hint.activity.title_sid_note")}" unless is_non_oda?
+    hint
+  end
+
+  def description_hint
+    hint = I18n.t("form.hint.activity.description")
+    hint += " #{I18n.t("form.hint.activity.description_sid_note")}" unless is_non_oda?
+    hint
+  end
+
   def aid_type
     return if super.blank?
     translate("activity.aid_type.#{super.downcase}")

--- a/app/views/activity_forms/purpose.html.haml
+++ b/app/views/activity_forms/purpose.html.haml
@@ -2,9 +2,9 @@
   = f.govuk_fieldset legend: { text: @page_title, tag: :h1, size: "xl" } do
     = f.govuk_text_field :title,
       label: { text: t("form.label.activity.title", level: custom_capitalisation(t("page_content.activity.level.#{f.object.level}"))) },
-      hint: { text: t("form.hint.activity.title", level: t("page_content.activity.level.#{f.object.level}")) }
+      hint: { text: @activity_presenter.title_hint }
 
     = f.govuk_text_area :description,
                         rows: 5,
-                        hint: { text: t("form.hint.activity.description") }
+                        hint: { text: @activity_presenter.description_hint }
 

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -126,7 +126,8 @@ en:
         country_partner_organisations: "Please provide up to ten country partner organisations. A name is required, provide a acronym where applicable, for example: 'National Council for the State Funding Agencies (CONFAP)'"
         csv_file: Upload a spreadsheet containing activity data in CSV format.
         csv_file_recover_from_error_html: Upload a spreadsheet containing activity data in CSV format. We recommend <a href="%{link}" class="govuk-link">downloading this CSV template</a>.
-        description: There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.
+        description: There is no character limit to this field.
+        description_sid_note: However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.
         fstc_applies: "Free-standing technical co-operation is defined as financing of activities whose primary purpose is to augment the level of knowledge, skills, technical know-how or productive aptitudes of the population of developing countries."
         fund_pillar: The Newton Fund largely comprises three pillar activities, which all activities must fall under. Use 'Not applicable' for delivery, other non-programme/project lines.
         gcrf_challenge_area: Select the most relevant GCRF challenge area for this activity. For broad programme calls, please select the challenge area most commonly represented across the individual projects within the programme. If the activity is a delivery line, you may select 'Not applicable'.
@@ -161,7 +162,8 @@ en:
           nutrition: This activity is intended to address the immediate or underlying determinants of malnutrition
         sdgs_apply: For broad programme calls, please select the SDG most commonly represented across the individual projects within the programme. If unable, or if the activity is a delivery line, you may select 'N/A'.
         sector_category_html: For example, research, education or small to medium-sized enterprise (SME) development. Choose one of the %{link}
-        title: A short title that explains the purpose of the %{level}. There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.
+        title: A short title that explains the purpose of the %{level}. There is no character limit to this field.
+        title_sid_note: However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.
         total_applications: You can enter 0 if this field is not applicable at the moment
         total_awards: You can enter 0 if this field is not applicable at the moment
   summary:

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -25,6 +25,106 @@ RSpec.describe ActivityPresenter do
     end
   end
 
+  describe "#title_hint" do
+    context "when the activity is a programme" do
+      it "includes all notes about the title field" do
+        activity = build(:programme_activity)
+
+        expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the programme (level B). There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the title field, but not SID information" do
+          activity = build(:programme_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the programme (level B). There is no character limit to this field.")
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      it "includes all notes about the title field" do
+        activity = build(:project_activity)
+
+        expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the project (level C). There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the title field, but not SID information" do
+          activity = build(:project_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the project (level C). There is no character limit to this field.")
+        end
+      end
+    end
+
+    context "when the activity is a third-party project" do
+      it "includes all notes about the title field" do
+        activity = build(:third_party_project_activity)
+
+        expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the third-party project (level D). There is no character limit to this field. However, when this data is published to Statistics in International Development the title will be truncated at 150 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the title field, but not SID information" do
+          activity = build(:third_party_project_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).title_hint).to eq("A short title that explains the purpose of the third-party project (level D). There is no character limit to this field.")
+        end
+      end
+    end
+  end
+
+  describe "#description_hint" do
+    context "when the activity is a programme" do
+      it "includes all notes about the description field" do
+        activity = build(:programme_activity)
+
+        expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the description field, but not SID information" do
+          activity = build(:programme_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field.")
+        end
+      end
+    end
+
+    context "when the activity is a project" do
+      it "includes all notes about the description field" do
+        activity = build(:project_activity)
+
+        expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the description field, but not SID information" do
+          activity = build(:project_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field.")
+        end
+      end
+    end
+
+    context "when the activity is a third-party project" do
+      it "includes all notes about the description field" do
+        activity = build(:third_party_project_activity)
+
+        expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field. However, when this data is published to Statistics in International Development the description will be truncated at 4000 characters.")
+      end
+
+      context "and non-ODA" do
+        it "includes character limit notes about the description field, but not SID information" do
+          activity = build(:third_party_project_activity, :ispf_funded, is_oda: false)
+
+          expect(ActivityPresenter.new(activity).description_hint).to eq("There is no character limit to this field.")
+        end
+      end
+    end
+  end
+
   describe "#aid_type" do
     it_behaves_like "a code translator", "aid_type", {type: "aid_type"}
 


### PR DESCRIPTION
## Changes in this PR

The purpose step of the activity form includes a note on both the title and description fields about truncation of data when published to Statistics in International Development. Non-ODA activities are not published to this, so the note is irrelevant and confusing in that context. This therefore hides the note when accessing the step on a non-ODA activity

## Screenshots of UI changes

### Before

<img width="752" alt="image" src="https://user-images.githubusercontent.com/40244233/220346047-36675ef5-e49f-46c8-9f70-5759ae0423b3.png">

### After

<img width="762" alt="image" src="https://user-images.githubusercontent.com/40244233/220346115-68532e61-8cc5-488e-aed8-fa2bce159a81.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
