### PR TITLE
(2870) Feature flag ODA bulk upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1245,7 +1245,8 @@ activity and on its child transactions (which can be actuals, refunds, and adjus
   - Add comments when editing budgets to be shown alongside the revisions
   - Improve design/content for the budgets area
   - Show "original" and "revised" budgets on the XML exports
-  
+- Feature flag ISPF ODA bulk upload
+
 [unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-132...HEAD
 [release-132]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-131...release-132
 [release-131]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-130...release-131

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -11,7 +11,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       - if @is_ispf
-        = render partial: "fund_section", locals: { type: :ispf_oda }
+        - if ROLLOUT.active?(:oda_bulk_upload)
+          = render partial: "fund_section", locals: { type: :ispf_oda }
         = render partial: "fund_section", locals: { type: :ispf_non_oda }
       - else
         = render partial: "fund_section", locals: { type: :non_ispf }

--- a/app/views/level_b/activities/uploads/new.html.haml
+++ b/app/views/level_b/activities/uploads/new.html.haml
@@ -11,7 +11,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       - unless hide_ispf_for_group?(:beis_users)
-        = render partial: "fund_section", locals: { type: :ispf_oda }
+        - if ROLLOUT.active?(:oda_bulk_upload)
+          = render partial: "fund_section", locals: { type: :ispf_oda }
         = render partial: "fund_section", locals: { type: :ispf_non_oda }
       = render partial: "fund_section", locals: { type: :non_ispf }
 

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -28,14 +28,26 @@ RSpec.describe Activities::UploadsController do
       end
 
       context "when the fund is ISPF" do
-        it "shows the ISPF ODA and non-ODA download links" do
-          report.update(fund: create(:fund_activity, :ispf))
+        before { report.update(fund: create(:fund_activity, :ispf)) }
 
+        it "shows the ISPF non-ODA download link" do
           get :new, params: {report_id: report.id}
 
-          expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
           expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
+          expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
           expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+        end
+
+        context "when the `oda_bulk_upload` feature flag is enabled" do
+          before { allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true) }
+
+          it "shows the ISPF ODA and non-ODA download links" do
+            get :new, params: {report_id: report.id}
+
+            expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
+            expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
+            expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+          end
         end
       end
 

--- a/spec/controllers/level_b/activities/uploads_controller_spec.rb
+++ b/spec/controllers/level_b/activities/uploads_controller_spec.rb
@@ -15,12 +15,24 @@ RSpec.describe LevelB::Activities::UploadsController do
   describe "#new" do
     render_views
 
-    it "shows the download links" do
+    it "shows the ISPF non-ODA and non-ISPF download links" do
       get :new, params: {organisation_id: organisation.id}
 
-      expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
+      expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
       expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
       expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+    end
+
+    context "when the `oda_bulk_upload` feature flag is enabled" do
+      before { allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true) }
+
+      it "shows all download links" do
+        get :new, params: {organisation_id: organisation.id}
+
+        expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
+        expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
+        expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+      end
     end
 
     context "when signed in as a partner organisation user" do

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -9,10 +9,11 @@ RSpec.feature "BEIS users can upload Level B activities" do
   before { authenticate!(user: user) }
 
   before do
-    visit new_organisation_level_b_activities_upload_path(organisation)
-
     allow(ROLLOUT).to receive(:active?).and_call_original
     allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
+    allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true)
+
+    visit new_organisation_level_b_activities_upload_path(organisation)
   end
 
   after { logout }

--- a/spec/features/users_can_upload_activities_spec.rb
+++ b/spec/features/users_can_upload_activities_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "users can upload activities" do
 
   before do
     allow(ROLLOUT).to receive(:active?).with(:activity_linking).and_return(true)
+    allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true)
 
     # Given I'm logged in as a PO
     authenticate!(user: user)


### PR DESCRIPTION
## Changes in this PR

This hides both the template download link and the upload form for ISPF ODA activities

We were considering combining ODA bulk upload feature flagging with activity linking feature flagging, however they feel like separate categories. If ISPF ODA was fully feature flagged, it might make sense to group this as a general ISPF ODA feature flag (with linking not possible until both ISPF ODA and non-ODA activities are allowed). However, users can still create ISPF ODA activities via the UI form if the `ispf_fund_in_stealth_mode` flag is inactive, so these flags feel like they relate to discrete features distinct from just ISPF ODA

## Screenshots of UI changes

### Before

<img width="747" alt="image" src="https://user-images.githubusercontent.com/40244233/226350032-df966113-8bd3-4a4d-b590-c3df7ca64c05.png">

<img width="780" alt="image" src="https://user-images.githubusercontent.com/40244233/226350104-9ab5b71c-3955-414f-9042-fcc5385f4547.png">

### After (with feature flag set to 0%)

<img width="766" alt="image" src="https://user-images.githubusercontent.com/40244233/226349900-f093f189-47ee-49d0-a8bf-5798bfaa7b72.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
