### PR TITLE
[2831a] Add transaction date to commitments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1218,6 +1218,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Add a feature flag to enable/disable the linked activities feature
 - Hardcode budget IATI status as "Indicative" (previously "Committed")
 - Fix error when submitting an invalid "purpose" step
+- Refactor Commitments:
+  - Add `transaction_date` field to be used in place of Financial Year and Quarter
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/db/data/20230220095332_set_transaction_date_on_commitments.rb
+++ b/db/data/20230220095332_set_transaction_date_on_commitments.rb
@@ -1,0 +1,14 @@
+# Run me with `rails runner db/data/20230220095332_set_transaction_date_on_commitments.rb`
+
+commitments_to_update = Commitment.where(transaction_date: nil)
+
+puts "Setting transaction date on #{commitments_to_update.count} Commitments"
+
+commitments_to_update.each do |commitment|
+  commitment.update(transaction_date: commitment.first_day_of_financial_period)
+  print "."
+end
+
+commitments_to_update.reload
+
+puts "\nThere are now #{commitments_to_update.count} commitments with no transaction date"

--- a/db/migrate/20230220094559_add_transaction_date_to_commitments.rb
+++ b/db/migrate/20230220094559_add_transaction_date_to_commitments.rb
@@ -1,0 +1,5 @@
+class AddTransactionDateToCommitments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :commitments, :transaction_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2023_02_27_114720) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "financial_quarter"
     t.integer "financial_year"
+    t.date "transaction_date"
     t.index ["activity_id"], name: "index_commitments_on_activity_id", unique: true
   end
 


### PR DESCRIPTION
## Changes in this PR

*Part 1 of 2*: We'll be running the migration script before merging the second PR #2030 which will update the codebase to reference the new field

This adds a `transaction_date` field to commitments that will be used instead of the Financial Year and Quarter, as well as a script that will populate this value from the current Financial Year and Quarter for existing Commitments.

New activities will, in future, use the planned start date or actual start date for their transaction date.

## Next steps

- [ ] Run `db/data/20230220095332_set_transaction_date_on_commitments.rb` on deployed environment
- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
