### PR TITLE
(2833) Only show IATI export with publishable activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1231,6 +1231,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Fix an accessibility issue on the Organisations page
 - Set `publish_to_iati` to `false` for non-ODA activities
 - Add `govuk-link` class to links where missing
+- Only provide an IATI export link if there are publishable activities
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/models/iati/xml_download.rb
+++ b/app/models/iati/xml_download.rb
@@ -38,7 +38,7 @@ module Iati
         Activity.send(level).where(
           source_fund_code: fund.id,
           extending_organisation: organisation
-        ).present?
+        ).publishable_to_iati.present?
       end
     end
 

--- a/spec/features/beis_users_can_download_exports_spec.rb
+++ b/spec/features/beis_users_can_download_exports_spec.rb
@@ -280,4 +280,15 @@ RSpec.feature "BEIS users can download exports" do
       }
     ])
   end
+
+  scenario "downloading IATI exports for a partner organisation" do
+    organisation = create(:partner_organisation)
+    publishable_activity = create(:programme_activity, :gcrf_funded, extending_organisation: organisation, publish_to_iati: true)
+    unpublishable_activity = create(:programme_activity, :newton_funded, extending_organisation: organisation, publish_to_iati: false)
+
+    visit exports_organisation_path(organisation)
+
+    expect(page).to have_content("#{publishable_activity.source_fund.name} IATI export for programme (level B) activities")
+    expect(page).not_to have_content("#{unpublishable_activity.source_fund.name} IATI export for programme (level B) activities")
+  end
 end


### PR DESCRIPTION
## Changes in this PR

The link to download an IATI export for an organisationfund/level combination of activities is shown if any activities exist for that combination. However, when preparing the XML, activities are only included if publishable to IATI (based on an activity's `publish_to_iati` attribute). This means links can be generated for exports that will contain no activities, which is invalid. This makes it so that a link is only shown if publishable activities exist for the given combination

## Screenshots of UI changes

These screenshots are taken from AMS local data, which may be out of sync with production

### Before

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/40244233/224108822-12ed4684-9694-4531-b9c7-d0850bd942ce.png">

### After

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/40244233/224109238-d8fb059f-e8b5-4a44-8870-94c7b810bdd9.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
