### PR TITLE
(2500b) Signpost adding actual comments on their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1234,6 +1234,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Only provide an IATI export link if there are publishable activities
 - Always show "Untitled activity" in breadcrumbs when an activity is untitled
 - Ensure upload forms are constrained to a 2 thirds layout for accessibility
+- Signpost how to add a comment after a failed actual/refund upload containing a comment
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/controllers/actuals/uploads_controller.rb
+++ b/app/controllers/actuals/uploads_controller.rb
@@ -54,6 +54,8 @@ class Actuals::UploadsController < BaseController
 
         @success = true
         flash.now[:notice] = t("action.actual.upload.success")
+      else
+        @invalid_with_comment = importer.invalid_with_comment
       end
     else
       @errors = []

--- a/app/services/actual/import.rb
+++ b/app/services/actual/import.rb
@@ -7,7 +7,7 @@ class Actual
       end
     }
 
-    attr_reader :errors, :imported_actuals
+    attr_reader :errors, :imported_actuals, :invalid_with_comment
 
     def self.column_headings
       Converter::FIELDS.values
@@ -17,6 +17,7 @@ class Actual
       @report = report
       @uploader = uploader
       @errors = []
+      @invalid_with_comment = false
     end
 
     def import(actuals)
@@ -35,6 +36,8 @@ class Actual
 
       importer.errors.each do |attr_name, (value, message)|
         add_error(index, attr_name, value, message)
+
+        @invalid_with_comment ||= row["Comment"].present?
       end
 
       importer.actual

--- a/app/views/actuals/uploads/new.html.haml
+++ b/app/views/actuals/uploads/new.html.haml
@@ -8,7 +8,13 @@
 
       = t("page_content.actuals.upload.copy_html", report_actuals_template_path: report_actuals_upload_path(@report_presenter, format: :csv))
 
-      = t("page_content.actuals.upload.warning_html")
+      .govuk-warning-text
+        %span.govuk-warning-text__icon{ "aria-hidden" => "true" }
+          = "!"
+        %strong.govuk-warning-text__text
+          %span.govuk-warning-text__assistive
+            = t("default.warning")
+          = t("page_content.actuals.upload.warning")
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/actuals/uploads/new.html.haml
+++ b/app/views/actuals/uploads/new.html.haml
@@ -8,13 +8,7 @@
 
       = t("page_content.actuals.upload.copy_html", report_actuals_template_path: report_actuals_upload_path(@report_presenter, format: :csv))
 
-      .govuk-warning-text
-        %span.govuk-warning-text__icon{ "aria-hidden" => "true" }
-          = "!"
-        %strong.govuk-warning-text__text
-          %span.govuk-warning-text__assistive
-            = t("default.warning")
-          = t("page_content.actuals.upload.warning")
+      = render partial: "shared/warning_text", locals: { warning_text: t("page_content.actuals.upload.warning") }
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/actuals/uploads/update.html.haml
+++ b/app/views/actuals/uploads/update.html.haml
@@ -12,6 +12,10 @@
         .govuk-grid-column-full
           = render partial: "error_table"
 
+      .govuk-grid-row
+        .govuk-grid-column-two-thirds
+          = render partial: "shared/warning_text", locals: { warning_text: t("page_content.actuals.upload.warning_comment_html") }
+
     .govuk-grid-row
       .govuk-grid-column-two-thirds
         = render partial: "upload_form"

--- a/app/views/actuals/uploads/update.html.haml
+++ b/app/views/actuals/uploads/update.html.haml
@@ -12,9 +12,10 @@
         .govuk-grid-column-full
           = render partial: "error_table"
 
-      .govuk-grid-row
-        .govuk-grid-column-two-thirds
-          = render partial: "shared/warning_text", locals: { warning_text: t("page_content.actuals.upload.warning_comment_html") }
+      - if @invalid_with_comment
+        .govuk-grid-row
+          .govuk-grid-column-two-thirds
+            = render partial: "shared/warning_text", locals: { warning_text: t("page_content.actuals.upload.warning_comment_html") }
 
     .govuk-grid-row
       .govuk-grid-column-two-thirds

--- a/app/views/reports/_actuals_upload.html.haml
+++ b/app/views/reports/_actuals_upload.html.haml
@@ -1,16 +1,24 @@
 %h3.govuk-heading-m
-  = t("tabs.actuals.providing.heading")
+  = t("tabs.actuals.add.heading")
 
 %p.govuk-body
-  = t("tabs.actuals.providing.copy_html")
+  = t("tabs.actuals.add.pre_list_text")
 
-%h3.govuk-heading-s
-  = t("tabs.actuals.upload.heading")
+  %ul.govuk-list.govuk-list--bullet
+    - t("tabs.actuals.add.list_items").each do |list_item|
+      %li
+        = list_item
 
-= t("tabs.actuals.upload.copy_html")
+%h4.govuk-heading-s
+  = t("tabs.actuals.add.upload.heading")
+
+%ul.govuk-list.govuk-list--bullet
+  - t("tabs.actuals.add.upload.list_items_html").each do |list_item_html|
+    %li
+      = list_item_html
 
 .govuk-inset-text
-  = t("tabs.actuals.upload.warning")
+  = t("tabs.actuals.add.upload.inset_warning")
 
 .govuk-button-group
   = link_to t("page_content.actuals.button.download_template"), report_actuals_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"

--- a/app/views/reports/_actuals_upload.html.haml
+++ b/app/views/reports/_actuals_upload.html.haml
@@ -1,25 +1,29 @@
-%h3.govuk-heading-m
-  = t("tabs.actuals.add.heading")
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h3.govuk-heading-m
+      = t("tabs.actuals.add.heading")
 
-%p.govuk-body
-  = t("tabs.actuals.add.pre_list_text")
+    %p.govuk-body
+      = t("tabs.actuals.add.pre_list_text")
 
-  %ul.govuk-list.govuk-list--bullet
-    - t("tabs.actuals.add.list_items").each do |list_item|
-      %li
-        = list_item
+      %ul.govuk-list.govuk-list--bullet
+        - t("tabs.actuals.add.list_items").each do |list_item|
+          %li
+            = list_item
 
-%h4.govuk-heading-s
-  = t("tabs.actuals.add.upload.heading")
+    %h4.govuk-heading-s
+      = t("tabs.actuals.add.upload.heading")
 
-%ul.govuk-list.govuk-list--bullet
-  - t("tabs.actuals.add.upload.list_items_html").each do |list_item_html|
-    %li
-      = list_item_html
+    %ul.govuk-list.govuk-list--bullet
+      - t("tabs.actuals.add.upload.list_items_html").each do |list_item_html|
+        %li
+          = list_item_html
 
-.govuk-inset-text
-  = t("tabs.actuals.add.upload.inset_warning")
+    .govuk-inset-text
+      = t("tabs.actuals.add.upload.inset_warning")
 
-.govuk-button-group
-  = link_to t("page_content.actuals.button.download_template"), report_actuals_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
-  = link_to t("page_content.actuals.button.upload"), new_report_actuals_upload_path(@report_presenter), class: "govuk-button"
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-button-group
+      = link_to t("page_content.actuals.button.download_template"), report_actuals_upload_path(@report_presenter, format: :csv), class: "govuk-button govuk-button--secondary"
+      = link_to t("page_content.actuals.button.upload"), new_report_actuals_upload_path(@report_presenter), class: "govuk-button"

--- a/app/views/shared/_warning_text.html.haml
+++ b/app/views/shared/_warning_text.html.haml
@@ -1,0 +1,7 @@
+.govuk-warning-text
+  %span.govuk-warning-text__icon{ "aria-hidden" => "true" }
+    = "!"
+  %strong.govuk-warning-text__text
+    %span.govuk-warning-text__assistive
+      = t("default.warning")
+    = warning_text

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -98,6 +98,7 @@ en:
             <li>Click the Browse button below and find the file you want to upload, then click Upload and continue.</li>
           </ol>
         warning: Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.
+        warning_comment_html: Comments can only be added via the bulk upload if they have an accompanying actual or refund value. If this is not the case, you will need to add the comment via the comments section of relevant activity. See <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005515501-Adding-your-Actuals-Data-">this guidance (opens in new tab)</a> for more information on uploading actuals and refunds.
   page_title:
     actual:
       edit: Edit actual spend

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -61,21 +61,19 @@ en:
     actuals:
       heading: Actuals / Refunds
       copy: Actuals and refunds that have already been added to this report are listed below.
-      providing:
+      add:
         heading: Adding more actuals and refunds data
-        copy_html: |
-          To add more actuals on this page:
-          <ul class="govuk-list govuk-list--bullet">
-          <li>Download the actuals data template</li>
-          <li>Complete the template with your additional actuals data</li>
-          <li>Upload the template</li>
-          </ul>
-      upload:
-        heading: Upload data
-        copy_html:
-          <p class="govuk-body">Large numbers of actuals and refunds can be added via the actuals upload.</p>
-          <p class="govuk-body">For guidance on uploading actuals and refunds, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.</p>
-        warning: Ensure you use the correct template (available below) when uploading the actuals and refunds.
+        pre_list_text: "To add more actuals on this page:"
+        list_items: 
+          - Download the actuals data template
+          - Complete the template with your additional actuals data
+          - Upload the template
+        upload:
+          heading: Upload data
+          list_items_html:
+            - Large numbers of actuals and refunds can be added via the actuals upload.
+            - For guidance on uploading actuals and refunds, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.
+          inset_warning: Ensure you use the correct template (available below) when uploading the actuals and refunds.
   page_content:
     actuals:
       button:

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -73,6 +73,7 @@ en:
           list_items_html:
             - Large numbers of actuals and refunds can be added via the actuals upload.
             - For guidance on uploading actuals and refunds, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload">guidance in the help centre (opens in new tab)</a>.
+            - If you need to upload comments about why there are no actuals/refunds, add an activity comment rather than uploading a blank actuals template.
           inset_warning: Ensure you use the correct template (available below) when uploading the actuals and refunds.
   page_content:
     actuals:

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -97,8 +97,7 @@ en:
             <li>Save the file in the CSV format with the UTF-8 encoding</li>
             <li>Click the Browse button below and find the file you want to upload, then click Upload and continue.</li>
           </ol>
-        warning_html:
-          <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.</strong></div>
+        warning: Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.
   page_title:
     actual:
       edit: Edit actual spend

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -156,6 +156,8 @@ RSpec.feature "users can upload actuals" do
       expect(page).to have_xpath("td[3]", text: "61")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.invalid_iati_organisation_type"))
     end
+
+    expect(page).to have_text("Comments can only be added via the bulk upload if they have an accompanying actual or refund value. If this is not the case, you will need to add the comment via the comments section of relevant activity.")
   end
 
   scenario "uploading a set of actuals with encoding errors" do

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -135,9 +135,15 @@ RSpec.feature "users can upload actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 
     upload_csv <<~CSV
-      Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference
-      #{ids[0]}                | 1                 | 2020           | fish         | Example University          | 80                          |
-      #{ids[1]}                | 1                 | 2020           | 30           | Example Foundation          | 61                          |
+      Activity RODA Identifier   | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{ids[0]}                  | 1                 | 2020           | fish         |              | Example University          | 80                          |                                       |
+      #{ids[1]}                  | 1                 | 2020           | 30           |              | Example Foundation          | 61                          |                                       |
+      #{ids[0]}                  | 1                 | 2020           | 0            |              |                             |                             |                                       |
+      #{ids[0]}                  | 1                 | 2020           | 4            | 5            |                             |                             |                                       |
+      #{ids[0]}                  | 1                 | 2020           | 5            | 0            |                             |                             |                                       |
+      #{ids[0]}                  | 1                 | 2020           | 0            | 0            |                             |                             |                                       |
+      #{ids[0]}                  | 1                 | 2020           |              | 0            |                             |                             |                                       |
+      #{ids[0]}                  | 1                 | 2020           |              |              |                             |                             |                                       |
     CSV
 
     expect(Actual.count).to eq(0)
@@ -155,6 +161,48 @@ RSpec.feature "users can upload actuals" do
       expect(page).to have_xpath("td[2]", text: "3")
       expect(page).to have_xpath("td[3]", text: "61")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.invalid_iati_organisation_type"))
+    end
+
+    within "//tbody/tr[3]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "4")
+      expect(page).to have_xpath("td[3]", text: "0, blank")
+      expect(page).to have_xpath("td[4]", text: "Actual can't be zero when refund is blank")
+    end
+
+    within "//tbody/tr[4]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "5")
+      expect(page).to have_xpath("td[3]", text: "4, 5")
+      expect(page).to have_xpath("td[4]", text: "Actual and refund are both filled")
+    end
+
+    within "//tbody/tr[5]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "6")
+      expect(page).to have_xpath("td[3]", text: "5, 0")
+      expect(page).to have_xpath("td[4]", text: "Refund can't be zero when actual is filled")
+    end
+
+    within "//tbody/tr[6]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "7")
+      expect(page).to have_xpath("td[3]", text: "0, 0")
+      expect(page).to have_xpath("td[4]", text: "Actual and refund are both zero")
+    end
+
+    within "//tbody/tr[7]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "8")
+      expect(page).to have_xpath("td[3]", text: "blank, 0")
+      expect(page).to have_xpath("td[4]", text: "Refund can't be zero when actual is blank")
+    end
+
+    within "//tbody/tr[8]" do
+      expect(page).to have_xpath("td[1]", text: "Actual Value/Refund Value")
+      expect(page).to have_xpath("td[2]", text: "9")
+      expect(page).to have_xpath("td[3]", text: "blank, blank")
+      expect(page).to have_xpath("td[4]", text: "Actual and refund are both blank")
     end
   end
 

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "users can upload actuals" do
     expect(page.html).to include t("page_content.actuals.upload.copy_html",
       report_actuals_template_path: report_actuals_upload_path(report, format: :csv))
 
-    expect(page.html).to include t("page_content.actuals.upload.warning_html")
+    expect(page).to have_text("Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.")
   end
 
   scenario "downloading a CSV template with activities for the current report" do

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -156,8 +156,28 @@ RSpec.feature "users can upload actuals" do
       expect(page).to have_xpath("td[3]", text: "61")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.actual.invalid_iati_organisation_type"))
     end
+  end
 
+  scenario "uploading invalid values with a comment" do
+    upload_csv <<~CSV
+      Activity RODA Identifier   | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{project.roda_identifier} | 1                 | 2020           | 0            | 0            |                             |                             |                                       | Woo!
+    CSV
+
+    expect(Actual.count).to eq(0)
+    expect(page).not_to have_text("The transactions were successfully imported.")
     expect(page).to have_text("Comments can only be added via the bulk upload if they have an accompanying actual or refund value. If this is not the case, you will need to add the comment via the comments section of relevant activity.")
+  end
+
+  scenario "uploading invalid values without a comment" do
+    upload_csv <<~CSV
+      Activity RODA Identifier   | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{project.roda_identifier} | 1                 | 2020           | 0            | 0            |                             |                             |                                       |
+    CSV
+
+    expect(Actual.count).to eq(0)
+    expect(page).not_to have_text("The transactions were successfully imported.")
+    expect(page).not_to have_text("Comments can only be added via the bulk upload if they have an accompanying actual or refund value. If this is not the case, you will need to add the comment via the comments section of relevant activity.")
   end
 
   scenario "uploading a set of actuals with encoding errors" do

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -441,6 +441,7 @@ RSpec.feature "Users can view reports" do
         expect(page).to have_text("Ensure you use the correct template (available below) when uploading the actuals and refunds.")
         expect(page).to have_text("Large numbers of actuals and refunds can be added via the actuals upload.")
         expect(page).to have_text("For guidance on uploading actuals and refunds, see")
+        expect(page).to have_text("If you need to upload comments about why there are no actuals/refunds, add an activity comment rather than uploading a blank actuals template.")
         expect(page).to have_link(
           "Download actuals and refunds data template",
           href: report_actuals_upload_path(report, format: :csv)

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -438,11 +438,17 @@ RSpec.feature "Users can view reports" do
 
         visit report_actuals_path(report)
 
-        expect(page.html).to include t("tabs.actuals.upload.copy_html")
-        expect(page).to have_link t("page_content.actuals.button.download_template"),
+        expect(page).to have_text("Ensure you use the correct template (available below) when uploading the actuals and refunds.")
+        expect(page).to have_text("Large numbers of actuals and refunds can be added via the actuals upload.")
+        expect(page).to have_text("For guidance on uploading actuals and refunds, see")
+        expect(page).to have_link(
+          "Download actuals and refunds data template",
           href: report_actuals_upload_path(report, format: :csv)
-        expect(page).to have_link "guidance in the help centre (opens in new tab)",
+        )
+        expect(page).to have_link(
+          "guidance in the help centre (opens in new tab)",
           href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005601882-Downloading-the-Actuals-Template-in-order-to-Bulk-Upload"
+        )
       end
 
       scenario "they can view and edit budgets in a report" do


### PR DESCRIPTION
## Changes in this PR

## Screenshots of UI changes

### Before

<img width="869" alt="image" src="https://user-images.githubusercontent.com/40244233/225071875-6a04285a-fcfe-4c72-9a4b-d15ca66b8a0b.png">

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/40244233/223768056-8d6d793c-b017-474b-9eff-d740126c246f.png">

### After

<img width="752" alt="image" src="https://user-images.githubusercontent.com/40244233/225071811-05eae441-c4bf-4f43-8346-e4aa7d80ba11.png">

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/40244233/225071631-46940b80-22f4-4ad4-86d3-64d78ed45066.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
