### PR TITLE
(2905) Budget edit success message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add inclusion validation for Activity attributes
 - Add "Previously reported under Newton Fund" ISPF tag
 - Rename Commitment date in Activity "Financials" tab
+- Change the colour of success messages to black
 
 ## Release 132 - 2023-03-16
 

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -50,7 +50,9 @@ class BudgetsController < BaseController
       .call(attributes: update_budget_params)
 
     if result.success?
-      flash[:notice] = t("action.budget.update.success")
+      flash[:notice] = t("action.budget.update.success",
+        financial_year: @budget_presenter.financial_year,
+        value: @budget_presenter.value)
       redirect_to organisation_activity_path(@activity.organisation, @activity)
     else
       render :edit

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -1,7 +1,7 @@
 - flash.each do |name, msg|
   - if msg.is_a?(String)
     %div{class: ["govuk-error-summary", "govuk-error-summary--#{name.to_s}"], options: {aria_labelledby: "error-summary-title", role: "alert", data_module: "govuk-error-summary"}}
-      %h2{class: "govuk-error-summary__title", id: "error-summary-title"}
+      %h2{class: "govuk-error-summary__title govuk-body", id: "error-summary-title"}
         = msg
 
   - elsif  msg.is_a?(Hash) & msg.key?(:errors) & msg.key?(:title)

--- a/config/locales/models/budget.en.yml
+++ b/config/locales/models/budget.en.yml
@@ -5,7 +5,7 @@ en:
       create:
         success: Budget successfully created
       update:
-        success: Budget successfully updated
+        success: Budget successfully updated. Current budget of %{financial_year} is now %{value}
       destroy:
         success: Budget successfully deleted
       bulk_download:

--- a/spec/features/users_can_edit_a_budget_spec.rb
+++ b/spec/features/users_can_edit_a_budget_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Users can edit a budget" do
         click_on t("default.button.submit")
       }.to change { HistoricalEvent.count }.by(1)
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated. Current budget of FY 2018-2019 is now £20.00")
       within("##{budget.id}") do
         expect(page).to have_content("20.00")
       end
@@ -58,7 +58,7 @@ RSpec.describe "Users can edit a budget" do
     let(:activity) { create(:project_activity, organisation: user.organisation) }
     let(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
 
-    let!(:budget) { create(:budget, parent_activity: activity, value: "10", report: report) }
+    let!(:budget) { create(:budget, parent_activity: activity, value: "10", financial_year: 2018, report: report) }
 
     scenario "a budget can be successfully edited and a history event added" do
       visit organisation_activity_path(user.organisation, activity)
@@ -72,7 +72,7 @@ RSpec.describe "Users can edit a budget" do
         click_on t("default.button.submit")
       }.to change { HistoricalEvent.count }.by(1)
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated. Current budget of FY 2018-2019 is now £20.00")
       within("##{budget.id}") do
         expect(page).to have_content("20.00")
       end
@@ -106,7 +106,7 @@ RSpec.describe "Users can edit a budget" do
       fill_in "budget[value]", with: "20"
       click_on t("default.button.submit")
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated. Current budget of FY 2018-2019 is now £20.00")
       within("##{budget.id}") do
         expect(page).to have_content("£20.00")
         expect(page).to have_link("1 revision", href: activity_budget_revisions_path(budget.parent_activity_id, budget))
@@ -117,7 +117,7 @@ RSpec.describe "Users can edit a budget" do
       fill_in "budget[audit_comment]", with: "This budget has been reduced"
       click_on t("default.button.submit")
 
-      expect(page).to have_content(t("action.budget.update.success"))
+      expect(page).to have_content("Budget successfully updated. Current budget of FY 2018-2019 is now £5.00")
       within("##{budget.id}") do
         expect(page).to have_content("£5.00")
         click_on "2 revisions"


### PR DESCRIPTION
## Changes in this PR
### Change colour of success message text to black
Currently, the success messages use a modified error summary component, with a
green border and green text.

Ideally, we shouldn't be using this component for this purpose, but for now it can be
improved by making the text black instead of green.

### Show financial year and value in the message when a Budget is updated
The success message when a Budget is updated current shows "Budget successfully
updated".

We want this to be more specific, so the message will now include the financial
year and the value. E.g., "Budget successfully updated. Current budget of FY
2015-2016 is now £7.00"

## Screenshots of UI changes

|Before|After|
|-|-|
|<img width="1169" alt="image" src="https://user-images.githubusercontent.com/47089130/227957406-2a81afe5-9451-416f-a342-68d3f92c6266.png">|<img width="1211" alt="image" src="https://user-images.githubusercontent.com/47089130/227956710-18d28645-9437-4f55-b658-f27a2408ae45.png">|


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
