### PR TITLE
[2839] Allow BEIS users to edit original commitment figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1226,7 +1226,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 ## [unreleased]
 
 - Update Commitment-importing script to infer `transaction_date` value from Activity values
-- Collect original commitment figure in new activity form and bulk activity upload
+- Collect original commitment figure in new activity form and bulk activity upload, only editable by BEIS users
 - Remove password reset field from new user form
 - Fix an accessibility issue on the Organisations page
 - Set `publish_to_iati` to `false` for non-ODA activities

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -78,7 +78,7 @@ class ActivityFormsController < BaseController
     when :tags
       skip_step unless @activity.is_ispf_funded?
     when :commitment
-      skip_step if @activity.commitment.present?
+      skip_step unless policy(@activity).set_commitment?
       @activity.build_commitment
     end
 
@@ -89,7 +89,11 @@ class ActivityFormsController < BaseController
     @activity = Activity.find(activity_id)
     @page_title = page_title(step)
 
-    authorize @activity
+    if step == :commitment
+      authorize @activity, :set_commitment?
+    else
+      authorize @activity
+    end
 
     updater = Activity::Updater.new(activity: @activity, params: params)
     updater.update(step)

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -81,6 +81,13 @@ class ActivityPolicy < ApplicationPolicy
     end
   end
 
+  def set_commitment?
+    return false if record.fund?
+    return true if beis_user?
+
+    record.commitment.nil? && editable_report? && record.organisation == user.organisation
+  end
+
   def destroy?
     false
   end

--- a/app/views/shared/activities/_activity.html.haml
+++ b/app/views/shared/activities/_activity.html.haml
@@ -116,8 +116,8 @@
       %dd.govuk-summary-list__value
         = activity_presenter.commitment&.value
       %dd.govuk-summary-list__actions
-        - if policy(activity_presenter).update? && activity_presenter.commitment.nil?
-          = a11y_action_link(t("default.link.add"), activity_step_path(activity_presenter, :commitment), t("activerecord.attributes.activity.commitment"))
+        - if policy(activity_presenter).set_commitment?
+          = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:commitment)}"), activity_step_path(activity_presenter, :commitment), t("activerecord.attributes.activity.commitment"))
 
   - if activity_presenter.is_project?
     .govuk-summary-list__row.uk_po_named_contact

--- a/spec/features/users_can_edit_an_activity_spec.rb
+++ b/spec/features/users_can_edit_an_activity_spec.rb
@@ -147,6 +147,36 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to have_content(t("action.programme.update.success"))
       end
     end
+
+    describe "editing the original commitment figure" do
+      ["programme", "project", "third_party_project"].each do |level|
+        context "when the activity is a #{level} level activity" do
+          it "can be edited" do
+            activity = create(
+              "#{level}_activity".to_sym,
+              commitment: create(
+                :commitment,
+                value: 500,
+                transaction_date: Date.today
+              )
+            )
+
+            visit organisation_activity_details_path(activity.organisation, activity)
+            expect(page).to have_content("Original commitment figure £500.00")
+
+            within(".commitment") do
+              click_on(t("default.link.edit"))
+            end
+
+            fill_in "activity[commitment][value]", with: "1000"
+
+            click_button t("form.button.activity.submit")
+            expect(page).to have_content(t("action.#{level}.update.success"))
+            expect(page).to have_content("Original commitment figure £1,000.00")
+          end
+        end
+      end
+    end
   end
 
   context "when signed in as a partner organisation user" do
@@ -222,6 +252,25 @@ RSpec.feature "Users can edit an activity" do
 
         expect(page).to have_css(".policy_marker_desertification", text: "Significant objective")
       end
+
+      it "the original commitment figure cannot be edited" do
+        activity = create(
+          :project_activity,
+          organisation: user.organisation,
+          commitment: create(
+            :commitment,
+            value: 500,
+            transaction_date: Date.today
+          )
+        )
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+        expect(page).to have_content("Original commitment figure £500.00")
+
+        within(".commitment") do
+          expect(page).not_to have_content(t("default.link.edit"))
+        end
+      end
     end
 
     context "when the activity is a third-party project" do
@@ -237,6 +286,25 @@ RSpec.feature "Users can edit an activity" do
 
         click_button t("form.button.activity.submit")
         expect(page).to have_content(t("action.third_party_project.update.success"))
+      end
+
+      it "the original commitment figure cannot be edited" do
+        activity = create(
+          :third_party_project_activity,
+          organisation: user.organisation,
+          commitment: create(
+            :commitment,
+            value: 500,
+            transaction_date: Date.today
+          )
+        )
+
+        visit organisation_activity_details_path(activity.organisation, activity)
+        expect(page).to have_content("Original commitment figure £500.00")
+
+        within(".commitment") do
+          expect(page).not_to have_content(t("default.link.edit"))
+        end
       end
     end
 

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:create_transfer)
 
         is_expected.to forbid_action(:update_linked_activity)
+        is_expected.to forbid_action(:set_commitment)
       end
     end
 
@@ -49,6 +50,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:create_transfer)
 
         is_expected.to forbid_action(:update_linked_activity)
+        is_expected.to permit_action(:set_commitment)
       end
 
       context "when it's an ISPF programme" do
@@ -97,6 +99,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_child)
         is_expected.to forbid_action(:create_transfer)
         is_expected.to forbid_action(:update_linked_activity)
+        is_expected.to permit_action(:set_commitment)
       end
 
       context "and the project is ISPF-funded" do
@@ -145,6 +148,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
         is_expected.to forbid_action(:update_linked_activity)
+        is_expected.to permit_action(:set_commitment)
       end
 
       context "when the activity is ISPF-funded" do
@@ -188,6 +192,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
         is_expected.to forbid_action(:update_linked_activity)
+        is_expected.to forbid_action(:set_commitment)
       end
     end
 
@@ -208,6 +213,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
           is_expected.to forbid_action(:update_linked_activity)
+          is_expected.to forbid_action(:set_commitment)
         end
       end
 
@@ -230,6 +236,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
           is_expected.to forbid_action(:update_linked_activity)
+          is_expected.to forbid_action(:set_commitment)
         end
 
         context "and there is an editable report for the user's organisation" do
@@ -243,6 +250,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
             is_expected.to forbid_action(:update_linked_activity)
+            is_expected.to forbid_action(:set_commitment)
           end
         end
       end
@@ -265,6 +273,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
           is_expected.to forbid_action(:update_linked_activity)
+          is_expected.to forbid_action(:set_commitment)
         end
       end
 
@@ -292,6 +301,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:create_adjustment)
             is_expected.to forbid_action(:update_linked_activity)
+            is_expected.to forbid_action(:set_commitment)
           end
         end
 
@@ -314,6 +324,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_refund)
             is_expected.to permit_action(:create_adjustment)
             is_expected.to forbid_action(:update_linked_activity)
+            is_expected.to permit_action(:set_commitment)
           end
 
           context "when the activity is ISPF-funded" do
@@ -332,6 +343,12 @@ RSpec.describe ActivityPolicy do
                 it { is_expected.to forbid_action(:update_linked_activity) }
               end
             end
+          end
+
+          context "when the activity already has a commitment set" do
+            let(:activity) { create(:project_activity, :with_commitment) }
+
+            it { is_expected.to forbid_action(:set_commitment) }
           end
         end
       end
@@ -354,6 +371,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create_refund)
           is_expected.to forbid_action(:create_adjustment)
           is_expected.to forbid_action(:update_linked_activity)
+          is_expected.to forbid_action(:set_commitment)
         end
       end
 
@@ -376,6 +394,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create_transfer)
             is_expected.to forbid_action(:create_refund)
             is_expected.to forbid_action(:update_linked_activity)
+            is_expected.to forbid_action(:set_commitment)
           end
         end
 
@@ -397,6 +416,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to permit_action(:create_transfer)
             is_expected.to permit_action(:create_refund)
             is_expected.to forbid_action(:update_linked_activity)
+            is_expected.to permit_action(:set_commitment)
           end
 
           context "when the activity is ISPF-funded" do
@@ -409,6 +429,12 @@ RSpec.describe ActivityPolicy do
 
               it { is_expected.to permit_action(:update_linked_activity) }
             end
+          end
+
+          context "when the activity already has a commitment set" do
+            let(:activity) { create(:third_party_project_activity, :with_commitment) }
+
+            it { is_expected.to forbid_action(:set_commitment) }
           end
         end
       end

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -380,13 +380,13 @@ RSpec.describe "shared/activities/_activity" do
       before { render }
 
       context "when redact_from_iati is false" do
-        let(:policy_stub) { double("policy", update?: true, redact_from_iati?: false) }
+        let(:policy_stub) { double("policy", update?: true, set_commitment?: true, redact_from_iati?: false) }
 
         it { is_expected.to_not show_the_publish_to_iati_field }
       end
 
       context "when redact_from_iati is true" do
-        let(:policy_stub) { double("policy", update?: true, redact_from_iati?: true) }
+        let(:policy_stub) { double("policy", update?: true, set_commitment?: true, redact_from_iati?: true) }
 
         it { is_expected.to show_the_publish_to_iati_field }
 
@@ -418,7 +418,7 @@ RSpec.describe "shared/activities/_activity" do
       it { is_expected.to_not show_the_edit_add_actions }
 
       context "and the policy allows a user to update" do
-        let(:policy_stub) { double("policy", update?: true, redact_from_iati?: false) }
+        let(:policy_stub) { double("policy", update?: true, set_commitment?: true, redact_from_iati?: false) }
 
         it { is_expected.to show_the_edit_add_actions }
 
@@ -524,6 +524,30 @@ RSpec.describe "shared/activities/_activity" do
           expect(body.find(".recipient_region .govuk-summary-list__key")).to have_content("Legacy field: not editable")
           expect(body.find(".recipient_country .govuk-summary-list__key")).to have_content("Legacy field: not editable")
           expect(body.find(".intended_beneficiaries .govuk-summary-list__key")).to have_content("Legacy field: not editable")
+        end
+      end
+    end
+
+    describe "setting the commitment value" do
+      before do
+        create(:report, :active, fund: activity.associated_fund, organisation: user.organisation)
+
+        render
+      end
+
+      context "when there is a commitment on the activity" do
+        let(:activity) { create(:project_activity, :with_commitment, organisation: user.organisation) }
+
+        it "does not show an edit button next to the commitment" do
+          expect(body.find(".commitment")).not_to have_link
+        end
+      end
+
+      context "when there is no commitment on the activity" do
+        let(:activity) { create(:project_activity, commitment: nil, organisation: user.organisation) }
+
+        it "shows an add button next to the commitment" do
+          expect(body.find(".commitment a")).to have_content("Add")
         end
       end
     end
@@ -636,6 +660,26 @@ RSpec.describe "shared/activities/_activity" do
           it "does not show an edit link for the linked programme" do
             expect(body.find(".linked_activity .govuk-summary-list__actions")).to_not have_content(t("default.link.edit"))
           end
+        end
+      end
+    end
+
+    describe "setting the commitment value" do
+      before { render }
+
+      context "when there is a commitment on the activity" do
+        let(:activity) { create(:project_activity, :with_commitment) }
+
+        it "shows an edit button next to the commitment" do
+          expect(body.find(".commitment a")).to have_content("Edit")
+        end
+      end
+
+      context "when there is no commitment on the activity" do
+        let(:activity) { create(:project_activity, commitment: nil) }
+
+        it "shows an add button next to the commitment" do
+          expect(body.find(".commitment a")).to have_content("Add")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR

We now allow BEIS users to add and edit an original commitment figure at all levels below Fund level.

Partner organisations can only add an original commitment figure at levels C and D (mandatory). Once it's been set, it can no longer be edited - they'll need to ask the BEIS team to do this for them.

## Screenshots of UI changes

#### Viewing level C activity commitment figure as a BEIS user

![image](https://user-images.githubusercontent.com/19826940/224350812-3ad4f97a-fa48-43fb-a8aa-54a6566a9625.png)

#### Viewing the same level C activity commitment figure as PO user

<img width="1289" alt="Screenshot 2023-03-10 at 15 04 27" src="https://user-images.githubusercontent.com/19826940/224350933-1ba635be-a126-49f0-9c0a-5c36f3ce549f.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
