### PR TITLE
[2907] Set local time zone of app to London

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Change the colour of success messages to black
 - Allow BEIS users to delete untitled activities and signpost PO users on the process
 - Add more information to the form guidance on the original commitment figure step
+- Set app's local time zone to "London"
 
 ## Release 132 - 2023-03-16
 

--- a/app/views/activities/show.xml.haml
+++ b/app/views/activities/show.xml.haml
@@ -1,5 +1,5 @@
 !!! XML
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
-  "generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
+  "generated-datetime" => "#{Time.current.strftime("%Y-%m-%dT%H:%M:%S")}"}
   = render partial: "shared/xml/activity",
     locals: { activity: @activity, reporting_organisation: @reporting_organisation, transactions: @actuals, budgets: @budgets, forecasts: @forecasts, commitment: @commitment }

--- a/app/views/exports/organisations/show.xml.haml
+++ b/app/views/exports/organisations/show.xml.haml
@@ -1,6 +1,6 @@
 !!! XML
 %iati-activities{"version" => "#{IATI_VERSION.gsub('_', '.')}",
-"generated-datetime" => "#{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}"}
+"generated-datetime" => "#{Time.current.strftime("%Y-%m-%dT%H:%M:%S")}"}
   - @activities.each do |activity|
     = render partial: "shared/xml/activity", locals: { activity: activity, reporting_organisation: @reporting_organisation, transactions: activity.net_spend_by_financial_quarter, budgets: activity.budgets, forecasts: activity.reportable_forecasts_for_level, commitment: activity.commitment }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,5 +69,7 @@ module Roda
 
     # serve dynamic error pages
     config.exceptions_app = routes
+
+    config.time_zone = "London"
   end
 end

--- a/script/training_db_sync.rb
+++ b/script/training_db_sync.rb
@@ -33,7 +33,7 @@ class TrainingDbSync
   end
 
   def timestamp
-    DateTime.now.iso8601
+    DateTime.current.iso8601
   end
 
   def source_service

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "BEIS users can upload Level B activities" do
 
       expect(page).to have_text(t("action.activity.upload.success"))
 
-      new_activities = Activity.where(created_at: DateTime.now)
+      new_activities = Activity.where(created_at: DateTime.current)
 
       expect(new_activities.count).to eq(2)
       expect(new_activities.pluck(:transparency_identifier)).to match_array(["1234", "1235"])

--- a/spec/features/beis_users_can_upload_level_b_budgets_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_budgets_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "BEIS users can upload Level B budgets" do
 
       expect(page).to have_text(t("action.budget.upload.success"))
 
-      new_budgets = Budget.where(created_at: DateTime.now)
+      new_budgets = Budget.where(created_at: DateTime.current)
 
       expect(new_budgets.count).to eq(2)
       expect(new_budgets.pluck(:value)).to match_array(["12345".to_d, "67890".to_d])

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Users can sign in" do
     context "user has a confirmed mobile number" do
       scenario "successful sign in via header link" do
         # Given a user with 2FA enabled and a confirmed mobile number exists
-        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.now)
+        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.current)
 
         # When I log in with that user's email and password
         visit root_path
@@ -80,7 +80,7 @@ RSpec.feature "Users can sign in" do
 
       scenario "unsuccessful OTP attempt" do
         # Given a user with 2FA enabled and a confirmed mobile number exists
-        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.now)
+        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.current)
 
         # When I log in with that user's email and password
         visit root_path
@@ -99,7 +99,7 @@ RSpec.feature "Users can sign in" do
 
       scenario "logins can be remembered for 30 days" do
         # Given a user with 2FA enabled and a confirmed mobile number exists
-        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.now)
+        user = create(:administrator, :mfa_enabled, mobile_number_confirmed_at: DateTime.current)
 
         # When I log in with MFA and choose Remember me
         visit root_path

--- a/spec/features/users_can_upload_activities_spec.rb
+++ b/spec/features/users_can_upload_activities_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "users can upload activities" do
 
       expect(page).to have_text(t("action.activity.upload.success"))
 
-      new_activities = Activity.where(created_at: DateTime.now)
+      new_activities = Activity.where(created_at: DateTime.current)
 
       expect(new_activities.count).to eq(2)
 


### PR DESCRIPTION
## Changes in this PR

Set TimeZone to London

This change was motivated by one of our tests using `Time.now` (BST) clashing with ActiveRecord storing times as UTC and failing.

Although [this article](https://thoughtbot.com/blog/its-about-time-zones) advises against setting a global timezone and recommends allowing users to set their own, this is a larger change than we have capacity (and need?) for at the moment.

We believe that all users should be accessing the site from a UK timezone, so this shouldn't change what they see.

Noticeable places this will change will be visible are:

    - The approval time on a Report
    - The time an export was uploaded to S3

Before this change, these would be one hour behind BST as they call `Time.current` which uses the app's time zone which defaulted to UTC, rather than the running machine's system timezone.

This also updates places we call `Time.now` to use `Time.current` to use the app's timezone instead, as recommended in the article linked above.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
