### PR TITLE
(2903) Make sure users can sign out if JavaScript is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Allow BEIS users to delete untitled activities and signpost PO users on the process
 - Add more information to the form guidance on the original commitment figure step
 - Set app's local time zone to "London"
+- Fix bug where users could not sign out if JavaScript was disabled
 
 ## Release 132 - 2023-03-16
 

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -32,4 +32,4 @@
           = link_to t("page_title.users.index"), users_path, class: "govuk-header__link"
 
       %li{ class: navigation_item_class(destroy_user_session_path) }
-        = link_to t("header.link.sign_out"), destroy_user_session_path, method: :delete, class: "govuk-header__link"
+        = link_to t("header.link.sign_out"), destroy_user_session_path, class: "govuk-header__link"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,7 +273,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/spec/features/users_can_sign_out_spec.rb
+++ b/spec/features/users_can_sign_out_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Users can sign out" do
   after { logout }
 
-  scenario "success", js: true do
+  scenario "success" do
     # Given a user exists
     user = create(:administrator)
     # And is logged in


### PR DESCRIPTION
## Changes in this PR
### Make sure users can sign out if JavaScript is disabled
Rails uses JavaScript to intercept requests from links that are given a
`method`, which allows us to use links for methods including DELETE. When
JavaScript is disabled, this falls back to a GET request.

Currently, this means that users see an error page when attempting to sign out
with JavaScript disabled, as Devise is expecting a DELETE request.

Devise allows us to specify the method used to sign out, so we can update this
to GET.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
