### PR TITLE
(2822) Add govuk-link class where missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1228,6 +1228,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Remove password reset field from new user form
 - Fix an accessibility issue on the Organisations page
 - Set `publish_to_iati` to `false` for non-ODA activities
+- Add `govuk-link` class to links where missing
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/views/activities/comments.html.haml
+++ b/app/views/activities/comments.html.haml
@@ -58,4 +58,4 @@
                       %dt.govuk-summary-list__key
                         Comment reported in
                       %dd.govuk-summary-list__value
-                        = link_to "#{report_presenter.financial_quarter_and_year} #{report_presenter.description}", report_path(comment.report)
+                        = link_to "#{report_presenter.financial_quarter_and_year} #{report_presenter.description}", report_path(comment.report), class: "govuk-link"

--- a/app/views/activities/historical_events.html.haml
+++ b/app/views/activities/historical_events.html.haml
@@ -59,5 +59,5 @@
                         %td.govuk-table__cell.previous-value= event.previous_value
                         %td.govuk-table__cell.new-value= event.new_value
                         %td.govuk-table__cell.report
-                          = link_to(event.report.financial_quarter_and_year, report_path(event.report)) if event.report
+                          = link_to(event.report.financial_quarter_and_year, report_path(event.report), class: "govuk-link") if event.report
 

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -18,4 +18,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to report", report_path(@report_presenter)
+      %p.govuk-body= link_to "Back to report", report_path(@report_presenter), class: "govuk-link"

--- a/app/views/adjustments/show.html.haml
+++ b/app/views/adjustments/show.html.haml
@@ -36,13 +36,13 @@
           %dt.govuk-summary-list__key
             = t("summary.headings.adjustment.activity")
           %dd.govuk-summary-list__value
-            = link_to("View", organisation_activity_financials_path(organisation_id: @activity.organisation.id, activity_id: @activity.id))
+            = link_to("View", organisation_activity_financials_path(organisation_id: @activity.organisation.id, activity_id: @activity.id), class: "govuk-link")
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("summary.headings.adjustment.report")
           %dd.govuk-summary-list__value
-            = link_to("View", report_path(@adjustment.report))
+            = link_to("View", report_path(@adjustment.report), class: "govuk-link")
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -18,4 +18,4 @@
       .actions
         = f.govuk_submit "Log in"
 
-    %p.govuk-body= link_to "Forgot password?", new_user_password_path
+    %p.govuk-body= link_to "Forgot password?", new_user_password_path, class: "govuk-link"

--- a/app/views/devise/sessions/otp_attempt.html.haml
+++ b/app/views/devise/sessions/otp_attempt.html.haml
@@ -23,7 +23,7 @@
       .govuk-grid-column-two-thirds
         %p.govuk-body
           Didn't get a message?
-          = link_to "Check your mobile number is correct", edit_mobile_number_path
+          = link_to "Check your mobile number is correct", edit_mobile_number_path, class: "govuk-link"
 
   .govuk-grid-row
     .govuk-grid-column-one-third

--- a/app/views/level_b/activities/uploads/new.html.haml
+++ b/app/views/level_b/activities/uploads/new.html.haml
@@ -17,4 +17,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", home_path
+      %p.govuk-body= link_to "Back to home", home_path, class: "govuk-link"

--- a/app/views/level_b/activities/uploads/update.html.haml
+++ b/app/views/level_b/activities/uploads/update.html.haml
@@ -23,4 +23,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", home_path
+      %p.govuk-body= link_to "Back to home", home_path, class: "govuk-link"

--- a/app/views/level_b/budgets/uploads/create.html.haml
+++ b/app/views/level_b/budgets/uploads/create.html.haml
@@ -19,4 +19,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", home_path
+      %p.govuk-body= link_to "Back to home", home_path, class: "govuk-link"

--- a/app/views/level_b/budgets/uploads/new.html.haml
+++ b/app/views/level_b/budgets/uploads/new.html.haml
@@ -30,4 +30,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to home", home_path
+      %p.govuk-body= link_to "Back to home", home_path, class: "govuk-link"

--- a/app/views/pages/cookie_statement.html.haml
+++ b/app/views/pages/cookie_statement.html.haml
@@ -57,7 +57,7 @@
 
       %p.govuk-body
         For more information on Google‘s cookies, please see the
-        = link_to "Google Privacy & Terms", "https://policies.google.com/technologies/cookies?hl=en-uk"
+        = link_to "Google Privacy & Terms", "https://policies.google.com/technologies/cookies?hl=en-uk", class: "govuk-link"
         site.
 
       %h2.govuk-heading-m

--- a/app/views/public/visitors/index.html.haml
+++ b/app/views/public/visitors/index.html.haml
@@ -9,7 +9,7 @@
       %p.govuk-body
         = succeed "." do
           This service is for reporting BEIS research and innovation
-          %a{href: "https://beisodahelp.zendesk.com/hc/en-gb/categories/360004750374-What-is-ODA-Spending-"} ODA
+          %a{href: "https://beisodahelp.zendesk.com/hc/en-gb/categories/360004750374-What-is-ODA-Spending-", class: "govuk-link"} ODA
 
       %p.govuk-body
         Use this service to:
@@ -29,5 +29,5 @@
 
       %p.govuk-body
         Please
-        %a{href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005351841-Accessing-the-Service"} request an account
+        %a{href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005351841-Accessing-the-Service", class: "govuk-link"} request an account
         if you have not yet received sign-in details to access this service.

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -66,7 +66,7 @@
         = t("activerecord.attributes.activity.linked_activity")
       %dd.govuk-summary-list__value
         - if activity_presenter.linked_activity
-          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity), class: "govuk-link"
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -41,7 +41,7 @@
         = t("activerecord.attributes.activity.linked_activity")
       %dd.govuk-summary-list__value
         - if activity_presenter.linked_activity
-          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity)
+          = link_to activity_presenter.linked_activity.title, organisation_activity_path(activity_presenter.linked_activity.organisation, activity_presenter.linked_activity), class: "govuk-link"
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))

--- a/app/views/shared/activities/uploads/_activities_table.html.haml
+++ b/app/views/shared/activities/uploads/_activities_table.html.haml
@@ -15,5 +15,4 @@
         %td.govuk-table__cell= activity_presenter.title
         %td.govuk-table__cell= activity_presenter.programme_status
         %td.govuk-table__cell
-          = link_to "View activity", organisation_activity_path(activity.organisation, activity)
-
+          = link_to "View activity", organisation_activity_path(activity.organisation, activity), class: "govuk-link"

--- a/app/views/shared/adjustments/_table.html.haml
+++ b/app/views/shared/adjustments/_table.html.haml
@@ -19,5 +19,5 @@
           %td.financial-period.govuk-table__cell= adjustment.financial_quarter_and_year
           %td.value.govuk-table__cell= adjustment.value
           %td.type.govuk-table__cell= adjustment.adjustment_type
-          %td.report.govuk-table__cell= link_to("Report", report_path(adjustment.report))
-          %td.actions.govuk-table__cell= link_to("View", activity_adjustment_path(@activity, adjustment))
+          %td.report.govuk-table__cell= link_to("Report", report_path(adjustment.report), class: "govuk-link")
+          %td.actions.govuk-table__cell= link_to("View", activity_adjustment_path(@activity, adjustment), class: "govuk-link")

--- a/app/views/shared/reports/_table_budgets.html.haml
+++ b/app/views/shared/reports/_table_budgets.html.haml
@@ -22,7 +22,7 @@
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell
             - if policy(budget).edit?
-              = link_to t("default.link.edit"), edit_activity_budget_path(budget.parent_activity, budget)
+              = link_to t("default.link.edit"), edit_activity_budget_path(budget.parent_activity, budget), class: "govuk-link"
             - else
               %span.govuk-visually-hidden
                 = t("table.cell.default.no_actions_available")

--- a/app/views/shared/transfers/_index.html.haml
+++ b/app/views/shared/transfers/_index.html.haml
@@ -47,7 +47,7 @@
               %td.govuk-table__cell= transfer.beis_identifier
               %td.govuk-table__cell
                 - if policy(transfer).update?
-                  = link_to "Edit", send("edit_activity_#{transfer_type}_path", @activity.id, transfer.id)
+                  = link_to "Edit", send("edit_activity_#{transfer_type}_path", @activity.id, transfer.id), class: "govuk-link"
                 - else
                   %span.govuk-visually-hidden
                     = t("table.cell.default.no_actions_available")

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -19,7 +19,7 @@
     .govuk-inset-text
       = succeed "." do
         = t("page_content.users.new.no_organisations.cta")
-        = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path
+        = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path, class: "govuk-link"
 
   = f.govuk_collection_radio_buttons :active,
       user_active_options,

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -63,7 +63,7 @@ en:
             This page shows all the new or updated forecasts you have reported in RODA since the last reporting quarter.
           </p>
           <p class="govuk-body">
-            For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+activities">uploading new activities</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities">uploading updates to activities</a> in the help centre.
+            For in-depth guidance, refer to <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=uploading+new+activities" class="govuk-link">uploading new activities</a> and <a href="https://beisodahelp.zendesk.com/hc/en-gb/search?utf8=%E2%9C%93&query=update+activities" class="govuk-link">uploading updates to activities</a> in the help centre.
           </p>
       summary:
         heading: Summary of the contents of this report


### PR DESCRIPTION
## Changes in this PR

Add `govuk-link` class to:
- Links in the sign-in journey
- "Back to home" links on level B activities and budgets upload pages
- "View activity" link on report pages
- "Back to report" link on activities upload page
- Edit budget link within reports
- Forecasts upload guidance
- Link to report in activity comments view and change history view
- Links to the activity and the report in the adjustments view
- Link to edit a transfer
- Cookie statement page
- New organisation link in user form

## Screenshots of UI changes (sample)

### Before
![Screenshot 2023-03-08 at 16 39 17](https://user-images.githubusercontent.com/579522/223774145-02f7a7bd-6593-4bb9-8753-26be4e3eb090.png)

### After
![Screenshot 2023-03-08 at 16 39 04](https://user-images.githubusercontent.com/579522/223774188-b7d7e06f-37e1-46a0-92ff-e55ad576bc7a.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
