### PR TITLE
(2909) Allow valid actual/refund without deleting invalid rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add more information to the form guidance on the original commitment figure step
 - Set app's local time zone to "London"
 - Fix bug where users could not sign out if JavaScript was disabled
+- Allow users to upload a single actual/refund without deleting the (invalid) default values in other rows of the template. Rows with (invalid) default values will be ignored in this case. Any other invalid values will still throw an error
 
 ## Release 132 - 2023-03-16
 

--- a/app/controllers/actuals/uploads_controller.rb
+++ b/app/controllers/actuals/uploads_controller.rb
@@ -45,7 +45,7 @@ class Actuals::UploadsController < BaseController
       @errors = importer.errors
 
       if @errors.empty?
-        imported_actuals = importer.imported_actuals.compact
+        imported_actuals = importer.imported_actuals
 
         @total_actuals = TotalPresenter.new(imported_actuals.sum(&:value)).value
         @grouped_actuals = imported_actuals

--- a/app/services/actual/import.rb
+++ b/app/services/actual/import.rb
@@ -55,6 +55,8 @@ class Actual
     end
 
     def has_only_default_value_errors?
+      return false if invalid_with_comment
+
       @errors.all? do |error|
         return false unless error.column == "Actual Value/Refund Value"
         error.message == I18n.t("importer.errors.actual.cannot_be_zero_when_refund_blank")

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature "users can upload actuals" do
     expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
 
-  scenario "uploading a valid actual alongside an (invalid) default value row" do
+  scenario "uploading a valid actual alongside an (invalid) default value row (without a comment)" do
     upload_csv <<~CSV
       Activity RODA Identifier   | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
       #{project.roda_identifier} | 1                 | 2020           | 5            |              |                             |                             |                                       |

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -138,6 +138,19 @@ RSpec.feature "users can upload actuals" do
     expect_to_see_successful_upload_summary_with(count: 2, total: 50)
   end
 
+  scenario "uploading a valid actual alongside an (invalid) default value row" do
+    upload_csv <<~CSV
+      Activity RODA Identifier   | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+      #{project.roda_identifier} | 1                 | 2020           | 5            |              |                             |                             |                                       |
+      #{project.roda_identifier} | 2                 | 2020           | 0            |              |                             |                             |                                       |
+    CSV
+
+    expect(Actual.count).to eq(1)
+    expect(page).to have_text(t("action.actual.upload.success"))
+    expect(page).not_to have_css("table.govuk-table.errors")
+    expect_to_see_successful_upload_summary_with(count: 1, total: 5)
+  end
+
   scenario "uploading an invalid set of actuals" do
     ids = [project, sibling_project].map(&:roda_identifier)
 

--- a/spec/services/actual/import_spec.rb
+++ b/spec/services/actual/import_spec.rb
@@ -606,4 +606,58 @@ RSpec.describe Actual::Import do
       end
     end
   end
+
+  describe "importing one valid row alongside rows with invalid values" do
+    let(:valid_row) {
+      {
+        "Activity RODA Identifier" => project.roda_identifier,
+        "Financial Quarter" => "1",
+        "Financial Year" => "2020",
+        "Actual Value" => "150.00",
+        "Refund Value" => nil
+      }
+    }
+
+    context "when the invalid values are the default values" do
+      let(:invalid_default_row) {
+        {
+          "Activity RODA Identifier" => project.roda_identifier,
+          "Financial Quarter" => "2",
+          "Financial Year" => "2020",
+          "Actual Value" => "0.00",
+          "Refund Value" => nil
+        }
+      }
+
+      it "imports the valid row and ignores the rest" do
+        importer.import([valid_row, invalid_default_row])
+
+        expect(importer.errors).to eq([])
+        expect(importer.imported_actuals.count).to eq(1)
+        expect(importer.imported_actuals).to match_array(report.actuals)
+      end
+    end
+
+    context "when non-default invalid values are included" do
+      let(:invalid_non_default_row) {
+        {
+          "Activity RODA Identifier" => project.roda_identifier,
+          "Financial Quarter" => "2",
+          "Financial Year" => "2020",
+          "Actual Value" => "0.00",
+          "Refund Value" => "0.00"
+        }
+      }
+
+      it "does not import any actuals and retains error information" do
+        importer.import([valid_row, invalid_non_default_row])
+
+        expect(Actual.count).to eq(0)
+        expect(importer.imported_actuals).to eq([])
+        expect(importer.errors).to eq([
+          Actual::Import::Error.new(1, "Actual Value/Refund Value", "0.00, 0.00", "Actual and refund are both zero")
+        ])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

### What and why

The actuals/refunds upload template is prepopulated with rows for all the activities to which you can add values. Previously, if you didn't want to provide values for all activities (e.g. if you just wanted to add values for one activity), you would have to remove all the remaining rows, since the default values are invalid

This makes it so that if there's at least one valid row and the only errors are default value errors, the valid row is imported and the invalid rows are ignored/discarded. This saves users the effort of manually deleting rows they don't care about

Rows with other errors will still prevent the import from completing, and the actual: zero, refund: blank error will still show if there are other errors and/or no valid rows

### How

The `has_only_default_value_errors?` method relies on the error column being the string "Actual Value/Refund Value" and the message being a specific translation. This doesn't feel as resilient as I'd like, but hopefully the tests are sufficient enough to catch a breaking change

I would have preferred to have access to the type hash created in `Converter#validate_values`, however getting this all the way up to the base `Import` class would likely mean a more significant refactor, modifying both the `Error` `Struct` and the iteration over `importer.errors` in `import_row`. If we added a `value_type` attribute to `Error`, this wouldn't be relevant to errors from non-value columns, which would make things a little messy

## Screenshots of UI changes

### Before

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/40244233/228557650-bbef280b-134e-4a7d-8051-bd0b33c6d09e.png">

(and so on)

### After

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/40244233/228557533-25976907-8488-4222-a701-4686714868a5.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
