### PR TITLE
(2778) Use $GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: script/docker-push
       - name: Set Docker tag as an output
         id: set_output
-        run: echo "::set-output name=docker_tag::${{ env.DOCKER_TAG }}"
+        run: echo "docker_tag=${{ env.DOCKER_TAG }}" >> $GITHUB_OUTPUT
   deploy_to_production:
     needs: build_and_push_to_dockerhub
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger_rebase.yml
+++ b/.github/workflows/trigger_rebase.yml
@@ -16,7 +16,7 @@ jobs:
         id: get-all-awaiting-pr-numbers
         run: |
           PR_NUMBER=$(curl https://api.github.com/repos/UKGovernmentBEIS/beis-report-official-development-assistance/pulls\?state\=open | jq -c '[.[] | select(.auto_merge!=null) | .number] | first')
-          echo "::set-output name=pr_number::$PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
   trigger_rebase_action:
     if: ${{ needs.fetch_oldest_pr_awaiting_automerge.outputs.pr_number != '' }}
     env:


### PR DESCRIPTION
## Changes in this PR

The `set-output` command is deprecated, and causes warnings to be thrown when used. Github plan to fully disable it on 31st May 2023 [1].

The suggested replacement approach is to use the `$GITHUB_OUTPUT` environment file, which is available by default.

(h/t @RobjS for the fix)

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Screenshots of UI changes
N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
