### PR TITLE
Fix Gemfile.lock Ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,7 +585,7 @@ DEPENDENCIES
   wicked
 
 RUBY VERSION
-   ruby 3.1.3p185
+   ruby 3.0.5p211
 
 BUNDLED WITH
    2.3.9


### PR DESCRIPTION
## Changes in this PR

When rolling back from 3.1.3 to 3.0.5, the Gemfile.lock didn't update its record of the Ruby version. This fixes that

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
