### PR TITLE
(2852) Make organisation IDs unique at `/reports`

### DIFF
--- a/app/views/shared/reports/_table_row.html.haml
+++ b/app/views/shared/reports/_table_row.html.haml
@@ -1,6 +1,7 @@
 %tr.govuk-table__row{id: report.id}
   - if defined?(index) && index == 0
-    %th.govuk-table__cell{rowspan: reports.count, scope: "rowgroup", id: report.organisation.id}= report.organisation.name
+    %th.govuk-table__cell{rowspan: reports.count, scope: "rowgroup", id: [report.organisation.id, type].join("-")}
+      = report.organisation.name
   %td.govuk-table__cell= report.financial_quarter_and_year
   - if type == "current"
     %td.govuk-table__cell= report.deadline

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -32,14 +32,17 @@ RSpec.feature "Users can view reports" do
         organisations.each do |organisation|
           expect_to_see_grouped_rows_of_reports_for_an_organisation(
             organisation: organisation,
-            expected_reports: reports.select { |r| r.organisation == organisation }
+            expected_reports: reports.select { |r| r.organisation == organisation },
+            selector: selector
           )
         end
       end
     end
 
-    def expect_to_see_grouped_rows_of_reports_for_an_organisation(organisation:, expected_reports:)
-      expect(page).to have_selector("th[id='#{organisation.id}']")
+    def expect_to_see_grouped_rows_of_reports_for_an_organisation(organisation:, expected_reports:, selector:)
+      expected_heading_id = [organisation.id, selector[1, selector.length - 1]].join("-")
+
+      expect(page).to have_selector("th[id='#{expected_heading_id}']")
       expect(page).to have_content organisation.name
 
       expected_reports.each do |report|


### PR DESCRIPTION
## Changes in this PR

For BEIS users, /reports has two tabs. On each tab, there is a heading column for organisation names. The `th` elements use the organisation's ID as their ID, but this is duplicated for each tab, which is an accessibility issue. This adds the tab heading/report status grouping ("current"/"approved") to the ID in order to create unique IDs

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
