### PR TITLE
(2911) Explictly unlink activities before deleting

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -205,6 +205,7 @@ class Activity < ApplicationRecord
 
   belongs_to :linked_activity, optional: true, class_name: "Activity"
   after_save :ensure_linked_activity_reciprocity
+  before_destroy :ensure_activities_are_unlinked, if: -> { linked_activity_id.present? }
 
   enum level: {
     fund: "fund",
@@ -662,6 +663,10 @@ class Activity < ApplicationRecord
       linked_activity.linked_activity = self
       linked_activity.save
     end
+  end
+
+  def ensure_activities_are_unlinked
+    update(linked_activity: nil)
   end
 
   def linkable_activities

--- a/spec/features/users_can_delete_an_activity_spec.rb
+++ b/spec/features/users_can_delete_an_activity_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Users can delete an activity" do
           end
 
           context "below programme level" do
-            let(:activity) { create(:project_activity, title: nil, form_state: "purpose") }
+            let(:activity) { create(:project_activity, title: nil, form_state: "identifier") }
             let!(:child_activity) { create(:third_party_project_activity, parent: activity) }
 
             it "deletes the activity, its associations and children, and confirms the deletion" do


### PR DESCRIPTION
## Changes in this PR

This ensures the remaining activity in a linked pair has its linked activity ID reset if its link is deleted. It's a precaution to avoid any errors based on assumptions that having a linked activity ID means that a linked activity exists in the database

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
