### PR TITLE
Add the current budget to the revisions page

### DIFF
--- a/app/views/budgets/edit.html.haml
+++ b/app/views/budgets/edit.html.haml
@@ -6,9 +6,7 @@
       %h1.govuk-heading-xl
         = t("page_title.budget.edit", financial_year: @budget_presenter.financial_year)
 
-      %p.govuk-body-l.govuk
-        %strong Current budget:
-        = @budget_presenter.value
+      = render partial: '/shared/budgets/current_budget', locals: { value: @budget_presenter.value }
 
       = form_with model: @budget, url: activity_budget_path(@activity) do |f|
         = f.govuk_error_summary

--- a/app/views/budgets/revisions.html.haml
+++ b/app/views/budgets/revisions.html.haml
@@ -6,6 +6,8 @@
       %h1.govuk-heading-xl
         = t("page_title.budget.revisions")
 
+      = render partial: '/shared/budgets/current_budget', locals: { value: BudgetPresenter.new(@audits.last.revision).value }
+
       %table.govuk-table
         %thead.govuk-table__head
           %tr.govuk-table__row

--- a/app/views/shared/budgets/_current_budget.html.haml
+++ b/app/views/shared/budgets/_current_budget.html.haml
@@ -1,0 +1,3 @@
+%p.govuk-body-l.govuk
+  %strong Current budget:
+  = value

--- a/spec/features/users_can_edit_a_budget_spec.rb
+++ b/spec/features/users_can_edit_a_budget_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe "Users can edit a budget" do
       end
 
       expect(page).to have_content("Budget revisions")
+      expect(page).to have_content("Current budget: £5.00")
 
       within("tbody") do
         expect(page.all("tr").count).to be 3


### PR DESCRIPTION
## Changes in this PR
### Add the current budget to the revisions page
The revisions page shows the current budget as the most recent revision. However, the prototype also shows the current budget as a standalone element to match the edit page.

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/47089130/227590252-35a054e6-0184-455d-89f0-84d0f9d17f74.png">

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
