### PR TITLE
(2844) Fix missing presenter when step is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1217,6 +1217,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - ODA only attributes are blank on non-ODA activities
 - Add a feature flag to enable/disable the linked activities feature
 - Hardcode budget IATI status as "Indicative" (previously "Committed")
+- Fix error when submitting an invalid "purpose" step
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...HEAD
 [release-130]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-129...release-130

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -22,8 +22,6 @@ class ActivityFormsController < BaseController
     when :linked_activity
       skip_step unless policy(@activity).update_linked_activity?
       @options = linkable_activities_options(@activity)
-    when :purpose
-      @activity_presenter = ActivityPresenter.new(@activity)
     when :objectives
       skip_step unless @activity.requires_objectives?
     when :call_present

--- a/app/views/activity_forms/purpose.html.haml
+++ b/app/views/activity_forms/purpose.html.haml
@@ -1,10 +1,11 @@
 = render layout: "wrapper" do |f|
+  - activity_presenter = ActivityPresenter.new(@activity)
   = f.govuk_fieldset legend: { text: @page_title, tag: :h1, size: "xl" } do
     = f.govuk_text_field :title,
       label: { text: t("form.label.activity.title", level: custom_capitalisation(t("page_content.activity.level.#{f.object.level}"))) },
-      hint: { text: @activity_presenter.title_hint }
+      hint: { text: activity_presenter.title_hint }
 
     = f.govuk_text_area :description,
                         rows: 5,
-                        hint: { text: @activity_presenter.description_hint }
+                        hint: { text: activity_presenter.description_hint }
 


### PR DESCRIPTION

## Changes in this PR
### Fix missing presenter when step is invalid
Currently, when the purpose step is invalid, the view is re-rendered without
an instance of ActivityPresenter, leading to an error.

This moves the instantiation of the presenter to the view so that it is
available for both steps.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
