### PR TITLE
(2938) Change how the app accesses s3 storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Support s3 access via ECS credentials, with the bucket name set as an environment variable
+
 ## Release 137 - 2023-08-02
 
 [Full changelog][137]

--- a/spec/services/export/s3_downloader_spec.rb
+++ b/spec/services/export/s3_downloader_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Export::S3Downloader do
   let(:response_body) { double("response_body", read: double) }
   let(:response) { double("response", body: response_body) }
   let(:aws_credentials) { double("aws credentials") }
+  let(:ecs_credentials) { double("ecs credentials") }
   let(:aws_client) { instance_double(Aws::S3::Client, get_object: response) }
 
   let(:s3_bucket) { double("s3 bucket") }
@@ -16,7 +17,7 @@ RSpec.describe Export::S3Downloader do
       bucket: s3_bucket
     )
   }
-
+  let(:bucket_name) { "dsit_exports_bucket" }
   let(:filename) { "Q1_report0101202312345.csv" }
 
   subject {
@@ -25,45 +26,110 @@ RSpec.describe Export::S3Downloader do
 
   before do
     allow(Aws::Credentials).to receive(:new).and_return(aws_credentials)
+    allow(Aws::ECSCredentials).to receive(:new).and_return(ecs_credentials)
     allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
     allow(Export::S3UploaderConfig).to receive(:new).and_return(s3_uploader_config)
   end
 
   describe "#initialize" do
-    context "when instantiating the Aws::S3::Client" do
-      it "sets `credentials:` using an Aws::Credentials object" do
-        subject
-
-        expect(Aws::Credentials).to have_received(:new).with(
-          s3_uploader_config.key_id,
-          s3_uploader_config.secret_key
-        )
-        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
-          credentials: aws_credentials
-        ))
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: bucket_name) { example.run }
       end
 
-      it "sets `region:` using the region from the S3UploaderConfig" do
-        subject
+      context "when instantiating the Aws::S3::Client" do
+        it "sets credentials: using an Aws::ECSCredentials object" do
+          subject
 
-        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
-          region: s3_uploader_config.region
-        ))
+          expect(Aws::ECSCredentials).to have_received(:new).with({retries: 3})
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            credentials: ecs_credentials
+          ))
+        end
+
+        it "sets region: using the hardcoded eu-west-2 region" do
+          subject
+
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            region: "eu-west-2"
+          ))
+        end
+      end
+    end
+
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is not present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: nil) { example.run }
+      end
+
+      context "when instantiating the Aws::S3::Client" do
+        it "sets `credentials:` using an Aws::Credentials object" do
+          subject
+
+          expect(Aws::Credentials).to have_received(:new).with(
+            s3_uploader_config.key_id,
+            s3_uploader_config.secret_key
+          )
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            credentials: aws_credentials
+          ))
+        end
+
+        it "sets `region:` using the region from the S3UploaderConfig" do
+          subject
+
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            region: s3_uploader_config.region
+          ))
+        end
       end
     end
   end
 
   describe "#download" do
-    it "gets the specified report CSV from S3" do
-      subject.download
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: bucket_name) { example.run }
+      end
 
-      expect(aws_client).to have_received(:get_object).with(
-        bucket: s3_bucket,
-        key: filename,
-        response_content_type: "text/csv"
-      )
-      expect(response).to have_received(:body)
-      expect(response_body).to have_received(:read)
+      it "gets the specified report CSV from the bucket defined by the env var" do
+        subject.download
+
+        expect(aws_client).to have_received(:get_object).with(
+          bucket: bucket_name,
+          key: filename,
+          response_content_type: "text/csv"
+        )
+        expect(response).to have_received(:body)
+        expect(response_body).to have_received(:read)
+      end
+
+      it "does not use the S3UploaderConfig" do
+        subject.download
+
+        expect(s3_uploader_config).to_not have_received(:region)
+        expect(s3_uploader_config).to_not have_received(:bucket)
+        expect(s3_uploader_config).to_not have_received(:key_id)
+        expect(s3_uploader_config).to_not have_received(:secret_key)
+      end
+    end
+
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is not present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: nil) { example.run }
+      end
+
+      it "gets the specified report CSV from the bucket in the config" do
+        subject.download
+
+        expect(aws_client).to have_received(:get_object).with(
+          bucket: s3_bucket,
+          key: filename,
+          response_content_type: "text/csv"
+        )
+        expect(response).to have_received(:body)
+        expect(response_body).to have_received(:read)
+      end
     end
 
     context "when something goes wrong with fetching the object from S3" do

--- a/spec/services/export/s3_uploader_config_spec.rb
+++ b/spec/services/export/s3_uploader_config_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module Export
   RSpec.describe S3UploaderConfig do
-    subject(:config) { S3UploaderConfig.new(use_public_bucket: true) }
+    subject(:config) { S3UploaderConfig.new(use_public_bucket: false) }
 
     context "when an expected credential is missing from VCAP_SERVICES" do
       around(:each) do |example|
@@ -10,7 +10,7 @@ module Export
           {
             "aws-s3-bucket":[
                 {
-                   "name": "beis-roda-staging-s3-export-download-bucket",
+                   "name": "beis-roda-staging-s3-export-download-bucket-private",
                    "credentials":{
                       "bucket_name":"exports_bucket",
                       "aws_access_key_id":"KEY_ID",

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Export::S3Uploader do
   let(:response) { double("response", etag: double) }
   let(:file) { Tempfile.open("tempfile") { |f| f << "my export here" } }
   let(:aws_credentials) { double("aws credentials") }
+  let(:ecs_credentials) { double("ecs credentials") }
   let(:aws_client) { instance_double(Aws::S3::Client, put_object: response) }
   let(:timestamp) { Time.current }
   let(:timestamped_filename) { "spending_breakdown-#{timestamp.to_formatted_s(:number)}.csv" }
@@ -22,6 +23,7 @@ RSpec.describe Export::S3Uploader do
   }
 
   let(:use_public_bucket) { false }
+  let(:bucket_name) { "dsit_exports_bucket" }
 
   subject do
     travel_to(timestamp) do
@@ -31,31 +33,63 @@ RSpec.describe Export::S3Uploader do
 
   before do
     allow(Aws::Credentials).to receive(:new).and_return(aws_credentials)
+    allow(Aws::ECSCredentials).to receive(:new).and_return(ecs_credentials)
     allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
     allow(Aws::S3::Resource).to receive(:new).and_return(s3_bucket_finder)
     allow(Export::S3UploaderConfig).to receive(:new).and_return(s3_uploader_config)
   end
 
   describe "#initialize" do
-    context "when instantiating the Aws::S3::Client" do
-      it "sets credentials: using an Aws::Credentials object" do
-        subject
-
-        expect(Aws::Credentials).to have_received(:new).with(
-          s3_uploader_config.key_id,
-          s3_uploader_config.secret_key
-        )
-        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
-          credentials: aws_credentials
-        ))
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: bucket_name) { example.run }
       end
 
-      it "sets region: using the region from the S3UploaderConfig" do
-        subject
+      context "when instantiating the Aws::S3::Client" do
+        it "sets credentials: using an Aws::ECSCredentials object" do
+          subject
 
-        expect(Aws::S3::Client).to have_received(:new).with(hash_including(
-          region: s3_uploader_config.region
-        ))
+          expect(Aws::ECSCredentials).to have_received(:new).with({retries: 3})
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            credentials: ecs_credentials
+          ))
+        end
+
+        it "sets region: using the hardcoded eu-west-2 region" do
+          subject
+
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            region: "eu-west-2"
+          ))
+        end
+      end
+    end
+
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is not present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: nil) { example.run }
+      end
+
+      context "when instantiating the Aws::S3::Client" do
+        it "sets credentials: using an Aws::Credentials object" do
+          subject
+
+          expect(Aws::Credentials).to have_received(:new).with(
+            s3_uploader_config.key_id,
+            s3_uploader_config.secret_key
+          )
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            credentials: aws_credentials
+          ))
+        end
+
+        it "sets region: using the region from the S3UploaderConfig" do
+          subject
+
+          expect(Aws::S3::Client).to have_received(:new).with(hash_including(
+            region: s3_uploader_config.region
+          ))
+        end
       end
     end
   end
@@ -67,12 +101,39 @@ RSpec.describe Export::S3Uploader do
       expect(aws_client).to have_received(:put_object).with(hash_including(body: file))
     end
 
-    it "uploads to the bucket defined by the S3UploaderConfig" do
-      subject.upload
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is present" do
+      around(:each) do |example|
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: bucket_name) { example.run }
+      end
 
-      expect(aws_client).to have_received(:put_object).with(
-        hash_including(bucket: s3_uploader_config.bucket)
-      )
+      it "uploads to the bucket defined by the env var" do
+        subject.upload
+
+        expect(aws_client).to have_received(:put_object).with(
+          hash_including(bucket: bucket_name)
+        )
+      end
+
+      it "does not use the S3UploaderConfig" do
+        subject.upload
+
+        expect(s3_uploader_config).to_not have_received(:region)
+        expect(s3_uploader_config).to_not have_received(:bucket)
+        expect(s3_uploader_config).to_not have_received(:key_id)
+        expect(s3_uploader_config).to_not have_received(:secret_key)
+      end
+    end
+
+    context "when the EXPORT_DOWNLOAD_S3_BUCKET env var is not present" do
+      it "uploads to the bucket defined by the S3UploaderConfig" do
+        ClimateControl.modify(EXPORT_DOWNLOAD_S3_BUCKET: nil) do
+          subject.upload
+
+          expect(aws_client).to have_received(:put_object).with(
+            hash_including(bucket: s3_uploader_config.bucket)
+          )
+        end
+      end
     end
 
     it "sets the filename using a timestamp" do

--- a/spec/services/export/s3_uploader_spec.rb
+++ b/spec/services/export/s3_uploader_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Export::S3Uploader do
     )
   }
 
-  let(:use_public_bucket) { true }
+  let(:use_public_bucket) { false }
 
   subject do
     travel_to(timestamp) do
@@ -84,16 +84,16 @@ RSpec.describe Export::S3Uploader do
     context "when the response from S3 has an _etag_" do
       let(:response) { double("response", etag: "abc123") }
 
-      it "uses Aws::S3:Resource to retrieve the uploaded object from its bucket" do
-        subject.upload
-
-        expect(Aws::S3::Resource).to have_received(:new).with(client: aws_client)
-        expect(s3_bucket_finder).to have_received(:bucket).with(s3_uploader_config.bucket)
-        expect(s3_bucket).to have_received(:object).with(timestamped_filename)
-      end
-
       context "when use_public_bucket is true" do
         let(:use_public_bucket) { true }
+
+        it "uses Aws::S3:Resource to retrieve the uploaded object from its bucket" do
+          subject.upload
+
+          expect(Aws::S3::Resource).to have_received(:new).with(client: aws_client)
+          expect(s3_bucket_finder).to have_received(:bucket).with(s3_uploader_config.bucket)
+          expect(s3_bucket).to have_received(:object).with(timestamped_filename)
+        end
 
         it "asks for a public_url" do
           subject.upload


### PR DESCRIPTION
## Changes in this PR

- Support s3 access via ECS credentials, with the bucket name set as an environment variable

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
