### PR TITLE
(2883) Expose implementing organisations to partner org users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Exclude planned activities from annual fund impact metrics CSV
 - Allow partner organisation users to list the implementing organisations
+- Add guidance about finding implementing organisation names on the report activities tab
 
 ## Release 133 - 2023-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Exclude planned activities from annual fund impact metrics CSV
+- Allow partner organisation users to list the implementing organisations
 
 ## Release 133 - 2023-03-30
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,7 +2,7 @@
 
 class OrganisationsController < BaseController
   def index
-    @role = params[:role]
+    @role = role
     @organisations = organisations
     authorize @organisations
 
@@ -20,11 +20,11 @@ class OrganisationsController < BaseController
   end
 
   def new
-    @organisation = Organisation.new(role: params[:role].singularize)
+    @organisation = Organisation.new(role: role.singularize)
     authorize @organisation
 
     add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: params[:role])
+    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: role)
   end
 
   def create
@@ -65,6 +65,10 @@ class OrganisationsController < BaseController
 
   private def id
     params[:id]
+  end
+
+  private def role
+    current_user.service_owner? ? params[:role] : "implementing_organisations"
   end
 
   private def organisations

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -6,14 +6,14 @@ class OrganisationsController < BaseController
     @organisations = organisations
     authorize @organisations
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@role.singularize}.index"), organisations_path(role: @role)
+    add_breadcrumb t("breadcrumbs.organisation.#{@role.singularize}.index"), organisations_path(role: @role)
   end
 
   def show
     organisation = Organisation.find(id)
     authorize organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{organisation.role}.index"), organisations_path(role: organisation.role.pluralize)
+    add_breadcrumb(*breadcrumb_index(organisation))
     add_breadcrumb organisation.name, :organisation_path
 
     @organisation_presenter = OrganisationPresenter.new(organisation)
@@ -23,8 +23,8 @@ class OrganisationsController < BaseController
     @organisation = Organisation.new(role: role.singularize)
     authorize @organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: role)
+    add_breadcrumb t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
+    add_breadcrumb t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: role)
   end
 
   def create
@@ -36,6 +36,8 @@ class OrganisationsController < BaseController
       flash[:notice] = t("action.organisation.create.success")
       redirect_to organisation_path(@organisation)
     else
+      add_breadcrumb t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
+      add_breadcrumb t("breadcrumbs.organisation.#{@organisation.role}.new"), new_organisation_path(role: @organisation.role.pluralize)
       render :new
     end
   end
@@ -44,7 +46,7 @@ class OrganisationsController < BaseController
     @organisation = Organisation.find(id)
     authorize @organisation
 
-    add_breadcrumb I18n.t("breadcrumbs.organisation.#{@organisation.role}.index"), organisations_path(role: @organisation.role.pluralize)
+    add_breadcrumb(*breadcrumb_index(@organisation))
     add_breadcrumb t("breadcrumbs.organisation.edit", name: @organisation.name), :edit_organisation_path
   end
 
@@ -59,6 +61,8 @@ class OrganisationsController < BaseController
       flash[:notice] = t("action.organisation.update.success")
       redirect_to organisation_path(@organisation)
     else
+      add_breadcrumb(*breadcrumb_index(@organisation))
+      add_breadcrumb t("breadcrumbs.organisation.edit", name: @organisation.name), :edit_organisation_path
       render :edit
     end
   end
@@ -80,5 +84,13 @@ class OrganisationsController < BaseController
   private def organisation_params
     params.require(:organisation)
       .permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role, :active)
+  end
+
+  private def breadcrumb_index(organisation)
+    if organisation.role == "service_owner"
+      [t("breadcrumbs.organisation.index"), organisations_path]
+    else
+      [t("breadcrumbs.organisation.#{organisation.role}.index"), organisations_path(role: organisation.role.pluralize)]
+    end
   end
 end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -1,6 +1,6 @@
 class OrganisationPolicy < ApplicationPolicy
   def index?
-    beis_user?
+    true
   end
 
   def show?
@@ -26,6 +26,14 @@ class OrganisationPolicy < ApplicationPolicy
   def download?
     return false if record.service_owner?
     beis_user?
+  end
+
+  class Scope < Scope
+    def resolve
+      return scope.all if user.service_owner?
+
+      Organisation.implementing
+    end
   end
 
   private def associated_user?

--- a/app/views/organisations/_partner_org_tabs.html.haml
+++ b/app/views/organisations/_partner_org_tabs.html.haml
@@ -1,0 +1,13 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-tabs
+      %h2.govuk-tabs__title
+        = t("page_title.organisations.implementing_organisations")
+
+      %ul.govuk-tabs__list{role: "tablist"}
+        %li{class: "govuk-tabs__list-item govuk-tabs__list-item--selected", role: "presentation"}
+          = link_to t("tabs.organisations.implementing_organisations"), organisations_path(role: "implementing_organisations"), { class: "govuk-tabs__tab", role: "tab", aria: { selected: true } }
+
+      .govuk-tabs__panel
+        - if @organisations
+          = render partial: "organisations/table", locals: { organisations: @organisations }

--- a/app/views/organisations/_service_owner_tabs.html.haml
+++ b/app/views/organisations/_service_owner_tabs.html.haml
@@ -1,0 +1,20 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-tabs
+      %h2.govuk-tabs__title
+        = t("page_title.organisation.index")
+
+      %ul.govuk-tabs__list{role: "tablist"}
+        - %w[partner_organisations matched_effort_providers external_income_providers implementing_organisations].each do |role|
+          %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}", role: "presentation"}
+            = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { selected: (role == @role) } }
+
+      .govuk-tabs__panel
+        %h2.govuk-heading-l
+          = t("page_title.organisations.#{@role}")
+
+        - if policy(Organisation).new?
+          = link_to(t("page_content.organisations.#{@role}.button.create"), new_organisation_path(role: @role), class: "govuk-button")
+
+        - if @organisations
+          = render partial: "organisations/table", locals: { organisations: @organisations }

--- a/app/views/organisations/_table.html.haml
+++ b/app/views/organisations/_table.html.haml
@@ -1,43 +1,26 @@
-.govuk-grid-row
-  .govuk-grid-column-full
-    .govuk-tabs
-      %h2.govuk-tabs__title
-        Organisations
+%table.govuk-table.organisations
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        =t("table.header.organisation.name")
+      %th.govuk-table__header
+        =t("table.header.organisation.beis_organisation_reference")
+      - if current_user.service_owner?
+        %th.govuk-table__header
+          %span.govuk-visually-hidden
+            = t("table.header.default.actions")
 
-      %ul.govuk-tabs__list{role: "tablist"}
-        - ["partner_organisations", "matched_effort_providers", "external_income_providers", "implementing_organisations"].each do |role|
-          %li{ class: "govuk-tabs__list-item #{role == @role ? "govuk-tabs__list-item--selected" : ""}", role: "presentation"}
-            = link_to t("tabs.organisations.#{role}"), organisations_path(role: role), { class: "govuk-tabs__tab", role: "tab", aria: { selected: (role == @role) } }
-
-      .govuk-tabs__panel
-        %h2.govuk-heading-l
-          = t("page_title.organisations.#{@role}")
-
-        - if policy(Organisation).new?
-          = link_to(t("page_content.organisations.#{@role}.button.create"), new_organisation_path(role: @role), class: "govuk-button")
-
-        - unless organisations.empty?
-          %table.govuk-table.organisations
-            %thead.govuk-table__head
-              %tr.govuk-table__row
-                %th.govuk-table__header
-                  =t("table.header.organisation.name")
-                %th.govuk-table__header
-                  =t("table.header.organisation.beis_organisation_reference")
-                %th.govuk-table__header
-                  %span.govuk-visually-hidden
-                    = t("table.header.default.actions")
-
-            %tbody.govuk-table__body
-              - organisations.each do |organisation|
-                %tr.govuk-table__row.organisation{id: organisation.id}
-                  %td.govuk-table__cell
-                    = organisation.name
-                    - unless organisation.active
-                      %span.govuk-tag.govuk-tag--grey= t('form.label.organisation.active.false')
-                  %td.govuk-table__cell= organisation.beis_organisation_reference
-                  %td.govuk-table__cell
-                    - if policy(organisation).show?
-                      = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
-                    - if policy(organisation).edit?
-                      = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name, ["govuk-!-margin-left-3"])
+  %tbody.govuk-table__body
+    - organisations.each do |organisation|
+      %tr.govuk-table__row.organisation{id: organisation.id}
+        %td.govuk-table__cell
+          = organisation.name
+          - unless organisation.active
+            %span.govuk-tag.govuk-tag--grey= t("form.label.organisation.active.false")
+        %td.govuk-table__cell= organisation.beis_organisation_reference
+        - if current_user.service_owner?
+          %td.govuk-table__cell
+            - if policy(organisation).show?
+              = a11y_action_link(t("default.link.show"), organisation_path(organisation), organisation.name)
+            - if policy(organisation).edit?
+              = a11y_action_link(t("default.link.edit"), edit_organisation_path(organisation), organisation.name, ["govuk-!-margin-left-3"])

--- a/app/views/organisations/index.html.haml
+++ b/app/views/organisations/index.html.haml
@@ -2,9 +2,11 @@
 
 %main.govuk-main-wrapper#main-content{ role: "main" }
   .govuk-grid-row
-    .govuk-grid-column-full
+    .govuk-grid-column-two-thirds
       %h1.govuk-heading-xl
         = t("page_title.organisation.index")
 
-      - if @organisations
-        = render partial: "organisations/table", locals: { organisations: @organisations }
+  - if current_user.service_owner?
+    = render partial: "service_owner_tabs"
+  - elsif current_user.partner_organisation?
+    = render partial: "partner_org_tabs"

--- a/app/views/reports/_activities_upload.html.haml
+++ b/app/views/reports/_activities_upload.html.haml
@@ -1,16 +1,21 @@
-%h3.govuk-heading-m
-  = t("tabs.activities.providing.heading")
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h3.govuk-heading-m
+      = t("tabs.activities.providing.heading")
 
-%p.govuk-body
-  = t("tabs.activities.providing.copy")
+    %p.govuk-body
+      = t("tabs.activities.providing.copy")
 
-%h3.govuk-heading-s
-  = t("tabs.activities.upload.heading")
+    %h3.govuk-heading-s
+      = t("tabs.activities.upload.heading")
 
-= t("tabs.activities.upload.copy_html")
+    %ul.govuk-list.govuk-list--bullet
+      - t("tabs.activities.upload.list_items_html", implementing_org_link: link_to_new_tab("Implementing organisations section", organisations_path)).each do |list_item_html|
+        %li
+          = list_item_html
 
-.govuk-inset-text
-  = t("tabs.activities.upload.warning")
+    .govuk-inset-text
+      = t("tabs.activities.upload.warning")
 
-.govuk-button-group
-  = link_to t("page_content.activities.button.upload"), new_report_activities_upload_path(@report_presenter), class: "govuk-button"
+    .govuk-button-group
+      = link_to t("page_content.activities.button.upload"), new_report_activities_upload_path(@report_presenter), class: "govuk-button"

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -314,8 +314,10 @@ en:
         copy: Activities data can be added by using the application interface or by uploading data.
       upload:
         heading: Upload data
-        copy_html: <p class="govuk-body">Large numbers of activities can be added via the activities upload.</p>
-          <p class="govuk-body">For guidance on uploading activities data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data">guidance in the help centre (opens in new tab)</a>.</p>
+        list_items_html:
+          - Large numbers of activities can be added via the activities upload.
+          - For guidance on uploading activities data, see the <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data">guidance in the help centre (opens in new tab)</a>.
+          - To get implementing organisation names, you can refer to the %{implementing_org_link}
         warning: Ensure you use the correct template when uploading activities data.
   page_title:
     activity:

--- a/spec/features/organisation_show_page_spec.rb
+++ b/spec/features/organisation_show_page_spec.rb
@@ -22,6 +22,14 @@ RSpec.feature "Organisation show page" do
 
         expect(page).to have_link t("page_content.organisation.button.edit_details"), href: edit_organisation_path(beis_user.organisation)
       end
+
+      scenario "the breadcrumbs have a link for organisations index" do
+        visit organisation_path(beis_user.organisation)
+
+        within ".govuk-breadcrumbs" do
+          expect(page).to have_link "Organisations", href: organisations_path
+        end
+      end
     end
   end
 

--- a/spec/features/users_can_view_implementing_organisations_spec.rb
+++ b/spec/features/users_can_view_implementing_organisations_spec.rb
@@ -1,0 +1,61 @@
+RSpec.feature "Users can view an organisation" do
+  context "when the user does not belong to BEIS" do
+    let(:organisation) { create(:partner_organisation) }
+    let(:user) { create(:partner_organisation_user, organisation: organisation) }
+
+    let!(:partner_organisations) { create_list(:partner_organisation, 3) }
+    let!(:matched_effort_provider_organisations) { create_list(:matched_effort_provider, 2) }
+    let!(:external_income_provider_organisations) { create_list(:external_income_provider, 2) }
+    before do
+      [
+        {name: "Z_is_active", active: true},
+        {name: "A_is_inactive", active: false}
+      ].each do |attrs|
+        create(:implementing_organisation).tap do |org|
+          OrgParticipation.create(
+            organisation: org,
+            activity: create(:project_activity),
+            role: "implementing"
+          )
+          org.active = attrs[:active]
+          org.name = attrs[:name]
+          org.save!
+        end
+      end
+    end
+
+    before do
+      authenticate!(user: user)
+    end
+
+    after { logout }
+
+    scenario "lists all organisations in the 'implementing' scope" do
+      visit organisations_path
+      expect(Organisation.implementing.count).to be >= 2
+
+      within ".organisations" do
+        Organisation.implementing.each do |org|
+          expect(page).to have_content(org.name)
+        end
+      end
+      expect(page).to have_css(".organisation", count: Organisation.implementing.count)
+
+      within ".govuk-breadcrumbs" do
+        expect(page).to have_content("Implementing organisations")
+      end
+
+      # check that inactive organisations come after active ones
+      # despite alphabetical order
+      expect(page.text).to match(/Z_is_active.*A_is_inactive/m)
+    end
+
+    scenario "does not list other types of organisation" do
+      visit organisations_path
+
+      expect(page).not_to have_content("Partner organisations")
+      expect(page).not_to have_link(organisations_path(role: "external_income_providers"))
+      expect(page).not_to have_link(organisations_path(role: "matched_effort_providers"))
+    end
+  end
+end

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -433,6 +433,29 @@ RSpec.feature "Users can view reports" do
         end
       end
 
+      scenario "they see helpful content about uploading activities data on the activities tab" do
+        report = create(:report, :active, organisation: partner_org_user.organisation)
+
+        visit report_activities_path(report)
+
+        expect(page).to have_text("Ensure you use the correct template when uploading activities data.")
+        expect(page).to have_text("Large numbers of activities can be added via the activities upload.")
+        expect(page).to have_text("For guidance on uploading activities data, see the")
+        expect(page).to have_text("To get implementing organisation names, you can refer to the")
+        expect(page).to have_link(
+          "Upload activity data",
+          href: new_report_activities_upload_path(report)
+        )
+        expect(page).to have_link(
+          "guidance in the help centre (opens in new tab)",
+          href: "https://beisodahelp.zendesk.com/hc/en-gb/articles/1500005510061-Understanding-the-Bulk-Upload-Functionality-to-Report-your-Data"
+        )
+        expect(page).to have_link(
+          "Implementing organisations section (opens in new tab)",
+          href: organisations_path
+        )
+      end
+
       scenario "they see helpful content about uploading actuals spend data and a link to the template on the actuals tab" do
         report = create(:report, :active, organisation: partner_org_user.organisation)
 

--- a/spec/features/users_can_view_the_site_navigation_spec.rb
+++ b/spec/features/users_can_view_the_site_navigation_spec.rb
@@ -19,13 +19,13 @@ RSpec.feature "Users can view the site navigation" do
     before { authenticate!(user: user) }
     after { logout }
 
-    it "shows the appropriate naviation" do
+    it "shows the appropriate navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"
       expect(page).to have_link t("page_title.home"), href: home_path
       expect(page).to have_link t("page_title.report.index"), href: reports_path
-      expect(page).not_to have_link t("page_title.organisation.index"), href: organisations_path, class: "govuk-header__link"
+      expect(page).to have_link t("page_title.organisation.index"), href: organisations_path, class: "govuk-header__link"
       expect(page).not_to have_link t("page_title.users.index"), href: users_path
     end
   end
@@ -35,7 +35,7 @@ RSpec.feature "Users can view the site navigation" do
     before { authenticate!(user: user) }
     after { logout }
 
-    it "shows the appropriate naviation" do
+    it "shows the appropriate navigation" do
       visit organisation_path(user.organisation)
 
       expect(page).to have_css ".govuk-header__navigation"

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe OrganisationPolicy do
       let(:user) { build_stubbed(:partner_organisation_user, organisation: organisation) }
 
       it "controls actions as expected" do
-        is_expected.to forbid_action(:index)
+        is_expected.to permit_action(:index)
         is_expected.to permit_action(:show)
         is_expected.to forbid_action(:bulk_upload)
         is_expected.to forbid_new_and_create_actions
@@ -37,14 +37,28 @@ RSpec.describe OrganisationPolicy do
     context "when the user does NOT belong to that organisation" do
       let(:user) { build_stubbed(:partner_organisation_user, organisation: create(:partner_organisation)) }
 
-      it "forbids all actions" do
-        is_expected.to forbid_action(:index)
+      it "only permits index" do
+        is_expected.to permit_action(:index)
         is_expected.to forbid_action(:show)
         is_expected.to forbid_action(:bulk_upload)
         is_expected.to forbid_new_and_create_actions
         is_expected.to forbid_edit_and_update_actions
         is_expected.to forbid_action(:destroy)
         is_expected.to forbid_action(:download)
+      end
+
+      context "when the organisation is an implementing organisation" do
+        let(:organisation) { create(:implementing_organisation) }
+
+        it "only permits index" do
+          is_expected.to permit_action(:index)
+          is_expected.to forbid_action(:show)
+          is_expected.to forbid_action(:bulk_upload)
+          is_expected.to forbid_new_and_create_actions
+          is_expected.to forbid_edit_and_update_actions
+          is_expected.to forbid_action(:destroy)
+          is_expected.to forbid_action(:download)
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR
- Allow partner organisation users to list the implementing organisations
- Add guidance about finding implementing organisation names on the report activities tab

## Screenshots of UI changes

### Before
![Screenshot 2023-03-27 at 20 09 03](https://user-images.githubusercontent.com/579522/228042302-9a64f28d-e8fd-480e-a0f3-c4c1127f98aa.png)

### After
![Screenshot 2023-03-27 at 20 07 42](https://user-images.githubusercontent.com/579522/228042178-cfea2d79-4881-4e8e-a9bb-b044bb1108ec.png)

![Screenshot 2023-03-27 at 20 08 00](https://user-images.githubusercontent.com/579522/228042173-54b653d5-96f6-44f4-b133-d946ab4d9554.png)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
