### PR TITLE
(2744) Add task to generate a CSV of Activities for annual fund impact metrics

### DIFF
--- a/lib/tasks/annual_fund_impact_metrics_activities.rake
+++ b/lib/tasks/annual_fund_impact_metrics_activities.rake
@@ -1,0 +1,41 @@
+require "csv-safe"
+
+namespace :activities do
+  task :annual_fund_impact_metrics, [:output_csv_path] => :environment do |_task, args|
+    desc "Generates a CSV file of Activities that will be used to pre-populate an annual
+          collaborative spreadsheet of fund impact metrics"
+
+    csv_path = args[:output_csv_path] || "tmp/annual_fund_impact_metrics.csv"
+
+    CSVSafe.open(csv_path, "wb") do |csv|
+      activities = Activity
+        .joins(:organisation)
+        .includes(:organisation, :actuals)
+        .where.not(programme_status: ["delivery", "agreement_in_place", "open_for_applications", "stopped"])
+        .order("organisations.name, programme_status")
+
+      # We want to exclude Activities that were completed more than two years ago. We have discussed
+      # this and determined that the best way to do this is to exclude those that have no Actuals
+      # reported in the last two years (including if there are no Actuals at all).
+      active_activities = activities.reject do |activity|
+        next unless activity.programme_status == "completed"
+
+        activity.actuals.none? { |actual| actual.date >= 2.years.ago.to_date }
+      end
+
+      headers = ["Partner Organisation name", "Activity name", "RODA ID", "Partner Organisation ID", "Status"]
+
+      csv << headers
+
+      active_activities.each do |activity|
+        partner_organisation_name = activity.organisation.name
+        activity_title = activity.title
+        roda_identifier = activity.roda_identifier
+        partner_organisation_identifier = activity.partner_organisation_identifier
+        status = activity.programme_status
+
+        csv << [partner_organisation_name, activity_title, roda_identifier, partner_organisation_identifier, status]
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -1,0 +1,95 @@
+require "tempfile"
+
+RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
+  let!(:completed_activity) { create(:fund_activity, programme_status: "completed") }
+  let!(:actual_2_years_ago) { create(:actual, date: 2.years.ago, parent_activity: completed_activity, report: nil) }
+  let!(:beis_organisation) { completed_activity.organisation }
+  let!(:completed_activity_no_actuals) { create(:fund_activity, programme_status: "completed") }
+  let!(:decided_activity) { create(:fund_activity, organisation: aardvark_organisation, programme_status: "decided") }
+  let!(:review_activity) { create(:fund_activity, organisation: aardvark_organisation, programme_status: "review") }
+  let!(:aardvark_organisation) { create(:beis_organisation, name: "Department for Aardvarks", iati_reference: "CZH-COH-111") }
+
+  let!(:delivery_activity) { create(:fund_activity, programme_status: "delivery") }
+  let!(:agreement_in_place_activity) { create(:fund_activity, programme_status: "agreement_in_place") }
+  let!(:open_for_applications_activity) { create(:fund_activity, programme_status: "open_for_applications") }
+  let!(:stopped_activity) { create(:fund_activity, programme_status: "stopped") }
+
+  let!(:completed_over_2_years_ago_activity) { create(:fund_activity, programme_status: "completed") }
+  let!(:actual_over_2_years_ago) { create(:actual, date: 2.years.ago - 1.day, parent_activity: completed_over_2_years_ago_activity, report: nil) }
+
+  let(:test_csv) { Tempfile.new(["fake", ".csv"]) }
+
+  before { freeze_time }
+
+  after do
+    subject.reenable
+    test_csv.unlink
+  end
+
+  subject { Rake::Task["activities:annual_fund_impact_metrics"] }
+
+  context "when the CSV path is not provided" do
+    before { allow(CSV).to receive(:open).and_return(nil) }
+
+    it "uses the default path" do
+      task.invoke
+
+      expect(CSV).to have_received(:open).with("tmp/annual_fund_impact_metrics.csv", "wb")
+    end
+  end
+
+  it "excludes Activities with `delivery`, `agreement_in_place`, `open_for_applications`, or `stopped` statuses" do
+    excluded_activity_titles = [
+      delivery_activity.title,
+      agreement_in_place_activity.title,
+      open_for_applications_activity.title,
+      stopped_activity.title
+    ]
+
+    task.invoke(test_csv.path)
+    result = test_csv.readlines
+
+    excluded_activities_present = result.any? do |activity|
+      excluded_activity_titles.any? { |title| activity.include?(title) }
+    end
+
+    expect(excluded_activities_present).to be(false)
+  end
+
+  it "excludes Activities with `completed` statuses if there are no Actuals reported in the last 2 years" do
+    excluded_activity_titles = [completed_over_2_years_ago_activity.title]
+
+    task.invoke(test_csv.path)
+    result = test_csv.readlines
+
+    excluded_activities_present = result.any? do |activity|
+      excluded_activity_titles.any? { |title| activity.include?(title) }
+    end
+
+    expect(excluded_activities_present).to be(false)
+  end
+
+  it "excludes Activities with `completed` statuses if it has no Actuals" do
+    excluded_activity_titles = [completed_activity_no_actuals.title]
+
+    task.invoke(test_csv.path)
+    result = test_csv.readlines
+
+    excluded_activities_present = result.any? do |activity|
+      excluded_activity_titles.any? { |title| activity.include?(title) }
+    end
+
+    expect(excluded_activities_present).to be(false)
+  end
+
+  it "generates a CSV file of Activities ordered by organisation name and status" do
+    task.invoke(test_csv.path)
+    result = test_csv.readlines
+
+    expect(result.count).to be 4
+    expect(result[0]).to eq "Partner Organisation name,Activity name,RODA ID,Partner Organisation ID,Status\n"
+    expect(result[1]).to eq "#{aardvark_organisation.name},#{review_activity.title},#{review_activity.roda_identifier},#{review_activity.partner_organisation_identifier},#{review_activity.programme_status}\n"
+    expect(result[2]).to eq "#{aardvark_organisation.name},#{decided_activity.title},#{decided_activity.roda_identifier},#{decided_activity.partner_organisation_identifier},#{decided_activity.programme_status}\n"
+    expect(result[3]).to eq "\"#{beis_organisation.name}\",#{completed_activity.title},#{completed_activity.roda_identifier},#{completed_activity.partner_organisation_identifier},#{completed_activity.programme_status}\n"
+  end
+end


### PR DESCRIPTION
## Changes in this PR
We want to be able to generate a CSV of activities that will be used to
pre-populate an annual collaborative spreadsheet of fund impact metrics.

This task will be used to capture a snapshot of activities once a year in
July.

The CSV will be created in the `tmp` folder. We have documentation describing
how to download files when connected remotely to an instance of the application.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
