### PR TITLE
(2805) Add global feature flag for linked activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1215,6 +1215,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Make error messages clearer when importing actuals and refunds
 - Fix login issues after running the training database sync script by clearing remember tokens during password reset step and clearing sessions as an additional step
 - ODA only attributes are blank on non-ODA activities
+- Add a feature flag to enable/disable the linked activities feature
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -69,7 +69,7 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def update_linked_activity?
-    return unless record.is_ispf_funded?
+    return unless ROLLOUT.active?(:activity_linking) && record.is_ispf_funded?
 
     if record.programme?
       return beis_user? && record.linked_child_activities.empty?

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -60,7 +60,7 @@
         = activity_presenter.transparency_identifier
       %dd.govuk-summary-list__actions
 
-  - if activity_presenter.is_ispf_funded?
+  - if ROLLOUT.active?(:activity_linking) && activity_presenter.is_ispf_funded?
     .govuk-summary-list__row.linked_activity
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.linked_activity")

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -35,7 +35,7 @@
       = activity_presenter.partner_organisation_identifier
     %dd.govuk-summary-list__actions
 
-  - if activity_presenter.is_ispf_funded?
+  - if ROLLOUT.active?(:activity_linking) && activity_presenter.is_ispf_funded?
     .govuk-summary-list__row.linked_activity
       %dt.govuk-summary-list__key
         = t("activerecord.attributes.activity.linked_activity")

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -10,6 +10,9 @@ RSpec.feature "BEIS users can upload Level B activities" do
 
   before do
     visit new_organisation_level_b_activities_upload_path(organisation)
+
+    allow(ROLLOUT).to receive(:active?).and_call_original
+    allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
   end
 
   after { logout }

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -232,77 +232,84 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.policy_marker_nutrition).to be_nil
       end
 
-      scenario "an ODA third-party project can be linked to an existing non-ODA third-party project" do
-        implementing_organisation = create(:implementing_organisation)
+      context "when the `activity_linking` feature flag is enabled" do
+        before do
+          allow(ROLLOUT).to receive(:active?).and_call_original
+          allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
+        end
 
-        non_oda_programme = create(:programme_activity, :ispf_funded,
-          is_oda: false,
-          extending_organisation: user.organisation)
-        _report = create(:report, :active, organisation: user.organisation, fund: non_oda_programme.associated_fund)
-        non_oda_project = create(:project_activity, :ispf_funded,
-          is_oda: false,
-          parent: non_oda_programme,
-          organisation: user.organisation,
-          extending_organisation: user.organisation,
-          ispf_themes: [1])
-        non_oda_3rdp_project = create(:third_party_project_activity, :ispf_funded,
-          is_oda: false,
-          extending_organisation: user.organisation,
-          parent: non_oda_project)
+        scenario "an ODA third-party project can be linked to an existing non-ODA third-party project" do
+          implementing_organisation = create(:implementing_organisation)
 
-        oda_programme = create(:programme_activity, :ispf_funded,
-          is_oda: true,
-          linked_activity: non_oda_programme,
-          extending_organisation: user.organisation)
-        oda_project = create(:project_activity, :ispf_funded,
-          is_oda: true,
-          parent: oda_programme,
-          organisation: user.organisation,
-          extending_organisation: user.organisation,
-          linked_activity: non_oda_project,
-          ispf_themes: [1])
+          non_oda_programme = create(:programme_activity, :ispf_funded,
+            is_oda: false,
+            extending_organisation: user.organisation)
+          _report = create(:report, :active, organisation: user.organisation, fund: non_oda_programme.associated_fund)
+          non_oda_project = create(:project_activity, :ispf_funded,
+            is_oda: false,
+            parent: non_oda_programme,
+            organisation: user.organisation,
+            extending_organisation: user.organisation,
+            ispf_themes: [1])
+          non_oda_3rdp_project = create(:third_party_project_activity, :ispf_funded,
+            is_oda: false,
+            extending_organisation: user.organisation,
+            parent: non_oda_project)
 
-        oda_3rdp_project = build(:third_party_project_activity,
-          parent: oda_project,
-          is_oda: true,
-          linked_activity_id: non_oda_3rdp_project.id,
-          benefitting_countries: ["AG", "HT"],
-          sdgs_apply: true,
-          sdg_1: 5,
-          ispf_themes: [1],
-          implementing_organisations: [implementing_organisation],
-          extending_organisation: user.organisation)
+          oda_programme = create(:programme_activity, :ispf_funded,
+            is_oda: true,
+            linked_activity: non_oda_programme,
+            extending_organisation: user.organisation)
+          oda_project = create(:project_activity, :ispf_funded,
+            is_oda: true,
+            parent: oda_programme,
+            organisation: user.organisation,
+            extending_organisation: user.organisation,
+            linked_activity: non_oda_project,
+            ispf_themes: [1])
 
-        visit activities_path
-
-        click_on(oda_project.title)
-        click_on t("tabs.activity.children")
-
-        click_on(t("action.activity.add_child"))
-
-        form = ActivityForm.new(activity: oda_3rdp_project, level: "project", fund: "ispf")
-        form.complete!
-
-        expect(page).to have_content t("action.third_party_project.create.success")
-
-        created_activity = form.created_activity
-
-        expect(created_activity.title).to eq(oda_3rdp_project.title)
-        expect(created_activity.is_oda).to eq(oda_3rdp_project.is_oda)
-        expect(created_activity.linked_activity).to eq(non_oda_3rdp_project)
-      end
-
-      context "without an editable report" do
-        scenario "a new third party project cannot be added" do
-          programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)
-          project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation, parent: programme)
+          oda_3rdp_project = build(:third_party_project_activity,
+            parent: oda_project,
+            is_oda: true,
+            linked_activity_id: non_oda_3rdp_project.id,
+            benefitting_countries: ["AG", "HT"],
+            sdgs_apply: true,
+            sdg_1: 5,
+            ispf_themes: [1],
+            implementing_organisations: [implementing_organisation],
+            extending_organisation: user.organisation)
 
           visit activities_path
 
-          click_on(project.title)
+          click_on(oda_project.title)
           click_on t("tabs.activity.children")
 
-          expect(page).to have_no_button t("action.activity.add_child")
+          click_on(t("action.activity.add_child"))
+
+          form = ActivityForm.new(activity: oda_3rdp_project, level: "project", fund: "ispf")
+          form.complete!
+
+          expect(page).to have_content t("action.third_party_project.create.success")
+
+          created_activity = form.created_activity
+
+          expect(created_activity.title).to eq(oda_3rdp_project.title)
+          expect(created_activity.is_oda).to eq(oda_3rdp_project.is_oda)
+          expect(created_activity.linked_activity).to eq(non_oda_3rdp_project)
+        end
+
+        context "without an editable report" do
+          scenario "a new third party project cannot be added" do
+            programme = create(:programme_activity, :gcrf_funded, extending_organisation: user.organisation)
+            project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation, parent: programme)
+
+            visit activities_path
+
+            click_on(project.title)
+            click_on t("tabs.activity.children")
+
+            expect(page).to have_no_button t("action.activity.add_child")
+          end
         end
       end
     end

--- a/spec/features/users_can_upload_activities_spec.rb
+++ b/spec/features/users_can_upload_activities_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature "users can upload activities" do
   }
 
   before do
+    allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
+
     # Given I'm logged in as a PO
     authenticate!(user: user)
 

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -129,7 +129,7 @@ class ActivityForm
   def fill_in_ispf_programme_activity_form
     fill_in_is_oda_step
     fill_in_identifier_step
-    fill_in_linked_activity_step
+    fill_in_linked_activity_step if ROLLOUT.active?(:activity_linking)
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step
@@ -152,7 +152,7 @@ class ActivityForm
 
   def fill_in_ispf_project_activity_form
     fill_in_identifier_step
-    fill_in_linked_activity_step
+    fill_in_linked_activity_step if ROLLOUT.active?(:activity_linking)
     fill_in_purpose_step
     fill_in_objectives_step if @activity.is_oda
     fill_in_sector_category_step

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe "shared/activities/_activity" do
       allow(view).to receive(:edit_activity_redaction_path).and_return("This path isn't important")
       allow(view).to receive(:organisation_activity_path).and_return("This path isn't important")
     end
+
+    allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
   end
 
   context "when the fund is GCRF" do

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -65,8 +65,6 @@ RSpec.describe "shared/activities/_activity" do
       allow(view).to receive(:edit_activity_redaction_path).and_return("This path isn't important")
       allow(view).to receive(:organisation_activity_path).and_return("This path isn't important")
     end
-
-    allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
   end
 
   context "when the fund is GCRF" do
@@ -145,25 +143,42 @@ RSpec.describe "shared/activities/_activity" do
         expect(rendered).not_to have_content(t("activerecord.attributes.activity.covid19_related"))
       end
 
-      context "when the programme has a linked programme" do
-        let(:linked_activity) { build(:programme_activity, :ispf_funded) }
-        let(:activity) {
-          build(
-            :programme_activity,
-            :ispf_funded,
-            ispf_themes: [1],
-            ispf_oda_partner_countries: ["IN"],
-            ispf_non_oda_partner_countries: ["CA"],
-            linked_activity: linked_activity
-          )
-        }
+      context "when the `activity_linking` feature flag is not active" do
+        it "does not show the Linked Activities row" do
+          expect(rendered).to_not have_css(".govuk-summary-list__row.linked_activity")
+        end
+      end
 
-        it "shows the linked programme" do
-          expect(rendered).to have_content(activity_presenter.linked_activity.title)
+      context "when the `activity_linking` feature flag is active" do
+        before do
+          allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
+          render
         end
 
-        it "does not show a link to edit the linked programme" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+        it "shows the Linked Activities row" do
+          expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
+        end
+
+        context "when the programme has a linked programme" do
+          let(:linked_activity) { build(:programme_activity, :ispf_funded) }
+          let(:activity) {
+            build(
+              :programme_activity,
+              :ispf_funded,
+              ispf_themes: [1],
+              ispf_oda_partner_countries: ["IN"],
+              ispf_non_oda_partner_countries: ["CA"],
+              linked_activity: linked_activity
+            )
+          }
+
+          it "shows the linked programme" do
+            expect(rendered).to have_content(activity_presenter.linked_activity.title)
+          end
+
+          it "does not show a link to edit the linked programme" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+          end
         end
       end
 
@@ -302,48 +317,58 @@ RSpec.describe "shared/activities/_activity" do
         end
       end
 
-      context "and it doesn't have a linked activity" do
-        before { render }
-
-        it "shows a link to add a linked activity" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+      context "when the `activity_linking` feature flag is not active" do
+        it "does not show the Linked Activities row" do
+          expect(rendered).to_not have_css(".govuk-summary-list__row.linked_activity")
         end
       end
 
-      context "and it has a linked activity" do
-        before do
-          activity.linked_activity = non_oda_activity
-          activity.save
+      context "when the `activity_linking` feature flag is active" do
+        before { allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true) }
 
-          render
+        context "and it doesn't have a linked activity" do
+          before { render }
+
+          it "shows a link to add a linked activity" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+          end
         end
 
-        it "shows the linked activity" do
-          expect(rendered).to have_content(activity_presenter.linked_activity.title)
+        context "and it has a linked activity" do
+          before do
+            activity.linked_activity = non_oda_activity
+            activity.save
+
+            render
+          end
+
+          it "shows the linked activity" do
+            expect(rendered).to have_content(activity_presenter.linked_activity.title)
+          end
+
+          it "shows a link to edit the linked activity" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
+          end
         end
 
-        it "shows a link to edit the linked activity" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
-        end
-      end
+        context "and it has child projects that are linked" do
+          let(:activity) { oda_project }
 
-      context "and it has child projects that are linked" do
-        let(:activity) { oda_project }
+          before do
+            oda_programme.linked_activity = non_oda_programme
+            oda_programme.save
 
-        before do
-          oda_programme.linked_activity = non_oda_programme
-          oda_programme.save
+            oda_project.linked_activity = non_oda_project
+            oda_project.save
 
-          oda_project.linked_activity = non_oda_project
-          oda_project.save
+            oda_third_party_project.linked_activity = non_oda_third_party_project
+            oda_third_party_project.save
+            render
+          end
 
-          oda_third_party_project.linked_activity = non_oda_third_party_project
-          oda_third_party_project.save
-          render
-        end
-
-        it "does not show an edit link for the linked project" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+          it "does not show an edit link for the linked project" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+          end
         end
       end
     end
@@ -420,54 +445,64 @@ RSpec.describe "shared/activities/_activity" do
           linked_activity: activity)
       }
 
-      context "and it doesn't have a linked activity" do
-        before { render }
-
-        it "shows a link to add a linked activity" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+      context "when the `activity_linking` feature flag is not active" do
+        it "does not show the Linked Activities row" do
+          expect(rendered).to_not have_css(".govuk-summary-list__row.linked_activity")
         end
       end
 
-      context "and it has a linked activity" do
-        before {
-          activity.linked_activity = non_oda_programme
-          activity.save
+      context "when the `activity_linking` feature flag is active" do
+        before { allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true) }
 
-          render
-        }
+        context "and it doesn't have a linked activity" do
+          before { render }
 
-        it "shows a link to edit the linked activity" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
+          it "shows a link to add a linked activity" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.add"))
+          end
         end
-      end
 
-      context "when the programme has any child projects that are linked" do
-        let!(:project) {
-          create(:project_activity,
-            :ispf_funded,
-            is_oda: true,
-            extending_organisation: user.organisation,
-            parent: activity)
-        }
+        context "and it has a linked activity" do
+          before {
+            activity.linked_activity = non_oda_programme
+            activity.save
 
-        let!(:linked_project) {
-          create(:project_activity,
-            :ispf_funded,
-            is_oda: false,
-            extending_organisation: user.organisation,
-            parent: non_oda_programme,
-            linked_activity: project)
-        }
+            render
+          }
 
-        before {
-          activity.linked_activity = non_oda_programme
-          activity.save
+          it "shows a link to edit the linked activity" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions a")).to have_content(t("default.link.edit"))
+          end
+        end
 
-          render
-        }
+        context "when the programme has any child projects that are linked" do
+          let!(:project) {
+            create(:project_activity,
+              :ispf_funded,
+              is_oda: true,
+              extending_organisation: user.organisation,
+              parent: activity)
+          }
 
-        it "does not show an edit link for the linked programme" do
-          expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+          let!(:linked_project) {
+            create(:project_activity,
+              :ispf_funded,
+              is_oda: false,
+              extending_organisation: user.organisation,
+              parent: non_oda_programme,
+              linked_activity: project)
+          }
+
+          before {
+            activity.linked_activity = non_oda_programme
+            activity.save
+
+            render
+          }
+
+          it "does not show an edit link for the linked programme" do
+            expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
+          end
         end
       end
     end
@@ -721,7 +756,6 @@ RSpec.describe "shared/activities/_activity" do
 
   RSpec::Matchers.define :show_ispf_specific_details do
     match do |actual|
-      expect(rendered).to have_css(".govuk-summary-list__row.linked_activity")
       expect(rendered).to have_css(".govuk-summary-list__row.is_oda")
 
       expect(rendered).to have_css(".govuk-summary-list__row.ispf_themes")


### PR DESCRIPTION
## Changes in this PR
### Put the wizard linked activities behind a feature flag
We want to disable the linked activities feature for now, to be re-enabled in
future. We have had some feedback that linking is confusing to POs while
there's no ODA funds being spent.

This hides the linked activities feature in the wizard unless the feature flag
is active.

### Put describe page and summary linked activities behind a feature flag
We want to disable the linked activities feature for now, to be re-enabled in
future. We have had some feedback that linking is confusing to POs while
there's no ODA funds being spent.

This hides the linked activities row on the describe page and summary unless
the feature flag is active.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
