### PR TITLE
(2879) Set `_roda_session` cookie to `SameSite: Strict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Show a validation error when a Budget is edited with a comment but without changing the value
 - Fix bug where current value was incorrect when editing a Budget with an invalid value
 - Use locales for the programme status of the activities in the annual fund impact metrics CSV
+- Use `SameSite: Strict` on `_roda_session` cookie to reduce risk of cross-site request forgery. In plain English, help prevent bad actors from using external sites to access RODA through the browser of a logged in user
 
 ## Release 133 - 2023-03-30
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -9,6 +9,7 @@ redis_store_params = {
   },
   key: "_roda_session",
   expire_after: 12.hours,
+  same_site: :strict,
   threadsafe: true
 }
 redis_store_params[:secure] = true if Rails.env.production?


### PR DESCRIPTION
## Changes in this PR

Notes:
- I'm not 100% certain we want this to be strict and not lax, but from reading the two linked webpages, it sounds like lax should be the default if otherwise unspecified, so perhaps we should _upgrade_ to strict. Possible that lax isn't the default for `Redis`/`Rack::Session` though. See the card for more context
- Does the changelog "plain English" explanation sound right? I'm not an expert on this

---

The most recent pen test highlighted that the `_roda_session` cookie was not using the `SameSite` security attribute, which makes the site more susceptible to cross-site request forgery (CSRF)

This sets the cookie to use `SameSite: Strict`. Another option is `SameSite: Lax`, but it sounds like this is the default, so perhaps we should strengthen it to use `Strict`

Some more information on the different options:
- https://web.dev/samesite-cookies-explained
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

## Screenshots of UI changes

### Before

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/40244233/228913940-98b6d581-0d1f-4686-9c0a-4cb03953444b.png">

### After

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/40244233/228913758-3fc15c85-4117-4af8-896d-12ad49fc6184.png">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
