### PR TITLE
List items in tab list links are presentational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1226,6 +1226,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Update Commitment-importing script to infer `transaction_date` value from Activity values
 - Collect original commitment figure in new activity form and bulk activity upload
 - Remove password reset field from new user form
+- Fix an accessibility issue on the Organisations page
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/views/organisations/_table.html.haml
+++ b/app/views/organisations/_table.html.haml
@@ -6,7 +6,7 @@
 
       %ul.govuk-tabs__list{role: "tablist"}
         - ["partner_organisations", "matched_effort_providers", "external_income_providers", "implementing_organisations"].each do |role|
-          %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}"}
+          %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}", role: "presentation"}
             = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { selected: (role == @role) } }
 
       .govuk-tabs__panel


### PR DESCRIPTION
## Changes in this PR

The `ul` element has the role `tablist`. The specification says that it must “own” `tab` elements.[1] We’ve chosen to give the links inside `li` the role `tab`, rather than give `li` elements `tab` role.

Even though an “owned element” is defined as “any DOM descendant of the element”, Axe tools raises a critical issue: “Element has children which are not allowed” for the `ul` with role `tablist`, and “Required ARIA parent role not present: tablist“ for the `a` elements with role `tab`, suggesting that it was expecting direct child/parent elements rather than going through the intermediate `li` element.

Elsewhere we fixed this by giving the `li` elements presentational roles

This also fixes 4 serious issues for the `li` elements: "List item does not have a \<ul\>, \<ol\> parent element without a role, or a role="list”".

[1] https://www.w3.org/TR/wai-aria-1.1/#tablist

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
