### PR TITLE
(2873) Prepopulate OCF when editing & prevent overwriting with `nil` when saving fails

### DIFF
--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -79,7 +79,7 @@ class ActivityFormsController < BaseController
       skip_step unless @activity.is_ispf_funded?
     when :commitment
       skip_step unless policy(@activity).set_commitment?
-      @activity.build_commitment
+      @activity.build_commitment unless @activity.commitment.present?
     end
 
     render_wizard

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -171,11 +171,13 @@ class Activity
 
       return if !activity.third_party_project? && value.blank?
 
-      activity.build_commitment(
-        value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
-      )
+      ActiveRecord::Base.transaction do
+        activity.build_commitment(
+          value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
+        )
 
-      activity.commitment.save!
+        activity.commitment.save!
+      end
     rescue => error
       activity.errors.add(:value, error)
     end

--- a/spec/services/activity/updater_spec.rb
+++ b/spec/services/activity/updater_spec.rb
@@ -5,55 +5,102 @@ RSpec.describe Activity::Updater do
 
   describe "#update" do
     describe "setting a commitment" do
-      let(:activity) { build(:programme_activity) }
+      context "when the activity does not yet have a commitment" do
+        let(:activity) { build(:programme_activity) }
 
-      before { activity.build_commitment }
+        before { activity.build_commitment }
 
-      context "with valid params" do
-        let(:params) {
-          ActionController::Parameters.new({
-            "activity" => {
-              "commitment" => {"value" => "1000"},
-              "activity_id" => activity.id
-            }
-          })
-        }
+        context "with valid params" do
+          let(:params) {
+            ActionController::Parameters.new({
+              "activity" => {
+                "commitment" => {"value" => "1000"},
+                "activity_id" => activity.id
+              }
+            })
+          }
 
-        it "sets the commitment on an activity" do
-          updater.update(:commitment)
+          it "sets the commitment on an activity" do
+            updater.update(:commitment)
 
-          expect(activity.commitment.value).to eq(1000)
-          expect(activity.commitment.transaction_date).to eq(activity.planned_start_date)
+            expect(activity.commitment.value).to eq(1000)
+            expect(activity.commitment.transaction_date).to eq(activity.planned_start_date)
+          end
+        end
+
+        context "with invalid params" do
+          let(:activity) { build(:programme_activity) }
+
+          let(:params) {
+            ActionController::Parameters.new({
+              "activity" => {
+                "commitment" => {"value" => "I'm not valid!"},
+                "activity_id" => activity.id
+              }
+            })
+          }
+
+          before do
+            updater.update(:commitment)
+            activity.build_commitment
+          end
+
+          it "swallows the error and adds it to the activity's errors" do
+            expect(activity.errors.full_messages.first).to eq(
+              "Value Validation failed: Value Value is not a number"
+            )
+          end
+
+          it "does not set the value or transaction date on the commitment" do
+            expect(activity.commitment.value).to be_nil
+            expect(activity.commitment.transaction_date).to be_nil
+            expect(activity.commitment).not_to be_persisted
+          end
         end
       end
 
-      context "with invalid params" do
-        let(:activity) { build(:programme_activity) }
+      context "when the activity already has a commitment" do
+        let(:activity) { create(:programme_activity, :with_commitment) }
 
-        let(:params) {
-          ActionController::Parameters.new({
-            "activity" => {
-              "commitment" => {"value" => "I'm not valid!"},
-              "activity_id" => activity.id
-            }
-          })
-        }
+        context "with valid params" do
+          let(:params) {
+            ActionController::Parameters.new({
+              "activity" => {
+                "commitment" => {"value" => "9999"},
+                "activity_id" => activity.id
+              }
+            })
+          }
 
-        before do
-          updater.update(:commitment)
-          activity.build_commitment
+          it "sets the commitment on an activity" do
+            updater.update(:commitment)
+
+            expect(activity.commitment.value).to eq(9999)
+            expect(activity.commitment.transaction_date).to eq(activity.planned_start_date)
+          end
         end
 
-        it "swallows the error and adds it to the activity's errors" do
-          expect(activity.errors.full_messages.first).to eq(
-            "Value Validation failed: Value Value is not a number"
-          )
-        end
+        context "with invalid params" do
+          let(:previous_commitment) { build(:commitment, value: 8888, transaction_date: Date.parse("2023-02-20")) }
+          let(:activity) { create(:programme_activity, commitment: previous_commitment) }
 
-        it "does not set the value or transaction date on the commitment" do
-          expect(activity.commitment.value).to be_nil
-          expect(activity.commitment.transaction_date).to be_nil
-          expect(activity.commitment).not_to be_persisted
+          let(:params) {
+            ActionController::Parameters.new({
+              "activity" => {
+                "commitment" => {"value" => "I'm not valid!"},
+                "activity_id" => activity.id
+              }
+            })
+          }
+
+          it "does not overwrite the original commitment" do
+            updater.update(:commitment)
+
+            activity.reload
+
+            expect(activity.commitment.value).to eq(previous_commitment.value)
+            expect(activity.commitment.transaction_date).to eq(previous_commitment.transaction_date)
+          end
         end
       end
 


### PR DESCRIPTION
## Changes in this PR

- Only builds a new Commitment on the Activity when rendering the "edit" page if one has not already been set on the Activity, showing the previous value to be edited.
- Prevents OCF being overwritten as `nil` when failing to save after a validation error by rolling back when `save!` raises an error.

## Screenshots of UI changes

### After (clicking on edit)

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/19826940/225274768-56e40bcd-5729-4d7b-a344-6fe0eed680b4.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
