### PR TITLE
(2516) Untitled activity deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add "Previously reported under Newton Fund" ISPF tag
 - Rename Commitment date in Activity "Financials" tab
 - Change the colour of success messages to black
+- Allow BEIS users to delete untitled activities and signpost PO users on the process
 
 ## Release 132 - 2023-03-16
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -10,6 +10,9 @@ class ActivitiesController < BaseController
 
   def index
     @organisation = Organisation.find(organisation_id)
+
+    @deleted_activity_roda_identifier = params[:deleted_activity_roda_identifier]
+
     if @organisation.service_owner?
       @partner_organisations = Organisation.partner_organisations
 
@@ -71,6 +74,19 @@ class ActivitiesController < BaseController
     authorize @activity, :destroy?
 
     prepare_default_activity_trail(@activity)
+  end
+
+  def destroy
+    @activity = Activity.find(id)
+
+    authorize @activity, :destroy?
+
+    @activity.destroy
+
+    redirect_to organisation_activities_path(
+      @activity.organisation,
+      deleted_activity_roda_identifier: @activity.roda_identifier
+    )
   end
 
   def historic

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -65,6 +65,14 @@ class ActivitiesController < BaseController
     end
   end
 
+  def confirm_destroy
+    @activity = Activity.find(id)
+
+    authorize @activity, :destroy?
+
+    prepare_default_activity_trail(@activity)
+  end
+
   def historic
     @organisation = Organisation.find(organisation_id)
     if @organisation.service_owner?

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -685,6 +685,10 @@ class Activity < ApplicationRecord
     Time.parse(spending_breakdown_filename[-18..-5])
   end
 
+  def can_be_deleted?
+    title.blank?
+  end
+
   def self.hierarchically_grouped_projects
     activities = all.to_a
     projects = activities.select(&:project?).sort_by { |a| a.roda_identifier.to_s }

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -93,6 +93,8 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def destroy?
+    return false if record.fund?
+    return true if record.title.blank? && beis_user?
     false
   end
 

--- a/app/views/activities/_deleted_activity_notification_banner.html.haml
+++ b/app/views/activities/_deleted_activity_notification_banner.html.haml
@@ -1,0 +1,9 @@
+.govuk-notification-banner.govuk-notification-banner--success{role: "alert", "aria-labelledby": "govuk-notification-banner-title", "data-module": "govuk-notification-banner"}
+  .govuk-notification-banner__header
+    %h2.govuk-notification-banner__title#govuk-notification-banner-title
+      = t("default.success")
+  .govuk-notification-banner__content
+    %h3.govuk-notification-banner__heading
+      = t("action.activity.delete.success.title")
+    %p.govuk-body
+      = t("action.activity.delete.success.body_html", roda_identifier: roda_identifier)

--- a/app/views/activities/confirm_destroy.html.haml
+++ b/app/views/activities/confirm_destroy.html.haml
@@ -1,0 +1,27 @@
+=content_for :page_title_prefix, t("document_title.activity.delete", roda_identifier: @activity.roda_identifier)
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %span.govuk-caption-xl
+        = t("action.activity.delete.confirmation.heading_caption", roda_identifier: @activity.roda_identifier)
+
+      %h1.govuk-heading-xl
+        = t("page_title.activity.delete")
+
+      %p.govuk-body
+        = t("action.activity.delete.confirmation.pre_list")
+
+      %ul.govuk-list.govuk-list--bullet
+        - t("action.activity.delete.confirmation.list_items").each do |list_item|
+          %li
+            = list_item
+
+      = form_with(url: "example.com", method: :delete) do |f|
+        .govuk-button-group
+          %button.govuk-button{ "data-module": "govuk-button" }
+            = t("default.button.confirm")
+
+          = link_to t("default.button.cancel"),
+              organisation_activity_path(@activity.organisation, @activity),
+              class: "govuk-link"

--- a/app/views/activities/confirm_destroy.html.haml
+++ b/app/views/activities/confirm_destroy.html.haml
@@ -17,7 +17,7 @@
           %li
             = list_item
 
-      = form_with(url: "example.com", method: :delete) do |f|
+      = form_with(url: organisation_activity_path(@activity.organisation, @activity), method: :delete) do |f|
         .govuk-button-group
           %button.govuk-button{ "data-module": "govuk-button" }
             = t("default.button.confirm")

--- a/app/views/activities/index.html.haml
+++ b/app/views/activities/index.html.haml
@@ -2,7 +2,10 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-full
+    .govuk-grid-column-two-thirds
+      - if @deleted_activity_roda_identifier
+        = render partial: "deleted_activity_notification_banner", locals: { roda_identifier: @deleted_activity_roda_identifier }
+
       %h1.govuk-heading-xl
         Activities
 

--- a/app/views/activities/index_beis.html.haml
+++ b/app/views/activities/index_beis.html.haml
@@ -2,10 +2,15 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-full
+    .govuk-grid-column-two-thirds
+      - if @deleted_activity_roda_identifier
+        = render partial: "deleted_activity_notification_banner", locals: { roda_identifier: @deleted_activity_roda_identifier }
+
       %h1.govuk-heading-xl
         Activities
 
       = render partial: "searches/form"
 
+  .govuk-grid-row
+    .govuk-grid-column-full
       = render partial: "shared/organisations/organisations_activities_table", locals: { partner_organisations: @partner_organisations }

--- a/app/views/reports_state/mark_qa_completed/confirm.html.haml
+++ b/app/views/reports_state/mark_qa_completed/confirm.html.haml
@@ -11,4 +11,4 @@
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
         = hidden_field_tag :state, "qa_completed"
-        = f.govuk_submit t("action.report.mark_qa_completed.confirm.button")
+        = f.govuk_submit t("default.button.confirm")

--- a/app/views/reports_state/request_changes/confirm.html.haml
+++ b/app/views/reports_state/request_changes/confirm.html.haml
@@ -11,4 +11,4 @@
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
         = hidden_field_tag :state, "awaiting_changes"
-        = f.govuk_submit t("action.report.request_changes.confirm.button")
+        = f.govuk_submit t("default.button.confirm")

--- a/app/views/reports_state/review/confirm.html.haml
+++ b/app/views/reports_state/review/confirm.html.haml
@@ -13,4 +13,4 @@
 
       = form_for @report_presenter, url: report_state_path(@report_presenter) do |f|
         = hidden_field_tag :state, "in_review"
-        = f.govuk_submit t("action.report.in_review.confirm.button")
+        = f.govuk_submit t("default.button.confirm")

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -59,7 +59,7 @@
               = t("action.activity.delete.details.answer.authorised")
 
             = link_to t("action.activity.delete.details.answer.authorised_action"),
-                "example.com",
+                organisation_activity_confirm_destroy_path(activity_presenter.organisation, activity_presenter),
                 class: "govuk-button govuk-button--warning",
                 "data-module": "govuk-button",
                 role: "button"

--- a/app/views/shared/activities/_activity_summary.html.haml
+++ b/app/views/shared/activities/_activity_summary.html.haml
@@ -45,3 +45,25 @@
       %dd.govuk-summary-list__actions
         - if policy(activity_presenter).update_linked_activity?
           = a11y_action_link(t("default.link.#{activity_presenter.call_to_action(:linked_activity)}"), activity_step_path(activity_presenter, :linked_activity), t("activerecord.attributes.activity.linked_activity"))
+
+- if activity_presenter.can_be_deleted?
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %details.govuk-details{"data-module" => "govuk-details"}
+        %summary.govuk-details__summary
+          %span.govuk-details__summary-text
+            = t("action.activity.delete.details.question")
+        .govuk-details__text
+          - if policy(activity_presenter).destroy?
+            %p
+              = t("action.activity.delete.details.answer.authorised")
+
+            = link_to t("action.activity.delete.details.answer.authorised_action"),
+                "example.com",
+                class: "govuk-button govuk-button--warning",
+                "data-module": "govuk-button",
+                role: "button"
+
+          - else
+            %p
+              = t("action.activity.delete.details.answer.unauthorised_html")

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -21,6 +21,8 @@ en:
       menu: Menu
       submit: Submit
       delete: Delete
+      confirm: Confirm
+      cancel: Cancel
     link:
       add: Add
       back: Back

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -33,6 +33,7 @@ en:
     error:
       unknown: Unknown error
     warning: Warning
+    success: Success
   table:
     header:
       default:

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -9,6 +9,13 @@ en:
             authorised: You can delete this activity as it has no title.
             authorised_action: Delete this activity
             unauthorised_html: Only BEIS can delete this activity. Please <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/requests/new">submit a support request (opens in new tab)</a>, including the activity identifier.
+        confirmation:
+          heading_caption: Deleting activity %{roda_identifier}
+          pre_list: "If you delete this activity:"
+          list_items:
+            - all financial data and associated child activities will also be deleted
+            - you may need to inform the partner organisation separately
+            - linked activities will be unlinked but they will not be deleted
       add_child: Add child activity
       download:
         link: Download the %{type} template
@@ -33,6 +40,7 @@ en:
   document_title:
     activity:
       edit: Activity %{name} - Publish to IATI
+      delete: Delete activity %{roda_identifier}
       index: Activities for %{partner_organisation_name}
       index_beis: Activities
       details: Activity %{name} - Details
@@ -320,6 +328,7 @@ en:
       other_funding: Other funding
       transfers: Transfers
       change_history: Change history
+      delete: Are you sure you want to delete this activity?
     activities:
       current: Current activities
       historic: Historic activities

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -16,6 +16,9 @@ en:
             - all financial data and associated child activities will also be deleted
             - you may need to inform the partner organisation separately
             - linked activities will be unlinked but they will not be deleted
+        success:
+          title: Activities deleted.
+          body_html: <strong>%{roda_identifier}</strong> and its child activities have been deleted.
       add_child: Add child activity
       download:
         link: Download the %{type} template

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -2,6 +2,13 @@
 en:
   action:
     activity:
+      delete:
+        details:
+          question: This activity has no title. Can we delete it?
+          answer:
+            authorised: You can delete this activity as it has no title.
+            authorised_action: Delete this activity
+            unauthorised_html: Only BEIS can delete this activity. Please <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/requests/new">submit a support request (opens in new tab)</a>, including the activity identifier.
       add_child: Add child activity
       download:
         link: Download the %{type} template

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -219,15 +219,11 @@ en:
       spending_download:
         button: Download spending breakdown as CSV file
       in_review:
-        confirm:
-          button: Confirm
         complete:
           title: "%{report_financial_quarter} %{report_organisation} report in review"
         button: Mark as in review
       request_changes:
         button: Request changes
-        confirm:
-          button: Confirm
         complete:
           title: "%{report_financial_quarter} %{report_organisation} report is now awaiting changes"
         failure: Report could not be moved to awaiting changes
@@ -235,8 +231,6 @@ en:
         complete:
           title: "%{report_financial_quarter} report for %{report_organisation} marked as QA completed"
         button: QA complete
-        confirm:
-          button: Confirm
         failure: Report could not be marked as QA completed
       approve:
         complete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
       Activity::Tab::VALID_TAB_NAMES.each do |tab|
         get tab, to: "activities#show", defaults: {tab: tab}
       end
+
+      get :confirm_destroy, to: "activities#confirm_destroy"
     end
     namespace :level_b do
       namespace :activities do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
 
   resources :organisations, except: [:destroy, :index, :new] do
     get "reports" => "organisation_reports#index"
-    resources :activities, except: [:create, :destroy] do
+    resources :activities, except: [:create] do
       collection do
         get "historic" => "activities#historic"
       end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -175,4 +175,37 @@ RSpec.describe ActivitiesController do
       end
     end
   end
+
+  describe "#confirm_destroy" do
+    let(:activity) { create(:programme_activity, title: nil, form_state: "purpose") }
+    let(:policy) { instance_double(ActivityPolicy) }
+    let(:user) { instance_double(User) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(ActivityPolicy).to receive(:new).and_return(policy)
+    end
+
+    context "when authorised" do
+      it "responds with status 200 OK" do
+        allow(policy).to receive(:destroy?).and_return(true)
+        allow(user).to receive(:service_owner?).and_return(true)
+
+        get :confirm_destroy, params: {organisation_id: activity.organisation, activity_id: activity.id}
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when unauthorised" do
+      it "responds with status 401 Unauthorized" do
+        allow(policy).to receive(:destroy?).and_return(false)
+        allow(user).to receive(:service_owner?).and_return(false)
+
+        get :confirm_destroy, params: {organisation_id: activity.organisation, activity_id: activity.id}
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/features/users_can_delete_an_activity_spec.rb
+++ b/spec/features/users_can_delete_an_activity_spec.rb
@@ -35,6 +35,38 @@ RSpec.feature "Users can delete an activity" do
           expect(page).to have_link("Delete this activity")
         end
       end
+
+      context "when clicking on the delete button" do
+        before do
+          find("details").click
+
+          click_on "Delete this activity"
+        end
+
+        it "starts the activity deletion journey" do
+          # breadcrumbs
+          expect(page).to have_link("Home")
+          expect(page).to have_link(activity.parent.title)
+          expect(page).to have_link("Untitled activity")
+
+          # view
+          expect(page).to have_content("Deleting activity #{activity.roda_identifier}")
+          expect(page).to have_content("Are you sure you want to delete this activity?")
+          expect(page).to have_content("all financial data and associated child activities will also be deleted")
+          expect(page).to have_content("you may need to inform the partner organisation separately")
+          expect(page).to have_content("linked activities will be unlinked but they will not be deleted")
+          expect(page).to have_button("Confirm")
+          expect(page).to have_link("Cancel")
+        end
+
+        context "when cancelling deletion" do
+          it "returns the user to the activity page" do
+            click_on "Cancel"
+
+            expect(page).to have_selector("details", text: "This activity has no title. Can we delete it?")
+          end
+        end
+      end
     end
   end
 

--- a/spec/features/users_can_delete_an_activity_spec.rb
+++ b/spec/features/users_can_delete_an_activity_spec.rb
@@ -1,0 +1,69 @@
+RSpec.feature "Users can delete an activity" do
+  before do
+    authenticate!(user: user)
+
+    visit organisation_activity_path(activity.organisation, activity)
+
+    expect(page).to have_content(activity.roda_identifier)
+  end
+
+  after { logout }
+
+  context "when logged in as a BEIS user" do
+    let(:user) { create(:beis_user) }
+
+    context "and viewing an activity with a title" do
+      let(:activity) { create(:programme_activity) }
+
+      it "doesn't show anything about deletion" do
+        expect(page).not_to have_selector("details", text: "This activity has no title. Can we delete it?")
+      end
+    end
+
+    context "and viewing an untitled activity" do
+      let(:activity) { create(:programme_activity, title: nil, form_state: "identifier") }
+
+      it "tells the user they can delete it" do
+        expect(page).to have_selector("details", text: "This activity has no title. Can we delete it?")
+
+        details_element = find("details")
+
+        details_element.click
+
+        within details_element do
+          expect(page).to have_content("You can delete this activity as it has no title.")
+          expect(page).to have_link("Delete this activity")
+        end
+      end
+    end
+  end
+
+  context "when logged in as a partner organisation user" do
+    let(:user) { create(:partner_organisation_user) }
+
+    context "and viewing an activity with a title" do
+      let(:activity) { create(:programme_activity, extending_organisation: user.organisation) }
+
+      it "doesn't show anything about deletion" do
+        expect(page).not_to have_selector("details", text: "This activity has no title. Can we delete it?")
+      end
+    end
+
+    context "and viewing an untitled activity" do
+      let(:activity) { create(:programme_activity, extending_organisation: user.organisation, title: nil, form_state: "identifier") }
+
+      it "tells the user BEIS can delete it" do
+        expect(page).to have_selector("details", text: "This activity has no title. Can we delete it?")
+
+        details_element = find("details")
+
+        details_element.click
+
+        within details_element do
+          expect(page).to have_content("Only BEIS can delete this activity.")
+          expect(page).to have_link("submit a support request (opens in new tab)")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/users_can_mark_a_report_as_awaiting_changes_spec.rb
+++ b/spec/features/users_can_mark_a_report_as_awaiting_changes_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
         perform_enqueued_jobs do
           visit report_path(report)
           click_link t("action.report.request_changes.button")
-          click_button t("action.report.request_changes.confirm.button")
+          click_button t("default.button.confirm")
         end
 
         expect(page).to have_content "awaiting changes"
@@ -37,7 +37,7 @@ RSpec.feature "Users can move reports into awaiting changes & view reports await
         perform_enqueued_jobs do
           visit report_path(report)
           click_link t("action.report.request_changes.button")
-          click_button t("action.report.request_changes.confirm.button")
+          click_button t("default.button.confirm")
         end
 
         expect(page).to have_content "awaiting changes"

--- a/spec/features/users_can_mark_a_report_as_qa_completed_spec.rb
+++ b/spec/features/users_can_mark_a_report_as_qa_completed_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can mark reports as QA completed" do
 
       visit report_path(report)
       click_link t("action.report.mark_qa_completed.button")
-      click_button t("action.report.mark_qa_completed.confirm.button")
+      click_button t("default.button.confirm")
 
       expect(page).to have_content "QA completed"
       expect(report.reload.state).to eql "qa_completed"

--- a/spec/features/users_can_mark_a_report_in_review_spec.rb
+++ b/spec/features/users_can_mark_a_report_in_review_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can move reports into review" do
 
       visit report_path(report)
       click_link t("action.report.in_review.button")
-      click_button t("action.report.in_review.confirm.button")
+      click_button t("default.button.confirm")
 
       expect(page).to have_content "in review"
       expect(report.reload.state).to eql "in_review"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2758,6 +2758,24 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#can_be_deleted?" do
+    context "when title is present" do
+      let(:activity) { build(:programme_activity) }
+
+      it "returns false" do
+        expect(activity.can_be_deleted?).to be(false)
+      end
+    end
+
+    context "when title is blank" do
+      let(:activity) { build(:programme_activity, title: nil, form_state: "identifier") }
+
+      it "returns true" do
+        expect(activity.can_be_deleted?).to be(true)
+      end
+    end
+  end
+
   def factory_name_by_activity_level(level)
     (level.underscore.parameterize(separator: "_") + "_activity").to_sym
   end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe ActivityPolicy do
 
         it { is_expected.to forbid_action(:update_linked_activity) }
       end
+
+      context "when the activity is untitled" do
+        let(:activity) { create(:programme_activity, title: "", form_state: "purpose") }
+
+        it { is_expected.to permit_action(:destroy) }
+      end
     end
 
     context "when the activity is a project" do
@@ -132,6 +138,12 @@ RSpec.describe ActivityPolicy do
           end
         end
       end
+
+      context "when the activity is untitled" do
+        let(:activity) { create(:project_activity, title: "", form_state: "purpose") }
+
+        it { is_expected.to permit_action(:destroy) }
+      end
     end
 
     context "when the activity is a third-party project" do
@@ -173,6 +185,12 @@ RSpec.describe ActivityPolicy do
             it { is_expected.to permit_action(:update_linked_activity) }
           end
         end
+      end
+
+      context "when the activity is untitled" do
+        let(:activity) { create(:third_party_project_activity, title: "", form_state: "purpose") }
+
+        it { is_expected.to permit_action(:destroy) }
       end
     end
   end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a project" do
       let(:activity) { create(:project_activity) }
 
-      it "only permits download, show, and redact_from_iati" do
+      it "only permits show, redact_from_iati, download and set_commitment" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
         is_expected.to permit_action(:download)
@@ -149,7 +149,7 @@ RSpec.describe ActivityPolicy do
     context "when the activity is a third-party project" do
       let(:activity) { create(:third_party_project_activity) }
 
-      it "only permits download, show, and redact_from_iati" do
+      it "only permits show, redact_from_iati, download and set_commitment" do
         is_expected.to permit_action(:show)
         is_expected.to permit_action(:redact_from_iati)
         is_expected.to permit_action(:download)


### PR DESCRIPTION
## Changes in this PR

- Allow BEIS users to delete untitled activities
- Signpost PO users on how to get untitled activities deleted

## Screenshots of UI changes

### Before

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/40244233/227241292-7bf7ec09-86a4-4b03-8c58-87e917e26f36.png">

### After

https://user-images.githubusercontent.com/40244233/227240995-dbe4a35a-b81b-46f6-ac55-764c4ea78b03.mov

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
