### PR TITLE
(2826) Make ODA-only fields blank for non-ODA activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1205,15 +1205,16 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Fix the display of successfully uploaded forecasts for the cases when:
   - the original forecast is deleted
   - the imported values were already in the report
-- Omit legacy fields for ISPF activities on the "details" page.
-- Remove legacy fields from ISPF reports.
+- Omit legacy fields for ISPF activities on the "details" page
+- Remove legacy fields from ISPF reports
 - Only generate IATI identifiers for ODA activities
 - Remove reference to truncating data published to Statistics in International Development for non-ODA activities
 - Hide IATI identifier and "Include in IATI XML export?" fields on activity details tab for non-ODA activities
-- Remove ODA fields from the non-ODA CSV upload template.
-- Move the comments column to the end of all the CSV templates.
+- Remove ODA fields from the non-ODA CSV upload template
+- Move the comments column to the end of all the CSV templates
 - Make error messages clearer when importing actuals and refunds
 - Fix login issues after running the training database sync script by clearing remember tokens during password reset step and clearing sessions as an additional step
+- ODA only attributes are blank on non-ODA activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -372,11 +372,11 @@ class Activity < ApplicationRecord
   end
 
   def finance
-    STANDARD_GRANT_FINANCE_CODE
+    STANDARD_GRANT_FINANCE_CODE unless is_non_oda?
   end
 
   def tied_status
-    UNTIED_TIED_STATUS_CODE
+    UNTIED_TIED_STATUS_CODE unless is_non_oda?
   end
 
   def capital_spend
@@ -384,7 +384,7 @@ class Activity < ApplicationRecord
   end
 
   def flow
-    DEFAULT_FLOW_TYPE
+    DEFAULT_FLOW_TYPE unless is_non_oda?
   end
 
   def default_currency

--- a/app/presenters/activity_csv_presenter.rb
+++ b/app/presenters/activity_csv_presenter.rb
@@ -54,6 +54,8 @@ class ActivityCsvPresenter < ActivityPresenter
   end
 
   def fstc_applies
+    return if super.nil? && is_non_oda?
+
     (super) ? "yes" : "no"
   end
 
@@ -70,14 +72,20 @@ class ActivityCsvPresenter < ActivityPresenter
   end
 
   def flow
+    return nil if to_model.flow.nil?
+
     "#{to_model.flow}: #{super}"
   end
 
   def finance
+    return nil if to_model.finance.nil?
+
     "#{to_model.finance}: #{super}"
   end
 
   def tied_status
+    return nil if to_model.tied_status.nil?
+
     "#{to_model.tied_status}: #{super}"
   end
 

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -28,6 +28,8 @@ class ActivityPresenter < SimpleDelegator
   end
 
   def covid19_related
+    return if super.nil?
+
     translate("activity.covid19_related.#{super}")
   end
 

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -32,8 +32,6 @@ class Activity
 
     def set_is_oda
       if params_for("is_oda") == "false"
-        activity.assign_attributes(transparency_identifier: nil)
-
         activity.assign_attributes(roda_identifier: "NODA-#{activity.roda_identifier}")
       end
       assign_attributes_for_step("is_oda")

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -32,6 +32,8 @@ class Activity
 
     def set_is_oda
       if params_for("is_oda") == "false"
+        activity.assign_attributes(transparency_identifier: nil)
+
         activity.assign_attributes(roda_identifier: "NODA-#{activity.roda_identifier}")
       end
       assign_attributes_for_step("is_oda")

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -85,8 +85,6 @@ class ActivityDefaults
   end
 
   def transparency_identifier
-    return nil if is_oda? == false
-
     [
       Organisation::SERVICE_OWNER_IATI_REFERENCE,
       roda_identifier

--- a/db/migrate/20230227114720_make_activity_oda_eligibility_nullable.rb
+++ b/db/migrate/20230227114720_make_activity_oda_eligibility_nullable.rb
@@ -1,0 +1,5 @@
+class MakeActivityOdaEligibilityNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :activities, :oda_eligibility, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_25_115632) do
+ActiveRecord::Schema.define(version: 2023_02_27_114720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2023_01_25_115632) do
     t.integer "total_applications"
     t.integer "total_awards"
     t.string "collaboration_type"
-    t.integer "oda_eligibility", default: 1, null: false
+    t.integer "oda_eligibility", default: 1
     t.boolean "fstc_applies"
     t.integer "policy_marker_gender", default: 1000
     t.integer "policy_marker_climate_change_adaptation", default: 1000

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -255,10 +255,21 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_non_oda_partner_countries).to match_array(non_oda_activity.ispf_non_oda_partner_countries)
       expect(created_activity.ispf_themes).to eq(non_oda_activity.ispf_themes)
       expect(created_activity.tags).to eq(non_oda_activity.tags)
-      expect(created_activity.transparency_identifier).to be_nil
       expect(created_activity.finance).to be_nil
       expect(created_activity.tied_status).to be_nil
       expect(created_activity.flow).to be_nil
+      expect(created_activity.transparency_identifier).to be_nil
+      expect(created_activity.oda_eligibility).to be_nil
+      expect(created_activity.fstc_applies).to be_nil
+      expect(created_activity.covid19_related).to be_nil
+      expect(created_activity.policy_marker_gender).to be_nil
+      expect(created_activity.policy_marker_climate_change_adaptation).to be_nil
+      expect(created_activity.policy_marker_climate_change_mitigation).to be_nil
+      expect(created_activity.policy_marker_biodiversity).to be_nil
+      expect(created_activity.policy_marker_desertification).to be_nil
+      expect(created_activity.policy_marker_disability).to be_nil
+      expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
+      expect(created_activity.policy_marker_nutrition).to be_nil
     end
 
     scenario "a new non-ODA programme can be linked to an existing ODA programme" do

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -255,6 +255,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_non_oda_partner_countries).to match_array(non_oda_activity.ispf_non_oda_partner_countries)
       expect(created_activity.ispf_themes).to eq(non_oda_activity.ispf_themes)
       expect(created_activity.tags).to eq(non_oda_activity.tags)
+      expect(created_activity.transparency_identifier).to be_nil
     end
 
     scenario "a new non-ODA programme can be linked to an existing ODA programme" do

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -256,6 +256,9 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.ispf_themes).to eq(non_oda_activity.ispf_themes)
       expect(created_activity.tags).to eq(non_oda_activity.tags)
       expect(created_activity.transparency_identifier).to be_nil
+      expect(created_activity.finance).to be_nil
+      expect(created_activity.tied_status).to be_nil
+      expect(created_activity.flow).to be_nil
     end
 
     scenario "a new non-ODA programme can be linked to an existing ODA programme" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -197,6 +197,9 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.transparency_identifier).to be_nil
+        expect(created_activity.finance).to be_nil
+        expect(created_activity.tied_status).to be_nil
+        expect(created_activity.flow).to be_nil
       end
 
       scenario "a non-ODA project can be linked to an existing ODA project" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -196,10 +196,21 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.tags).to eq(activity.tags)
-        expect(created_activity.transparency_identifier).to be_nil
         expect(created_activity.finance).to be_nil
         expect(created_activity.tied_status).to be_nil
         expect(created_activity.flow).to be_nil
+        expect(created_activity.transparency_identifier).to be_nil
+        expect(created_activity.oda_eligibility).to be_nil
+        expect(created_activity.fstc_applies).to be_nil
+        expect(created_activity.covid19_related).to be_nil
+        expect(created_activity.policy_marker_gender).to be_nil
+        expect(created_activity.policy_marker_climate_change_adaptation).to be_nil
+        expect(created_activity.policy_marker_climate_change_mitigation).to be_nil
+        expect(created_activity.policy_marker_biodiversity).to be_nil
+        expect(created_activity.policy_marker_desertification).to be_nil
+        expect(created_activity.policy_marker_disability).to be_nil
+        expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
+        expect(created_activity.policy_marker_nutrition).to be_nil
       end
 
       scenario "a non-ODA project can be linked to an existing ODA project" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -196,6 +196,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.tags).to eq(activity.tags)
+        expect(created_activity.transparency_identifier).to be_nil
       end
 
       scenario "a non-ODA project can be linked to an existing ODA project" do

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -215,6 +215,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
         expect(created_activity.tags).to eq(activity.tags)
+        expect(created_activity.transparency_identifier).to be_nil
       end
 
       scenario "an ODA third-party project can be linked to an existing non-ODA third-party project" do

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -216,6 +216,9 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.transparency_identifier).to be_nil
+        expect(created_activity.finance).to be_nil
+        expect(created_activity.tied_status).to be_nil
+        expect(created_activity.flow).to be_nil
       end
 
       scenario "an ODA third-party project can be linked to an existing non-ODA third-party project" do

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -215,10 +215,21 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
         expect(created_activity.tags).to eq(activity.tags)
-        expect(created_activity.transparency_identifier).to be_nil
         expect(created_activity.finance).to be_nil
         expect(created_activity.tied_status).to be_nil
         expect(created_activity.flow).to be_nil
+        expect(created_activity.transparency_identifier).to be_nil
+        expect(created_activity.oda_eligibility).to be_nil
+        expect(created_activity.fstc_applies).to be_nil
+        expect(created_activity.covid19_related).to be_nil
+        expect(created_activity.policy_marker_gender).to be_nil
+        expect(created_activity.policy_marker_climate_change_adaptation).to be_nil
+        expect(created_activity.policy_marker_climate_change_mitigation).to be_nil
+        expect(created_activity.policy_marker_biodiversity).to be_nil
+        expect(created_activity.policy_marker_desertification).to be_nil
+        expect(created_activity.policy_marker_disability).to be_nil
+        expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
+        expect(created_activity.policy_marker_nutrition).to be_nil
       end
 
       scenario "an ODA third-party project can be linked to an existing non-ODA third-party project" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -22,16 +22,38 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "#finance" do
-    it "always returns Standard Grant, code '110'" do
-      activity = Activity.new
-      expect(activity.finance).to eq "110"
+    let(:activity) { Activity.new }
+
+    subject { activity.finance }
+
+    it "returns Standard Grant, code '110'" do
+      expect(subject).to eq "110"
+    end
+
+    context "when non-ODA" do
+      before { activity.is_oda = false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
     end
   end
 
   describe "#tied_status" do
-    it "always returns Untied, code '5'" do
-      activity = Activity.new
-      expect(activity.tied_status).to eq "5"
+    let(:activity) { Activity.new }
+
+    subject { activity.tied_status }
+
+    it "returns Untied, code '5'" do
+      expect(subject).to eq "5"
+    end
+
+    context "when non-ODA" do
+      before { activity.is_oda = false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
     end
   end
 
@@ -43,9 +65,20 @@ RSpec.describe Activity, type: :model do
   end
 
   describe "#flow" do
-    it "always returns the default ODA flow type, code '10'" do
-      activity = Activity.new
-      expect(activity.flow).to eq "10"
+    let(:activity) { Activity.new }
+
+    subject { activity.flow }
+
+    it "returns the default ODA flow type, code '10'" do
+      expect(subject).to eq "10"
+    end
+
+    context "when non-ODA" do
+      before { activity.is_oda = false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -170,6 +170,34 @@ RSpec.describe Activity, type: :model do
     it { should strip_attribute(:partner_organisation_identifier) }
   end
 
+  describe "callbacks" do
+    describe "#set_non_oda_defaults" do
+      let(:activity) { create(:programme_activity, :ispf_funded) }
+
+      context "when is_oda has changed to false" do
+        before do
+          activity.is_oda = false
+          activity.save
+        end
+
+        it "sets ODA only attributes to nil" do
+          expect(activity.transparency_identifier).to be_nil
+          expect(activity.oda_eligibility).to be_nil
+          expect(activity.fstc_applies).to be_nil
+          expect(activity.covid19_related).to be_nil
+          expect(activity.policy_marker_gender).to be_nil
+          expect(activity.policy_marker_climate_change_adaptation).to be_nil
+          expect(activity.policy_marker_climate_change_mitigation).to be_nil
+          expect(activity.policy_marker_biodiversity).to be_nil
+          expect(activity.policy_marker_desertification).to be_nil
+          expect(activity.policy_marker_disability).to be_nil
+          expect(activity.policy_marker_disaster_risk_reduction).to be_nil
+          expect(activity.policy_marker_nutrition).to be_nil
+        end
+      end
+    end
+  end
+
   describe "validations" do
     it { should validate_attribute(:planned_start_date).with(:date_within_boundaries) }
     it { should validate_attribute(:planned_end_date).with(:date_within_boundaries) }

--- a/spec/presenters/activity_csv_presenter_spec.rb
+++ b/spec/presenters/activity_csv_presenter_spec.rb
@@ -22,31 +22,64 @@ RSpec.describe ActivityCsvPresenter do
   end
 
   describe "#flow" do
+    let(:is_oda) { true }
+    let(:activity) { build(:project_activity, is_oda: is_oda) }
+
+    subject { described_class.new(activity).flow }
+
+    context "when activity is non-ODA" do
+      let(:is_oda) { false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
     context "when there is a non-empty flow" do
       it "returns 'flow code: description'" do
-        activity = build(:project_activity)
-        result = described_class.new(activity).flow
-        expect(result).to eq("10: ODA")
+        expect(subject).to eq("10: ODA")
       end
     end
   end
 
   describe "#finance" do
+    let(:is_oda) { true }
+    let(:activity) { build(:project_activity, is_oda: is_oda) }
+
+    subject { described_class.new(activity).finance }
+
+    context "when activity is non-ODA" do
+      let(:is_oda) { false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
     context "when there is a non-empty finance" do
       it "returns 'finance code: description'" do
-        activity = build(:project_activity)
-        result = described_class.new(activity).finance
-        expect(result).to eq("110: Standard grant")
+        expect(subject).to eq("110: Standard grant")
       end
     end
   end
 
   describe "#tied_status" do
+    let(:is_oda) { true }
+    let(:activity) { build(:project_activity, is_oda: is_oda) }
+
+    subject { described_class.new(activity).tied_status }
+
+    context "when activity is non-ODA" do
+      let(:is_oda) { false }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
     context "when there is a non-empty tied status" do
       it "returns 'tied status code: description'" do
-        activity = build(:project_activity)
-        result = described_class.new(activity).tied_status
-        expect(result).to eq("5: Untied")
+        expect(subject).to eq("5: Untied")
       end
     end
   end
@@ -186,14 +219,35 @@ RSpec.describe ActivityCsvPresenter do
   end
 
   describe "#fstc_applies" do
-    it "returns yes or no" do
-      activity = build(:project_activity, fstc_applies: true)
+    let(:fstc_applies) { true }
+    let(:is_oda) { nil }
+    let(:activity) { build(:project_activity, fstc_applies: fstc_applies, is_oda: is_oda) }
 
-      expect(described_class.new(activity).fstc_applies).to eq "yes"
+    subject { described_class.new(activity).fstc_applies }
 
-      activity = build(:project_activity, fstc_applies: false)
+    context "when super is nil and activity is non-ODA" do
+      let(:fstc_applies) { nil }
+      let(:is_oda) { false }
 
-      expect(described_class.new(activity).fstc_applies).to eq "no"
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when fstc_applies is true" do
+      let(:fstc_applies) { true }
+
+      it "returns yes" do
+        expect(subject).to eq "yes"
+      end
+    end
+
+    context "when fstc_applies is false" do
+      let(:fstc_applies) { false }
+
+      it "returns no" do
+        expect(subject).to eq "no"
+      end
     end
   end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -172,10 +172,21 @@ RSpec.describe ActivityPresenter do
   describe "#covid19_related" do
     it_behaves_like "a code translator", "covid19_related", {type: "covid19_related_research", source: "beis"}
 
+    let(:covid19_related) { 3 }
+    let(:activity) { build(:project_activity, covid19_related: covid19_related) }
+
+    subject { described_class.new(activity).covid19_related }
+
+    context "when the super value is nil" do
+      let(:covid19_related) { nil }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
     it "returns the locale value for the code" do
-      activity = build(:project_activity, covid19_related: 3)
-      result = described_class.new(activity).covid19_related
-      expect(result).to eql("New activity that will somewhat focus on COVID-19")
+      expect(subject).to eql("New activity that will somewhat focus on COVID-19")
     end
   end
 

--- a/spec/services/activity_defaults_spec.rb
+++ b/spec/services/activity_defaults_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ActivityDefaults do
 
     subject { activity_defaults.call }
 
-    describe "`is_oda` and `transparency_identifier`" do
+    describe "is_oda" do
       let(:parent_activity) { create(:programme_activity, :ispf_funded) }
 
       context "when activity is ODA" do
@@ -46,10 +46,6 @@ RSpec.describe ActivityDefaults do
         it "sets is_oda to true" do
           expect(subject[:is_oda]).to be true
         end
-
-        it "sets the transparency_identifier" do
-          expect(subject[:transparency_identifier]).to eq expected_transparency_identifier
-        end
       end
 
       context "when activity is not ODA" do
@@ -57,10 +53,6 @@ RSpec.describe ActivityDefaults do
 
         it "sets is_oda to false" do
           expect(subject[:is_oda]).to be false
-        end
-
-        it "sets the transparency_identifier to nil" do
-          expect(subject[:transparency_identifier]).to be_nil
         end
       end
 
@@ -73,10 +65,6 @@ RSpec.describe ActivityDefaults do
           it "sets is_oda to true" do
             expect(subject[:is_oda]).to be true
           end
-
-          it "sets the transparency_identifier" do
-            expect(subject[:transparency_identifier]).to eq expected_transparency_identifier
-          end
         end
 
         context "when parent activity is not ODA" do
@@ -85,10 +73,6 @@ RSpec.describe ActivityDefaults do
           it "sets is_oda to false" do
             expect(subject[:is_oda]).to be false
           end
-
-          it "sets the transparency_identifier to nil" do
-            expect(subject[:transparency_identifier]).to be_nil
-          end
         end
 
         context "when parent activity `is_oda` is nil" do
@@ -96,10 +80,6 @@ RSpec.describe ActivityDefaults do
 
           it "sets is_oda to nil" do
             expect(subject[:is_oda]).to be nil
-          end
-
-          it "sets the transparency_identifier" do
-            expect(subject[:transparency_identifier]).to eq expected_transparency_identifier
           end
         end
       end


### PR DESCRIPTION
> I did a lot of thinking about where to place the nullifying of the attributes. I ended up putting them in a before_save > callback. Happy to hear any better ideas. My thinking:
> 1. They can't go in the ActivityDefaults class because that is only applied to new activities. We don't want to apply this class to existing activities because it has some new activity only logic.
> 2. We could create a new NonOdaDefaults class, but then we have to be careful to apply it everywhere + it won't actually do much, it will only set some attributes to nil.
> 3. Even though the Activity class is large, I think there is stuff that is less-related than this that could be moved into another class potentially.
> 4. I've nullified the non-persisted defaults here, so it's nice that they are in the same place. 

## Changes in this PR
### Make sure the transparency indicator is nil for all non-ODA activities
Currently, the transparency indicator is set as `nil` in the ActivityDefaults
class.

However, these defaults are only applied to activities at the start of the UI
wizard, or through the import function.

This means that non-ODA activities that are created via the UI that do not have
a non-ODA parent, will have a transparency indicator. 

To fix, apply the defaults once non-ODA is selected as part of the wizard
journey as well.

### Update non-persisted defaults when activity is non-ODA
These defaults should be null is the activity is non-ODA.

### Make ODA activity eligibility column nullable
ODA eligibility should be null if the activity is non-ODA.

Make the column nullable. 

### Nullify activity columns when activity is non-ODA
Certain columns should be null when an activity is non-ODA.

An activity can be created as non-ODA if it's parent activity is non-ODA, or if
it created through the import function, but can also change to non-ODA as part
of the UI wizard.

Add a before_save callback which sets any ODA-only attributes to nil when
is_oda is false, and the is_oda value has changed.

This also moves the nullification of transparency identifier to the model along
with the other null attributes.

### Update presenters for when non-ODA activities have nil attributes
The presenters don't currently handle when some of the activity attributes are
nil.

Now that these can be nil for the non-ODA activities, update them.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
