### PR TITLE
(2851) Make activity upload form IDs unique

### DIFF
--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -35,7 +35,7 @@ class Activities::UploadsController < BaseController
     @report_presenter = ReportPresenter.new(report)
     upload = CsvFileUpload.new(params[:report], :activity_csv)
     @success = false
-    @type = params[:type].to_sym
+    @type = CGI.escapeHTML(params[:type]).to_sym
     is_oda = Activity::Import.is_oda_by_type(type: @type)
 
     prepare_default_report_trail(report)

--- a/app/controllers/level_b/activities/uploads_controller.rb
+++ b/app/controllers/level_b/activities/uploads_controller.rb
@@ -27,7 +27,7 @@ class LevelB::Activities::UploadsController < BaseController
     @organisation_presenter = OrganisationPresenter.new(organisation)
     upload = CsvFileUpload.new(params[:organisation], :activity_csv)
     @success = false
-    @type = params[:type].to_sym
+    @type = CGI.escapeHTML(params[:type]).to_sym
     is_oda = Activity::Import.is_oda_by_type(type: @type)
 
     if upload.valid?

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -76,6 +76,29 @@ module ActivityHelper
       activity.third_party_project? && ThirdPartyProjectPolicy.new(user, activity).download?
   end
 
+  def activity_csv_upload_file_field(builder:, recovered_from_error:, path_helper:, instance:, type:)
+    default_id = GOVUKDesignSystemFormBuilder::Base.new(nil, builder.object_name, :activity_csv).field_id
+    unique_id = [default_id, type.to_s.dasherize].join("--")
+    default_hint_id = default_id.gsub("field", "hint")
+    unique_hint_id = unique_id.gsub("field", "hint")
+
+    label_translation_path = "form.label.activity.csv_file"
+    label_translation_path += "_recover_from_error" if recovered_from_error
+
+    hint_translation_path = "form.hint.activity.csv_file"
+    hint_translation_path += "_recover_from_error_html" if recovered_from_error
+
+    hint_text = recovered_from_error ?
+      t(hint_translation_path, link: send(path_helper, instance, {type: type, format: :csv})) : t(hint_translation_path)
+
+    field = builder.govuk_file_field :activity_csv,
+      label: {text: t(label_translation_path), hidden: !recovered_from_error, for: unique_id},
+      hint: {text: hint_text, id: unique_hint_id},
+      id: unique_id
+
+    field.gsub("aria-describedby=\"#{default_hint_id}\"", "aria-describedby=\"#{unique_hint_id}\"")
+  end
+
   private
 
   def is_commentable_programme?(activity:)

--- a/app/views/shared/activities/uploads/_upload_form.html.haml
+++ b/app/views/shared/activities/uploads/_upload_form.html.haml
@@ -1,13 +1,5 @@
 .govuk-body.upload-form{class: "upload-form--#{type.to_s.dasherize}"}
   = form_with model: instance, url: send(path_helper, instance, type: type) do |f|
-
-    - if local_assigns[:recovered_from_error]
-      = f.govuk_file_field :activity_csv,
-        label: { text: t("form.label.activity.csv_file_recover_from_error") },
-        hint: { text: t("form.hint.activity.csv_file_recover_from_error_html", link: send(path_helper, instance, { type: type, format: :csv })) }
-    - else
-      = f.govuk_file_field :activity_csv,
-        label: { text: t("form.label.activity.csv_file"), hidden: true },
-        hint: { text: t("form.hint.activity.csv_file") }
+    = activity_csv_upload_file_field(builder: f, recovered_from_error: local_assigns[:recovered_from_error], path_helper: path_helper, instance: instance, type: type).html_safe
 
     = f.govuk_submit t("action.activity.upload.button")


### PR DESCRIPTION
## Changes in this PR

Oof. This was painful

This overwrites the default IDs for the `input` and `div.govuk-hint` elements, the `for` attribute of the `label` element, and the `aria-describedby` attribute of the `input` element, in order to address critical accessibility issues highlighted by axe DevTools

Would welcome any insight on better ways to do this, but I've already spent a few hours investigating/trial and erroring to get to this point

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
