### PR TITLE
WIP Import level D budgets redux

### DIFF
--- a/db/data/20230718131711_import_ukri_level_d_budgets_redux.rb
+++ b/db/data/20230718131711_import_ukri_level_d_budgets_redux.rb
@@ -1,0 +1,54 @@
+# Run me with `rails runner db/data/20230718131711_import_ukri_level_d_budgets.rb`
+
+# Script to add budgets to activities when those budgets cannot be added via bulk upload (for example they are for a
+# level not currently handled by bulk upload).
+
+# Re-usable if you replace `file_name` with the path to your chosen csv.
+# Note that the script expects column headers of the following form: "Activity RODA ID"; "Budget amount"; "Type";
+# "Financial year" The order of the columns is not sensitive.
+
+# Details of budgets that cannot be successfully created are logged to the terminal at the end of the script run.
+
+require "csv"
+
+def get_financial_year(financial_year_range)
+  financial_year_range.split("-")[0]
+end
+
+file_name = "ukri_level_d_budget_upload_test.csv"
+
+puts "Loading csv data from #{file_name}"
+
+file = File.open(file_name)
+budget_data = CSV.parse(file.read, headers: true)
+
+puts "Creating budgets..."
+
+logged_unsuccessful = []
+
+budget_data.each do |row|
+  activity_id = row["Activity RODA ID"]
+  parent_activity = Activity.find_by(roda_identifier: activity_id)
+
+  value = row["Budget amount"]
+  budget_type = Budget.budget_types.key(row["Type"].to_i) # `budget_type` should be provided as `"direct"` or `"other_official"`, and this gets those keys by the database value they correspond to
+  financial_year = get_financial_year(row["Financial year"])
+
+  result = CreateBudget.new(activity: parent_activity).call(attributes: {value: value, budget_type: budget_type, financial_year: financial_year})
+
+  raise Error unless result.success?
+
+  puts "Budget #{result.object.id} created."
+rescue
+  logged_unsuccessful.push(row)
+  puts "Budget for #{row["Activity RODA ID"]} in financial year #{row["Financial year"]} could not be created."
+end
+
+puts "Budget creation complete."
+
+if logged_unsuccessful.size > 0
+  puts "The following budgets could not be created and have not been saved to the database:"
+  logged_unsuccessful.each do |row|
+    puts "#{row["Activity RODA ID"]} in #{row["Financial year"]}"
+  end
+end


### PR DESCRIPTION
This is a partial fix for #2173, but there is a big outstanding issue. Details below and in the commit message

---

After syncing production data with my local environment, the original data migration file didn't work for me. I've fixed most of the issues in a separate file and simplified it by using `CreateBudget`, however the `Report` model has the following validation:

```ruby
validates_presence_of :report, unless: -> { parent_activity&.organisation&.service_owner? }
```

BEIS/DSIT is the only 'service owner' organisation and Level D activities don't belong to the BEIS/DSIT `organisation`, so a report is needed

There will only be an `editable_report_for_activity` (used in `CreateBudget`) if there's a current open report, and we probably don't want to add these to the current open report in any case, since that will be for the current financial year and quarter

We could connect these budgets to an old report if one exists, but since reports belong to a specific financial quarter, we'll either need DSIT to provide a financial quarter for all of these budgets, or we could assign them to a report in the first financial quarter for the given financial year (I think they've suggested this for some other purpose before)

We *might* need to deal with there being no report for the financial quarter in either case

But it would be good to clarify if they want these adding to historical reports as these are not usually modified once approved

Alternatively, I think there could be a way to persist these without a report by bypassing validations, but we'd have to be sure DSIT are happy having budgets on level D activities that aren't attached to a report, since the schema isn't designed for this scenario - it only allows report-less budgets at level B

If we are attaching these to a report, we could probably still use `CreateBudget` to do most of the work, then take its `.object` and add a (non-editable) report to it, then try saving again
