### PR TITLE
(2880) Ensure user is authorised to download activity XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prevent users from editing fund activities via the bulk upload
 - Use correct column name in bulk upload results when trying to update an activity that cannot be found
 - Fix accessibility issue of overflowing contents on the reports table and users table when zoomed in
+- Ensure non-BEIS users cannot download activities as XML
 
 ## Release 132 - 2023-03-16
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -50,6 +50,8 @@ class ActivitiesController < BaseController
         render template: tab.template, locals: tab.locals
       end
       format.xml do |_format|
+        authorize @activity, :download?
+
         @commitment = @activity.commitment
         @activities = @activity.child_activities.order("created_at ASC").map { |activity| ActivityPresenter.new(activity) }
 

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -71,11 +71,6 @@ module ActivityHelper
     end
   end
 
-  def can_download_as_xml?(activity:, user:)
-    activity.project? && ProjectPolicy.new(user, activity).download? ||
-      activity.third_party_project? && ThirdPartyProjectPolicy.new(user, activity).download?
-  end
-
   private
 
   def is_commentable_programme?(activity:)

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -61,6 +61,10 @@ class ActivityPolicy < ApplicationPolicy
     false
   end
 
+  def download?
+    beis_user?
+  end
+
   def redact_from_iati?
     if beis_user?
       return true unless record.fund?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -19,10 +19,6 @@ class ProjectPolicy < ApplicationPolicy
     false
   end
 
-  def download?
-    beis_user?
-  end
-
   def redact_from_iati?
     beis_user?
   end

--- a/app/views/activities/children.html.haml
+++ b/app/views/activities/children.html.haml
@@ -13,7 +13,7 @@
 
   .govuk-grid-row
     .govuk-grid-column-full
-      - if can_download_as_xml?(activity: @activity, user: current_user)
+      - if policy(@activity).download?
         = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
 
   .govuk-grid-row

--- a/app/views/activities/details.html.haml
+++ b/app/views/activities/details.html.haml
@@ -13,7 +13,7 @@
 
   .govuk-grid-row
     .govuk-grid-column-full
-      - if can_download_as_xml?(activity: @activity, user: current_user)
+      - if policy(@activity).download?
         = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
 
   .govuk-grid-row

--- a/app/views/activities/financials.html.haml
+++ b/app/views/activities/financials.html.haml
@@ -13,7 +13,7 @@
 
   .govuk-grid-row
     .govuk-grid-column-full
-      - if can_download_as_xml?(activity: @activity, user: current_user)
+      - if policy(@activity).download?
         = link_to t("default.button.download_as_xml"), organisation_activity_path(@activity.organisation, @activity, format: :xml), class: "govuk-button"
 
   .govuk-grid-row

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -29,6 +29,30 @@ RSpec.describe ActivitiesController do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "does not allow downloading a programme as XML" do
+      programme = create(:programme_activity, extending_organisation: user.organisation)
+
+      get :show, params: {organisation_id: user.organisation.id, id: programme.id, format: :xml}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "does not allow downloading a project as XML" do
+      project = create(:project_activity, organisation: user.organisation)
+
+      get :show, params: {organisation_id: user.organisation.id, id: project.id, format: :xml}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "does not allow downloading a third-party project as XML" do
+      third_party_project = create(:third_party_project_activity, organisation: user.organisation)
+
+      get :show, params: {organisation_id: user.organisation.id, id: third_party_project.id, format: :xml}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   shared_examples "fetches activities" do |params|

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -259,66 +259,6 @@ RSpec.describe ActivityHelper, type: :helper do
     end
   end
 
-  describe "#can_download_as_xml?" do
-    let(:user) { double(:user) }
-
-    context "when the activity is a project" do
-      let(:activity) { build(:project_activity) }
-
-      context "when the user can download projects" do
-        before { allow_any_instance_of(ProjectPolicy).to receive(:download?).and_return(true) }
-
-        it "returns true" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to be(true)
-        end
-      end
-
-      context "when the user cannot download projects" do
-        before { allow_any_instance_of(ProjectPolicy).to receive(:download?).and_return(false) }
-
-        it "returns false" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
-        end
-      end
-    end
-
-    context "when the activity is a third-party project" do
-      let(:activity) { build(:third_party_project_activity) }
-
-      context "when the user can download third-party projects" do
-        before { allow_any_instance_of(ThirdPartyProjectPolicy).to receive(:download?).and_return(true) }
-
-        it "returns true" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to be(true)
-        end
-      end
-
-      context "when the user cannot download third-party projects" do
-        before { allow_any_instance_of(ThirdPartyProjectPolicy).to receive(:download?).and_return(false) }
-
-        it "returns false" do
-          expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
-        end
-      end
-    end
-
-    context "when the activity is a fund" do
-      let(:activity) { build(:fund_activity) }
-
-      it "returns false" do
-        expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
-      end
-    end
-
-    context "when the activity is a programme" do
-      let(:activity) { build(:programme_activity) }
-
-      it "returns false" do
-        expect(can_download_as_xml?(activity: activity, user: user)).to be(false)
-      end
-    end
-  end
-
   def authorise_creating_comments(commentable_type:, authorise: true)
     without_partial_double_verification do
       case commentable_type

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:create)
         is_expected.to permit_action(:edit)
         is_expected.to permit_action(:update)
+        is_expected.to permit_action(:download)
         is_expected.to forbid_action(:destroy)
         is_expected.to forbid_action(:redact_from_iati)
         is_expected.to forbid_action(:create_refund)
@@ -40,6 +41,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:create)
         is_expected.to permit_action(:edit)
         is_expected.to permit_action(:update)
+        is_expected.to permit_action(:download)
 
         is_expected.to forbid_action(:destroy)
         is_expected.to permit_action(:redact_from_iati)
@@ -84,9 +86,10 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      it "only permits show and redact_from_iati" do
+      it "only permits download, show, and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
+        is_expected.to permit_action(:download)
 
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
@@ -134,9 +137,10 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      it "only permits show and redact_from_iati" do
+      it "only permits download, show, and redact_from_iati" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
+        is_expected.to permit_action(:download)
 
         is_expected.to forbid_action(:create)
         is_expected.to forbid_action(:edit)
@@ -185,6 +189,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:edit)
         is_expected.to forbid_action(:update)
         is_expected.to forbid_action(:destroy)
+        is_expected.to forbid_action(:download)
         is_expected.to forbid_action(:redact_from_iati)
 
         is_expected.to forbid_action(:create_child)
@@ -206,6 +211,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:edit)
           is_expected.to forbid_action(:update)
           is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:download)
           is_expected.to forbid_action(:redact_from_iati)
 
           is_expected.to forbid_action(:create_child)
@@ -229,6 +235,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:edit)
           is_expected.to forbid_action(:update)
           is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:download)
           is_expected.to forbid_action(:redact_from_iati)
 
           is_expected.to forbid_action(:create_child)
@@ -266,6 +273,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:edit)
           is_expected.to forbid_action(:update)
           is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:download)
           is_expected.to forbid_action(:redact_from_iati)
 
           is_expected.to forbid_action(:create_child)
@@ -294,6 +302,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:edit)
             is_expected.to forbid_action(:update)
             is_expected.to forbid_action(:destroy)
+            is_expected.to forbid_action(:download)
             is_expected.to forbid_action(:redact_from_iati)
 
             is_expected.to forbid_action(:create_child)
@@ -310,12 +319,13 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, and update_linked_activity" do
+          it "only forbids download, destroy, redact_from_iati, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
             is_expected.to permit_action(:update)
 
+            is_expected.to forbid_action(:download)
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
 
@@ -363,6 +373,7 @@ RSpec.describe ActivityPolicy do
           is_expected.to forbid_action(:create)
           is_expected.to forbid_action(:edit)
           is_expected.to forbid_action(:update)
+          is_expected.to forbid_action(:download)
           is_expected.to forbid_action(:destroy)
           is_expected.to forbid_action(:redact_from_iati)
 
@@ -387,6 +398,7 @@ RSpec.describe ActivityPolicy do
             is_expected.to forbid_action(:create)
             is_expected.to forbid_action(:edit)
             is_expected.to forbid_action(:update)
+            is_expected.to forbid_action(:download)
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
 
@@ -403,12 +415,13 @@ RSpec.describe ActivityPolicy do
             report.update(state: :active)
           end
 
-          it "only forbids destroy, redact_from_iati, create_child, and update_linked_activity" do
+          it "only forbids download, destroy, redact_from_iati, create_child, and update_linked_activity" do
             is_expected.to permit_action(:show)
             is_expected.to permit_action(:create)
             is_expected.to permit_action(:edit)
             is_expected.to permit_action(:update)
 
+            is_expected.to forbid_action(:download)
             is_expected.to forbid_action(:destroy)
             is_expected.to forbid_action(:redact_from_iati)
 

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe ProjectPolicy do
       is_expected.to forbid_new_and_create_actions
       is_expected.to forbid_edit_and_update_actions
       is_expected.to forbid_action(:destroy)
-      is_expected.to permit_action(:download)
       is_expected.to permit_action(:redact_from_iati)
     end
 
@@ -35,7 +34,6 @@ RSpec.describe ProjectPolicy do
       is_expected.to permit_new_and_create_actions
       is_expected.to permit_edit_and_update_actions
       is_expected.to forbid_action(:destroy)
-      is_expected.to forbid_action(:download)
       is_expected.to forbid_action(:redact_from_iati)
     end
 

--- a/spec/policies/third_party_project_policy_spec.rb
+++ b/spec/policies/third_party_project_policy_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe ThirdPartyProjectPolicy do
       is_expected.to forbid_new_and_create_actions
       is_expected.to forbid_edit_and_update_actions
       is_expected.to forbid_action(:destroy)
-      is_expected.to permit_action(:download)
       is_expected.to permit_action(:redact_from_iati)
     end
 
@@ -35,7 +34,6 @@ RSpec.describe ThirdPartyProjectPolicy do
       is_expected.to forbid_new_and_create_actions
       is_expected.to permit_edit_and_update_actions
       is_expected.to forbid_action(:destroy)
-      is_expected.to forbid_action(:download)
       is_expected.to forbid_action(:redact_from_iati)
     end
 


### PR DESCRIPTION
## Changes in this PR
- Ensure non-BEIS users cannot download activities as XML

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
