### PR TITLE
(2867) Allow users to enter commas when submitting an original commitment figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Improve design/content for the budgets area
   - Show "original" and "revised" budgets on the XML exports
 - Feature flag ISPF ODA bulk upload
+- Allow users to enter commas in Original Commitment Figure values
 
 ## Release 132 - 2023-03-16
 

--- a/app/controllers/activity_forms_controller.rb
+++ b/app/controllers/activity_forms_controller.rb
@@ -105,10 +105,13 @@ class ActivityFormsController < BaseController
       when :implementing_organisation
         @implementing_organisations = Organisation.active.sorted_by_name
         render_step :implementing_organisation
-      when :commitment
-        render_step :commitment
       end
 
+      return
+    end
+
+    if step == :commitment && @activity.commitment&.errors.present?
+      render_step :commitment
       return
     end
 

--- a/app/services/activity/import/converter.rb
+++ b/app/services/activity/import/converter.rb
@@ -314,7 +314,10 @@ class Activity
       def convert_commitment(commitment_value)
         return if commitment_value.blank?
 
-        Commitment.new(value: commitment_value)
+        converted_value = ConvertFinancialValue.new.convert(commitment_value.to_s)
+        Commitment.new(value: converted_value)
+      rescue ConvertFinancialValue::Error
+        raise I18n.t("importer.errors.commitment.not_a_number")
       end
 
       def parse_date(date, message)

--- a/app/services/activity/import/creator.rb
+++ b/app/services/activity/import/creator.rb
@@ -66,7 +66,7 @@ class Activity
         end
 
         if @activity.third_party_project? && row["Original commitment figure"].blank?
-          @errors[:commitment] = ["", I18n.t("importer.errors.activity.commitment_required")]
+          @errors[:commitment] = ["", I18n.t("importer.errors.commitment.required")]
         end
 
         return true if @activity.save(context: Activity::VALIDATION_STEPS)

--- a/app/services/activity/updater.rb
+++ b/app/services/activity/updater.rb
@@ -171,15 +171,12 @@ class Activity
 
       return if !activity.third_party_project? && value.blank?
 
-      ActiveRecord::Base.transaction do
-        activity.build_commitment(
-          value: value, transaction_date: infer_transaction_date_from_activity_attributes(activity)
-        )
+      commitment = activity.commitment || Commitment.new
+      commitment.activity = activity
+      commitment.value = value
+      commitment.transaction_date = infer_transaction_date_from_activity_attributes(activity)
 
-        activity.commitment.save!
-      end
-    rescue => error
-      activity.errors.add(:value, error)
+      commitment.save
     end
 
     def assign_attributes_for_step(step)

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -582,4 +582,6 @@ en:
           partner_organisation_identifier_present: The partner organisation identifier cannot be changed. Please remove the PO identifier from this row and try again.
           commitment: The original commitment figure cannot be updated via the bulk upload. Please remove the original commitment figure from this row and try again.
         unauthorised: You are not authorised to report against this activity
-        commitment_required: An original commitment figure is required for level D activities
+      commitment:
+        required: An original commitment figure is required for level D activities
+        not_a_number: The original commitment figure must be a valid number

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -536,6 +536,9 @@ en:
               proposed_linked_has_other_link: The proposed activity is already linked
               same_oda_type: Linked activities must be of opposite ODA types
               unlinked_parents: The parents of linked activities must be linked
+            commitment:
+              value:
+                not_a_number: Value must be a valid number
   importer:
     errors:
       activity:

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe ActivityFormsController do
 
     context "when updating a commitment" do
       it "checks whether the user has permission to specifically set the commitment" do
-        put_step(:commitment, {value: "100"})
+        put_step(:commitment, {commitment: {value: "100"}})
 
         expect(policy).not_to have_received(:update?)
         expect(policy).to have_received(:set_commitment?)

--- a/spec/controllers/activity_forms_controller_spec.rb
+++ b/spec/controllers/activity_forms_controller_spec.rb
@@ -444,11 +444,27 @@ RSpec.describe ActivityFormsController do
     end
 
     context "when updating a commitment" do
+      let(:activity) { programme }
+
       it "checks whether the user has permission to specifically set the commitment" do
         put_step(:commitment, {commitment: {value: "100"}})
 
         expect(policy).not_to have_received(:update?)
         expect(policy).to have_received(:set_commitment?)
+      end
+
+      context "with valid params" do
+        it "allows the user to set the commitment" do
+          put_step(:commitment, {commitment: {value: "100"}})
+
+          expect(programme.reload.commitment.value).to eq(100)
+        end
+      end
+
+      context "with invalid params" do
+        it "re-renders the commitment-setting page" do
+          expect(put_step(:commitment, {commitment: {value: "INVALID"}})).to render_current_step
+        end
       end
     end
   end

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -100,17 +100,10 @@ RSpec.feature "BEIS users can upload Level B activities" do
     end
 
     within "//tbody/tr[2]" do
-      expect(page).to have_xpath("td[1]", text: "Free Standing Technical Cooperation")
-      expect(page).to have_xpath("td[2]", text: "3")
-      expect(page).to have_xpath("td[3]", text: "")
-      expect(page).to have_xpath("td[4]", text: t("activerecord.errors.models.activity.attributes.fstc_applies.inclusion"))
-    end
-
-    within "//tbody/tr[3]" do
       expect(page).to have_xpath("td[1]", text: "Original commitment figure")
       expect(page).to have_xpath("td[2]", text: "")
       expect(page).to have_xpath("td[3]", text: "invalid")
-      expect(page).to have_xpath("td[4]", text: "Original commitment figure is invalid")
+      expect(page).to have_xpath("td[4]", text: "The original commitment figure must be a valid number")
     end
   end
 

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -1012,6 +1012,18 @@ RSpec.describe Activity::Import do
         end
       end
 
+      context "when present and containing commas" do
+        it "creates and sets the Commitment" do
+          new_activity_attributes["Original commitment figure"] = "100,000.50"
+          rows = [new_activity_attributes]
+
+          expect { subject.import(rows) }.to change { Commitment.count }.by(1)
+          new_activity = Activity.order(:created_at).last
+
+          expect(new_activity.commitment.value).to eq(100000.50)
+        end
+      end
+
       context "when present but invalid" do
         it "has an error" do
           new_activity_attributes["Original commitment figure"] = "Invalid!"
@@ -1026,7 +1038,7 @@ RSpec.describe Activity::Import do
           expect(subject.errors.first.csv_row).to eq(2)
           expect(subject.errors.first.csv_column_name).to eq("Original commitment figure")
           expect(subject.errors.first.attribute_name).to eq(:commitment)
-          expect(subject.errors.first.message).to eq("Original commitment figure is invalid")
+          expect(subject.errors.first.message).to eq("The original commitment figure must be a valid number")
         end
       end
 

--- a/spec/services/activity/updater_spec.rb
+++ b/spec/services/activity/updater_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Activity::Updater do
   describe "#update" do
     describe "setting a commitment" do
       context "when the activity does not yet have a commitment" do
-        let(:activity) { build(:programme_activity) }
-
-        before { activity.build_commitment }
+        let(:activity) { create(:programme_activity) }
 
         context "with valid params" do
           let(:params) {
@@ -25,6 +23,23 @@ RSpec.describe Activity::Updater do
 
             expect(activity.commitment.value).to eq(1000)
             expect(activity.commitment.transaction_date).to eq(activity.planned_start_date)
+          end
+
+          context "when the user enters a comma in the value" do
+            let(:params) {
+              ActionController::Parameters.new({
+                "activity" => {
+                  "commitment" => {"value" => "1,000,000.50"},
+                  "activity_id" => activity.id
+                }
+              })
+            }
+
+            it "sets the commitment on an activity" do
+              updater.update(:commitment)
+
+              expect(activity.commitment.value).to eq(1000000.50)
+            end
           end
         end
 
@@ -46,7 +61,7 @@ RSpec.describe Activity::Updater do
 
           it "adds the error to the commitment's errors" do
             expect(activity.commitment.errors.full_messages.first).to include(
-              "Value is not a number"
+              "Value must be a valid number"
             )
           end
 

--- a/spec/services/activity/updater_spec.rb
+++ b/spec/services/activity/updater_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Activity::Updater do
         end
 
         context "with invalid params" do
-          let(:activity) { build(:programme_activity) }
+          let(:activity) { create(:programme_activity) }
 
           let(:params) {
             ActionController::Parameters.new({
@@ -42,19 +42,16 @@ RSpec.describe Activity::Updater do
 
           before do
             updater.update(:commitment)
-            activity.build_commitment
           end
 
-          it "swallows the error and adds it to the activity's errors" do
-            expect(activity.errors.full_messages.first).to eq(
-              "Value Validation failed: Value Value is not a number"
+          it "adds the error to the commitment's errors" do
+            expect(activity.commitment.errors.full_messages.first).to include(
+              "Value is not a number"
             )
           end
 
-          it "does not set the value or transaction date on the commitment" do
-            expect(activity.commitment.value).to be_nil
-            expect(activity.commitment.transaction_date).to be_nil
-            expect(activity.commitment).not_to be_persisted
+          it "doesn't save the commitment" do
+            expect(activity.reload.commitment).to be_nil
           end
         end
       end
@@ -140,7 +137,7 @@ RSpec.describe Activity::Updater do
         it "throws an error with an empty commitment value" do
           updater.update(:commitment)
 
-          expect(activity.errors.full_messages.first).to include("Value Validation failed: Value Value can't be blank")
+          expect(activity.commitment.errors.full_messages.first).to include("Value can't be blank")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR

This PR refactors a couple of things before making it possible for users to enter commas in the Original Commitment Figure form field:
1. Validation errors are now handled at the `Commitment` level, rather than its parent `Activity` which allow us to validate the Commitment itself _before_ relying on ActiveRecord's `save!` populating errors from the model level. This has required a slight change in the `ActivityFormsController` to catch these.
1. We no longer use the `build_commitment` method to create a new Commitment in the `Updater` class, but create the Commitment in isolation before linking it to an Activity to line up more closely with the approach taken for creating a `Budget`. It didn't feel necessary to extract this logic into its own `*Creator`-type class just yet as we only call this in one place (in the `Activity::Updater`) at the moment. This has made it easier to catch the errors thrown by `ConvertFinancialValue` when validations fail.

## Screenshots of UI changes

### Before

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/19826940/226378044-6d5564d0-174b-43b3-9b88-f9a5f63eca93.png">

### After

(not a thing)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
