### PR TITLE
(2861) Tidy up budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1243,6 +1243,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - Only budget value can be edited
   - Add a budget revisions page
   - Add comments when editing budgets to be shown alongside the revisions
+  - Improve design/content for the budgets area
   
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-132...HEAD
 [release-132]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...release-132

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -31,6 +31,7 @@ class BudgetsController < BaseController
 
   def edit
     @budget = Budget.find(id)
+    @budget_presenter = BudgetPresenter.new(@budget)
     authorize @budget
 
     @activity = Activity.find(activity_id)
@@ -41,6 +42,7 @@ class BudgetsController < BaseController
 
   def update
     @budget = Budget.find(id)
+    @budget_presenter = BudgetPresenter.new(@budget)
     authorize @budget
 
     @activity = Activity.find(activity_id)

--- a/app/views/budgets/edit.html.haml
+++ b/app/views/budgets/edit.html.haml
@@ -1,10 +1,10 @@
-=content_for :page_title_prefix, t("page_title.budget.edit")
+=content_for :page_title_prefix, t("page_title.budget.edit", financial_year: @budget_presenter.financial_year)
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
-        = t("page_title.budget.edit")
+        = t("page_title.budget.edit", financial_year: @budget_presenter.financial_year)
 
       %p.govuk-body-l.govuk
         %strong Current budget:

--- a/app/views/budgets/edit.html.haml
+++ b/app/views/budgets/edit.html.haml
@@ -13,7 +13,7 @@
       = form_with model: @budget, url: activity_budget_path(@activity) do |f|
         = f.govuk_error_summary
 
-        = f.govuk_text_field :value, class: "govuk-input govuk-input--width-10"
+        = f.govuk_text_field :value, prefix_text: '£', class: "govuk-input govuk-input--width-10"
         = f.govuk_text_area :audit_comment
 
         = link_to t("default.button.delete"), activity_budget_path(@activity, @budget), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this budget?" }

--- a/app/views/budgets/edit.html.haml
+++ b/app/views/budgets/edit.html.haml
@@ -6,6 +6,10 @@
       %h1.govuk-heading-xl
         = t("page_title.budget.edit")
 
+      %p.govuk-body-l.govuk
+        %strong Current budget:
+        = @budget_presenter.value
+
       = form_with model: @budget, url: activity_budget_path(@activity) do |f|
         = f.govuk_error_summary
 

--- a/app/views/budgets/new.html.haml
+++ b/app/views/budgets/new.html.haml
@@ -34,6 +34,6 @@
           options: { selected: f.object.financial_year.to_i, prompt: t("form.prompt.budget.financial_year"), include_blank: true },
           label: { size: "m", tag: "h2" }
 
-        = f.govuk_text_field :value, class: "govuk-input govuk-input--width-10"
+        = f.govuk_text_field :value, prefix_text: '£', class: "govuk-input govuk-input--width-10"
 
         = f.govuk_submit t("default.button.submit")

--- a/app/views/shared/budgets/_table.html.haml
+++ b/app/views/shared/budgets/_table.html.haml
@@ -5,11 +5,11 @@
         %th{ scope: "col", class: ["govuk-table__header"] }
           =t("table.header.budget.financial_year")
         %th{ scope: "col", class: ["govuk-table__header"] }
-          Type
-        %th{ scope: "col", class: ["govuk-table__header"] }
           =t("table.header.budget.value")
         %th{ scope: "col", class: ["govuk-table__header"] }
           =t("table.header.budget.revisions")
+        %th{ scope: "col", class: ["govuk-table__header"] }
+          =t("table.header.budget.budget_type")
         %th{ scope: "col", class: ["govuk-table__header"] }
           =t("table.header.budget.providing_organisation")
         %th{ scope: "col", class: ["govuk-table__header"] }
@@ -20,9 +20,9 @@
         %tr.govuk-table__row{id: budget.id}
           %td{ scope: "row", class: "govuk-table__cell" }
             = budget.financial_year
-          %td.govuk-table__cell= budget.budget_type
           %td.govuk-table__cell= budget.value
           %td.govuk-table__cell= link_to_revisions(budget)
+          %td.govuk-table__cell= budget.budget_type
           %td.govuk-table__cell= budget.providing_organisation_name
           %td.govuk-table__cell
             - if policy(budget).edit?

--- a/app/views/shared/budgets/_table.html.haml
+++ b/app/views/shared/budgets/_table.html.haml
@@ -13,6 +13,7 @@
         %th{ scope: "col", class: ["govuk-table__header"] }
           =t("table.header.budget.providing_organisation")
         %th{ scope: "col", class: ["govuk-table__header"] }
+          =t("table.header.budget.action")
 
     %tbody.govuk-table__body
       - budgets.each do |budget|

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -52,9 +52,9 @@ en:
     header:
       budget:
         financial_year: Financial year
-        budget_type: Type
         value: Budget amount
         revisions: Revisions
+        budget_type: Type
         providing_organisation: Providing organisation
         action: Action
     body:

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -74,7 +74,7 @@ en:
       no_budgets: There are no budgets created during this reporting cycle.
   page_title:
     budget:
-      edit: Edit budget
+      edit: Edit budget for %{financial_year}
       index: Budgets
       new: Create budget
       revisions: Budget revisions

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -56,6 +56,7 @@ en:
         value: Budget amount
         revisions: Revisions
         providing_organisation: Providing organisation
+        action: Action
     body:
       budget:
         edit_noun: budget

--- a/spec/features/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_budgets_spec.rb
@@ -65,17 +65,17 @@ RSpec.feature "BEIS users can upload Level B budgets" do
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[1]", text: "FY 2016-2017")
-      expect(page).to have_xpath("td[2]", text: "Other official development assistance")
-      expect(page).to have_xpath("td[3]", text: "£67,890.00")
-      expect(page).to have_xpath("td[4]", text: "None")
+      expect(page).to have_xpath("td[2]", text: "£67,890.00")
+      expect(page).to have_xpath("td[3]", text: "None")
+      expect(page).to have_xpath("td[4]", text: "Other official development assistance")
       expect(page).to have_xpath("td[5]", text: "Lovely Co")
     end
 
     within "//tbody/tr[2]" do
       expect(page).to have_xpath("td[1]", text: "FY 2011-2012")
-      expect(page).to have_xpath("td[2]", text: "Direct")
-      expect(page).to have_xpath("td[3]", text: "£12,345.00")
-      expect(page).to have_xpath("td[4]", text: "None")
+      expect(page).to have_xpath("td[2]", text: "£12,345.00")
+      expect(page).to have_xpath("td[3]", text: "None")
+      expect(page).to have_xpath("td[4]", text: "Direct")
       expect(page).to have_xpath("td[5]", text: "Department for Business, Energy and Industrial Strategy")
     end
   end

--- a/spec/features/users_can_edit_a_budget_spec.rb
+++ b/spec/features/users_can_edit_a_budget_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Users can edit a budget" do
     end
 
     scenario "a budget can be successfully edited and a history event added" do
+      expect(page).to have_content("Edit budget for FY 2018-2019")
       expect(page).to have_content("Current budget: £10.00")
       fill_in "budget[value]", with: "20"
 

--- a/spec/features/users_can_edit_a_budget_spec.rb
+++ b/spec/features/users_can_edit_a_budget_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Users can edit a budget" do
     end
 
     scenario "a budget can be successfully edited and a history event added" do
+      expect(page).to have_content("Current budget: £10.00")
       fill_in "budget[value]", with: "20"
 
       expect {


### PR DESCRIPTION
> Follows from https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2056

## Changes in this PR
> Various content/design changes to align the budgets area with the [prototype](https://roda-design-ideas-production.up.railway.app/#sprint-12)

### Add missing "Action" heading to budgets table
Table headers shouldn't be empty for accessibility reasons.

This adds an "Action" heading to the budget table on the financials tab.
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/47089130/224051089-734c64ba-051b-47e7-88fa-2b87af52b8e9.png">

### Rearrange columns on the financials budget table
The most recent prototype has shifted the "Type" column to after the
"Revisions" column.

This also uses the translations where they were accidentally missed in the
past.
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/47089130/224051328-8e3c40c4-71dd-4180-8ad5-15c194ee3e44.png">

### Show the current budget amount on the edit page
The prototype has some text showing the current budget on the edit page.

<img width="877" alt="image" src="https://user-images.githubusercontent.com/47089130/224051472-9346a30e-a1aa-492b-b133-982e90b6cead.png">

### Show the financial year of the budget being edited
The prototype shows the financial year that the budget is for in the heading.
<img width="958" alt="image" src="https://user-images.githubusercontent.com/47089130/224051714-22cf022d-23ca-409a-a463-0987b2f8e1bd.png">

### Show the pound prefix on the budget amount inputs
The prototype shows a £ symbol prefix on the budget amount input.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/47089130/224051878-cdec0642-7e03-427d-b5ec-fdd8f47272c8.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
