### PR TITLE
Tidy up HTTP status assertions

### DIFF
--- a/spec/controllers/activity_comments_controller_spec.rb
+++ b/spec/controllers/activity_comments_controller_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user" do
         let(:user) { partner_organisation_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :new, params: {activity_id: programme_activity.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -47,10 +47,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :new, params: {activity_id: project_activity.id, report_id: project_activity_report.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -67,10 +67,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
         let(:user) { create(:partner_organisation_user) }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :new, params: {activity_id: project_activity.id, report_id: project_activity_report.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -111,10 +111,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user" do
         let(:user) { partner_organisation_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           post_comment(activity_id: programme_activity.id, report_id: "")
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -123,10 +123,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           post_comment(activity_id: project_activity.id, report_id: project_activity_report.id)
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -146,10 +146,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
         let(:user) { create(:partner_organisation_user) }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           post_comment(activity_id: project_activity.id, report_id: project_activity_report.id)
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -172,10 +172,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user" do
         let(:user) { partner_organisation_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :edit, params: {activity_id: programme_activity.id, id: existing_programme_activity_comment.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -184,10 +184,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :edit, params: {activity_id: project_activity.id, id: existing_project_activity_comment.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -204,10 +204,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
         let(:user) { create(:partner_organisation_user) }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           get :edit, params: {activity_id: project_activity.id, id: existing_project_activity_comment.id}
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -249,10 +249,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user" do
         let(:user) { partner_organisation_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           put_comment(comment_id: existing_programme_activity_comment.id, activity_id: programme_activity.id)
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -261,10 +261,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a BEIS user" do
         let(:user) { beis_user }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           put_comment(comment_id: existing_project_activity_comment.id, activity_id: project_activity.id)
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -284,10 +284,10 @@ RSpec.describe ActivityCommentsController do
       context "when signed in as a partner organisation user whose organisation is different to the activity's report" do
         let(:user) { create(:partner_organisation_user) }
 
-        it "responds with a 401" do
+        it "responds with status 401 Unauthorized" do
           put_comment(comment_id: existing_project_activity_comment.id, activity_id: project_activity.id)
 
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end

--- a/spec/controllers/actuals/history_uploads_controller_spec.rb
+++ b/spec/controllers/actuals/history_uploads_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Actuals::HistoryUploadsController do
     end
 
     describe "#new" do
-      it "returns unauthorized (401)" do
+      it "responds with status 401 Unauthorized" do
         get :new, params: {report_id: report.id}
 
         expect(response).to have_http_status(:unauthorized)
@@ -60,7 +60,7 @@ RSpec.describe Actuals::HistoryUploadsController do
     end
 
     describe "#update" do
-      it "returns unauthorized (401)" do
+      it "responds with status 401 Unauthorized" do
         put :update, params: {report_id: report.id}
 
         expect(response).to have_http_status(:unauthorized)

--- a/spec/controllers/exports/organisations_controller_spec.rb
+++ b/spec/controllers/exports/organisations_controller_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe Exports::OrganisationsController do
     end
   end
 
-  shared_examples "responds with a 401" do
+  shared_examples "responds with status 401 Unauthorized" do
     it "does not allow the user to access the export" do
-      expect(response.status).to eq(401)
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
   shared_examples "allows the user to access the export" do
-    it "responds with a 200" do
-      expect(response.status).to eq(200)
+    it "responds with status 200 OK" do
+      expect(response).to have_http_status(:ok)
     end
 
     it "sets the CSV headers correctly" do
@@ -99,7 +99,7 @@ RSpec.describe Exports::OrganisationsController do
         get :actuals, params: {id: organisation.id, format: :csv}
       end
 
-      include_examples "responds with a 401"
+      include_examples "responds with status 401 Unauthorized"
     end
 
     describe "#programme_activities" do
@@ -107,7 +107,7 @@ RSpec.describe Exports::OrganisationsController do
         get :programme_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "responds with a 401"
+      include_examples "responds with status 401 Unauthorized"
     end
 
     describe "#project_activities" do
@@ -115,7 +115,7 @@ RSpec.describe Exports::OrganisationsController do
         get :project_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "responds with a 401"
+      include_examples "responds with status 401 Unauthorized"
     end
 
     describe "#third_party_project_activities" do
@@ -123,7 +123,7 @@ RSpec.describe Exports::OrganisationsController do
         get :third_party_project_activities, params: {id: organisation.id, fund: fund.short_name, format: :xml}
       end
 
-      include_examples "responds with a 401"
+      include_examples "responds with status 401 Unauthorized"
     end
   end
 

--- a/spec/controllers/exports_controller_spec.rb
+++ b/spec/controllers/exports_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ExportsController do
       it "does not allow the user to access the index" do
         get "index"
 
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -52,15 +52,15 @@ RSpec.describe ExportsController do
       let(:user) { create(:partner_organisation_user) }
 
       it "does not allow the user to access the download" do
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "when logged in as a BEIS user" do
       let(:user) { create(:beis_user) }
 
-      it "responds with a 200" do
-        expect(response.status).to eq(200)
+      it "responds with status 200 OK" do
+        expect(response).to have_http_status(:ok)
       end
 
       it "sets the CSV headers correctly" do
@@ -84,15 +84,15 @@ RSpec.describe ExportsController do
       let(:user) { create(:partner_organisation_user) }
 
       it "does not allow the user to access the download" do
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "when logged in as a BEIS user" do
       let(:user) { create(:beis_user) }
 
-      it "responds with a 200" do
-        expect(response.status).to eq(200)
+      it "responds with status 200 OK" do
+        expect(response).to have_http_status(:ok)
       end
 
       it "sets the CSV headers correctly" do

--- a/spec/controllers/implementing_organisations_controller_spec.rb
+++ b/spec/controllers/implementing_organisations_controller_spec.rb
@@ -26,20 +26,20 @@ RSpec.describe ImplementingOrganisationsController do
     context "when signed in as a BEIS user" do
       let(:user) { create(:beis_user) }
 
-      it "responds with a 401" do
+      it "responds with status 401 Unauthorized" do
         get :new, params: {activity_id: activity.id}
 
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "when the activity has no editable report" do
-      it "responds with a 401" do
+      it "responds with status 401 Unauthorized" do
         report.destroy
 
         get :new, params: {activity_id: activity.id}
 
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -85,14 +85,14 @@ RSpec.describe ImplementingOrganisationsController do
     context "when logged in as another partner organisation user" do
       let(:other_user) { create(:partner_organisation_user) }
 
-      it "responds with a 401" do
+      it "responds with status 401 Unauthorized" do
         logout
         authenticate!(user: other_user)
         allow(controller).to receive(:current_user).and_return(other_user)
 
         delete_org_participation
 
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/controllers/level_b/activities/uploads_controller_spec.rb
+++ b/spec/controllers/level_b/activities/uploads_controller_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe LevelB::Activities::UploadsController do
     context "when signed in as a partner organisation user" do
       let(:user) { create(:partner_organisation_user) }
 
-      it "responds with a 401" do
+      it "responds with status 401 Unauthorized" do
         get :new, params: {organisation_id: organisation.id}
 
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PagesController, "#show" do
     context "GET /pages/#{page}" do
       subject { get :show, params: {id: page} }
 
-      it { should have_http_status(200) }
+      it { should have_http_status(:ok) }
       it { should render_template(page) }
 
       context "when user is logged in" do
@@ -15,7 +15,7 @@ RSpec.describe PagesController, "#show" do
           allow(controller).to receive(:current_user).and_return(stub_user)
         end
 
-        it { should have_http_status(200) }
+        it { should have_http_status(:ok) }
         it { should render_template(page) }
       end
     end

--- a/spec/controllers/report_comments_controller_spec.rb
+++ b/spec/controllers/report_comments_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ReportCommentsController do
     context "when signed in as a BEIS user" do
       let(:user) { create(:beis_user) }
 
-      it "responds with a 200" do
-        expect(response.status).to eq(200)
+      it "responds with status 200 OK" do
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -26,16 +26,16 @@ RSpec.describe ReportCommentsController do
       context "when the report belongs to the user's organisation" do
         let(:report) { build(:report, :active, id: SecureRandom.uuid, organisation: user.organisation) }
 
-        it "responds with a 200" do
-          expect(response.status).to eq(200)
+        it "responds with status 200 OK" do
+          expect(response).to have_http_status(:ok)
         end
       end
 
       context "when the report does not belong to the user's organisation" do
         let(:report) { build(:report, id: SecureRandom.uuid) }
 
-        it "responds with a 401" do
-          expect(response.status).to eq(401)
+        it "responds with status 401 Unauthorized" do
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end

--- a/spec/features/users_can_activate_reports_spec.rb
+++ b/spec/features/users_can_activate_reports_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can activate reports" do
 
         visit edit_report_state_path(report)
 
-        expect(page.status_code).to eql 401
+        expect(page).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/features/users_can_approve_a_report_spec.rb
+++ b/spec/features/users_can_approve_a_report_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Users can approve reports" do
 
       visit edit_report_state_path(report)
 
-      expect(page.status_code).to eql 401
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/features/users_can_edit_a_forecast_spec.rb
+++ b/spec/features/users_can_edit_a_forecast_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Users can edit a forecast" do
         click_on "Edit"
       end
 
-      expect(page).to have_http_status(:success)
+      expect(page).to have_http_status(:ok)
 
       fill_in "Forecasted spend amount", with: "£20000"
 

--- a/spec/features/users_can_export_spending_breakdown_spec.rb
+++ b/spec/features/users_can_export_spending_breakdown_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Users can export spending breakdown" do
       click_link partner_organisation.name
       click_link "Download Newton Fund spending breakdown"
 
-      expect(page.status_code).to eq 200
+      expect(page).to have_http_status(:ok)
 
       headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
       expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))
@@ -67,21 +67,21 @@ RSpec.feature "Users can export spending breakdown" do
 
     scenario "they cannot download spending breakdown for all organisations" do
       visit exports_path
-      expect(page.status_code).to eq 401
+      expect(page).to have_http_status(:unauthorized)
     end
 
     scenario "they cannot download spending breakdown for an organisation they are not associated with" do
       other_organisation = create(:partner_organisation)
       visit spending_breakdown_exports_organisation_path(other_organisation)
 
-      expect(page.status_code).to eq 401
+      expect(page).to have_http_status(:unauthorized)
     end
 
     scenario "they can download spending breakdown for an organisation they are associated with" do
       visit exports_organisation_path(organisation)
       click_link "Download Newton Fund spending breakdown"
 
-      expect(page.status_code).to eq 200
+      expect(page).to have_http_status(:ok)
 
       headers = CSV.parse(page.body.delete_prefix("\ufeff"), headers: true).headers
       expect(headers).to include(t("activerecord.attributes.activity.roda_identifier"))

--- a/spec/features/users_can_mark_a_report_in_review_spec.rb
+++ b/spec/features/users_can_mark_a_report_in_review_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Users can move reports into review" do
 
       visit edit_report_state_path(report)
 
-      expect(page.status_code).to eql 401
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/features/users_can_submit_a_report_spec.rb
+++ b/spec/features/users_can_submit_a_report_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Users can submit a report" do
 
         visit edit_report_state_path(report)
 
-        expect(page.status_code).to eql 401
+        expect(page).to have_http_status(:unauthorized)
       end
     end
   end
@@ -87,7 +87,7 @@ RSpec.feature "Users can submit a report" do
 
       visit edit_report_state_path(report)
 
-      expect(page.status_code).to eql 401
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -216,7 +216,7 @@ RSpec.feature "Users can view reports" do
       click_link t("action.report.download.button")
 
       expect(page.response_headers["Content-Type"]).to include("text/csv")
-      expect(page.status_code).to eq 200
+      expect(page).to have_http_status(:ok)
     end
 
     context "when the report has an export_filename" do
@@ -487,7 +487,7 @@ RSpec.feature "Users can view reports" do
 
         visit report_path(another_report)
 
-        expect(page).to have_http_status(401)
+        expect(page).to have_http_status(:unauthorized)
       end
 
       scenario "they see helpful guidance about and can download a CSV of their own report" do
@@ -506,7 +506,7 @@ RSpec.feature "Users can view reports" do
         expect(page.response_headers["Content-Type"]).to include("text/csv")
 
         expect(page.response_headers["Content-Type"]).to include("text/csv")
-        expect(page.status_code).to eq 200
+        expect(page).to have_http_status(:ok)
       end
     end
 

--- a/spec/requests/domain_redirect_spec.rb
+++ b/spec/requests/domain_redirect_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe "Canonical domain redirect", type: :request do
 
   it "redirects to the canonical domain" do
     expect(get("http://test.local/")).to redirect_to("http://beis-roda.com/")
-    expect(response.status).to eq(301)
+    expect(response).to have_http_status(:moved_permanently)
   end
 
   it "keeps the original path" do
     expect(get("http://test.local/pages/cookie_statement")).to redirect_to("http://beis-roda.com/pages/cookie_statement")
-    expect(response.status).to eq(301)
+    expect(response).to have_http_status(:moved_permanently)
   end
 
   it "keeps query strings in place" do
     expect(get("http://test.local/pages/cookie_statement?foo=bar")).to redirect_to("http://beis-roda.com/pages/cookie_statement?foo=bar")
-    expect(response.status).to eq(301)
+    expect(response).to have_http_status(:moved_permanently)
   end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe "the custom error pages" do
   it "responds with a custom 404 page" do
     get "/404"
 
-    expect(response).to have_http_status(404)
+    expect(response).to have_http_status(:not_found)
     expect(response.body).to include t("page_title.errors.not_found")
   end
 
   it "responds with a custom 500 page" do
     get "/500"
 
-    expect(response).to have_http_status(500)
+    expect(response).to have_http_status(:internal_server_error)
     expect(response.body).to include t("page_title.errors.internal_server_error")
   end
 
   it "responds with a custom 422 page" do
     get "/422"
 
-    expect(response).to have_http_status(422)
+    expect(response).to have_http_status(:unprocessable_entity)
     expect(response.body).to include t("page_title.errors.unacceptable")
   end
 end

--- a/spec/requests/host_urls_are_whitelisted_spec.rb
+++ b/spec/requests/host_urls_are_whitelisted_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "host urls are checked against a whitelist", type: :request do
   scenario "a whitelisted host is accepted and an OK response is received" do
     get root_path, headers: {"Host" => "test.local"}
-    expect(response).to have_http_status("200")
+    expect(response).to have_http_status(:ok)
   end
 
   scenario "a bad host is rejected and the request is forbidden" do
     get root_path, headers: {"Host" => "baddomain.com"}
-    expect(response).to have_http_status("403")
+    expect(response).to have_http_status(:forbidden)
   end
 end

--- a/spec/support/shared_examples/transfer_controller.rb
+++ b/spec/support/shared_examples/transfer_controller.rb
@@ -3,6 +3,8 @@ RSpec.shared_examples "a transfer controller" do
     allow(controller).to receive(:current_user).and_return(user)
   end
 
+  subject { response }
+
   context "when logged in as a beis user" do
     let(:user) { create(:beis_user) }
 
@@ -12,13 +14,13 @@ RSpec.shared_examples "a transfer controller" do
       describe "#new" do
         before { get :new, params: {activity_id: activity.id} }
 
-        it { should respond_with 200 }
+        it { should have_http_status(:ok) }
       end
 
       describe "#edit" do
         before { get :edit, params: {activity_id: activity.id, id: transfer.id} }
 
-        it { should respond_with 200 }
+        it { should have_http_status(:ok) }
       end
     end
 
@@ -28,13 +30,13 @@ RSpec.shared_examples "a transfer controller" do
       describe "#new" do
         before { get :new, params: {activity_id: activity.id} }
 
-        it { should respond_with 401 }
+        it { should have_http_status(:unauthorized) }
       end
 
       describe "#edit" do
         before { get :edit, params: {activity_id: activity.id, id: transfer.id} }
 
-        it { should respond_with 401 }
+        it { should have_http_status(:unauthorized) }
       end
     end
   end
@@ -48,13 +50,13 @@ RSpec.shared_examples "a transfer controller" do
       describe "#new" do
         before { get :new, params: {activity_id: activity.id} }
 
-        it { should respond_with 401 }
+        it { should have_http_status(:unauthorized) }
       end
 
       describe "#edit" do
         before { get :edit, params: {activity_id: activity.id, id: transfer.id} }
 
-        it { should respond_with 401 }
+        it { should have_http_status(:unauthorized) }
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

Previously, there was a lack of consistent syntax/helper method usage when testing the HTTP status of a controller response or page. This cleans things up by using the `have_http_status` matcher in combination with a status symbol[1]. It also makes the `it` descriptions more consistent when referencing status codes

[1] https://github.com/rails/rails/blob/v4.0.0/guides/source/layouts_and_rendering.md#the-status-option

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
