### PR TITLE
[2827] Collect original commitment figure in new Activity form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1224,6 +1224,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Update Commitment-importing script to infer `transaction_date` value from Activity values
+- Collect original commitment figure in the new activity form
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -77,6 +77,9 @@ class ActivityFormsController < BaseController
       @implementing_organisations = Organisation.active.sorted_by_name
     when :tags
       skip_step unless @activity.is_ispf_funded?
+    when :commitment
+      skip_step if @activity.commitment.present?
+      @activity.build_commitment
     end
 
     render_wizard
@@ -98,6 +101,8 @@ class ActivityFormsController < BaseController
       when :implementing_organisation
         @implementing_organisations = Organisation.active.sorted_by_name
         render_step :implementing_organisation
+      when :commitment
+        render_step :commitment
       end
 
       return

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -160,6 +160,9 @@ class ActivityFormsController < BaseController
   def page_title(step)
     if step == :identifier && @activity.programme?
       t("page_title.activity_form.show.identifier_level_b")
+    elsif step == :commitment
+      optional = @activity.third_party_project? ? "" : " #{t("optional")}"
+      t("page_title.activity_form.show.commitment", optional: optional)
     else
       t(
         "page_title.activity_form.show.#{step}",

--- a/app/helpers/commitment_helper.rb
+++ b/app/helpers/commitment_helper.rb
@@ -1,0 +1,8 @@
+module CommitmentHelper
+  def infer_transaction_date_from_activity_attributes(activity)
+    return activity.planned_start_date if activity.planned_start_date
+    return activity.actual_start_date if activity.actual_start_date
+
+    activity.created_at.to_date
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -57,7 +57,8 @@ class Activity < ApplicationRecord
     :oda_eligibility_lead,
     :uk_po_named_contact,
     :implementing_organisation,
-    :tags
+    :tags,
+    :commitment
   ]
 
   VALIDATION_STEPS = [
@@ -90,7 +91,8 @@ class Activity < ApplicationRecord
     :oda_eligibility_step,
     :oda_eligibility_lead_step,
     :uk_po_named_contact_step,
-    :implementing_organisation_step
+    :implementing_organisation_step,
+    :commitment_step
   ]
 
   FORM_STATE_VALIDATION_LIST = FORM_STEPS.map(&:to_s).push("complete")

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -4,6 +4,7 @@ class Commitment < ApplicationRecord
   belongs_to :activity
 
   validates :value, presence: true
+
   validates :value, numericality: {
     greater_than: 0,
     less_than_or_equal_to: 99_999_999_999.00

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -316,6 +316,12 @@ class ActivityPresenter < SimpleDelegator
     ActionController::Base.helpers.number_to_currency(super, unit: "£")
   end
 
+  def commitment
+    return if super.nil?
+
+    CommitmentPresenter.new(super)
+  end
+
   def linkable_activity_select_label
     "#{roda_identifier} (#{title})"
   end

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -3,6 +3,7 @@ class Activity
     include DateHelper
     include CodelistHelper
     include ActivityHelper
+    include CommitmentHelper
 
     DEFAULT_PROGRAMME_STATUS_FOR_FUNDS = "spend_in_progress"
 
@@ -163,6 +164,18 @@ class Activity
         .permit(tags: [])
         .fetch("tags", []).reject(&:blank?)
       activity.assign_attributes(tags: tags)
+    end
+
+    def set_commitment
+      value = activity_params.require(:commitment).fetch(:value)
+
+      activity.build_commitment(
+        value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
+      )
+
+      activity.commitment.save!
+    rescue => error
+      activity.errors.add(:value, error)
     end
 
     def assign_attributes_for_step(step)

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -169,6 +169,8 @@ class Activity
     def set_commitment
       value = activity_params.require(:commitment).fetch(:value)
 
+      return if !activity.third_party_project? && value.blank?
+
       activity.build_commitment(
         value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
       )

--- a/app/services/commitment/import.rb
+++ b/app/services/commitment/import.rb
@@ -78,6 +78,8 @@ class Commitment
     end
 
     class RowImporter
+      include CommitmentHelper
+
       attr_reader :errors, :commitment, :row_number, :row
 
       def initialize(row_number, row)
@@ -117,11 +119,7 @@ class Commitment
 
       def transaction_date
         activity = Activity.find(activity_id)
-
-        return activity.planned_start_date if activity.planned_start_date
-        return activity.actual_start_date if activity.actual_start_date
-
-        activity.created_at.to_date
+        infer_transaction_date_from_activity_attributes(activity)
       end
 
       def set_commitment

--- a/app/views/activity_forms/commitment.html.haml
+++ b/app/views/activity_forms/commitment.html.haml
@@ -1,0 +1,7 @@
+= render layout: "wrapper" do |f|
+  = f.fields_for :commitment, @activity.commitment do |commitment_form|
+    = commitment_form.govuk_error_summary
+    = commitment_form.govuk_text_field :value,
+      label: { text: @page_title, tag: 'h1', size: 'xl' },
+      hint: { text: t("form.hint.activity.commitment") },
+      prefix_text: "£"

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -109,6 +109,16 @@
       - if policy(activity_presenter).update? && step_is_complete_or_next?(activity: activity_presenter, step: :sector)
         = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:sector)}"), activity_step_path(activity_presenter, :sector_category), t("activerecord.attributes.activity.sector"))
 
+  - unless activity_presenter.fund?
+    .govuk-summary-list__row.commitment
+      %dt.govuk-summary-list__key
+        = t("activerecord.attributes.activity.commitment")
+      %dd.govuk-summary-list__value
+        = activity_presenter.commitment&.value
+      %dd.govuk-summary-list__actions
+        - if policy(activity_presenter).update? && activity_presenter.commitment.nil?
+          = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :commitment), t("activerecord.attributes.activity.commitment"))
+
   - if activity_presenter.is_project?
     .govuk-summary-list__row.uk_po_named_contact
       %dt.govuk-summary-list__key

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -2,6 +2,7 @@
 en:
   app:
     title: Report your Official Development Assistance
+  optional: (optional)
   date:
     formats:
       default: "%-d %b %Y"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -137,6 +137,7 @@ en:
         intended_beneficiaries: Select all that apply
         linked_activity: If the activity you are trying to link does not appear in the selection, it's possible it is already linked to another activity.
         objectives: Please refrain from using any abbreviations
+        commitment: How much is the original commitment?
         oda_eligibility_lead: This will be used by us as a first point of contact for anything ODA related.
         oda_eligibility: ODA eligibility is determined by the OECD. The primary purpose of the research must be to benefit a DAC list country. The title and description are collected in line with OECD specification, and benefitting countries must be on the OECD DAC list – and referenced using the correct code
         options:
@@ -347,6 +348,7 @@ en:
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility_lead: Who is the ODA Eligibility Contact for this activity?
         oda_eligibility: Is this activity ODA eligible?
+        commitment: Original commitment figure
         policy_markers: Policy markers
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -348,7 +348,7 @@ en:
         objectives: What are the aims/objectives of this %{level}?
         oda_eligibility_lead: Who is the ODA Eligibility Contact for this activity?
         oda_eligibility: Is this activity ODA eligible?
-        commitment: Original commitment figure
+        commitment: Original commitment figure%{optional}
         policy_markers: Policy markers
         programme_status: A description of the status of the activity
         purpose: What is the purpose of the %{level}?

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -393,6 +393,7 @@ en:
         objectives: Aims or objectives
         oda_eligibility: ODA eligibility
         oda_eligibility_lead: ODA eligibility lead contact name
+        commitment: Original commitment figure
         covid19_related: Covid-19 related research
         programme_status: Activity status
         country_partner_organisations: Newton Fund Country Partner Organisations

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -305,6 +305,24 @@ RSpec.describe ActivityFormsController do
         end
       end
     end
+
+    describe "commitment" do
+      let(:user) { create(:beis_user) }
+
+      context "when it has not yet been set" do
+        let(:activity) { create(:programme_activity, commitment: nil) }
+        subject { get_step :commitment }
+
+        it { is_expected.to render_current_step }
+      end
+
+      context "when it has already been set" do
+        let(:activity) { create(:programme_activity, commitment: create(:commitment, value: 1000)) }
+        subject { get_step :commitment }
+
+        it { is_expected.to skip_to_next_step }
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -51,6 +51,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_commitment do
+      after(:build) do |activity|
+        activity.commitment = build(:commitment)
+      end
+    end
+
     factory :fund_activity do
       level { :fund }
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
   context "when the source fund is GCRF" do
     let(:identifier) { "a-fund-has-an-accountable-organisation" }
     let!(:activity) do
-      build(:programme_activity, :gcrf_funded,
+      build(:programme_activity, :gcrf_funded, :with_commitment,
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
         sdgs_apply: true,
@@ -67,13 +67,14 @@ RSpec.feature "BEIS users can create a programme level activity" do
         activity: created_activity,
         organisation: partner_organisation
       )
+      expect(created_activity.commitment.value).to eq(activity.commitment.value)
     end
   end
 
   context "when the source fund is Newton" do
     let(:identifier) { "a-fund-has-an-accountable-organisation" }
     let!(:activity) do
-      build(:programme_activity, :newton_funded,
+      build(:programme_activity, :newton_funded, :with_commitment,
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
         sdgs_apply: true,
@@ -117,13 +118,14 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.accountable_organisation_type).to eq("10")
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.commitment.value).to eq(activity.commitment.value)
     end
   end
 
   context "when the source fund is OODA" do
     let(:identifier) { "a-fund-has-an-accountable-organisation" }
     let!(:activity) do
-      build(:programme_activity, :ooda_funded,
+      build(:programme_activity, :ooda_funded, :with_commitment,
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
         sdgs_apply: true,
@@ -165,6 +167,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.accountable_organisation_type).to eq("10")
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.commitment.value).to eq(activity.commitment.value)
     end
   end
 
@@ -172,6 +175,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
     let(:identifier) { "a-fund-has-an-accountable-organisation" }
     let!(:oda_activity) do
       build(:programme_activity,
+        :with_commitment,
         parent: create(:fund_activity, :ispf),
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
@@ -186,6 +190,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
 
     let!(:non_oda_activity) do
       build(:programme_activity,
+        :with_commitment,
         parent: create(:fund_activity, :ispf),
         partner_organisation_identifier: identifier,
         benefitting_countries: ["AG", "HT"],
@@ -228,6 +233,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.sdg_1).to eq(oda_activity.sdg_1)
       expect(created_activity.oda_eligibility).to eq(oda_activity.oda_eligibility)
       expect(created_activity.tags).to eq(oda_activity.tags)
+      expect(created_activity.commitment.value).to eq(oda_activity.commitment.value)
     end
 
     scenario "a non-ODA activity can be created" do
@@ -270,6 +276,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.policy_marker_disability).to be_nil
       expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
       expect(created_activity.policy_marker_nutrition).to be_nil
+      expect(created_activity.commitment.value).to eq(non_oda_activity.commitment.value)
     end
 
     context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can create a project" do
         programme = create(:programme_activity, :newton_funded, extending_organisation: user.organisation)
         report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
 
-        activity = build(:project_activity, :newton_funded,
+        activity = build(:project_activity, :newton_funded, :with_commitment,
           country_partner_organisations: ["National Council for the State Funding Agencies (CONFAP)"],
           benefitting_countries: ["AG", "HT"],
           sdgs_apply: true,
@@ -75,12 +75,14 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to be_none
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       scenario "a new project can be added to an ISPF ODA programme" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation)
         report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
         activity = build(:project_activity,
+          :with_commitment,
           parent: programme,
           is_oda: true,
           ispf_oda_partner_countries: ["IN"],
@@ -146,12 +148,14 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.tags).to eq(activity.tags)
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       scenario "a new project can be added to an ISPF non-ODA programme" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation, is_oda: false)
         report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
         activity = build(:project_activity,
+          :with_commitment,
           parent: programme,
           is_oda: false,
           ispf_non_oda_partner_countries: ["IN"],
@@ -211,6 +215,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.policy_marker_disability).to be_nil
         expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
         expect(created_activity.policy_marker_nutrition).to be_nil
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       context "when the `activity_linking` feature flag is enabled" do
@@ -229,12 +234,11 @@ RSpec.feature "Users can create a project" do
             is_oda: true,
             ispf_themes: [1],
             extending_organisation: user.organisation)
-
           non_oda_programme = create(:programme_activity, :ispf_funded,
             is_oda: false,
             linked_activity: oda_programme,
             extending_organisation: user.organisation)
-          non_oda_project = build(:project_activity, :ispf_funded,
+          non_oda_project = build(:project_activity, :ispf_funded, :with_commitment,
             parent: non_oda_programme,
             is_oda: false,
             linked_activity_id: oda_project.id,

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can create a third-party project" do
         project = create(:project_activity, :gcrf_funded, organisation: user.organisation, extending_organisation: user.organisation, parent: programme)
         _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
 
-        activity = build(:third_party_project_activity, :gcrf_funded,
+        activity = build(:third_party_project_activity, :gcrf_funded, :with_commitment,
           country_partner_organisations: ["National Council for the State Funding Agencies (CONFAP)"],
           benefitting_countries: ["AG", "HT"],
           sdgs_apply: true,
@@ -76,6 +76,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
         expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       scenario "a new third party project can be added to an ISPF ODA project" do
@@ -92,6 +93,7 @@ RSpec.feature "Users can create a third-party project" do
         implementing_organisation = create(:implementing_organisation)
 
         activity = build(:third_party_project_activity,
+          :with_commitment,
           parent: project,
           is_oda: true,
           ispf_oda_partner_countries: ["IN"],
@@ -156,6 +158,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
         expect(created_activity.tags).to eq(activity.tags)
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       scenario "a new third party project can be added to an ISPF non-ODA project" do
@@ -172,6 +175,7 @@ RSpec.feature "Users can create a third-party project" do
         implementing_organisation = create(:implementing_organisation)
 
         activity = build(:third_party_project_activity,
+          :with_commitment,
           parent: project,
           is_oda: false,
           ispf_non_oda_partner_countries: ["IN"],
@@ -230,6 +234,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.policy_marker_disability).to be_nil
         expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
         expect(created_activity.policy_marker_nutrition).to be_nil
+        expect(created_activity.commitment.value).to eq(activity.commitment.value)
       end
 
       context "when the `activity_linking` feature flag is enabled" do
@@ -267,8 +272,8 @@ RSpec.feature "Users can create a third-party project" do
             extending_organisation: user.organisation,
             linked_activity: non_oda_project,
             ispf_themes: [1])
-
           oda_3rdp_project = build(:third_party_project_activity,
+            :with_commitment,
             parent: oda_project,
             is_oda: true,
             linked_activity_id: non_oda_3rdp_project.id,

--- a/spec/helpers/commitment_helper_spec.rb
+++ b/spec/helpers/commitment_helper_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe CommitmentHelper, type: :helper do
+  describe "#infer_transaction_date_from_activity_attributes" do
+    context "when the specified activity has a `planned_start_date`" do
+      let(:activity) { build(:project_activity, planned_start_date: "2023-02-20") }
+
+      it "returns the planned start date" do
+        expect(
+          helper.infer_transaction_date_from_activity_attributes(activity)
+        ).to eq(activity.planned_start_date)
+      end
+    end
+
+    context "when the specified activity has an `actual_start_date` with no `planned_start_date`" do
+      let(:activity) {
+        build(:project_activity, planned_start_date: nil, actual_start_date: "2023-02-20")
+      }
+
+      it "returns the actual start date" do
+        expect(
+          helper.infer_transaction_date_from_activity_attributes(activity)
+        ).to eq(activity.actual_start_date)
+      end
+    end
+
+    context "when the specified activity unexpectedly has neither `actual_start_date` nor `planned_start_date`" do
+      let(:activity) {
+        build(
+          :project_activity,
+          planned_start_date: nil,
+          actual_start_date: nil,
+          created_at: Time.zone.parse("21-Feb-2023 12:08:00")
+        )
+      }
+
+      it "returns the date the activity was created" do
+        expect(
+          helper.infer_transaction_date_from_activity_attributes(activity)
+        ).to eq(activity.created_at.to_date)
+      end
+    end
+  end
+end

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -901,4 +901,22 @@ RSpec.describe ActivityPresenter do
       expect(described_class.new(activity).total_forecasted).to eq("£50.00")
     end
   end
+
+  describe "#commitment" do
+    context "when the activity has a commitment" do
+      let(:activity) { build(:programme_activity, commitment: build(:commitment)) }
+
+      it "returns a CommitmentPresenter" do
+        expect(described_class.new(activity).commitment).to be_a(CommitmentPresenter)
+      end
+    end
+
+    context "when the activity has no commitment" do
+      let(:activity) { build(:programme_activity, commitment: nil) }
+
+      it "returns nil" do
+        expect(described_class.new(activity).commitment).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/activity/updater_spec.rb
+++ b/spec/services/activity/updater_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Activity::Updater do
+  subject(:updater) { Activity::Updater.new(activity: activity, params: params) }
+
+  describe "#update" do
+    describe "setting a commitment" do
+      let(:activity) { build(:programme_activity) }
+
+      before { activity.build_commitment }
+
+      context "with valid params" do
+        let(:params) {
+          ActionController::Parameters.new({
+            "activity" => {
+              "commitment" => {"value" => "1000"},
+              "activity_id" => activity.id
+            }
+          })
+        }
+
+        it "sets the commitment on an activity" do
+          updater.update(:commitment)
+
+          expect(activity.commitment.value).to eq(1000)
+          expect(activity.commitment.transaction_date).to eq(activity.planned_start_date)
+        end
+      end
+
+      context "with invalid params" do
+        let(:activity) { build(:programme_activity) }
+
+        let(:params) {
+          ActionController::Parameters.new({
+            "activity" => {
+              "commitment" => {"value" => "I'm not valid!"},
+              "activity_id" => activity.id
+            }
+          })
+        }
+
+        before do
+          updater.update(:commitment)
+          activity.build_commitment
+        end
+
+        it "swallows the error and adds it to the activity's errors" do
+          expect(activity.errors.full_messages.first).to eq(
+            "Value Validation failed: Value Value is not a number"
+          )
+        end
+
+        it "does not set the value or transaction date on the commitment" do
+          expect(activity.commitment.value).to be_nil
+          expect(activity.commitment.transaction_date).to be_nil
+          expect(activity.commitment).not_to be_persisted
+        end
+      end
+    end
+  end
+end

--- a/spec/services/activity/updater_spec.rb
+++ b/spec/services/activity/updater_spec.rb
@@ -56,6 +56,46 @@ RSpec.describe Activity::Updater do
           expect(activity.commitment).not_to be_persisted
         end
       end
+
+      ["programme", "project"].each do |level|
+        context "when it's a #{level}" do
+          let(:activity) { build("#{level}_activity".to_sym, commitment: Commitment.new) }
+
+          let(:params) {
+            ActionController::Parameters.new({
+              "activity" => {
+                "commitment" => {"value" => ""},
+                "activity_id" => activity.id
+              }
+            })
+          }
+
+          it "doesn't throw an error with an empty commitment value" do
+            updater.update(:commitment)
+
+            expect(activity.errors.full_messages).to be_empty
+          end
+        end
+      end
+
+      context "when it's a third-party project" do
+        let(:activity) { build(:third_party_project_activity, commitment: Commitment.new) }
+
+        let(:params) {
+          ActionController::Parameters.new({
+            "activity" => {
+              "commitment" => {"value" => ""},
+              "activity_id" => activity.id
+            }
+          })
+        }
+
+        it "throws an error with an empty commitment value" do
+          updater.update(:commitment)
+
+          expect(activity.errors.full_messages.first).to include("Value Validation failed: Value Value can't be blank")
+        end
+      end
     end
   end
 end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -38,6 +38,7 @@ class ActivityForm
     fill_in_gcrf_strategic_area
     fill_in_gcrf_challenge_area
     fill_in_oda_eligibility
+    fill_in_commitment
   end
 
   def fill_in_newton_programme_activity_form
@@ -57,6 +58,7 @@ class ActivityForm
     fill_in_fund_pillar
     fill_in_covid19_related
     fill_in_oda_eligibility
+    fill_in_commitment
   end
 
   def fill_in_ooda_programme_activity_form
@@ -74,6 +76,7 @@ class ActivityForm
     fill_in_sdgs_apply
     fill_in_covid19_related
     fill_in_oda_eligibility
+    fill_in_commitment
   end
 
   def fill_in_gcrf_project_activity_form
@@ -99,6 +102,7 @@ class ActivityForm
     fill_in_oda_eligibility
     fill_in_oda_eligibility_lead
     fill_in_named_contact
+    fill_in_commitment
   end
 
   def fill_in_newton_project_activity_form
@@ -124,6 +128,7 @@ class ActivityForm
     fill_in_oda_eligibility
     fill_in_oda_eligibility_lead
     fill_in_named_contact
+    fill_in_commitment
   end
 
   def fill_in_ispf_programme_activity_form
@@ -148,6 +153,7 @@ class ActivityForm
     fill_in_ispf_themes
     fill_in_oda_eligibility if @activity.is_oda
     fill_in_tags
+    fill_in_commitment
   end
 
   def fill_in_ispf_project_activity_form
@@ -184,6 +190,7 @@ class ActivityForm
     fill_in_named_contact
     fill_in_implementing_organisation if @activity.third_party_project?
     fill_in_tags
+    fill_in_commitment
   end
 
   def fill_in_is_oda_step
@@ -501,6 +508,12 @@ class ActivityForm
     activity.tags&.each do |tag|
       find("input[value='#{tag}']", visible: :all).click
     end
+    click_button I18n.t("form.button.activity.submit")
+  end
+
+  def fill_in_commitment
+    expect(page).to have_content I18n.t("page_title.activity_form.show.commitment")
+    fill_in "activity[commitment][value]", with: activity.commitment.value
     click_button I18n.t("form.button.activity.submit")
   end
 end

--- a/spec/support/activity_form.rb
+++ b/spec/support/activity_form.rb
@@ -512,7 +512,8 @@ class ActivityForm
   end
 
   def fill_in_commitment
-    expect(page).to have_content I18n.t("page_title.activity_form.show.commitment")
+    optional = activity.third_party_project? ? "" : " (optional)"
+    expect(page).to have_content I18n.t("page_title.activity_form.show.commitment", optional: optional)
     fill_in "activity[commitment][value]", with: activity.commitment.value
     click_button I18n.t("form.button.activity.submit")
   end


### PR DESCRIPTION
## Changes in this PR

**Note: currently based off unmerged branch in #2030 so for the purposes of reviewing this, start at [90c8352](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2040/commits/90c8352e2b5d561c2124b821d97245c87d64c9a8)**

Adds new Original Commitment Figure page to the new activity journey. This is optional at levels B and C but required at level D.

## Screenshots of UI changes

### After

#### New form step

<img width="945" alt="image" src="https://user-images.githubusercontent.com/19826940/221250550-8496f416-fb25-4639-8d39-702a716b8eb1.png">


#### New form step with errors (need to fix breadcrumbs disappearing)

<img width="936" alt="image" src="https://user-images.githubusercontent.com/19826940/221250492-63b2fb90-d0bb-496a-a8f7-ab650a474a20.png">

#### Viewing in activity details

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/19826940/221250694-da022b8b-b9a6-4d46-904c-730df2e15f69.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
