### PR TITLE
(2920) Use locales for programme status on Activities download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add guidance about finding implementing organisation names on the report activities tab
 - Show a validation error when a Budget is edited with a comment but without changing the value
 - Fix bug where current value was incorrect when editing a Budget with an invalid value
+- Use locales for the programme status of the activities in the annual fund impact metrics CSV
 
 ## Release 133 - 2023-03-30
 

--- a/lib/tasks/annual_fund_impact_metrics_activities.rake
+++ b/lib/tasks/annual_fund_impact_metrics_activities.rake
@@ -32,7 +32,7 @@ namespace :activities do
         activity_title = activity.title
         roda_identifier = activity.roda_identifier
         partner_organisation_identifier = activity.partner_organisation_identifier
-        status = activity.programme_status
+        status = I18n.t("activity.programme_status.#{activity.programme_status}")
 
         csv << [partner_organisation_name, activity_title, roda_identifier, partner_organisation_identifier, status]
       end

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
 
     expect(result.count).to be 4
     expect(result[0]).to eq "Partner Organisation name,Activity name,RODA ID,Partner Organisation ID,Status\n"
-    expect(result[1]).to eq "#{aardvark_organisation.name},#{review_activity.title},#{review_activity.roda_identifier},#{review_activity.partner_organisation_identifier},#{review_activity.programme_status}\n"
-    expect(result[2]).to eq "#{aardvark_organisation.name},#{decided_activity.title},#{decided_activity.roda_identifier},#{decided_activity.partner_organisation_identifier},#{decided_activity.programme_status}\n"
-    expect(result[3]).to eq "\"#{beis_organisation.name}\",#{completed_activity.title},#{completed_activity.roda_identifier},#{completed_activity.partner_organisation_identifier},#{completed_activity.programme_status}\n"
+    expect(result[1]).to eq "#{aardvark_organisation.name},#{review_activity.title},#{review_activity.roda_identifier},#{review_activity.partner_organisation_identifier},Review\n"
+    expect(result[2]).to eq "#{aardvark_organisation.name},#{decided_activity.title},#{decided_activity.roda_identifier},#{decided_activity.partner_organisation_identifier},Decided\n"
+    expect(result[3]).to eq "\"#{beis_organisation.name}\",#{completed_activity.title},#{completed_activity.roda_identifier},#{completed_activity.partner_organisation_identifier},Completed\n"
   end
 end


### PR DESCRIPTION
## Changes in this PR
### Use locales for programme status on Activities download
Currently, the programme status for Activities in the annual fund impact
metrics CSV is the value from the database, which is a snake case string.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
