### PR TITLE
(2878) Add inclusion validators to Activity attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix accessibility issue of overflowing contents on the reports table and users table when zoomed in
 - Ensure non-BEIS users cannot download activities as XML
 - Use a safer method to display accessible links that can contain user input
+- Add inclusion validation for Activity attributes
 
 ## Release 132 - 2023-03-16
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -53,4 +53,11 @@ module FormHelper
   def benefitting_countries_in_region_for_form(region)
     BenefittingCountry.non_graduated_for_region(region)
   end
+
+  def all_benefitting_country_codes
+    benefitting_regions_for_form
+      .reduce([]) { |countries, region| countries << BenefittingCountry.non_graduated_for_region(region) }
+      .flatten
+      .map(&:code)
+  end
 end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -40,4 +40,14 @@ RSpec.describe FormHelper, type: :helper do
       expect(helper.list_of_budget_financial_years.first.name).to eq "2010-2011"
     end
   end
+
+  describe "#all_benefitting_country_codes" do
+    subject { helper.all_benefitting_country_codes }
+
+    it "returns an array of all possible benefitting country codes" do
+      expect(subject.size).to be 142
+      expect(subject.first).to eq "DZ"
+      expect(subject.last).to eq "WS"
+    end
+  end
 end


### PR DESCRIPTION
> Pivoted a couple of times on this. I have another branch where I add validation that matches the exact options `validates :sector_category, presence: true, inclusion: {in: ->(activity) { activity.sector_category_radio_options.map(&:code) }}, on: :sector_category_step` instead of `validates :sector_category, presence: true, inclusion: {in: Codelist.new(type: "sector_category").values_for("code")}, on: :sector_category_step`, but it invalidates 35 Activities and I don't want us to have to deal with that. I think from a security perspective this should be fine? 

## Changes in this PR
### Add inclusion validators to Activity attributes
The results of a recent pen test raised that various attributes of an Activity
can be set to arbitrary values.

This adds inclusion validation for the attributes.

Validation is kept loose where we use codelists, we only check whether a value
is in the corresponding codelist, and not whether the value is current. This
means that whilst a user could potentially enter an incorrect code, no
malicious values can be entered. Because of this, no older activities will be
invalidated (e.g., Activities that have a withdrawn `sector_category` code).

Some validators use helper methods so that the options are consistent between
the validation and radio options; whilst not ideal, this ensures the code is
DRY.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
