### PR TITLE
(2871) Allow setting new commitment on existing activity via bulk upload

### DIFF
--- a/app/services/activity/import.rb
+++ b/app/services/activity/import.rb
@@ -100,8 +100,6 @@ class Activity
         add_error(index, :parent_id, row["Parent RODA ID"], I18n.t("importer.errors.activity.cannot_update.parent_present")) && return
       elsif row["Partner Organisation Identifier"].present?
         add_error(index, :partner_organisation_identifier, row["Partner Organisation Identifier"], I18n.t("importer.errors.activity.cannot_update.partner_organisation_identifier_present")) && return
-      elsif row["Original commitment figure"].present?
-        add_error(index, :commitment, row["Original commitment figure"], I18n.t("importer.errors.activity.cannot_update.commitment")) && return
       else
         updater = ActivityUpdater.new(
           row: row,
@@ -155,6 +153,10 @@ class Activity
         end
 
         return unless @errors.blank?
+
+        if row["Original commitment figure"].present? && @activity.commitment.present?
+          @errors[:commitment] = [row["Original commitment figure"], I18n.t("importer.errors.activity.cannot_update.commitment")]
+        end
 
         @activity.assign_attributes(attributes)
 


### PR DESCRIPTION
## Changes in this PR

Before this, any inclusion of the Commitment in the upload template would cause the bulk upload to fail. We believe all users should be able to at least initially set a Commitment on an existing activity if it doesn't exist so they can upload historical data all in one go.

If there's already a commitment, we render an error message to let users know they'll need to edit this via the user interface.

[Trello card](https://trello.com/c/6oiOPlMW/2871-allow-ocf-to-be-set-when-updating-existing-activities-via-bulk-upload-as-well-as-creating)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
