### PR TITLE
(2857) Provide text for untitled activity link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1232,6 +1232,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Set `publish_to_iati` to `false` for non-ODA activities
 - Add `govuk-link` class to links where missing
 - Only provide an IATI export link if there are publishable activities
+- Always show "Untitled activity" in breadcrumbs when an activity is untitled
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/controllers/concerns/activities/breadcrumbed.rb
+++ b/app/controllers/concerns/activities/breadcrumbed.rb
@@ -16,7 +16,7 @@ module Activities
       elsif current_user.service_owner? && (activity.fund? || activity.programme?)
         # Show fund/programme breadcrumbs (these don't belong to an organisation)
         add_breadcrumb activity.parent.title, organisation_activity_path(activity.parent.organisation, activity.parent) if activity.parent
-        add_breadcrumb activity.title, organisation_activity_path(activity.organisation, activity, tab: args[:tab])
+        add_breadcrumb activity_title(activity), organisation_activity_path(activity.organisation, activity, tab: args[:tab])
 
         return
       elsif activity.historic?


### PR DESCRIPTION
## Changes in this PR

In the UI form for adding activities, before the activity has a title, there's a link in the breadcrumbs without any text in it, which makes it unnoticeable to most users and also an accessibility issue

In `Activities::Breadcrumbed` we already have a method for providing fallback text of "Untitled activity" where an activity doesn't have a title, but we weren't using this under particular conditions. This makes it so that we use it in all conditions, which fixes the issue

## Screenshots of UI changes

### Before

<img width="757" alt="image" src="https://user-images.githubusercontent.com/40244233/224325642-adc688a8-bbe1-4b50-af93-a88fd2730258.png">

### After

<img width="774" alt="image" src="https://user-images.githubusercontent.com/40244233/224325584-562f80c9-b1a1-4026-9b8c-8b50ec6728e4.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
