### PR TITLE
Removes ispf_fund_in_stealth_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
+
 ## Release 138 - 2023-10-27
 
 [Full changelog][138]

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -21,7 +21,6 @@ class ActivitiesController < BaseController
       render "activities/index_beis"
     else
       @funds = Activity.fund.order(:title)
-      @funds = @funds.not_ispf if hide_ispf_for_group?(:beis_users)
       @grouped_activities = Activity::GroupedActivitiesFetcher.new(
         user: current_user,
         organisation: @organisation,

--- a/app/controllers/exports/organisations_controller.rb
+++ b/app/controllers/exports/organisations_controller.rb
@@ -17,11 +17,7 @@ class Exports::OrganisationsController < BaseController
     add_breadcrumb(t("breadcrumbs.export.index"), exports_path) if policy([:export, Organisation]).index?
     add_breadcrumb t("breadcrumbs.export.organisation.show", name: @organisation.name), :exports_organisation_path
 
-    @funds = if hide_ispf_for_user?(current_user)
-      Fund.not_ispf
-    else
-      Fund.all
-    end
+    @funds = Fund.all
     @xml_downloads = Iati::XmlDownload.all_for_organisation(@organisation) if policy([:export, @organisation]).show_xml?
   end
 
@@ -31,7 +27,6 @@ class Exports::OrganisationsController < BaseController
     respond_to do |format|
       format.csv do
         activities = Activity.where(organisation: @organisation)
-        activities = activities.not_ispf if hide_ispf_for_user?(current_user)
         export = Actual::Export.new(activities)
 
         stream_csv_download(filename: "actuals.csv", headers: export.headers) do |csv|

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -8,11 +8,7 @@ class ExportsController < BaseController
     add_breadcrumb t("breadcrumbs.export.index"), :exports_path
 
     @organisations = policy_scope(Organisation).partner_organisations
-    @funds = if hide_ispf_for_user?(current_user)
-      Fund.not_ispf
-    else
-      Fund.all
-    end
+    @funds = Fund.all
   end
 
   def external_income

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -54,7 +54,6 @@ class ReportsController < BaseController
 
     @report = Report.new
     @funds = Activity.fund
-    @funds = @funds.not_ispf if hide_ispf_for_user?(current_user)
 
     authorize @report
   end
@@ -66,7 +65,6 @@ class ReportsController < BaseController
     authorize @report
 
     @funds = Activity.fund
-    @funds = @funds.not_ispf if hide_ispf_for_user?(current_user)
 
     @report.assign_attributes(report_creatable_params.merge(state: "active"))
     if @report.valid?(:new)

--- a/app/models/iati/xml_download.rb
+++ b/app/models/iati/xml_download.rb
@@ -20,18 +20,12 @@ module Iati
 
       def all_for_organisation(organisation)
         LEVELS.map { |level|
-          funds.map { |fund|
+          Fund.all.map { |fund|
             next unless organisation_has_activities_for_level_and_fund?(organisation, level, fund)
 
             new(organisation: organisation, level: level, fund: fund)
           }
         }.flatten.compact
-      end
-
-      private def funds
-        return Fund.not_ispf if hide_ispf_for_group?(:beis_users)
-
-        Fund.all
       end
 
       private def organisation_has_activities_for_level_and_fund?(organisation, level, fund)

--- a/app/services/activity/grouped_activities_fetcher.rb
+++ b/app/services/activity/grouped_activities_fetcher.rb
@@ -4,7 +4,6 @@ class Activity
       @organisation = organisation
       @scope = scope
       @activities = ActivityPolicy::Scope.new(user, Activity).resolve
-      @activities = @activities.not_ispf if hide_ispf_for_user?(user)
     end
 
     def call

--- a/app/services/activity_search.rb
+++ b/app/services/activity_search.rb
@@ -33,9 +33,9 @@ class ActivitySearch
 
   def activities
     @_activities ||= if @user.service_owner?
-      hide_ispf_for_user?(@user) ? Activity.not_ispf : Activity.all
+      Activity.all
     else
-      hide_ispf_for_user?(@user) ? Activity.not_ispf.where(extending_organisation: @user.organisation) : Activity.where(extending_organisation: @user.organisation)
+      Activity.where(extending_organisation: @user.organisation)
     end
   end
 end

--- a/app/services/report/grouped_reports_fetcher.rb
+++ b/app/services/report/grouped_reports_fetcher.rb
@@ -1,17 +1,11 @@
 class Report
   class GroupedReportsFetcher
     def current
-      @current ||= fetch(reports.not_approved)
+      @current ||= fetch(Report.not_approved)
     end
 
     def approved
-      @approved ||= fetch(reports.approved)
-    end
-
-    private def reports
-      return Report.not_ispf if hide_ispf_for_group?(:beis_users)
-
-      Report
+      @approved ||= fetch(Report.approved)
     end
 
     private def fetch(relation)

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -15,8 +15,6 @@ class Report
     private
 
     def reports
-      return Report.where(organisation: organisation).not_ispf if hide_ispf_for_group?(:partner_organisation_users)
-
       Report.where(organisation: organisation)
     end
 

--- a/app/views/level_b/activities/uploads/new.html.haml
+++ b/app/views/level_b/activities/uploads/new.html.haml
@@ -10,10 +10,10 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      - unless hide_ispf_for_group?(:beis_users)
-        - if ROLLOUT.active?(:oda_bulk_upload)
-          = render partial: "fund_section", locals: { type: :ispf_oda }
-        = render partial: "fund_section", locals: { type: :ispf_non_oda }
+
+      - if ROLLOUT.active?(:oda_bulk_upload)
+        = render partial: "fund_section", locals: { type: :ispf_oda }
+      = render partial: "fund_section", locals: { type: :ispf_non_oda }
       = render partial: "fund_section", locals: { type: :non_ispf }
 
   .govuk-grid-row

--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -13,11 +13,3 @@ end
 Rollout::UI.configure do
   instance { ROLLOUT }
 end
-
-def hide_ispf_for_group?(user_group)
-  ROLLOUT.get(:ispf_fund_in_stealth_mode).groups.include?(user_group)
-end
-
-def hide_ispf_for_user?(user)
-  ROLLOUT.active?(:ispf_fund_in_stealth_mode, user)
-end

--- a/spec/controllers/exports/organisations_controller_spec.rb
+++ b/spec/controllers/exports/organisations_controller_spec.rb
@@ -56,18 +56,6 @@ RSpec.describe Exports::OrganisationsController do
 
         expect(assigns(:xml_downloads)).to be_nil
       end
-
-      context "when the feature flag hiding ISPF is enabled" do
-        before do
-          allow(ROLLOUT).to receive(:active?).and_return(true)
-        end
-
-        it "does not fetch ISPF" do
-          expect(Fund).to receive(:not_ispf)
-
-          get "show", params: {id: organisation.id}
-        end
-      end
     end
 
     describe "#external_income" do
@@ -145,18 +133,6 @@ RSpec.describe Exports::OrganisationsController do
 
         expect(assigns(:xml_downloads)).to be_an(Array)
       end
-
-      context "when the feature flag hiding ISPF is enabled" do
-        before do
-          allow(ROLLOUT).to receive(:active?).and_return(true)
-        end
-
-        it "does not fetch ISPF" do
-          expect(Fund).to receive(:not_ispf)
-
-          get "show", params: {id: organisation.id}
-        end
-      end
     end
 
     describe "#external_income" do
@@ -168,31 +144,16 @@ RSpec.describe Exports::OrganisationsController do
     end
 
     describe "#actuals" do
-      context "when the feature flag hiding ISPF is not enabled" do
-        before do
-          allow(ROLLOUT).to receive(:active?).and_return(false)
-          allow(Activity).to receive(:where)
+      before do
+        allow(Activity).to receive(:where)
 
-          get :actuals, params: {id: organisation.id, format: :csv}
-        end
-
-        include_examples "allows the user to access the export"
-
-        it "fetches all the organisation's activities" do
-          expect(Activity).to have_received(:where).with(organisation: organisation)
-        end
+        get :actuals, params: {id: organisation.id, format: :csv}
       end
 
-      context "when the feature flag hiding ISPF is enabled" do
-        before do
-          allow(ROLLOUT).to receive(:active?).and_return(true)
-        end
+      include_examples "allows the user to access the export"
 
-        it "fetches the organisation's non-ISPF activities" do
-          expect(Activity).to receive_message_chain(:where, :not_ispf)
-
-          get :actuals, params: {id: organisation.id, format: :csv}
-        end
+      it "fetches all the organisation's activities" do
+        expect(Activity).to have_received(:where).with(organisation: organisation)
       end
     end
 

--- a/spec/controllers/exports_controller_spec.rb
+++ b/spec/controllers/exports_controller_spec.rb
@@ -21,24 +21,10 @@ RSpec.describe ExportsController do
     context "when logged in as a BEIS user" do
       let(:user) { create(:beis_user) }
 
-      context "when the feature flag hiding ISPF is not enabled" do
-        it "fetches all the funds" do
-          expect(Fund).to receive(:all)
+      it "fetches all the funds" do
+        expect(Fund).to receive(:all)
 
-          get "index"
-        end
-      end
-
-      context "when the feature flag hiding ISPF is enabled" do
-        before do
-          allow(ROLLOUT).to receive(:active?).and_return(true)
-        end
-
-        it "fetches non-ISPF funds only" do
-          expect(Fund).to receive(:not_ispf)
-
-          get "index"
-        end
+        get "index"
       end
     end
   end

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -315,20 +315,6 @@ RSpec.feature "BEIS users can create a programme level activity" do
         expect(created_activity.linked_activity).to eq(linked_oda_activity)
       end
     end
-
-    context "and the feature flag hiding ISPF is enabled for BEIS users" do
-      before do
-        mock_feature = double(:feature, groups: [:beis_users])
-        allow(ROLLOUT).to receive(:get).and_return(mock_feature)
-        allow(ROLLOUT).to receive(:active?).and_return(true)
-      end
-
-      scenario "there is no link to create a programme" do
-        visit organisation_activities_path(partner_organisation)
-
-        expect(page).to_not have_button t("form.button.activity.new_child", name: oda_activity.associated_fund.title)
-      end
-    end
   end
 
   def expect_implementing_organisation_to_be_the_partner_organisation(

--- a/spec/features/beis_users_can_create_a_report_spec.rb
+++ b/spec/features/beis_users_can_create_a_report_spec.rb
@@ -20,20 +20,6 @@ RSpec.feature "BEIS users can create a report" do
     and_the_report_is_active
   end
 
-  context "when the feature flag hiding ISPF is enabled for BEIS users" do
-    let!(:ispf_fund) { create(:fund_activity, :ispf) }
-
-    before do
-      allow(ROLLOUT).to receive(:active?).with(:ispf_fund_in_stealth_mode, beis_user).and_return(true)
-    end
-
-    scenario "they cannot create an ISPF report" do
-      given_i_am_a_logged_in_beis_user
-      when_i_am_on_the_new_report_page
-      then_i_cannot_choose_ispf_as_the_fund
-    end
-  end
-
   def given_i_am_a_logged_in_beis_user
     authenticate!(user: beis_user)
   end
@@ -63,9 +49,5 @@ RSpec.feature "BEIS users can create a report" do
 
   def when_i_am_on_the_new_report_page
     visit new_report_path
-  end
-
-  def then_i_cannot_choose_ispf_as_the_fund
-    expect(page).not_to have_content("International Science Partnerships Fund")
   end
 end

--- a/spec/features/beis_users_can_upload_level_b_activities_spec.rb
+++ b/spec/features/beis_users_can_upload_level_b_activities_spec.rb
@@ -459,20 +459,6 @@ RSpec.feature "BEIS users can upload Level B activities" do
 
       expect(page).to have_text("Another comment")
     end
-
-    context "when the feature flag hiding ISPF is enabled for BEIS users" do
-      before do
-        mock_feature = double(:feature, groups: [:beis_users])
-        allow(ROLLOUT).to receive(:get).and_return(mock_feature)
-      end
-
-      it "does not show the ISPF template download links" do
-        visit new_organisation_level_b_activities_upload_path(organisation)
-
-        expect(page).to_not have_content("ISPF")
-        expect(page).to have_content("GCRF/NF/OODA")
-      end
-    end
   end
 
   def expect_change_to_be_recorded_as_historical_event(

--- a/spec/features/users_can_view_activities_spec.rb
+++ b/spec/features/users_can_view_activities_spec.rb
@@ -99,48 +99,4 @@ RSpec.feature "Users can view activities" do
       }
     end
   end
-
-  context "when the feature flag hiding ISPF is enabled" do
-    let(:organisation) { create(:partner_organisation) }
-    let!(:ispf_programme) { create(:programme_activity, :ispf_funded, extending_organisation: organisation) }
-    let!(:ispf_project) { create(:project_activity, organisation: organisation, parent: ispf_programme) }
-
-    before do
-      authenticate!(user: user)
-      allow(ROLLOUT).to receive(:active?).with(:ispf_fund_in_stealth_mode, user).and_return(true)
-    end
-    after { logout }
-
-    context "a BEIS user" do
-      let(:user) { create(:beis_user) }
-
-      scenario "does not see ISPF activities" do
-        visit organisation_activities_path(organisation_id: organisation.id)
-
-        expect(page).not_to have_content("International Science Partnerships Fund")
-        expect(page).not_to have_content(ispf_programme.title)
-        expect(page).not_to have_content(ispf_project.title)
-      end
-    end
-
-    context "a partner organisation user" do
-      let(:user) { create(:partner_organisation_user, organisation: organisation) }
-
-      scenario "does not see ISPF activities on their organisation page" do
-        visit organisation_activities_path(organisation_id: organisation.id)
-
-        expect(page).not_to have_content("International Science Partnerships Fund")
-        expect(page).not_to have_content(ispf_programme.title)
-        expect(page).not_to have_content(ispf_project.title)
-      end
-
-      scenario "does not see ISPF activities on their homepage" do
-        visit home_path
-
-        expect(page).not_to have_content("International Science Partnerships Fund")
-        expect(page).not_to have_content(ispf_programme.title)
-        expect(page).not_to have_content(ispf_project.title)
-      end
-    end
-  end
 end

--- a/spec/models/iati/xml_download_spec.rb
+++ b/spec/models/iati/xml_download_spec.rb
@@ -59,25 +59,6 @@ RSpec.describe Iati::XmlDownload do
         ])
         expect(downloads.map(&:organisation).uniq).to eq([organisation])
       end
-
-      context "and the feature flag hiding ISPF is enabled" do
-        before do
-          mock_feature = double(:feature, groups: [:beis_users])
-          allow(ROLLOUT).to receive(:get).and_return(mock_feature)
-        end
-
-        it "does not return XML downloads for ISPF" do
-          downloads = described_class.all_for_organisation(organisation)
-
-          expect(downloads.count).to eq(9)
-
-          expect(downloads.map { |p| p.fund.short_name }).to eq(%w[
-            NF GCRF OODA
-            NF GCRF OODA
-            NF GCRF OODA
-          ])
-        end
-      end
     end
 
     context "when the organisation has publishable activities for some levels and funds" do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -20,24 +20,4 @@ RSpec.describe "Rollout" do
       expect(ROLLOUT.active_in_group?(:partner_organisation_users, user)).to be(true)
     end
   end
-
-  describe "#hide_ispf_for_group?" do
-    it "provides a more readable interface to check if the feature is enabled for that group" do
-      mock_feature = double(:feature, groups: [:real_group])
-      allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(mock_feature)
-
-      expect(hide_ispf_for_group?(:real_group)).to be(true)
-      expect(hide_ispf_for_group?(:fake_group)).to be(false)
-    end
-  end
-
-  describe "#hide_ispf_for_user?" do
-    let(:user) { double(:user) }
-
-    it "provides a more readable interface to check if the feature is enabled for that user" do
-      expect(ROLLOUT).to receive(:active?).with(:ispf_fund_in_stealth_mode, user)
-
-      hide_ispf_for_user?(user)
-    end
-  end
 end

--- a/spec/services/activity_search_spec.rb
+++ b/spec/services/activity_search_spec.rb
@@ -95,22 +95,6 @@ RSpec.describe ActivitySearch do
         expect(activity_search.results).to match_array [alice_third_party_project, bob_project]
       end
     end
-
-    context "when the feature flag hiding ISPF is enabled" do
-      let!(:ispf_fund) { create(:fund_activity, :ispf) }
-      let!(:ispf_programme) { create(:programme_activity, :ispf_funded, title: "ISPF programme") }
-      let(:query) { "ISPF" }
-
-      before do
-        allow(ROLLOUT).to receive(:active?).and_return(true)
-      end
-
-      describe "searching for ISPF activities" do
-        it "returns nothing" do
-          expect(activity_search.results).to be_empty
-        end
-      end
-    end
   end
 
   context "for partner organisations" do
@@ -200,22 +184,6 @@ RSpec.describe ActivitySearch do
 
       it "returns the matching activities" do
         expect(activity_search.results).to match_array [alice_third_party_project]
-      end
-    end
-
-    context "when the feature flag hiding ISPF is enabled" do
-      let!(:ispf_fund) { create(:fund_activity, :ispf) }
-      let!(:ispf_programme) { create(:programme_activity, :ispf_funded, title: "ISPF programme", extending_organisation: alice.organisation) }
-      let(:query) { "ISPF" }
-
-      before do
-        allow(ROLLOUT).to receive(:active?).and_return(true)
-      end
-
-      describe "searching for ISPF activities" do
-        it "returns nothing" do
-          expect(activity_search.results).to be_empty
-        end
       end
     end
   end

--- a/spec/services/report/grouped_reports_fetcher_spec.rb
+++ b/spec/services/report/grouped_reports_fetcher_spec.rb
@@ -22,26 +22,6 @@ RSpec.describe Report::GroupedReportsFetcher do
         organisation2 => organisation2_approved_reports
       })
     end
-
-    context "when the feature flag hiding ISPF is enabled for BEIS users" do
-      before do
-        feature = double(:feature, groups: [:beis_users])
-        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
-      end
-
-      it "only returns approved non-ISPF reports" do
-        non_ispf_approved_reports = build_list(:report, 3, organisation: organisation1)
-        non_ispf_approved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_approved_reports)
-
-        expect(Report).to receive_message_chain(:not_ispf, :approved).and_return(non_ispf_approved_relation_double)
-        expect(non_ispf_approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_approved_relation_double)
-        expect(non_ispf_approved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(non_ispf_approved_reports)
-
-        expect(subject.approved).to eq({
-          organisation1 => non_ispf_approved_reports
-        })
-      end
-    end
   end
 
   describe "#current" do
@@ -60,25 +40,6 @@ RSpec.describe Report::GroupedReportsFetcher do
         organisation1 => organisation1_unapproved_reports,
         organisation2 => organisation2_unapproved_reports
       })
-    end
-
-    context "when the feature flag hiding ISPF is enabled for BEIS users" do
-      before do
-        feature = double(:feature, groups: [:beis_users])
-        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
-      end
-
-      it "only returns unapproved non-ISPF reports" do
-        non_ispf_unapproved_reports = build_list(:report, 2, organisation: organisation1)
-        non_ispf_unapproved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_unapproved_reports)
-        expect(non_ispf_unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_unapproved_relation_double)
-        expect(non_ispf_unapproved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(non_ispf_unapproved_reports)
-
-        expect(Report).to receive_message_chain(:not_ispf, :not_approved).and_return(non_ispf_unapproved_relation_double)
-        expect(subject.current).to eq({
-          organisation1 => non_ispf_unapproved_reports
-        })
-      end
     end
   end
 end

--- a/spec/services/report/organisation_reports_fetcher_spec.rb
+++ b/spec/services/report/organisation_reports_fetcher_spec.rb
@@ -21,27 +21,6 @@ RSpec.describe Report::OrganisationReportsFetcher do
 
       expect(subject).to eq(approved_reports)
     end
-
-    context "when the feature flag hiding ISPF is enabled for partner organisation users" do
-      before do
-        feature = double(:feature, groups: [:partner_organisation_users])
-        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
-      end
-
-      it "only returns approved non-ISPF reports" do
-        non_ispf_approved_reports = build_list(:report, 3, :approved, organisation: organisation)
-
-        non_ispf_approved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_approved_reports)
-
-        expect(Report).to receive(:where).with(organisation: organisation).and_return(non_ispf_approved_relation_double)
-        expect(non_ispf_approved_relation_double).to receive_message_chain(:not_ispf, :approved).and_return(non_ispf_approved_relation_double)
-
-        expect(non_ispf_approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_approved_relation_double)
-        expect(non_ispf_approved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(non_ispf_approved_reports)
-
-        expect(subject).to eq(non_ispf_approved_reports)
-      end
-    end
   end
 
   describe "#current" do
@@ -59,27 +38,6 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(unapproved_reports)
 
       expect(subject).to eq(unapproved_reports)
-    end
-
-    context "when the feature flag hiding ISPF is enabled for partner organisation users" do
-      before do
-        feature = double(:feature, groups: [:partner_organisation_users])
-        allow(ROLLOUT).to receive(:get).with(:ispf_fund_in_stealth_mode).and_return(feature)
-      end
-
-      it "only returns active unapproved non-ISPF reports for the organisation" do
-        non_ispf_unapproved_reports = build_list(:report, 2, :active, organisation: organisation)
-
-        non_ispf_unapproved_relation_double = double(ActiveRecord::Relation, "[]": non_ispf_unapproved_reports)
-
-        expect(Report).to receive(:where).with(organisation: organisation).and_return(non_ispf_unapproved_relation_double)
-        expect(non_ispf_unapproved_relation_double).to receive_message_chain(:not_ispf, :not_approved).and_return(non_ispf_unapproved_relation_double)
-
-        expect(non_ispf_unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(non_ispf_unapproved_relation_double)
-        expect(non_ispf_unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(non_ispf_unapproved_reports)
-
-        expect(subject).to eq(non_ispf_unapproved_reports)
-      end
     end
   end
 end


### PR DESCRIPTION
The ISPF is now live, meaning we no longer need a mode that hides ISPF funds from users. 

Trello: ticket [2943](https://trello.com/c/NTyNjH3d/2943-remove-the-ispf-hiding-feature-flag)

## Changes in this PR
This PR removes the Rollout handled flag to exclude ISPF. All switches in the code triggered by the hide ISPF flag have been removed, along with now-redundant tests associated with that flag.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
