### PR TITLE
(2901) Add ISPF tag for `Previously reported under Newton Fund`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Ensure non-BEIS users cannot download activities as XML
 - Use a safer method to display accessible links that can contain user input
 - Add inclusion validation for Activity attributes
+- Add "Previously reported under Newton Fund" ISPF tag
 
 ## Release 132 - 2023-03-16
 

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -240,11 +240,11 @@ RSpec.describe CodelistHelper, type: :helper do
       it "returns the BEIS codes and descriptions" do
         options = helper.tags_options
 
-        expect(options.length).to eq 6
+        expect(options.length).to eq 7
         expect(options.first.code).to eq 1
         expect(options.first.description).to eq "Ayrton Fund"
-        expect(options.last.code).to eq 6
-        expect(options.last.description).to eq "Previously reported under GCRF"
+        expect(options.last.code).to eq 7
+        expect(options.last.description).to eq "Previously reported under Newton Fund"
       end
     end
   end

--- a/vendor/data/codelists/BEIS/tags.yml
+++ b/vendor/data/codelists/BEIS/tags.yml
@@ -11,3 +11,5 @@ data:
     description: Previously reported under OODA
   - code: 6
     description: Previously reported under GCRF
+  - code: 7
+    description: Previously reported under Newton Fund


### PR DESCRIPTION
## Changes in this PR
We have been asked to add an additional ISPF tag for `Previously reported under Newton Fund`.
<img width="582" alt="image" src="https://user-images.githubusercontent.com/47089130/227558857-5820d2ee-f691-4746-a9af-72b8bb3370de.png">
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
