### PR TITLE
(2865) Consistent "Back to report" navigation in upload to report journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1235,6 +1235,7 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
 - Always show "Untitled activity" in breadcrumbs when an activity is untitled
 - Ensure upload forms are constrained to a 2 thirds layout for accessibility
 - Signpost how to add a comment after a failed actual/refund upload containing a comment
+- Add "Back to report" links at all stages of the actuals and forecasts upload journeys
 
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...HEAD
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -18,4 +18,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %p.govuk-body= link_to "Back to report", report_path(@report_presenter), class: "govuk-link"
+      %p.govuk-body= link_to t("action.activity.upload.back_link"), report_path(@report_presenter), class: "govuk-link"

--- a/app/views/activities/uploads/update.html.haml
+++ b/app/views/activities/uploads/update.html.haml
@@ -25,4 +25,4 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = link_to "Back to report", report_path(@report_presenter), class: "govuk-link"
+      = link_to t("action.activity.upload.back_link"), report_path(@report_presenter), class: "govuk-link"

--- a/app/views/actuals/uploads/new.html.haml
+++ b/app/views/actuals/uploads/new.html.haml
@@ -26,3 +26,7 @@
 
         %p.govuk-body
           = "This report is #{@report_presenter.state.downcase}, so CSV upload is unavailable."
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to t("action.actual.upload.back_link"), report_path(@report_presenter), class: "govuk-link"

--- a/app/views/actuals/uploads/update.html.haml
+++ b/app/views/actuals/uploads/update.html.haml
@@ -29,4 +29,7 @@
     .govuk-grid-row
       .govuk-grid-column-full
         = render partial: "shared/actuals/actuals_by_activity"
-        = link_to t("importer.success.actual.back_link"), report_actuals_path(@report_presenter), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to t("action.actual.upload.back_link"), report_actuals_path(@report_presenter), class: "govuk-link"

--- a/app/views/forecasts/uploads/new.html.haml
+++ b/app/views/forecasts/uploads/new.html.haml
@@ -31,3 +31,7 @@
 
         %p.govuk-body
           = "This report is #{@report_presenter.state.downcase}, so CSV upload is unavailable."
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to t("action.forecast.upload.back_link"), report_path(@report_presenter), class: "govuk-link"

--- a/app/views/forecasts/uploads/update.html.haml
+++ b/app/views/forecasts/uploads/update.html.haml
@@ -25,4 +25,7 @@
     .govuk-grid-row
       .govuk-grid-column-full
         = render partial: "shared/forecasts/forecasts_by_activity"
-        = link_to t("importer.success.back_link"), report_forecasts_path(@report_presenter), class: "govuk-button"
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body= link_to t("action.forecast.upload.back_link"), report_forecasts_path(@report_presenter), class: "govuk-link"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -12,6 +12,7 @@ en:
         file_missing_or_invalid: Please upload a valid CSV file
         link: Upload activities
         success: The activities were successfully imported.
+        back_link: Back to report
       type:
         ispf_oda: ISPF ODA
         ispf_non_oda: ISPF non-ODA

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -16,6 +16,7 @@ en:
         file_missing_or_invalid: Please upload a valid CSV file
         link: Upload actuals
         success: The transactions were successfully imported.
+        back_link: Back to report
   form:
     label:
       actual:
@@ -156,6 +157,3 @@ en:
         both_zero: Actual and refund are both zero
         both_blank: Actual and refund are both blank
         non_numeric: Actual and refund values must be blank or numeric
-    success:
-      actual:
-        back_link: Back to report

--- a/config/locales/models/forecast.en.yml
+++ b/config/locales/models/forecast.en.yml
@@ -16,6 +16,7 @@ en:
         file_missing_or_invalid: Please upload a valid CSV file
         link: Upload forecasts
         success: The forecasts were successfully imported.
+        back_link: Back to report
   form:
     label:
       forecast:
@@ -80,7 +81,6 @@ en:
   importer:
     success:
       heading: Successful uploads
-      back_link: Back to report
     errors:
       forecast:
         non_numeric_value: The value must be numeric

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "users can upload actuals" do
     expect(page).to have_text(t("page_title.actual.upload_success"))
     expect(page).to have_css(".actuals tr", count: count)
     expect(page).to have_link(
-      t("importer.success.actual.back_link"),
+      t("action.actual.upload.back_link"),
       href: report_actuals_path(report)
     )
     within ".totals" do
@@ -40,6 +40,7 @@ RSpec.feature "users can upload actuals" do
       report_actuals_template_path: report_actuals_upload_path(report, format: :csv))
 
     expect(page).to have_text("Uploading actuals and refunds data is an append operation. Uploading the same data twice will result in duplication. See the guidance for more details.")
+    expect(page.html).to include t("action.actual.upload.back_link")
   end
 
   scenario "downloading a CSV template with activities for the current report" do
@@ -82,6 +83,10 @@ RSpec.feature "users can upload actuals" do
     click_button t("action.actual.upload.button")
     expect(Actual.count).to eq(0)
     expect(page).to have_text(t("action.actual.upload.file_missing_or_invalid"))
+    expect(page).to have_link(
+      t("action.actual.upload.back_link"),
+      href: report_actuals_path(report)
+    )
   end
 
   scenario "uploading a valid set of actuals" do
@@ -226,6 +231,10 @@ RSpec.feature "users can upload actuals" do
     expect(Actual.count).to eq(0)
     expect(page).not_to have_text("The transactions were successfully imported.")
     expect(page).not_to have_text("Comments can only be added via the bulk upload if they have an accompanying actual or refund value. If this is not the case, you will need to add the comment via the comments section of relevant activity.")
+    expect(page).to have_link(
+      t("action.actual.upload.back_link"),
+      href: report_actuals_path(report)
+    )
   end
 
   scenario "uploading a set of actuals with encoding errors" do

--- a/spec/features/users_can_upload_forecasts_spec.rb
+++ b/spec/features/users_can_upload_forecasts_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "users can upload forecasts" do
     expect(page).to have_text(t("importer.success.heading"))
     expect(page).to have_css(".forecasts tr", count: count)
     expect(page).to have_link(
-      t("importer.success.back_link"),
+      t("action.forecast.upload.back_link"),
       href: report_forecasts_path(report)
     )
     within ".totals" do
@@ -111,6 +111,7 @@ RSpec.feature "users can upload forecasts" do
     click_button t("action.forecast.upload.button")
     expect(Forecast.unscoped.count).to eq(0)
     expect(page).to have_text(t("action.forecast.upload.file_missing_or_invalid"))
+    expect(page).to have_link(t("action.forecast.upload.back_link"))
   end
 
   scenario "uploading a valid set of forecasts" do
@@ -141,7 +142,6 @@ RSpec.feature "users can upload forecasts" do
 
     # upload info not present
     expect(page).not_to have_text(t("importer.success.heading"))
-    expect(page).not_to have_link(t("importer.success.back_link"))
 
     within "//tbody/tr[1]" do
       expect(page).to have_xpath("td[1]", text: "FC 2021/22 FY Q3")
@@ -149,6 +149,8 @@ RSpec.feature "users can upload forecasts" do
       expect(page).to have_xpath("td[3]", text: "not a number")
       expect(page).to have_xpath("td[4]", text: t("importer.errors.forecast.non_numeric_value"))
     end
+
+    expect(page).to have_link(t("action.forecast.upload.back_link"))
   end
 
   scenario "uploading a partially completed template" do


### PR DESCRIPTION
## Changes in this PR
- Add "Back to report" links at all stages of the actuals and forecasts upload journeys

## Screenshots of UI changes

### Illustrated with Actuals/refunds, but similar for forecasts

#### Before
![Upload - first stage - actuals](https://user-images.githubusercontent.com/579522/224989159-007449ac-cbaa-4f19-951a-5e3100a58732.png)

#### After
![Actual upload - first page](https://user-images.githubusercontent.com/579522/224989185-e83fd6f2-6f61-4a6f-9c66-3967be7c5f58.png)

#### Before
![Upload - error path - actuals](https://user-images.githubusercontent.com/579522/224989379-cabe9dd4-c002-45b3-911e-ca4bbe54ab1c.png)

#### After
![Actual upload - error](https://user-images.githubusercontent.com/579522/224989417-b0c7c180-1245-46cc-94d8-43b61bb400fd.png)

#### Before
![Screenshot 2023-03-14 at 11 39 23](https://user-images.githubusercontent.com/579522/224989979-c30ccb2b-7cda-4990-bde8-7c2fd88da2fd.png)

#### After
![Actual upload - success](https://user-images.githubusercontent.com/579522/224989682-b0207935-ff3c-4832-82b7-075e6edaace0.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
