### PR TITLE
(2855) Prevent updating of funds via the bulk upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Feature flag ISPF ODA bulk upload
 - Allow users to enter commas in Original Commitment Figure values
 - Prevent users from editing fund activities via the bulk upload
+- Use correct column name in bulk upload results when trying to update an activity that cannot be found
 
 ## Release 132 - 2023-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Show "original" and "revised" budgets on the XML exports
 - Feature flag ISPF ODA bulk upload
 - Allow users to enter commas in Original Commitment Figure values
+- Prevent users from editing fund activities via the bulk upload
 
 ## Release 132 - 2023-03-16
 

--- a/app/services/activity/import/updater.rb
+++ b/app/services/activity/import/updater.rb
@@ -18,6 +18,11 @@ class Activity
           return
         end
 
+        if @activity&.fund?
+          @errors[:roda_identifier] = [row["RODA ID"], I18n.t("importer.errors.activity.cannot_update.fund")]
+          return
+        end
+
         @errors.update(@converter.errors)
       end
 

--- a/app/services/activity/import/updater.rb
+++ b/app/services/activity/import/updater.rb
@@ -75,7 +75,7 @@ class Activity
 
       def find_activity_by_roda_id(roda_id)
         activity = Activity.by_roda_identifier(roda_id)
-        @errors[:roda_id] ||= [roda_id, I18n.t("importer.errors.activity.not_found")] if activity.nil?
+        @errors[:roda_identifier] ||= [roda_id, I18n.t("importer.errors.activity.not_found")] if activity.nil?
 
         activity
       end

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -581,6 +581,7 @@ en:
           parent_present: There is an existing RODA ID present, but there is a parent activity specified too, which will overwrite the existing parent. Please remove the parent ID from this row and try again.
           partner_organisation_identifier_present: The partner organisation identifier cannot be changed. Please remove the PO identifier from this row and try again.
           commitment: The original commitment figure cannot be updated via the bulk upload. Please remove the original commitment figure from this row and try again.
+          fund: You cannot update a fund (level A) activity
         unauthorised: You are not authorised to report against this activity
       commitment:
         required: An original commitment figure is required for level D activities

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
   end
 
   scenario "updating an existing activity" do
-    activity_to_update = create(:fund_activity, :newton)
+    activity_to_update = create(:programme_activity, :newton_funded)
 
     within ".upload-form--non-ispf" do
       content = <<~CSV

--- a/spec/services/activity/import_level_b_spec.rb
+++ b/spec/services/activity/import_level_b_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Activity::Import do
         expect(subject.errors.count).to eq(1)
 
         expect(subject.errors.first.csv_row).to eq(2)
-        expect(subject.errors.first.csv_column_name).to eq("roda_id")
-        expect(subject.errors.first.attribute_name).to eq(:roda_id)
+        expect(subject.errors.first.csv_column_name).to eq("RODA ID")
+        expect(subject.errors.first.attribute_name).to eq(:roda_identifier)
         expect(subject.errors.first.value).to eq("FAKE RODA ID")
         expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
       end

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -213,6 +213,25 @@ RSpec.describe Activity::Import do
       allow(ActivityPolicy).to receive(:new).and_return(activity_policy_double)
     end
 
+    it "does not allow the user to update a Level A (Fund) Activity" do
+      gcrf_fund_activity = create(:fund_activity, :gcrf)
+
+      existing_activity_attributes["RODA ID"] = gcrf_fund_activity.roda_identifier
+
+      expect { subject.import([existing_activity_attributes]) }.to_not change { gcrf_fund_activity }
+
+      expect(subject.created.count).to eq(0)
+      expect(subject.updated.count).to eq(0)
+
+      expect(subject.errors.count).to eq(1)
+
+      expect(subject.errors.first.csv_row).to eq(2)
+      expect(subject.errors.first.csv_column_name).to eq("RODA ID")
+      expect(subject.errors.first.attribute_name).to eq(:roda_identifier)
+      expect(subject.errors.first.value).to eq(gcrf_fund_activity.roda_identifier)
+      expect(subject.errors.first.message).to eq("You cannot update a fund (level A) activity")
+    end
+
     it "has an error if an Activity does not exist" do
       existing_activity_attributes["RODA ID"] = "FAKE RODA ID"
 

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -243,8 +243,8 @@ RSpec.describe Activity::Import do
       expect(subject.errors.count).to eq(1)
 
       expect(subject.errors.first.csv_row).to eq(2)
-      expect(subject.errors.first.csv_column_name).to eq("roda_id")
-      expect(subject.errors.first.attribute_name).to eq(:roda_id)
+      expect(subject.errors.first.csv_column_name).to eq("RODA ID")
+      expect(subject.errors.first.attribute_name).to eq(:roda_identifier)
       expect(subject.errors.first.value).to eq("FAKE RODA ID")
       expect(subject.errors.first.message).to eq(I18n.t("importer.errors.activity.not_found"))
     end


### PR DESCRIPTION
## Changes in this PR

The bulk upload now presents the user with an error when they try to upload a CSV with a fund activity's RODA identifier in the "RODA ID" column.

This PR also fixes a small bug where the wrong Activity column was being used for an activity that wasn't found.



## Screenshots of UI changes

### Before

#### Incorrect column

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/19826940/226671223-f120d9cc-1bc0-4ffe-bcdb-e2099bc34c19.png">

### After

#### Corrected error column

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/19826940/226670320-9ec5a482-3e06-4b8f-af8c-6330a0ae0147.png">

#### New error

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/19826940/226669629-3eb6cb56-3365-4a3b-b15c-6cab810089cb.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
