### PR TITLE
(2802) Hide fields irrelevant to non-ODA activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove legacy fields from ISPF reports.
 - Only generate IATI identifiers for ODA activities
 - Remove reference to truncating data published to Statistics in International Development for non-ODA activities
+- Hide IATI identifier and "Include in IATI XML export?" fields on activity details tab for non-ODA activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -52,12 +52,13 @@
       = activity_presenter.roda_identifier
     %dd.govuk-summary-list__actions
 
-  .govuk-summary-list__row.transparency-identifier
-    %dt.govuk-summary-list__key
-      = t("activerecord.attributes.activity.transparency_identifier")
-    %dd.govuk-summary-list__value
-      = activity_presenter.transparency_identifier
-    %dd.govuk-summary-list__actions
+  - unless activity_presenter.is_non_oda?
+    .govuk-summary-list__row.transparency-identifier
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.transparency_identifier")
+      %dd.govuk-summary-list__value
+        = activity_presenter.transparency_identifier
+      %dd.govuk-summary-list__actions
 
   - if activity_presenter.is_ispf_funded?
     .govuk-summary-list__row.linked_activity
@@ -501,7 +502,7 @@
         - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :oda_eligibility_lead)
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:oda_eligibility_lead)}"), activity_step_path(activity_presenter, :oda_eligibility_lead), t("activerecord.attributes.activity.oda_eligibility_lead"))
 
-  - if policy(activity_presenter).redact_from_iati?
+  - if policy(activity_presenter).redact_from_iati? && !activity_presenter.is_non_oda?
     .govuk-summary-list__row.publish_to_iati
       %dt.govuk-summary-list__key
         = t("summary.label.activity.publish_to_iati.label")

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -197,6 +197,8 @@ RSpec.describe "shared/activities/_activity" do
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.sustainable_development_goals"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.aid_type"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.transparency_identifier"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.publish_to_iati"))
         end
       end
     end
@@ -289,6 +291,8 @@ RSpec.describe "shared/activities/_activity" do
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.channel_of_delivery_code"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility"))
           expect(rendered).not_to have_content(t("activerecord.attributes.activity.oda_eligibility_lead"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.transparency_identifier"))
+          expect(rendered).not_to have_content(t("activerecord.attributes.activity.publish_to_iati"))
         end
 
         it "doesn't allow editing the ODA / non-ODA field" do
@@ -356,6 +360,12 @@ RSpec.describe "shared/activities/_activity" do
       let(:policy_stub) { double("policy", update?: true, redact_from_iati?: true) }
 
       it { is_expected.to show_the_publish_to_iati_field }
+
+      context "when the activity is non-ODA" do
+        let(:activity) { build(:programme_activity, is_oda: false) }
+
+        it { is_expected.not_to show_the_publish_to_iati_field }
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

Non-ODA activities are not reported to IATI, therefore the IATI identifier and "Include in IATI export?" fields are irrelevant and confusing when looking at the activity details tab for such activities. This removes them in this context

## Screenshots of UI changes

### Before

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/40244233/220354835-ce031b93-96fc-49f8-8ffe-ba3dca7b7355.png">

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/40244233/220354875-c2132607-5559-4c6f-a43c-ea0186e4907e.png">

### After

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/40244233/220355152-7c9c31c6-c9ca-4224-a3b6-704cd276f99c.png">

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/40244233/220355242-fb6c038e-afc8-462d-a8fa-c4aaccbca97a.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
