### PR TITLE
(2827b) collect original commitment figure form

### DIFF
--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -101,9 +101,6 @@ class ActivityFormsController < BaseController
         @implementing_organisations = Organisation.active.sorted_by_name
         render_step :implementing_organisation
       when :commitment
-        value = params.require(:activity).require(:commitment).fetch(:value, nil)
-
-        @activity.create_commitment(value: value)
         render_step :commitment
       end
 

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -169,7 +169,7 @@ class Activity
     def set_commitment
       value = activity_params.require(:commitment).fetch(:value, nil)
 
-      activity.commitment = Commitment.new(
+      activity.build_commitment(
         value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
       )
       activity.commitment.save!


### PR DESCRIPTION
I've made some slight changes, simplifying things and avoiding the repeated building/creation. Testing in the UI, it looks like all the errors appear as expected

I noticed if I put a `binding.pry` after the `activity.commitment = Commitment.new` lines, it wouldn't actually reach the next part (the `.save!` line) in some invalid data cases, whereas doing it this way (with `.build_commitment`) it does. I guess that method failed (silently?) and that's why in the controller you had to build/create it again (because the first time didn't work at all)