### PR TITLE
(2834) Set `publish_to_iati` to `false` on non-ODA activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1227,6 +1227,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Collect original commitment figure in new activity form and bulk activity upload
 - Remove password reset field from new user form
 - Fix an accessibility issue on the Organisations page
+- Set `publish_to_iati` to `false` for non-ODA activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -700,7 +700,7 @@ class Activity < ApplicationRecord
   private
 
   def set_non_oda_defaults
-    defaults = ODA_ONLY_ATTRIBUTES.to_h { |attribute| [attribute, nil] }
+    defaults = ODA_ONLY_ATTRIBUTES.to_h { |attribute| [attribute, nil] }.merge(publish_to_iati: false)
     assign_attributes(defaults)
   end
 

--- a/app/services/find_programme_activities.rb
+++ b/app/services/find_programme_activities.rb
@@ -1,20 +1,16 @@
 class FindProgrammeActivities
   include Pundit::Authorization
 
-  attr_accessor :organisation, :user, :fund_code, :include_ispf_non_oda_activities
+  attr_accessor :organisation, :user, :fund_code
 
-  def initialize(organisation:, user:, fund_code: nil, include_ispf_non_oda_activities: false)
+  def initialize(organisation:, user:, fund_code: nil)
     @organisation = organisation
     @user = user
     @fund_code = fund_code
-    @include_ispf_non_oda_activities = include_ispf_non_oda_activities
   end
 
   def call
-    is_oda = [nil, true]
-    is_oda << false if include_ispf_non_oda_activities
-
-    programmes = ProgrammePolicy::Scope.new(user, Activity.programme.where(is_oda: is_oda))
+    programmes = ProgrammePolicy::Scope.new(user, Activity.programme)
       .resolve
       .includes(
         :organisation,

--- a/app/services/find_project_activities.rb
+++ b/app/services/find_project_activities.rb
@@ -1,13 +1,12 @@
 class FindProjectActivities
   include Pundit::Authorization
 
-  attr_accessor :organisation, :user, :fund_code, :include_ispf_non_oda_activities
+  attr_accessor :organisation, :user, :fund_code
 
-  def initialize(organisation:, user:, fund_code: nil, include_ispf_non_oda_activities: false)
+  def initialize(organisation:, user:, fund_code: nil)
     @organisation = organisation
     @user = user
     @fund_code = fund_code
-    @include_ispf_non_oda_activities = include_ispf_non_oda_activities
   end
 
   def call
@@ -27,10 +26,7 @@ class FindProjectActivities
   private
 
   def projects_scope
-    is_oda = [nil, true]
-    is_oda << false if include_ispf_non_oda_activities
-
-    query_conditions = {is_oda: is_oda}
+    query_conditions = {}
     query_conditions[:source_fund_code] = fund_code if fund_code.present?
     query_conditions[:organisation_id] = organisation.id if !organisation.service_owner?
 

--- a/app/services/find_third_party_project_activities.rb
+++ b/app/services/find_third_party_project_activities.rb
@@ -1,13 +1,12 @@
 class FindThirdPartyProjectActivities
   include Pundit::Authorization
 
-  attr_accessor :organisation, :user, :fund_code, :include_ispf_non_oda_activities
+  attr_accessor :organisation, :user, :fund_code
 
-  def initialize(organisation:, user:, fund_code: nil, include_ispf_non_oda_activities: false)
+  def initialize(organisation:, user:, fund_code: nil)
     @organisation = organisation
     @user = user
     @fund_code = fund_code
-    @include_ispf_non_oda_activities = include_ispf_non_oda_activities
   end
 
   def call
@@ -27,10 +26,7 @@ class FindThirdPartyProjectActivities
   private
 
   def projects_scope
-    is_oda = [nil, true]
-    is_oda << false if include_ispf_non_oda_activities
-
-    query_conditions = {is_oda: is_oda}
+    query_conditions = {}
     query_conditions[:source_fund_code] = fund_code if fund_code.present?
     query_conditions[:organisation_id] = organisation.id if !organisation.service_owner?
 

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -68,6 +68,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
         organisation: partner_organisation
       )
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+      expect(created_activity.publish_to_iati).to eq(true)
     end
   end
 
@@ -119,6 +121,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+      expect(created_activity.publish_to_iati).to eq(true)
     end
   end
 
@@ -168,6 +172,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
 
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+      expect(created_activity.publish_to_iati).to eq(true)
     end
   end
 
@@ -234,6 +240,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(oda_activity.oda_eligibility)
       expect(created_activity.tags).to eq(oda_activity.tags)
       expect(created_activity.commitment.value).to eq(oda_activity.commitment.value)
+
+      expect(created_activity.publish_to_iati).to eq(true)
     end
 
     scenario "a non-ODA activity can be created" do
@@ -277,6 +285,8 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
       expect(created_activity.policy_marker_nutrition).to be_nil
       expect(created_activity.commitment.value).to eq(non_oda_activity.commitment.value)
+
+      expect(created_activity.publish_to_iati).to eq(false)
     end
 
     context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       )
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-      expect(created_activity.publish_to_iati).to eq(true)
+      expect(created_activity.publish_to_iati).to be(true)
     end
   end
 
@@ -122,7 +122,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-      expect(created_activity.publish_to_iati).to eq(true)
+      expect(created_activity.publish_to_iati).to be(true)
     end
   end
 
@@ -173,7 +173,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-      expect(created_activity.publish_to_iati).to eq(true)
+      expect(created_activity.publish_to_iati).to be(true)
     end
   end
 
@@ -241,7 +241,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.tags).to eq(oda_activity.tags)
       expect(created_activity.commitment.value).to eq(oda_activity.commitment.value)
 
-      expect(created_activity.publish_to_iati).to eq(true)
+      expect(created_activity.publish_to_iati).to be(true)
     end
 
     scenario "a non-ODA activity can be created" do
@@ -286,7 +286,7 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.policy_marker_nutrition).to be_nil
       expect(created_activity.commitment.value).to eq(non_oda_activity.commitment.value)
 
-      expect(created_activity.publish_to_iati).to eq(false)
+      expect(created_activity.publish_to_iati).to be(false)
     end
 
     context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/beis_users_can_create_an_organisation_spec.rb
+++ b/spec/features/beis_users_can_create_an_organisation_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.language_code).to eq("cs")
       expect(organisation.default_currency).to eq("PLN")
       expect(organisation.role).to eq("partner_organisation")
-      expect(organisation.active).to eq(true)
+      expect(organisation.active).to be(true)
     end
 
     scenario "successfully creating a matched effort provider organisation" do
@@ -94,7 +94,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.language_code).to eq("cs")
       expect(organisation.default_currency).to eq("PLN")
       expect(organisation.role).to eq("matched_effort_provider")
-      expect(organisation.active).to eq(true)
+      expect(organisation.active).to be(true)
     end
 
     scenario "successfully creating a external income provider organisation" do
@@ -126,7 +126,7 @@ RSpec.feature "BEIS users can create organisations" do
       expect(organisation.language_code).to eq("ru")
       expect(organisation.default_currency).to eq("RUB")
       expect(organisation.role).to eq("external_income_provider")
-      expect(organisation.active).to eq(true)
+      expect(organisation.active).to be(true)
     end
 
     scenario "successfully creating an implementing organisation" do

--- a/spec/features/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/beis_users_can_edit_a_user_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "BEIS users can edit other users" do
     click_on t("default.button.submit")
 
     expect(page).to have_content("User successfully updated")
-    expect(user.reload.active).to be false
+    expect(user.reload.active).to be(false)
   end
 
   scenario "an inactive user can be reactivated" do
@@ -96,7 +96,7 @@ RSpec.feature "BEIS users can edit other users" do
     click_on t("default.button.submit")
 
     expect(page).to have_content("User successfully updated")
-    expect(user.reload.active).to be true
+    expect(user.reload.active).to be(true)
   end
 
   context "editing a user with a non-lowercase email address" do

--- a/spec/features/users_can_create_a_matched_effort_spec.rb
+++ b/spec/features/users_can_create_a_matched_effort_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Users can create a matched effort" do
           funding_type: "Reciprocal"
         )
       )
-      expect(page.find(:xpath, "//input[@value='#{template.category}']").checked?).to be false
+      expect(page.find(:xpath, "//input[@value='#{template.category}']").checked?).to be(false)
     end
 
     scenario "they receive errors when required fields are left blank" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -76,6 +76,8 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(true)
       end
 
       scenario "a new project can be added to an ISPF ODA programme" do
@@ -149,6 +151,8 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(true)
       end
 
       scenario "a new project can be added to an ISPF non-ODA programme" do
@@ -216,6 +220,8 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
         expect(created_activity.policy_marker_nutrition).to be_nil
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(false)
       end
 
       context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.implementing_organisations).to be_none
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(true)
+        expect(created_activity.publish_to_iati).to be(true)
       end
 
       scenario "a new project can be added to an ISPF ODA programme" do
@@ -152,7 +152,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(true)
+        expect(created_activity.publish_to_iati).to be(true)
       end
 
       scenario "a new project can be added to an ISPF non-ODA programme" do
@@ -221,7 +221,7 @@ RSpec.feature "Users can create a project" do
         expect(created_activity.policy_marker_nutrition).to be_nil
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(false)
+        expect(created_activity.publish_to_iati).to be(false)
       end
 
       context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(true)
+        expect(created_activity.publish_to_iati).to be(true)
       end
 
       scenario "a new third party project can be added to an ISPF ODA project" do
@@ -162,7 +162,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(true)
+        expect(created_activity.publish_to_iati).to be(true)
       end
 
       scenario "a new third party project can be added to an ISPF non-ODA project" do
@@ -240,7 +240,7 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.policy_marker_nutrition).to be_nil
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
-        expect(created_activity.publish_to_iati).to eq(false)
+        expect(created_activity.publish_to_iati).to be(false)
       end
 
       context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -77,6 +77,8 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.oda_eligibility_lead).to eq(activity.oda_eligibility_lead)
         expect(created_activity.uk_po_named_contact).to eq(activity.uk_po_named_contact)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(true)
       end
 
       scenario "a new third party project can be added to an ISPF ODA project" do
@@ -159,6 +161,8 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.implementing_organisations).to eq(activity.implementing_organisations)
         expect(created_activity.tags).to eq(activity.tags)
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(true)
       end
 
       scenario "a new third party project can be added to an ISPF non-ODA project" do
@@ -235,6 +239,8 @@ RSpec.feature "Users can create a third-party project" do
         expect(created_activity.policy_marker_disaster_risk_reduction).to be_nil
         expect(created_activity.policy_marker_nutrition).to be_nil
         expect(created_activity.commitment.value).to eq(activity.commitment.value)
+
+        expect(created_activity.publish_to_iati).to eq(false)
       end
 
       context "when the `activity_linking` feature flag is enabled" do

--- a/spec/features/users_can_create_an_external_income_spec.rb
+++ b/spec/features/users_can_create_an_external_income_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Users can create a external income" do
       expect(external_income.financial_quarter).to eq(financial_quarter.quarter)
       expect(external_income.financial_year).to eq(financial_quarter.financial_year.start_year)
       expect(external_income.amount).to eq(2345.00)
-      expect(external_income.oda_funding).to eq(true)
+      expect(external_income.oda_funding).to be(true)
 
       within("table.implementing_organisations") do
         expect(page).to have_content(external_income_provider.name)

--- a/spec/features/users_can_edit_an_external_income_spec.rb
+++ b/spec/features/users_can_edit_an_external_income_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Users can edit an external income" do
 
       expect(external_income.reload.organisation).to eq(external_income_provider)
       expect(external_income.financial_quarter).to eq(4)
-      expect(external_income.oda_funding).to eq(false)
+      expect(external_income.oda_funding).to be(false)
     end
 
     scenario "they see errors when a required field is missing" do

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ActivityHelper, type: :helper do
         before { authorise_creating_comments(commentable_type: :programme_activity, authorise: true) }
 
         it "returns true" do
-          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to eq(true)
+          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to be(true)
         end
       end
 
@@ -82,7 +82,7 @@ RSpec.describe ActivityHelper, type: :helper do
         end
 
         it "returns false" do
-          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to eq(false)
+          expect(helper.show_link_to_add_comment?(activity: programme_activity, report: nil)).to be(false)
         end
       end
     end
@@ -96,13 +96,13 @@ RSpec.describe ActivityHelper, type: :helper do
 
         context "when a report exists" do
           it "returns true" do
-            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to eq(true)
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to be(true)
           end
         end
 
         context "when a report does not exist" do
           it "returns false" do
-            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to eq(false)
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to be(false)
           end
         end
       end
@@ -115,13 +115,13 @@ RSpec.describe ActivityHelper, type: :helper do
 
         context "when a report exists" do
           it "returns false" do
-            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to eq(false)
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: report)).to be(false)
           end
         end
 
         context "when a report does not exist" do
           it "returns false" do
-            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to eq(false)
+            expect(helper.show_link_to_add_comment?(activity: project_activity, report: nil)).to be(false)
           end
         end
       end
@@ -136,7 +136,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns true" do
           authorise_updating_comments(commentable_type: :programme_activity, authorise: true)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to eq(true)
+          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to be(true)
         end
       end
 
@@ -144,7 +144,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns false" do
           authorise_updating_comments(commentable_type: :programme_activity, authorise: false)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to eq(false)
+          expect(helper.show_link_to_edit_comment?(comment: existing_programme_activity_comment)).to be(false)
         end
       end
     end
@@ -156,7 +156,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns true" do
           authorise_updating_comments(commentable_type: :project_activity, authorise: true)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to eq(true)
+          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to be(true)
         end
       end
 
@@ -164,7 +164,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns false" do
           authorise_updating_comments(commentable_type: :project_activity, authorise: false)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to eq(false)
+          expect(helper.show_link_to_edit_comment?(comment: existing_project_activity_comment)).to be(false)
         end
       end
     end
@@ -177,7 +177,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns true" do
           authorise_updating_comments(commentable_type: :non_activity, authorise: true)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to eq(true)
+          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to be(true)
         end
       end
 
@@ -185,7 +185,7 @@ RSpec.describe ActivityHelper, type: :helper do
         it "returns false" do
           authorise_updating_comments(commentable_type: :non_activity, authorise: false)
 
-          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to eq(false)
+          expect(helper.show_link_to_edit_comment?(comment: existing_actual_comment)).to be(false)
         end
       end
     end
@@ -269,7 +269,7 @@ RSpec.describe ActivityHelper, type: :helper do
         before { allow_any_instance_of(ProjectPolicy).to receive(:download?).and_return(true) }
 
         it "returns true" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to eql(true)
+          expect(can_download_as_xml?(activity: activity, user: user)).to be(true)
         end
       end
 
@@ -277,7 +277,7 @@ RSpec.describe ActivityHelper, type: :helper do
         before { allow_any_instance_of(ProjectPolicy).to receive(:download?).and_return(false) }
 
         it "returns false" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to eql(false)
+          expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
         end
       end
     end
@@ -289,7 +289,7 @@ RSpec.describe ActivityHelper, type: :helper do
         before { allow_any_instance_of(ThirdPartyProjectPolicy).to receive(:download?).and_return(true) }
 
         it "returns true" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to eql(true)
+          expect(can_download_as_xml?(activity: activity, user: user)).to be(true)
         end
       end
 
@@ -297,7 +297,7 @@ RSpec.describe ActivityHelper, type: :helper do
         before { allow_any_instance_of(ThirdPartyProjectPolicy).to receive(:download?).and_return(false) }
 
         it "returns false" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to eql(false)
+          expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
         end
       end
     end
@@ -306,7 +306,7 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:activity) { build(:fund_activity) }
 
       it "returns false" do
-        expect(can_download_as_xml?(activity: activity, user: user)).to eql(false)
+        expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
       end
     end
 
@@ -314,7 +314,7 @@ RSpec.describe ActivityHelper, type: :helper do
       let(:activity) { build(:programme_activity) }
 
       it "returns false" do
-        expect(can_download_as_xml?(activity: activity, user: user)).to eql(false)
+        expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns true" do
         %w[training staging sandbox development].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
-          expect(helper.display_env_name?).to eql(true)
+          expect(helper.display_env_name?).to be(true)
         end
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns false" do
         ["production", "something", "", nil].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
-          expect(helper.display_env_name?).to eql(false)
+          expect(helper.display_env_name?).to be(false)
         end
       end
     end

--- a/spec/lib/iati_validator/xml_spec.rb
+++ b/spec/lib/iati_validator/xml_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe "IATIValidator::XML#valid?" do
 
   context "the xml is blank" do
     let(:xml) { "" }
-    it { is_expected.to be false }
+    it { is_expected.to be(false) }
   end
 
   context "the xml contains a control code" do
     let(:xml) { File.read("#{Rails.root}/spec/fixtures/iati_xml/minimal.xml").sub("REPLACE ME", "\u0002") }
-    it { is_expected.to be false }
+    it { is_expected.to be(false) }
   end
 
   context "the xml is valid" do
     let(:xml) { File.read("#{Rails.root}/spec/fixtures/iati_xml/minimal.xml") }
-    it { is_expected.to be true }
+    it { is_expected.to be(true) }
   end
 
   describe "the IATI tests (run with '--tag full_iati_test')", full_iati_test: true do
@@ -28,7 +28,7 @@ RSpec.describe "IATIValidator::XML#valid?" do
       Dir.glob("tmp/IATI-Schemas/tests/*-tests/should-pass/**/*.xml").each do |filename|
         context "#{filename} should pass" do
           let(:xml) { File.read(filename) }
-          it { is_expected.to be true }
+          it { is_expected.to be(true) }
         end
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe "IATIValidator::XML#valid?" do
       Dir.glob("tmp/IATI-Schemas/tests/*-tests/should-fail/**/*.xml").each do |filename|
         context "#{filename} should fail" do
           let(:xml) { File.read(filename) }
-          it { is_expected.to be false }
+          it { is_expected.to be(false) }
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Activity, type: :model do
         end
 
         it "sets publish_to_iati to false" do
-          expect(activity.publish_to_iati).to eq(false)
+          expect(activity.publish_to_iati).to be(false)
         end
       end
     end
@@ -699,7 +699,7 @@ RSpec.describe Activity, type: :model do
         it "validates that no other countries are selected" do
           activity.ispf_oda_partner_countries = ["IN", "NONE"]
 
-          expect(activity.valid?).to eq(false)
+          expect(activity.valid?).to be(false)
           expect(activity.errors[:ispf_oda_partner_countries].first).to eq(t("activerecord.errors.models.activity.attributes.ispf_oda_partner_countries.none_exclusive"))
         end
       end
@@ -712,7 +712,7 @@ RSpec.describe Activity, type: :model do
         it "validates that no other countries are selected" do
           activity.ispf_non_oda_partner_countries = ["IN", "NONE"]
 
-          expect(activity.valid?).to eq(false)
+          expect(activity.valid?).to be(false)
           expect(activity.errors[:ispf_non_oda_partner_countries].first).to eq(t("activerecord.errors.models.activity.attributes.ispf_non_oda_partner_countries.none_exclusive"))
         end
       end
@@ -985,13 +985,13 @@ RSpec.describe Activity, type: :model do
     it "returns true if all extending_organisation fields are present" do
       activity = build(:fund_activity)
 
-      expect(activity.has_extending_organisation?).to be true
+      expect(activity.has_extending_organisation?).to be(true)
     end
 
     it "returns false if all extending_organisation fields are not present" do
       activity = build(:project_activity, extending_organisation: nil)
 
-      expect(activity.has_extending_organisation?).to be false
+      expect(activity.has_extending_organisation?).to be(false)
     end
   end
 
@@ -999,7 +999,7 @@ RSpec.describe Activity, type: :model do
     it "returns true when there is one or more implementing organisations" do
       activity = create(:project_activity_with_implementing_organisations)
 
-      expect(activity.has_implementing_organisations?).to be true
+      expect(activity.has_implementing_organisations?).to be(true)
     end
   end
 
@@ -1966,7 +1966,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:fund_activity) }
 
         it "returns false" do
-          expect(activity.send(method.to_sym)).to eq(false)
+          expect(activity.send(method.to_sym)).to be(false)
         end
       end
 
@@ -1975,7 +1975,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :newton_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -1983,7 +1983,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :ispf_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -1991,7 +1991,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
 
           it "returns false" do
-            expect(activity.send(method.to_sym)).to eq(false)
+            expect(activity.send(method.to_sym)).to be(false)
           end
         end
       end
@@ -2004,7 +2004,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :newton_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2012,7 +2012,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2020,7 +2020,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
             it "returns false" do
-              expect(activity.send(method.to_sym)).to eq(false)
+              expect(activity.send(method.to_sym)).to be(false)
             end
           end
         end
@@ -2038,7 +2038,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:fund_activity) }
 
         it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          expect(activity.send(method.to_sym)).to be(true)
         end
       end
 
@@ -2047,7 +2047,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :newton_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -2055,7 +2055,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :ispf_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -2063,7 +2063,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
 
           it "returns false" do
-            expect(activity.send(method.to_sym)).to eq(false)
+            expect(activity.send(method.to_sym)).to be(false)
           end
         end
       end
@@ -2076,7 +2076,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :newton_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2084,7 +2084,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2092,7 +2092,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
             it "returns false" do
-              expect(activity.send(method.to_sym)).to eq(false)
+              expect(activity.send(method.to_sym)).to be(false)
             end
           end
         end
@@ -2106,7 +2106,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:fund_activity) }
 
         it "returns false" do
-          expect(activity.send(method.to_sym)).to eq(false)
+          expect(activity.send(method.to_sym)).to be(false)
         end
       end
 
@@ -2114,7 +2114,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity) }
 
         it "returns false" do
-          expect(activity.send(method.to_sym)).to eq(false)
+          expect(activity.send(method.to_sym)).to be(false)
         end
       end
 
@@ -2126,7 +2126,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :newton_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2134,7 +2134,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded) }
 
             it "returns true" do
-              expect(activity.send(method.to_sym)).to eq(true)
+              expect(activity.send(method.to_sym)).to be(true)
             end
           end
 
@@ -2142,7 +2142,7 @@ RSpec.describe Activity, type: :model do
             let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
             it "returns false" do
-              expect(activity.send(method.to_sym)).to eq(false)
+              expect(activity.send(method.to_sym)).to be(false)
             end
           end
         end
@@ -2156,7 +2156,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:fund_activity) }
 
         it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          expect(activity.send(method.to_sym)).to be(true)
         end
       end
     end
@@ -2166,7 +2166,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :newton_funded) }
 
         it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          expect(activity.send(method.to_sym)).to be(true)
         end
       end
 
@@ -2174,7 +2174,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :gcrf_funded) }
 
         it "returns true" do
-          expect(activity.send(method.to_sym)).to eq(true)
+          expect(activity.send(method.to_sym)).to be(true)
         end
       end
 
@@ -2182,7 +2182,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :ispf_funded) }
 
         it "returns false" do
-          expect(activity.send(method.to_sym)).to eq(false)
+          expect(activity.send(method.to_sym)).to be(false)
         end
       end
     end
@@ -2195,7 +2195,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :newton_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -2203,7 +2203,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded) }
 
           it "returns true" do
-            expect(activity.send(method.to_sym)).to eq(true)
+            expect(activity.send(method.to_sym)).to be(true)
           end
         end
 
@@ -2211,7 +2211,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
           it "returns false" do
-            expect(activity.send(method.to_sym)).to eq(false)
+            expect(activity.send(method.to_sym)).to be(false)
           end
         end
       end
@@ -2223,7 +2223,7 @@ RSpec.describe Activity, type: :model do
       let(:activity) { build(:fund_activity) }
 
       it "returns false" do
-        expect(activity.requires_collaboration_type?).to eq(false)
+        expect(activity.requires_collaboration_type?).to be(false)
       end
     end
 
@@ -2232,7 +2232,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :newton_funded) }
 
         it "returns true" do
-          expect(activity.requires_collaboration_type?).to eq(true)
+          expect(activity.requires_collaboration_type?).to be(true)
         end
       end
 
@@ -2240,7 +2240,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :gcrf_funded) }
 
         it "returns true" do
-          expect(activity.requires_collaboration_type?).to eq(true)
+          expect(activity.requires_collaboration_type?).to be(true)
         end
       end
 
@@ -2248,7 +2248,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :ispf_funded) }
 
         it "returns false" do
-          expect(activity.requires_collaboration_type?).to eq(false)
+          expect(activity.requires_collaboration_type?).to be(false)
         end
       end
     end
@@ -2258,7 +2258,7 @@ RSpec.describe Activity, type: :model do
         let(:programme) { build(:programme_activity, :ispf_funded, is_oda: nil) }
 
         it "returns true" do
-          expect(programme.requires_is_oda?).to eq(true)
+          expect(programme.requires_is_oda?).to be(true)
         end
       end
 
@@ -2266,7 +2266,7 @@ RSpec.describe Activity, type: :model do
         let(:programme) { build(:programme_activity, :newton_funded) }
 
         it "returns false" do
-          expect(programme.requires_is_oda?).to eq(false)
+          expect(programme.requires_is_oda?).to be(false)
         end
       end
 
@@ -2274,7 +2274,7 @@ RSpec.describe Activity, type: :model do
         let(:project) { build(:project_activity, :ispf_funded) }
 
         it "returns false" do
-          expect(project.requires_is_oda?).to eq(false)
+          expect(project.requires_is_oda?).to be(false)
         end
       end
 
@@ -2282,7 +2282,7 @@ RSpec.describe Activity, type: :model do
         let(:programme) { build(:programme_activity, :ispf_funded, is_oda: true) }
 
         it "returns false" do
-          expect(programme.requires_is_oda?).to eq(false)
+          expect(programme.requires_is_oda?).to be(false)
         end
       end
     end
@@ -2295,7 +2295,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :newton_funded) }
 
           it "returns true" do
-            expect(activity.requires_collaboration_type?).to eq(true)
+            expect(activity.requires_collaboration_type?).to be(true)
           end
         end
 
@@ -2303,7 +2303,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded) }
 
           it "returns true" do
-            expect(activity.requires_collaboration_type?).to eq(true)
+            expect(activity.requires_collaboration_type?).to be(true)
           end
         end
 
@@ -2311,7 +2311,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
           it "returns false" do
-            expect(activity.requires_collaboration_type?).to eq(false)
+            expect(activity.requires_collaboration_type?).to be(false)
           end
         end
       end
@@ -2323,7 +2323,7 @@ RSpec.describe Activity, type: :model do
       let(:activity) { build(:fund_activity) }
 
       it "returns false" do
-        expect(activity.is_non_oda?).to eq(false)
+        expect(activity.is_non_oda?).to be(false)
       end
     end
 
@@ -2332,7 +2332,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :newton_funded) }
 
         it "returns false" do
-          expect(activity.is_non_oda?).to eq(false)
+          expect(activity.is_non_oda?).to be(false)
         end
       end
 
@@ -2340,7 +2340,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :ispf_funded) }
 
         it "returns false" do
-          expect(activity.is_non_oda?).to eq(false)
+          expect(activity.is_non_oda?).to be(false)
         end
       end
 
@@ -2348,7 +2348,7 @@ RSpec.describe Activity, type: :model do
         let(:activity) { build(:programme_activity, :ispf_funded, is_oda: false) }
 
         it "returns true" do
-          expect(activity.is_non_oda?).to eq(true)
+          expect(activity.is_non_oda?).to be(true)
         end
       end
     end
@@ -2361,7 +2361,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :newton_funded) }
 
           it "returns false" do
-            expect(activity.is_non_oda?).to eq(false)
+            expect(activity.is_non_oda?).to be(false)
           end
         end
 
@@ -2369,7 +2369,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded) }
 
           it "returns false" do
-            expect(activity.is_non_oda?).to eq(false)
+            expect(activity.is_non_oda?).to be(false)
           end
         end
 
@@ -2377,7 +2377,7 @@ RSpec.describe Activity, type: :model do
           let(:activity) { build(factory_name, :ispf_funded, is_oda: false) }
 
           it "returns true" do
-            expect(activity.is_non_oda?).to eq(true)
+            expect(activity.is_non_oda?).to be(true)
           end
         end
       end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -194,6 +194,10 @@ RSpec.describe Activity, type: :model do
           expect(activity.policy_marker_disaster_risk_reduction).to be_nil
           expect(activity.policy_marker_nutrition).to be_nil
         end
+
+        it "sets publish_to_iati to false" do
+          expect(activity.publish_to_iati).to eq(false)
+        end
       end
     end
   end

--- a/spec/models/actual_spec.rb
+++ b/spec/models/actual_spec.rb
@@ -3,24 +3,24 @@ RSpec.describe Actual do
     context "with no validation context" do
       it "allows positive values" do
         actual = build(:actual, value: 10_000)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
 
       it "does not allow negative values" do
         actual = build(:actual, value: -10_000)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
     end
 
     context "with the `:history` validation context" do
       it "allows positive values" do
         actual = build(:actual, value: 10_000)
-        expect(actual.valid?(:history)).to be true
+        expect(actual.valid?(:history)).to be(true)
       end
 
       it "allows negative values" do
         actual = build(:actual, value: -10_000)
-        expect(actual.valid?(:history)).to be true
+        expect(actual.valid?(:history)).to be(true)
       end
     end
   end

--- a/spec/models/csv_file_upload_spec.rb
+++ b/spec/models/csv_file_upload_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CsvFileUpload do
     end
 
     it "is valid" do
-      expect(upload.valid?).to be true
+      expect(upload.valid?).to be(true)
     end
 
     it "returns the expected rows" do
@@ -40,7 +40,7 @@ RSpec.describe CsvFileUpload do
       end
 
       it "is valid" do
-        expect(upload.valid?).to be true
+        expect(upload.valid?).to be(true)
       end
 
       it "parses the CSV without the BOM" do
@@ -58,7 +58,7 @@ RSpec.describe CsvFileUpload do
       end
 
       it "is invalid" do
-        expect(upload.valid?).to be false
+        expect(upload.valid?).to be(false)
       end
 
       it "returns no rows" do
@@ -71,7 +71,7 @@ RSpec.describe CsvFileUpload do
     let(:file) { nil }
 
     it "is invalid" do
-      expect(upload.valid?).to be false
+      expect(upload.valid?).to be(false)
     end
 
     it "returns no rows" do

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Forecast, type: :model do
 
       it "should validate the presence of report" do
         actual = build_stubbed(:actual, parent_activity: activity, report: nil)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Forecast, type: :model do
 
       it "should not validate the presence of report" do
         actual = build_stubbed(:actual, parent_activity: activity, report: nil)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
     end
   end

--- a/spec/models/fund_spec.rb
+++ b/spec/models/fund_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe Fund do
     context "when the fund is GCRF" do
       let(:id) { gcrf_code }
 
-      it { is_expected.to be true }
+      it { is_expected.to be(true) }
     end
 
     context "when the fund is not GCRF" do
       let(:id) { newton_code }
 
-      it { is_expected.to be false }
+      it { is_expected.to be(false) }
     end
   end
 
@@ -127,13 +127,13 @@ RSpec.describe Fund do
     context "when the fund is Newton" do
       let(:id) { newton_code }
 
-      it { is_expected.to be true }
+      it { is_expected.to be(true) }
     end
 
     context "when the fund is not Newton" do
       let(:id) { gcrf_code }
 
-      it { is_expected.to be false }
+      it { is_expected.to be(false) }
     end
   end
 
@@ -144,13 +144,13 @@ RSpec.describe Fund do
     context "when the fund is ISPF" do
       let(:id) { ispf_code }
 
-      it { is_expected.to be true }
+      it { is_expected.to be(true) }
     end
 
     context "when the fund is not ISPF" do
       let(:id) { gcrf_code }
 
-      it { is_expected.to be false }
+      it { is_expected.to be(false) }
     end
   end
 

--- a/spec/models/historical_event_spec.rb
+++ b/spec/models/historical_event_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe HistoricalEvent, type: :model do
       end
 
       it "should read back an boolean" do
-        expect(persisted_event.new_value).to be true
-        expect(persisted_event.previous_value).to be true
+        expect(persisted_event.new_value).to be(true)
+        expect(persisted_event.previous_value).to be(true)
       end
     end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -46,25 +46,25 @@ RSpec.describe Organisation, type: :model do
       it "returns true if it does matches a known structure XX-XXX-" do
         organisation = build(:partner_organisation, iati_reference: "GB-GOV-13")
         result = organisation.valid?
-        expect(result).to eq(true)
+        expect(result).to be(true)
       end
 
       it "returns true if it does match an unexpected value of the same XX-XXX- structure" do
         organisation = build(:partner_organisation, iati_reference: "GB-COH-1234567asdfghj")
         result = organisation.valid?
-        expect(result).to eq(true)
+        expect(result).to be(true)
       end
 
       it "returns true if the country code is 3 characters long" do
         organisation = build(:partner_organisation, iati_reference: "CZH-COH-111")
         result = organisation.valid?
-        expect(result).to eq(true)
+        expect(result).to be(true)
       end
 
       it "returns false if it doesn't match the structure XX-XXX-" do
         organisation = build(:partner_organisation, iati_reference: "1234")
         result = organisation.valid?
-        expect(result).to eq(false)
+        expect(result).to be(false)
       end
 
       it "returns an error message if it is invalid" do
@@ -106,19 +106,19 @@ RSpec.describe Organisation, type: :model do
     it "makes the organisation valid if it is between 2 and 5 characters long" do
       organisation = build(:partner_organisation, beis_organisation_reference: "ABCD")
       result = organisation.valid?
-      expect(result).to eq(true)
+      expect(result).to be(true)
     end
 
     it "makes the organisation invalid if it is over 5 characters long" do
       organisation = build(:partner_organisation, beis_organisation_reference: "ABCDEF")
       result = organisation.valid?
-      expect(result).to eq(false)
+      expect(result).to be(false)
     end
 
     it "makes the organisation invalid if contains non alphabetical characters" do
       organisation = build(:partner_organisation, beis_organisation_reference: "123")
       result = organisation.valid?
-      expect(result).to eq(false)
+      expect(result).to be(false)
     end
 
     it "returns an error message if it is invalid" do
@@ -132,7 +132,7 @@ RSpec.describe Organisation, type: :model do
     it "does not validate if the organisation is not a reporter" do
       organisation = build(:external_income_provider, beis_organisation_reference: "ABCDEF")
       result = organisation.valid?
-      expect(result).to eq(true)
+      expect(result).to be(true)
     end
   end
 
@@ -178,7 +178,7 @@ RSpec.describe Organisation, type: :model do
 
         result = beis_organisation.service_owner?
 
-        expect(result).to eq(true)
+        expect(result).to be(true)
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Organisation, type: :model do
 
         result = other_organisation.service_owner?
 
-        expect(result).to eq(false)
+        expect(result).to be(false)
       end
     end
 
@@ -198,7 +198,7 @@ RSpec.describe Organisation, type: :model do
 
         result = other_organisation.service_owner?
 
-        expect(result).to eq(false)
+        expect(result).to be(false)
       end
     end
   end
@@ -333,41 +333,41 @@ RSpec.describe Organisation, type: :model do
   end
 
   describe "#is_government?" do
-    it "should be true for a Government organisation_type" do
+    it "should be(true) for a Government organisation_type" do
       organisation = create(:partner_organisation, organisation_type: 10)
-      expect(organisation.is_government?).to eq true
+      expect(organisation.is_government?).to be(true)
     end
 
-    it "should be true for a Government organisation_type" do
+    it "should be(true) for a Government organisation_type" do
       organisation = create(:partner_organisation, organisation_type: 11)
-      expect(organisation.is_government?).to eq true
+      expect(organisation.is_government?).to be(true)
     end
 
-    it "should be false for an NGO organisation_type" do
+    it "should be(false) for an NGO organisation_type" do
       organisation = create(:partner_organisation, organisation_type: 21)
-      expect(organisation.is_government?).to eq false
+      expect(organisation.is_government?).to be(false)
     end
   end
 
   describe "#is_reporter?" do
-    it "should be true for partner organisations" do
+    it "should be(true) for partner organisations" do
       organisation = build(:partner_organisation)
-      expect(organisation.is_reporter?).to eq true
+      expect(organisation.is_reporter?).to be(true)
     end
 
-    it "should be true for BEIS" do
+    it "should be(true) for BEIS" do
       organisation = build(:beis_organisation)
-      expect(organisation.is_reporter?).to eq true
+      expect(organisation.is_reporter?).to be(true)
     end
 
-    it "should be false for matched effort providers" do
+    it "should be(false) for matched effort providers" do
       organisation = build(:matched_effort_provider)
-      expect(organisation.is_reporter?).to eq false
+      expect(organisation.is_reporter?).to be(false)
     end
 
-    it "should be false for external income providers" do
+    it "should be(false) for external income providers" do
       organisation = build(:external_income_provider)
-      expect(organisation.is_reporter?).to eq false
+      expect(organisation.is_reporter?).to be(false)
     end
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -20,40 +20,40 @@ RSpec.describe Report, type: :model do
         new_valid_report = build(:report, fund: existing_approved_report.fund, organisation: organisation)
         new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
 
-        expect(new_invalid_report.valid?(:new)).to eql(false)
-        expect(new_valid_report.valid?).to eql(true)
+        expect(new_invalid_report.valid?(:new)).to be(false)
+        expect(new_valid_report.valid?).to be(true)
       end
 
       it "validates the presence of financial_quarter and financial_year" do
         new_report = build(:report, financial_quarter: nil, financial_year: nil)
 
-        expect(new_report.valid?(:new)).to eql(false)
-        expect(new_report.valid?).to eql(true)
+        expect(new_report.valid?(:new)).to be(false)
+        expect(new_report.valid?).to be(true)
       end
 
       context "validates that the financial quarter is previous to the current quarter" do
         it "when creating a report for the next finanical quarter in the same financial year" do
           travel_to(Date.parse("01-04-2020")) do
             new_report = build(:report, financial_quarter: 2, financial_year: 2020)
-            expect(new_report.valid?(:new)).to eql(false)
+            expect(new_report.valid?(:new)).to be(false)
           end
         end
         it "when creating a report for the next finanical quarter in the next financial year" do
           travel_to(Date.parse("01-02-2020")) do
             new_report = build(:report, financial_quarter: 1, financial_year: 2020)
-            expect(new_report.valid?(:new)).to eql(false)
+            expect(new_report.valid?(:new)).to be(false)
           end
         end
         it "when creating a report for the previous financial quarter in the same financial year" do
           travel_to(Date.parse("01-08-2020")) do
             new_report = build(:report, financial_quarter: 1, financial_year: 2020)
-            expect(new_report.valid?(:new)).to eql(true)
+            expect(new_report.valid?(:new)).to be(true)
           end
         end
         it "when creating a report for the previous financial quarter in the previous financial year" do
           travel_to(Date.parse("01-04-2020")) do
             new_report = build(:report, financial_quarter: 4, financial_year: 2019)
-            expect(new_report.valid?(:new)).to eql(true)
+            expect(new_report.valid?(:new)).to be(true)
           end
         end
       end
@@ -66,7 +66,7 @@ RSpec.describe Report, type: :model do
             create(:report, :approved, organisation: organisation, fund: fund, financial_quarter: 4, financial_year: 2018)
             travel_to(Date.parse("01-04-2020")) do
               new_report = build(:report, organisation: organisation, fund: fund, financial_quarter: 3, financial_year: 2018)
-              expect(new_report.valid?(:new)).to eql(false)
+              expect(new_report.valid?(:new)).to be(false)
             end
           end
         end
@@ -76,7 +76,7 @@ RSpec.describe Report, type: :model do
             travel_to(Date.parse("01-04-2020")) do
               new_report = build(:report, organisation: organisation, fund: fund, financial_quarter: 4, financial_year: 2018)
 
-              expect(new_report.valid?(:new)).to eql(true)
+              expect(new_report.valid?(:new)).to be(true)
             end
           end
         end
@@ -157,7 +157,7 @@ RSpec.describe Report, type: :model do
   context "when editing the report details i.e. in the `edit` validation context" do
     it "does not allow a deadline which is in the past" do
       report = build(:report, deadline: Date.yesterday)
-      expect(report.valid?(:edit)).to eq false
+      expect(report.valid?(:edit)).to be(false)
     end
   end
 
@@ -317,7 +317,7 @@ RSpec.describe Report, type: :model do
       }
 
       it "returns true" do
-        expect(ispf_report.for_ispf?).to eq(true)
+        expect(ispf_report.for_ispf?).to be(true)
       end
     end
 
@@ -327,7 +327,7 @@ RSpec.describe Report, type: :model do
       }
 
       it "returns false" do
-        expect(gcrf_report.for_ispf?).to eq(false)
+        expect(gcrf_report.for_ispf?).to be(false)
       end
     end
   end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -2,24 +2,24 @@ RSpec.describe Result do
   describe "#success?" do
     it "returns true when set to true" do
       result = described_class.new(true).success?
-      expect(result).to eq true
+      expect(result).to be(true)
     end
 
     it "returns false when set to false" do
       result = described_class.new(false).success?
-      expect(result).to eq false
+      expect(result).to be(false)
     end
   end
 
   describe "#failure?" do
     it "returns true when set to false" do
       result = described_class.new(false).failure?
-      expect(result).to eq true
+      expect(result).to be(true)
     end
 
     it "returns false when set to true" do
       result = described_class.new(true).failure?
-      expect(result).to eq false
+      expect(result).to be(false)
     end
   end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Transaction, type: :model do
 
       it "should validate the presence of report" do
         actual = build_stubbed(:actual, parent_activity: activity, report: nil)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe Transaction, type: :model do
 
       it "should not validate the presence of report" do
         actual = build_stubbed(:actual, parent_activity: activity, report: nil)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
     end
 
@@ -192,32 +192,32 @@ RSpec.describe Transaction, type: :model do
     context "value must be a maximum of 99,999,999,999.00 (100 billion minus one)" do
       it "allows the maximum possible value" do
         actual = build(:actual, parent_activity: activity, value: 99_999_999_999.00)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
 
       it "allows one penny" do
         actual = build(:actual, parent_activity: activity, value: 0.01)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
 
       it "does not allow a value of 0" do
         actual = build(:actual, parent_activity: activity, value: 0)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
 
       it "does not allow a value of more than 99,999,999,999.00" do
         actual = build(:actual, parent_activity: activity, value: 100_000_000_000.00)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
 
       it "allows a value between 1 and 99,999,999,999.00" do
         actual = build(:actual, parent_activity: activity, value: 500_000.00)
-        expect(actual.valid?).to be true
+        expect(actual.valid?).to be(true)
       end
 
       it "does not allow a negative value" do
         actual = build(:actual, parent_activity: activity, value: -500_000.00)
-        expect(actual.valid?).to be false
+        expect(actual.valid?).to be(false)
       end
     end
   end

--- a/spec/requests/activity_forms_spec.rb
+++ b/spec/requests/activity_forms_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Activity forms", type: :request do
         expect(response).to redirect_to_step("sustainable_development_goals")
 
         expect(activity.reload.collaboration_type).to eq("2")
-        expect(activity.reload.fstc_applies).to eq(false)
+        expect(activity.reload.fstc_applies).to be(false)
         expect(activity.reload.channel_of_delivery_code).to eq("40000")
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe "Activity forms", type: :request do
 
           expect(response).to redirect_to_next_step
 
-          expect(activity.reload.fstc_applies).to eq(true)
+          expect(activity.reload.fstc_applies).to be(true)
         end
       end
     end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Rollout" do
     let(:user) { build(:beis_user) }
 
     it "is part of the beis_users group and not the partner_organisation_users group", :use_original_rollout do
-      expect(ROLLOUT.active_in_group?(:beis_users, user)).to be true
-      expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be false
+      expect(ROLLOUT.active_in_group?(:beis_users, user)).to be(true)
+      expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be(false)
     end
   end
 
@@ -16,8 +16,8 @@ RSpec.describe "Rollout" do
     let(:user) { build(:partner_organisation_user) }
 
     it "is part of the partner_organisation_users group and not the beis_users group", :use_original_rollout do
-      expect(ROLLOUT.active_in_group?(:beis_users, user)).to be false
-      expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be true
+      expect(ROLLOUT.active_in_group?(:beis_users, user)).to be(false)
+      expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be(true)
     end
   end
 
@@ -26,8 +26,8 @@ RSpec.describe "Rollout" do
       mock_feature = double(:feature, groups: [:real_group])
       allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(mock_feature)
 
-      expect(hide_ispf_for_group?(:real_group)).to be true
-      expect(hide_ispf_for_group?(:fake_group)).to be false
+      expect(hide_ispf_for_group?(:real_group)).to be(true)
+      expect(hide_ispf_for_group?(:fake_group)).to be(false)
     end
   end
 

--- a/spec/services/activity/import_level_b_spec.rb
+++ b/spec/services/activity/import_level_b_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Activity::Import do
         expect(existing_newton_level_b_activity.sector_category).to eq("112")
         expect(existing_newton_level_b_activity.collaboration_type).to eq(existing_newton_level_b_activity_attributes["Collaboration type (Bi/Multi Marker)"])
         expect(existing_newton_level_b_activity.aid_type).to eq(existing_newton_level_b_activity_attributes["Aid type"])
-        expect(existing_newton_level_b_activity.fstc_applies).to eq(true)
+        expect(existing_newton_level_b_activity.fstc_applies).to be(true)
         expect(existing_newton_level_b_activity.objectives).to eq(existing_newton_level_b_activity_attributes["Aims/Objectives"])
         expect(existing_newton_level_b_activity.beis_identifier).to eq(existing_newton_level_b_activity_attributes["BEIS ID"])
         expect(existing_newton_level_b_activity.uk_po_named_contact).to eq(existing_newton_level_b_activity_attributes["UK PO Named Contact"])
-        expect(existing_newton_level_b_activity.sdgs_apply).to eql(true)
+        expect(existing_newton_level_b_activity.sdgs_apply).to be(true)
         expect(existing_newton_level_b_activity.country_partner_organisations).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
         expect(existing_newton_level_b_activity.form_state).to eq "complete"
       end
@@ -264,7 +264,7 @@ RSpec.describe Activity::Import do
         expect(new_activity.fund_pillar).to eq(new_newton_activity_attributes["Newton Fund Pillar"].to_i)
         expect(new_activity.call_open_date).to be_nil
         expect(new_activity.call_close_date).to be_nil
-        expect(new_activity.call_present).to eq(false)
+        expect(new_activity.call_present).to be(false)
         expect(new_activity.planned_start_date).to eq(DateTime.parse(new_newton_activity_attributes["Planned start date"]))
         expect(new_activity.planned_end_date).to eq(DateTime.parse(new_newton_activity_attributes["Planned end date"]))
         expect(new_activity.actual_start_date).to eq(DateTime.parse(new_newton_activity_attributes["Actual start date"]))
@@ -273,12 +273,12 @@ RSpec.describe Activity::Import do
         expect(new_activity.sector_category).to eq("112")
         expect(new_activity.collaboration_type).to eq(new_newton_activity_attributes["Collaboration type (Bi/Multi Marker)"])
         expect(new_activity.aid_type).to eq(new_newton_activity_attributes["Aid type"])
-        expect(new_activity.fstc_applies).to eq(true)
+        expect(new_activity.fstc_applies).to be(true)
         expect(new_activity.objectives).to eq(new_newton_activity_attributes["Aims/Objectives"])
         expect(new_activity.beis_identifier).to eq("")
         expect(new_activity.uk_po_named_contact).to eq(new_newton_activity_attributes["UK PO Named Contact"])
         expect(new_activity.country_partner_organisations).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
-        expect(new_activity.sdgs_apply).to eql(true)
+        expect(new_activity.sdgs_apply).to be(true)
       end
 
       it "sets BEIS as the accountable organisation" do

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -188,13 +188,13 @@ RSpec.describe Activity::Import do
   describe "::is_oda_by_type" do
     context "when passed `:ispf_oda` as the type" do
       it "returns true" do
-        expect(Activity::Import.is_oda_by_type(type: :ispf_oda)).to eq(true)
+        expect(Activity::Import.is_oda_by_type(type: :ispf_oda)).to be(true)
       end
     end
 
     context "when passed `:ispf_non_oda` as the type" do
       it "returns true" do
-        expect(Activity::Import.is_oda_by_type(type: :ispf_non_oda)).to eq(false)
+        expect(Activity::Import.is_oda_by_type(type: :ispf_non_oda)).to be(false)
       end
     end
 
@@ -316,13 +316,13 @@ RSpec.describe Activity::Import do
       expect(existing_activity.policy_marker_disaster_risk_reduction).to eq("not_targeted")
       expect(existing_activity.policy_marker_nutrition).to eq("not_assessed")
       expect(existing_activity.aid_type).to eq(existing_activity_attributes["Aid type"])
-      expect(existing_activity.fstc_applies).to eq(true)
+      expect(existing_activity.fstc_applies).to be(true)
       expect(existing_activity.objectives).to eq(existing_activity_attributes["Aims/Objectives"])
       expect(existing_activity.beis_identifier).to eq(existing_activity_attributes["BEIS ID"])
       expect(existing_activity.uk_po_named_contact).to eq(existing_activity_attributes["UK PO Named Contact"])
-      expect(existing_activity.sdgs_apply).to eql(true)
+      expect(existing_activity.sdgs_apply).to be(true)
 
-      expect(existing_activity.implementing_organisations.count).to eql(1)
+      expect(existing_activity.implementing_organisations.count).to eq(1)
       expect(existing_activity.implementing_organisations.first.name)
         .to eq("Impl. Org 1")
 
@@ -582,7 +582,7 @@ RSpec.describe Activity::Import do
       expect(new_activity.fund_pillar).to eq(new_activity_attributes["Newton Fund Pillar"].to_i)
       expect(new_activity.call_open_date).to eq(DateTime.parse(new_activity_attributes["Call open date"]))
       expect(new_activity.call_close_date).to eq(DateTime.parse(new_activity_attributes["Call close date"]))
-      expect(new_activity.call_present).to eq(true)
+      expect(new_activity.call_present).to be(true)
       expect(new_activity.planned_start_date).to eq(DateTime.parse(new_activity_attributes["Planned start date"]))
       expect(new_activity.planned_end_date).to eq(DateTime.parse(new_activity_attributes["Planned end date"]))
       expect(new_activity.actual_start_date).to eq(DateTime.parse(new_activity_attributes["Actual start date"]))
@@ -592,13 +592,13 @@ RSpec.describe Activity::Import do
       expect(new_activity.channel_of_delivery_code).to eq(new_activity_attributes["Channel of delivery code"])
       expect(new_activity.collaboration_type).to eq(new_activity_attributes["Collaboration type (Bi/Multi Marker)"])
       expect(new_activity.aid_type).to eq(new_activity_attributes["Aid type"])
-      expect(new_activity.fstc_applies).to eq(true)
+      expect(new_activity.fstc_applies).to be(true)
       expect(new_activity.objectives).to eq(new_activity_attributes["Aims/Objectives"])
       expect(new_activity.beis_identifier).to eq(new_activity_attributes["BEIS ID"])
       expect(new_activity.uk_po_named_contact).to eq(new_activity_attributes["UK PO Named Contact"])
       expect(new_activity.country_partner_organisations).to eq(["Association of Example Companies (AEC)", "Board of Sample Organisations (BSO)"])
-      expect(new_activity.sdgs_apply).to eql(true)
-      expect(new_activity.publish_to_iati).to eq(true)
+      expect(new_activity.sdgs_apply).to be(true)
+      expect(new_activity.publish_to_iati).to be(true)
     end
 
     context "with a parent activity that is incomplete" do
@@ -652,7 +652,7 @@ RSpec.describe Activity::Import do
 
       expect(new_activity.call_open_date).to be_nil
       expect(new_activity.call_close_date).to be_nil
-      expect(new_activity.call_present).to eq(false)
+      expect(new_activity.call_present).to be(false)
     end
 
     it "has an error if the benefitting countries are invalid" do
@@ -1281,7 +1281,7 @@ RSpec.describe Activity::Import do
 
         new_activity = Activity.order(:created_at).last
 
-        expect(new_activity.publish_to_iati).to eq(false)
+        expect(new_activity.publish_to_iati).to be(false)
       end
     end
   end

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -1276,6 +1276,25 @@ RSpec.describe Activity::Import do
         expect(new_activity.roda_identifier).to start_with("NODA-")
       end
 
+      it "sets ODA-only attributes to nil" do
+        expect { subject.import([new_non_oda_programme_attributes]) }.to change { Activity.count }.by(1)
+
+        new_activity = Activity.order(:created_at).last
+
+        expect(new_activity.transparency_identifier).to be_nil
+        expect(new_activity.oda_eligibility).to be_nil
+        expect(new_activity.fstc_applies).to be_nil
+        expect(new_activity.covid19_related).to be_nil
+        expect(new_activity.policy_marker_gender).to be_nil
+        expect(new_activity.policy_marker_climate_change_adaptation).to be_nil
+        expect(new_activity.policy_marker_climate_change_mitigation).to be_nil
+        expect(new_activity.policy_marker_biodiversity).to be_nil
+        expect(new_activity.policy_marker_desertification).to be_nil
+        expect(new_activity.policy_marker_disability).to be_nil
+        expect(new_activity.policy_marker_disaster_risk_reduction).to be_nil
+        expect(new_activity.policy_marker_nutrition).to be_nil
+      end
+
       it "sets publish_to_iati to false" do
         expect { subject.import([new_non_oda_programme_attributes]) }.to change { Activity.count }.by(1)
 

--- a/spec/services/activity_defaults_spec.rb
+++ b/spec/services/activity_defaults_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ActivityDefaults do
         let(:is_oda) { true }
 
         it "sets is_oda to true" do
-          expect(subject[:is_oda]).to be true
+          expect(subject[:is_oda]).to be(true)
         end
       end
 
@@ -52,7 +52,7 @@ RSpec.describe ActivityDefaults do
         let(:is_oda) { false }
 
         it "sets is_oda to false" do
-          expect(subject[:is_oda]).to be false
+          expect(subject[:is_oda]).to be(false)
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe ActivityDefaults do
           let(:parent_activity) { create(:fund_activity, is_oda: true) }
 
           it "sets is_oda to true" do
-            expect(subject[:is_oda]).to be true
+            expect(subject[:is_oda]).to be(true)
           end
         end
 
@@ -71,7 +71,7 @@ RSpec.describe ActivityDefaults do
           let(:parent_activity) { create(:fund_activity, is_oda: false) }
 
           it "sets is_oda to false" do
-            expect(subject[:is_oda]).to be false
+            expect(subject[:is_oda]).to be(false)
           end
         end
 
@@ -189,7 +189,7 @@ RSpec.describe ActivityDefaults do
         let(:parent_activity) { ispf_oda_programme }
 
         it "sets the is_oda attribute to true" do
-          expect(subject[:is_oda]).to eq(true)
+          expect(subject[:is_oda]).to be(true)
         end
       end
 
@@ -197,7 +197,7 @@ RSpec.describe ActivityDefaults do
         let(:parent_activity) { ispf_non_oda_programme }
 
         it "sets the is_oda attribute to false" do
-          expect(subject[:is_oda]).to eq(false)
+          expect(subject[:is_oda]).to be(false)
         end
       end
     end
@@ -258,7 +258,7 @@ RSpec.describe ActivityDefaults do
         let(:parent_activity) { ispf_oda_project }
 
         it "sets the is_oda attribute to true" do
-          expect(subject[:is_oda]).to eq(true)
+          expect(subject[:is_oda]).to be(true)
         end
       end
 
@@ -266,7 +266,7 @@ RSpec.describe ActivityDefaults do
         let(:parent_activity) { ispf_non_oda_project }
 
         it "sets the is_oda attribute to false" do
-          expect(subject[:is_oda]).to eq(false)
+          expect(subject[:is_oda]).to be(false)
         end
       end
     end

--- a/spec/services/actual/history_import_spec.rb
+++ b/spec/services/actual/history_import_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Actual::HistoryImport do
     subject { described_class.new(report: @report, csv: @valid_csv, user: @user) }
 
     it "returns true" do
-      expect(subject.call).to be true
+      expect(subject.call).to be(true)
     end
 
     it "creates the actuals" do
@@ -66,7 +66,7 @@ RSpec.describe Actual::HistoryImport do
     subject { described_class.new(report: @report, csv: @invalid_headers_csv, user: @user) }
 
     it "returns false" do
-      expect(subject.call).to be false
+      expect(subject.call).to be(false)
     end
 
     it "returns the correct number of errors" do
@@ -88,7 +88,7 @@ RSpec.describe Actual::HistoryImport do
     subject { described_class.new(report: @report, csv: @invalid_csv, user: @user) }
 
     it "returns false" do
-      expect(subject.call).to be false
+      expect(subject.call).to be(false)
     end
 
     it "returns all of the errors" do
@@ -148,7 +148,7 @@ RSpec.describe Actual::HistoryImport do
       subject { described_class.new(report: @report, row_number: 2, row: row) }
 
       it "returns true" do
-        expect(subject.call).to be true
+        expect(subject.call).to be(true)
       end
 
       it "returns no errors" do
@@ -218,7 +218,7 @@ RSpec.describe Actual::HistoryImport do
       subject { described_class.new(report: @report, row_number: 2, row: row) }
 
       it "returns false" do
-        expect(subject.call).to be false
+        expect(subject.call).to be(false)
       end
 
       it "returns errors" do
@@ -251,7 +251,7 @@ RSpec.describe Actual::HistoryImport do
       subject { described_class.new(report: @report, row_number: 2, row: row) }
 
       it "returns false" do
-        expect(subject.call).to be false
+        expect(subject.call).to be(false)
       end
 
       it "returns errors" do
@@ -287,7 +287,7 @@ RSpec.describe Actual::HistoryImport do
       subject { described_class.new(report: @report, row_number: 2, row: row) }
 
       it "returns false" do
-        expect(subject.call).to be false
+        expect(subject.call).to be(false)
       end
 
       it "returns errors" do

--- a/spec/services/breadcrumb_context_spec.rb
+++ b/spec/services/breadcrumb_context_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BreadcrumbContext do
 
     describe "#empty?" do
       it "should return false" do
-        expect(subject.empty?).to be false
+        expect(subject.empty?).to be(false)
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe BreadcrumbContext do
   context "when the breadcrumb context is not set" do
     describe "#empty?" do
       it "should return true" do
-        expect(subject.empty?).to be true
+        expect(subject.empty?).to be(true)
       end
     end
 

--- a/spec/services/budget/import_level_b_spec.rb
+++ b/spec/services/budget/import_level_b_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Budget::Import do
         expect(new_budget.period_start_date).to eq(financial_year.start_date)
         expect(new_budget.period_end_date).to eq(financial_year.end_date)
         expect(new_budget.currency).to eq("GBP")
-        expect(new_budget.ingested).to eq(false)
+        expect(new_budget.ingested).to be(false)
         expect(new_budget.report_id).to be_nil
         expect(new_budget.funding_type).to be_nil
         expect(new_budget.providing_organisation_id).to eq(beis_organisation_id)
@@ -215,7 +215,7 @@ RSpec.describe Budget::Import do
             expect(new_budget.period_start_date).to eq(financial_year.start_date)
             expect(new_budget.period_end_date).to eq(financial_year.end_date)
             expect(new_budget.currency).to eq("GBP")
-            expect(new_budget.ingested).to eq(false)
+            expect(new_budget.ingested).to be(false)
             expect(new_budget.report_id).to be_nil
             expect(new_budget.funding_type).to be_nil
             expect(new_budget.providing_organisation_id).to be_nil

--- a/spec/services/commitment/import_spec.rb
+++ b/spec/services/commitment/import_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Commitment::Import do
     let(:invalid_headers_csv) { load_csv_fixture("invalid_headers.csv") }
 
     it "stops and returns false" do
-      expect(subject.call(invalid_headers_csv)).to eq false
+      expect(subject.call(invalid_headers_csv)).to be(false)
     end
 
     it "returns a helpful error message" do
@@ -57,7 +57,7 @@ RSpec.describe Commitment::Import do
       end
 
       it "returns true" do
-        expect(subject.call(valid_csv)).to eq true
+        expect(subject.call(valid_csv)).to be(true)
       end
 
       it "returns the imported items" do
@@ -89,7 +89,7 @@ RSpec.describe Commitment::Import do
       end
 
       it "returns false" do
-        expect(subject.call(invalid_csv)).to eq false
+        expect(subject.call(invalid_csv)).to be(false)
       end
 
       it "returns no imported items" do
@@ -125,7 +125,7 @@ RSpec.describe Commitment::Import do
       subject { described_class.new(1, row) }
 
       it "returns true" do
-        expect(subject.call).to eq true
+        expect(subject.call).to be(true)
       end
 
       it "returns the commitment" do
@@ -151,7 +151,7 @@ RSpec.describe Commitment::Import do
       subject { described_class.new(100, row) }
 
       it "returns false" do
-        expect(subject.call).to eq false
+        expect(subject.call).to be(false)
       end
 
       it "returns a helpful error message" do
@@ -177,7 +177,7 @@ RSpec.describe Commitment::Import do
       subject { described_class.new(10, row) }
 
       it "returns false" do
-        expect(subject.call).to eq false
+        expect(subject.call).to be(false)
       end
 
       it "returns a helpful error message" do
@@ -204,7 +204,7 @@ RSpec.describe Commitment::Import do
       subject { described_class.new(11, row) }
 
       it "returns false" do
-        expect(subject.call).to eq false
+        expect(subject.call).to be(false)
       end
 
       it "returns a helpful error message" do
@@ -230,7 +230,7 @@ RSpec.describe Commitment::Import do
       subject { described_class.new(1, row) }
 
       it "returns false" do
-        expect(subject.call).to eq false
+        expect(subject.call).to be(false)
       end
 
       it "returns a helpful error message" do

--- a/spec/services/create_actual_spec.rb
+++ b/spec/services/create_actual_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CreateActual do
 
       result = described_class.new(activity: activity).call(attributes: {})
 
-      expect(result.success?).to be true
+      expect(result.success?).to be(true)
     end
 
     context "when passed Actual" do
@@ -32,7 +32,7 @@ RSpec.describe CreateActual do
 
         result = described_class.new(activity: activity).call(attributes: {})
 
-        expect(result.success?).to be false
+        expect(result.success?).to be(false)
       end
     end
 

--- a/spec/services/create_budget_spec.rb
+++ b/spec/services/create_budget_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CreateBudget do
 
       result = described_class.new(activity: activity).call(attributes: {})
 
-      expect(result.success?).to be true
+      expect(result.success?).to be(true)
     end
 
     context "when the budget isn't valid" do
@@ -47,7 +47,7 @@ RSpec.describe CreateBudget do
 
         result = described_class.new(activity: activity).call(attributes: {})
 
-        expect(result.success?).to be false
+        expect(result.success?).to be(false)
       end
     end
 

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreateUser do
     it "returns a successful result" do
       result = CreateUser.new(user: user, organisation: build_stubbed(:partner_organisation)).call
 
-      expect(result.success?).to eq(true)
+      expect(result.success?).to be(true)
     end
 
     it "sends a welcome email to the user" do

--- a/spec/services/field_inference_spec.rb
+++ b/spec/services/field_inference_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FieldInference do
 
     it "allows one matching value to be assigned" do
       subject.assign(activity, :aid_type, "B01")
-      expect(activity.fstc_applies).to eq(false)
+      expect(activity.fstc_applies).to be(false)
     end
 
     it "blocks two matching fields from setting different values of the dependent" do

--- a/spec/services/find_programme_activities_spec.rb
+++ b/spec/services/find_programme_activities_spec.rb
@@ -38,43 +38,5 @@ RSpec.describe FindProgrammeActivities do
         expect(result).not_to include programme_from_another_fund
       end
     end
-
-    context "including or excluding ISPF non-ODA activities" do
-      let!(:oda_programme) {
-        create(
-          :programme_activity,
-          :ispf_funded,
-          extending_organisation: other_organisation,
-          is_oda: true
-        )
-      }
-
-      let!(:non_oda_programme) {
-        create(
-          :programme_activity,
-          :ispf_funded,
-          extending_organisation: other_organisation,
-          is_oda: false
-        )
-      }
-
-      context "when `include_ispf_non_oda_activities` is not passed" do
-        it "includes only programmes with `is_oda` values of `true` or `nil`" do
-          result = described_class.new(organisation: other_organisation, user: user).call
-
-          expect(result).to match_array([extending_organisation_programme, oda_programme])
-          expect(result).not_to include(other_programme, non_oda_programme)
-        end
-      end
-
-      context "when `include_ispf_non_oda_activities` is passed as true" do
-        it "includes all programmes for the organisation" do
-          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
-
-          expect(result).to match_array([extending_organisation_programme, oda_programme, non_oda_programme])
-          expect(result).not_to include other_programme
-        end
-      end
-    end
   end
 end

--- a/spec/services/find_project_activities_spec.rb
+++ b/spec/services/find_project_activities_spec.rb
@@ -22,29 +22,6 @@ RSpec.describe FindProjectActivities do
 
         expect(result).to match_array [fund_1_organisation_project, other_project]
       end
-
-      context "filtering by `include_ispf_non_oda_activities`" do
-        let!(:oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: true) }
-        let!(:non_oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: false) }
-
-        it "excludes ISPF non-ODA activities by default" do
-          result = described_class.new(organisation: service_owner, user: user).call
-
-          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, other_project, oda_project]
-        end
-
-        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
-          result = described_class.new(organisation: service_owner, user: user, include_ispf_non_oda_activities: true).call
-
-          expect(result).to match_array [
-            fund_1_organisation_project,
-            fund_2_organisation_project,
-            other_project,
-            oda_project,
-            non_oda_project
-          ]
-        end
-      end
     end
 
     context "when the organisation is not the service owner" do
@@ -58,28 +35,6 @@ RSpec.describe FindProjectActivities do
         result = described_class.new(organisation: other_organisation, user: user, fund_code: 1).call
 
         expect(result).to match_array [fund_1_organisation_project]
-      end
-
-      context "filtering by `include_ispf_non_oda_activities`" do
-        let!(:oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: true) }
-        let!(:non_oda_project) { create(:project_activity, :ispf_funded, organisation: other_organisation, is_oda: false) }
-
-        it "excludes ISPF non-ODA activities by default" do
-          result = described_class.new(organisation: other_organisation, user: user).call
-
-          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, oda_project]
-        end
-
-        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
-          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
-
-          expect(result).to match_array [
-            fund_1_organisation_project,
-            fund_2_organisation_project,
-            oda_project,
-            non_oda_project
-          ]
-        end
       end
     end
   end

--- a/spec/services/find_third_party_project_activities_spec.rb
+++ b/spec/services/find_third_party_project_activities_spec.rb
@@ -22,44 +22,6 @@ RSpec.describe FindThirdPartyProjectActivities do
 
         expect(result).to match_array [fund_1_organisation_project, other_project]
       end
-
-      context "filtering by `include_ispf_non_oda_activities`" do
-        let!(:oda_project) {
-          create(
-            :third_party_project_activity,
-            :ispf_funded,
-            organisation: other_organisation,
-            is_oda: true
-          )
-        }
-
-        let!(:non_oda_project) {
-          create(
-            :third_party_project_activity,
-            :ispf_funded,
-            organisation: other_organisation,
-            is_oda: false
-          )
-        }
-
-        it "excludes ISPF non-ODA activities by default" do
-          result = described_class.new(organisation: service_owner, user: user).call
-
-          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, other_project, oda_project]
-        end
-
-        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
-          result = described_class.new(organisation: service_owner, user: user, include_ispf_non_oda_activities: true).call
-
-          expect(result).to match_array [
-            fund_1_organisation_project,
-            fund_2_organisation_project,
-            other_project,
-            oda_project,
-            non_oda_project
-          ]
-        end
-      end
     end
 
     context "when the organisation is not the service owner" do
@@ -73,43 +35,6 @@ RSpec.describe FindThirdPartyProjectActivities do
         result = described_class.new(organisation: other_organisation, user: user, fund_code: 1).call
 
         expect(result).to match_array [fund_1_organisation_project]
-      end
-
-      context "filtering by `include_ispf_non_oda_activities`" do
-        let!(:oda_project) {
-          create(
-            :third_party_project_activity,
-            :ispf_funded,
-            organisation: other_organisation,
-            is_oda: true
-          )
-        }
-
-        let!(:non_oda_project) {
-          create(
-            :third_party_project_activity,
-            :ispf_funded,
-            organisation: other_organisation,
-            is_oda: false
-          )
-        }
-
-        it "excludes ISPF non-ODA activities by default" do
-          result = described_class.new(organisation: other_organisation, user: user).call
-
-          expect(result).to match_array [fund_1_organisation_project, fund_2_organisation_project, oda_project]
-        end
-
-        it "includes ISPF non-ODA activities when `include_ispf_non_oda_activities` is true" do
-          result = described_class.new(organisation: other_organisation, user: user, include_ispf_non_oda_activities: true).call
-
-          expect(result).to match_array [
-            fund_1_organisation_project,
-            fund_2_organisation_project,
-            oda_project,
-            non_oda_project
-          ]
-        end
       end
     end
   end

--- a/spec/services/update_actual_spec.rb
+++ b/spec/services/update_actual_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe UpdateActual do
       it "returns a successful result" do
         result = updater.call(attributes: {})
 
-        expect(result.success?).to be true
+        expect(result.success?).to be(true)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe UpdateActual do
       it "returns a failed result" do
         result = updater.call(attributes: {})
 
-        expect(result.success?).to be false
+        expect(result.success?).to be(false)
       end
     end
 

--- a/spec/services/update_budget_spec.rb
+++ b/spec/services/update_budget_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UpdateBudget do
       let(:result) { subject.call(attributes: attributes) }
 
       it "returns a successful result" do
-        expect(result.success?).to be true
+        expect(result.success?).to be(true)
       end
 
       it "records a historic event" do
@@ -77,7 +77,7 @@ RSpec.describe UpdateBudget do
 
         result = subject.call(attributes: {})
 
-        expect(result.success?).to be false
+        expect(result.success?).to be(false)
       end
     end
 

--- a/spec/services/update_refund_spec.rb
+++ b/spec/services/update_refund_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UpdateRefund do
       it "returns a successful result" do
         result = updater.call(attributes: {})
 
-        expect(result.success?).to be true
+        expect(result.success?).to be(true)
       end
 
       it "uses HistoryRecorder to record a historical event" do
@@ -53,7 +53,7 @@ RSpec.describe UpdateRefund do
       it "returns a failed result" do
         result = updater.call(attributes: {})
 
-        expect(result.success?).to be false
+        expect(result.success?).to be(false)
       end
 
       it "does not record a historical event" do

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe UpdateUser do
     it "returns a successful result" do
       result = described_class.new(user: user, organisation: build_stubbed(:partner_organisation)).call
 
-      expect(result.success?).to eq(true)
-      expect(result.failure?).to eq(false)
+      expect(result.success?).to be(true)
+      expect(result.failure?).to be(false)
     end
 
     context "when an organisation is provided" do

--- a/spec/support/shared_examples/sanitises_monetary_fields.rb
+++ b/spec/support/shared_examples/sanitises_monetary_fields.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "sanitises monetary field" do
       it "returns an unsuccessful result" do
         attributes = ActionController::Parameters.new(value: "abc 123.00 xyz").permit!
         result = subject.call(attributes: attributes)
-        expect(result.success).to be false
+        expect(result.success).to be(false)
       end
     end
 

--- a/spec/validators/date_not_in_future_validator_spec.rb
+++ b/spec/validators/date_not_in_future_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DateNotInFutureValidator do
     context "when date is nil" do
       it "is valid" do
         subject.date = nil
-        expect(subject.valid?).to be true
+        expect(subject.valid?).to be(true)
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe DateNotInFutureValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.date = Date.new(2004, 11, 24)
-        expect(subject.valid?).to be true
+        expect(subject.valid?).to be(true)
 
         travel_back
       end
@@ -37,7 +37,7 @@ RSpec.describe DateNotInFutureValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.date = Date.new(2003, 1, 1)
-        expect(subject.valid?).to be true
+        expect(subject.valid?).to be(true)
 
         travel_back
       end
@@ -48,7 +48,7 @@ RSpec.describe DateNotInFutureValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.date = Date.new(2005, 1, 1)
-        expect(subject.valid?).to be false
+        expect(subject.valid?).to be(false)
 
         travel_back
       end

--- a/spec/validators/date_not_in_past_validator_spec.rb
+++ b/spec/validators/date_not_in_past_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DateNotInPastValidator do
     context "when date is nil" do
       it "is valid" do
         subject.deadline = nil
-        expect(subject.valid?).to be true
+        expect(subject.valid?).to be(true)
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe DateNotInPastValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.deadline = Date.new(2004, 11, 24)
-        expect(subject.valid?).to be false
+        expect(subject.valid?).to be(false)
 
         travel_back
       end
@@ -37,7 +37,7 @@ RSpec.describe DateNotInPastValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.deadline = Date.new(2005, 1, 1)
-        expect(subject.valid?).to be true
+        expect(subject.valid?).to be(true)
 
         travel_back
       end
@@ -48,7 +48,7 @@ RSpec.describe DateNotInPastValidator do
         travel_to Time.zone.local(2004, 11, 24)
 
         subject.deadline = Date.new(2003, 1, 1)
-        expect(subject.valid?).to be false
+        expect(subject.valid?).to be(false)
 
         travel_back
       end

--- a/spec/validators/date_within_boundaries_validator_spec.rb
+++ b/spec/validators/date_within_boundaries_validator_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe DateWithinBoundariesValidator do
   describe "when date is nil" do
     it "is valid" do
       subject.date = nil
-      expect(subject.valid?).to be true
+      expect(subject.valid?).to be(true)
     end
   end
 
   describe "when date is within range" do
     it "is valid" do
       subject.date = Date.today
-      expect(subject.valid?).to be true
+      expect(subject.valid?).to be(true)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe DateWithinBoundariesValidator do
   describe "when date is more than 10 years ago" do
     xit "is not valid" do
       subject.date = 11.years.ago
-      expect(subject.valid?).to be false
+      expect(subject.valid?).to be(false)
     end
   end
 
@@ -40,14 +40,14 @@ RSpec.describe DateWithinBoundariesValidator do
   describe "when date is more than 17 years ago" do
     it "is not valid" do
       subject.date = 18.years.ago
-      expect(subject.valid?).to be false
+      expect(subject.valid?).to be(false)
     end
   end
 
   describe "when date is more than 25 years in the future" do
     it "is not valid" do
       subject.date = 26.years.from_now
-      expect(subject.valid?).to be false
+      expect(subject.valid?).to be(false)
     end
   end
 end

--- a/spec/validators/end_date_after_start_date_validator_spec.rb
+++ b/spec/validators/end_date_after_start_date_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EndDateAfterStartDateValidator do
       subject.planned_start_date = Date.today
       subject.planned_end_date = Date.today
 
-      expect(subject.valid?).to be true
+      expect(subject.valid?).to be(true)
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe EndDateAfterStartDateValidator do
       subject.planned_start_date = Date.tomorrow
       subject.planned_end_date = Date.today
 
-      expect(subject.valid?).to be false
+      expect(subject.valid?).to be(false)
     end
 
     it "adds an error message to the :planned_end_date" do


### PR DESCRIPTION
## Changes in this PR

- Set `publish_to_iati` to `false` on non-ODA activities
- Add missing spec
- Remove redundant functionality in activity finder classes

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
