### PR TITLE
(2858) Remove duplicate hidden fields on radio collections

### DIFF
--- a/app/views/activity_forms/covid19_related.html.haml
+++ b/app/views/activity_forms/covid19_related.html.haml
@@ -1,3 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :covid19_related
   = f.govuk_collection_radio_buttons :covid19_related, covid19_related_radio_options, :code, :description, legend: { tag: 'h1', size: 'xl', text: @page_title }

--- a/app/views/activity_forms/fund_pillar.html.haml
+++ b/app/views/activity_forms/fund_pillar.html.haml
@@ -1,3 +1,2 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :fund_pillar
   = f.govuk_collection_radio_buttons :fund_pillar, fund_pillar_radio_options, :code, :description, legend: { tag: 'h1', size: 'xl', text: @page_title }, hint: { text: t("form.hint.activity.fund_pillar") }

--- a/app/views/activity_forms/gcrf_challenge_area.html.haml
+++ b/app/views/activity_forms/gcrf_challenge_area.html.haml
@@ -1,5 +1,4 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :gcrf_challenge_area
   = f.govuk_collection_radio_buttons :gcrf_challenge_area,
     gcrf_challenge_area_options,
     :code,

--- a/app/views/activity_forms/gdi.html.haml
+++ b/app/views/activity_forms/gdi.html.haml
@@ -1,5 +1,4 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :gdi, value: nil
   = f.govuk_collection_radio_buttons :gdi,
     gdi_radio_options,
     :code,

--- a/app/views/activity_forms/oda_eligibility.html.haml
+++ b/app/views/activity_forms/oda_eligibility.html.haml
@@ -1,5 +1,4 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :oda_eligibility, value: nil
   = f.govuk_collection_radio_buttons :oda_eligibility,
     oda_eligibility_radio_options,
     :value,

--- a/app/views/activity_forms/programme_status.html.haml
+++ b/app/views/activity_forms/programme_status.html.haml
@@ -1,5 +1,4 @@
 = render layout: "wrapper" do |f|
-  = f.hidden_field :programme_status, value: nil
   = f.govuk_collection_radio_buttons :programme_status,
     programme_status_radio_options,
     :value,

--- a/app/views/activity_forms/sector.html.haml
+++ b/app/views/activity_forms/sector.html.haml
@@ -1,6 +1,5 @@
 = render layout: "wrapper" do |f|
   = f.govuk_error_summary
-  = f.hidden_field :sector, value: nil
   = f.govuk_collection_radio_buttons :sector,
     sector_radio_options(category: f.object.sector_category),
     :code,

--- a/app/views/activity_forms/sector_category.html.haml
+++ b/app/views/activity_forms/sector_category.html.haml
@@ -1,6 +1,5 @@
 = render layout: "wrapper" do |f|
   = f.govuk_error_summary
-  = f.hidden_field :sector_category, value: nil
   = f.govuk_collection_radio_buttons :sector_category,
     sector_category_radio_options,
     :code,


### PR DESCRIPTION
## Changes in this PR

On various pages that used `f.govuk_collection_radio_buttons`, we were also using `f.hidden_field`, but this is included by default with `f.govuk_collection_radio_buttons`[1]. This led to a redundant hidden field being created with the same ID as the radio button collection, which is an accessibility issue. This removes the duplicate hidden fields from relevant pages, fixing the issue

[1] https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
