### PR TITLE
(2792) Remove MFA from new user form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,6 +1225,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 
 - Update Commitment-importing script to infer `transaction_date` value from Activity values
 - Collect original commitment figure in new activity form and bulk activity upload
+- Remove password reset field from new user form
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -4,8 +4,9 @@
   = f.govuk_text_field :name
   = f.govuk_email_field :email, disabled: (action_name == "edit")
 
-  = f.govuk_check_boxes_fieldset :reset_mfa, multiple: false, legend: { text: t("form.legend.user.reset_mfa") }, hint: { text: t("form.hint.user.reset_mfa") } do
-    = f.govuk_check_box :reset_mfa, true, multiple: false, label: { text: t("form.label.user.reset_mfa") }
+  - if @user.persisted?
+    = f.govuk_check_boxes_fieldset :reset_mfa, multiple: false, legend: { text: t("form.legend.user.reset_mfa") }, hint: { text: t("form.hint.user.reset_mfa") } do
+      = f.govuk_check_box :reset_mfa, true, multiple: false, label: { text: t("form.label.user.reset_mfa") }
 
   - if @service_owner.present?
     = f.govuk_radio_buttons_fieldset :organisation, classes: "user-organisations" do

--- a/spec/features/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/beis_users_can_invite_new_users_spec.rb
@@ -76,6 +76,7 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
     # Fill out the form
     expect(page).to have_content(t("page_title.users.new"))
+    expect(page).not_to have_content("Reset the user's mobile number?")
     fill_in "user[name]", with: new_user_name
     fill_in "user[email]", with: new_user_email
     choose organisation.name

--- a/spec/features/beis_users_can_invite_new_users_spec.rb
+++ b/spec/features/beis_users_can_invite_new_users_spec.rb
@@ -35,14 +35,14 @@ RSpec.feature "BEIS users can invite new users to the service" do
       it "shows the user validation errors instead" do
         visit new_user_path
 
-        expect(page).to have_content(t("page_title.users.new"))
+        expect(page).to have_content("Create user")
         fill_in "user[name]", with: "" # deliberately omit a value
         fill_in "user[email]", with: "" # deliberately omit a value
 
-        click_button t("default.button.submit")
+        click_button "Submit"
 
-        expect(page).to have_content(t("activerecord.errors.models.user.attributes.name.blank"))
-        expect(page).to have_content(t("activerecord.errors.models.user.attributes.email.blank"))
+        expect(page).to have_content("Enter a full name")
+        expect(page).to have_content("Enter an email address")
       end
     end
   end
@@ -52,20 +52,20 @@ RSpec.feature "BEIS users can invite new users to the service" do
 
     it "does not show them the manage user button" do
       visit organisation_path(user.organisation)
-      expect(page).not_to have_content(t("page_title.users.index"))
+      expect(page).not_to have_content("Users")
     end
   end
 
   def create_user(organisation, new_user_name, new_user_email)
     # Navigate from the landing page
     visit organisation_path(organisation)
-    click_on(t("page_title.users.index"))
+    click_on("Users")
 
     # Navigate to the users page
-    expect(page).to have_content(t("page_title.users.index"))
+    expect(page).to have_content("Users")
 
     # Create a new user
-    click_on(t("page_content.users.button.create"))
+    click_on("Add user")
 
     # We expect to see BEIS separately on this page
     within(".user-organisations") do
@@ -75,13 +75,13 @@ RSpec.feature "BEIS users can invite new users to the service" do
     end
 
     # Fill out the form
-    expect(page).to have_content(t("page_title.users.new"))
     expect(page).not_to have_content("Reset the user's mobile number?")
+    expect(page).to have_content("Create user")
     fill_in "user[name]", with: new_user_name
     fill_in "user[email]", with: new_user_email
     choose organisation.name
 
     # Submit the form
-    click_button t("default.button.submit")
+    click_button "Submit"
   end
 end


### PR DESCRIPTION
## Changes in this PR

Remove the mobile number reset field from the new user form

## Screenshots of UI changes

### Before

<img width="767" alt="image" src="https://user-images.githubusercontent.com/40244233/223573842-44cc7c68-b523-4aa6-9184-d3bbb6ba296b.png">

### After

<img width="796" alt="image" src="https://user-images.githubusercontent.com/40244233/223573521-6e2d022b-4b55-4289-9fe9-35b0b9908d16.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
