### PR TITLE
(2851) Make activity upload form IDs unique

### DIFF
--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -33,9 +33,9 @@ class Activities::UploadsController < BaseController
     authorize report, :upload?
 
     @report_presenter = ReportPresenter.new(report)
-    upload = CsvFileUpload.new(params[:report], :activity_csv)
-    @success = false
     @type = params[:type].to_sym
+    upload = CsvFileUpload.new(params[:report], :"activity_csv_#{@type}")
+    @success = false
     is_oda = Activity::Import.is_oda_by_type(type: @type)
 
     prepare_default_report_trail(report)

--- a/app/controllers/level_b/activities/uploads_controller.rb
+++ b/app/controllers/level_b/activities/uploads_controller.rb
@@ -25,9 +25,9 @@ class LevelB::Activities::UploadsController < BaseController
     authorize :level_b, :activity_upload?
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
-    upload = CsvFileUpload.new(params[:organisation], :activity_csv)
-    @success = false
     @type = params[:type].to_sym
+    upload = CsvFileUpload.new(params[:organisation], :"activity_csv_#{@type}")
+    @success = false
     is_oda = Activity::Import.is_oda_by_type(type: @type)
 
     if upload.valid?

--- a/app/views/shared/activities/uploads/_upload_form.html.haml
+++ b/app/views/shared/activities/uploads/_upload_form.html.haml
@@ -2,11 +2,11 @@
   = form_with model: instance, url: send(path_helper, instance, type: type) do |f|
 
     - if local_assigns[:recovered_from_error]
-      = f.govuk_file_field :activity_csv,
+      = f.govuk_file_field :"activity_csv_#{type}",
         label: { text: t("form.label.activity.csv_file_recover_from_error") },
         hint: { text: t("form.hint.activity.csv_file_recover_from_error_html", link: send(path_helper, instance, { type: type, format: :csv })) }
     - else
-      = f.govuk_file_field :activity_csv,
+      = f.govuk_file_field :"activity_csv_#{type}",
         label: { text: t("form.label.activity.csv_file"), hidden: true },
         hint: { text: t("form.hint.activity.csv_file") }
 

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Activities::UploadsController do
     it "asks CsvFileUpload to prepare the uploaded activities" do
       put :update, params: {report_id: report.id, report: file_upload, type: "non_ispf"}
 
-      expect(CsvFileUpload).to have_received(:new).with(file_upload, :activity_csv)
+      expect(CsvFileUpload).to have_received(:new).with(file_upload, :activity_csv_non_ispf)
     end
 
     context "when upload is valid" do

--- a/spec/controllers/level_b/activities/uploads_controller_spec.rb
+++ b/spec/controllers/level_b/activities/uploads_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe LevelB::Activities::UploadsController do
     it "asks CsvFileUpload to prepare the uploaded activities" do
       put :update, params: {organisation_id: organisation.id, organisation: file_upload, type: "non_ispf"}
 
-      expect(CsvFileUpload).to have_received(:new).with(file_upload, :activity_csv)
+      expect(CsvFileUpload).to have_received(:new).with(file_upload, :activity_csv_non_ispf)
     end
 
     context "when upload is valid" do

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
     csv_text = csv.to_s
 
     within ".upload-form--non-ispf" do
-      upload_csv csv_text
+      upload_csv(content: csv_text, type: :non_ispf)
     end
 
     expect(Activity.count - old_count).to eq(2)
@@ -69,7 +69,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
   scenario "uploading a set of activities with a BOM at the start" do
     freeze_time do
       within ".upload-form--non-ispf" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_non_ispf_activities_upload.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_non_ispf_activities_upload.csv", type: :non_ispf)
       end
 
       expect(page).to have_text(t("action.activity.upload.success"))
@@ -85,7 +85,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
     old_count = Activity.count
 
     within ".upload-form--non-ispf" do
-      attach_file_and_click_submit(filepath: "spec/fixtures/csv/invalid_level_b_activities_upload.csv")
+      attach_file_and_click_submit(filepath: "spec/fixtures/csv/invalid_level_b_activities_upload.csv", type: :non_ispf)
     end
 
     expect(Activity.count - old_count).to eq(0)
@@ -117,10 +117,12 @@ RSpec.feature "BEIS users can upload Level B activities" do
     activity_to_update = create(:fund_activity, :newton)
 
     within ".upload-form--non-ispf" do
-      upload_csv <<~CSV
+      content = <<~CSV
         RODA ID                               | Title     | Sector | Benefitting Countries |
         #{activity_to_update.roda_identifier} | New Title | 11110  | BR                    |
       CSV
+
+      upload_csv(content: content, type: :non_ispf)
     end
 
     expect(page).to have_text(t("action.activity.upload.success"))
@@ -151,10 +153,12 @@ RSpec.feature "BEIS users can upload Level B activities" do
     activity_to_update = create(:project_activity, :gcrf_funded, organisation: organisation)
 
     within ".upload-form--non-ispf" do
-      upload_csv <<~CSV
+      content = <<~CSV
         RODA ID                               | Title     | Sector | Partner Organisation Identifier |
         #{activity_to_update.roda_identifier} | New Title | 11110  | new-id-oh-no                    |
       CSV
+
+      upload_csv(content: content, type: :non_ispf)
     end
 
     expect(page).not_to have_text(t("action.activity.upload.success"))
@@ -182,7 +186,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
       old_count = Activity.count
 
       within ".upload-form--ispf-non-oda" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload.csv", type: :ispf_non_oda)
       end
 
       expect(Activity.count - old_count).to eq(0)
@@ -290,7 +294,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
       old_count = Activity.count
 
       within ".upload-form--ispf-oda" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload.csv", type: :ispf_oda)
       end
 
       expect(Activity.count - old_count).to eq(1)
@@ -310,7 +314,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
 
     scenario "linking an activity to a non-ODA activity via the bulk upload" do
       within ".upload-form--ispf-oda" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload_with_linked_non_oda_activity.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_oda_activities_upload_with_linked_non_oda_activity.csv", type: :ispf_oda)
       end
 
       new_activity = Activity.find_by(title: "A title")
@@ -364,7 +368,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
       old_count = Activity.count
 
       within ".upload-form--ispf-non-oda" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_non_oda_activities_upload.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_non_oda_activities_upload.csv", type: :ispf_non_oda)
       end
 
       expect(Activity.count - old_count).to eq(1)
@@ -384,7 +388,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
 
     scenario "linking an activity to an ODA activity via the bulk upload" do
       within ".upload-form--ispf-non-oda" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_non_oda_activities_upload_with_linked_oda_activity.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_ispf_non_oda_activities_upload_with_linked_oda_activity.csv", type: :ispf_non_oda)
       end
 
       new_activity = Activity.find_by(title: "A title")
@@ -437,7 +441,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
       old_count = Activity.count
 
       within ".upload-form--non-ispf" do
-        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_non_ispf_activities_upload.csv")
+        attach_file_and_click_submit(filepath: "spec/fixtures/csv/valid_level_b_non_ispf_activities_upload.csv", type: :non_ispf)
       end
 
       expect(Activity.count - old_count).to eq(2)
@@ -495,17 +499,17 @@ RSpec.feature "BEIS users can upload Level B activities" do
     end
   end
 
-  def attach_file_and_click_submit(filepath:)
-    attach_file "organisation[activity_csv]", File.new(filepath).path
+  def attach_file_and_click_submit(filepath:, type:)
+    attach_file "organisation[activity_csv_#{type}]", File.new(filepath).path
     click_button t("action.activity.upload.button")
   end
 
-  def upload_csv(content)
+  def upload_csv(content:, type:)
     file = Tempfile.new("new_activities.csv")
     file.write(content.gsub(/ *\| */, ","))
     file.close
 
-    attach_file_and_click_submit(filepath: file.path)
+    attach_file_and_click_submit(filepath: file.path, type: type)
 
     file.unlink
   end
@@ -513,6 +517,6 @@ RSpec.feature "BEIS users can upload Level B activities" do
   def upload_empty_csv
     headings = Activity::Import::Field.where_level_and_type(level: :level_b, type: :non_ispf).map(&:heading)
 
-    upload_csv(headings.join(", "))
+    upload_csv(content: headings.join(", "), type: :non_ispf)
   end
 end


### PR DESCRIPTION
## Changes in this PR

This adds the type to the IDs for the `input` and `div.govuk-hint` elements, the `for` attribute of the `label` element, and the `aria-describedby` attribute of the `input` element, in order to address critical accessibility issues highlighted by axe DevTools

Replaces #2059

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
