### PR TITLE
Exclude planned activities from annual fund impact metrics CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Exclude planned activities from annual fund impact metrics CSV
+
 ## Release 133 - 2023-03-30
 
 [Full changelog][133]

--- a/lib/tasks/annual_fund_impact_metrics_activities.rake
+++ b/lib/tasks/annual_fund_impact_metrics_activities.rake
@@ -11,7 +11,7 @@ namespace :activities do
       activities = Activity
         .joins(:organisation)
         .includes(:organisation, :actuals)
-        .where.not(programme_status: ["delivery", "agreement_in_place", "open_for_applications", "stopped"])
+        .where.not(programme_status: ["delivery", "agreement_in_place", "open_for_applications", "stopped", "planned"])
         .order("organisations.name, programme_status")
 
       # We want to exclude Activities that were completed more than two years ago. We have discussed

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
   let!(:agreement_in_place_activity) { create(:fund_activity, programme_status: "agreement_in_place") }
   let!(:open_for_applications_activity) { create(:fund_activity, programme_status: "open_for_applications") }
   let!(:stopped_activity) { create(:fund_activity, programme_status: "stopped") }
+  let!(:planned_activity) { create(:fund_activity, programme_status: "planned") }
 
   let!(:completed_over_2_years_ago_activity) { create(:fund_activity, programme_status: "completed") }
   let!(:actual_over_2_years_ago) { create(:actual, date: 2.years.ago - 1.day, parent_activity: completed_over_2_years_ago_activity, report: nil) }
@@ -38,12 +39,13 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
     end
   end
 
-  it "excludes Activities with `delivery`, `agreement_in_place`, `open_for_applications`, or `stopped` statuses" do
+  it "excludes Activities with `delivery`, `agreement_in_place`, `open_for_applications`, `stopped`, or `planned` statuses" do
     excluded_activity_titles = [
       delivery_activity.title,
       agreement_in_place_activity.title,
       open_for_applications_activity.title,
-      stopped_activity.title
+      stopped_activity.title,
+      planned_activity.title
     ]
 
     task.invoke(test_csv.path)


### PR DESCRIPTION
## Changes in this PR
We have been asked whether we can also exclude planned activities from the annual fund impact metrics CSV, in addition to the already excluded activities.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
