### PR TITLE
Add migration to add is_non_oda column to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
+- Add migration to add is_non_oda column to reports
 
 ## Release 138 - 2023-10-27
 

--- a/db/migrate/20231030124418_add_is_non_oda_to_report.rb
+++ b/db/migrate/20231030124418_add_is_non_oda_to_report.rb
@@ -1,0 +1,12 @@
+class AddIsNonOdaToReport < ActiveRecord::Migration[6.1]
+  def up
+    add_column :reports, :is_non_oda, :boolean
+
+    ispf = Activity.by_roda_identifier("ISPF")
+    Report.where(fund_id: ispf.id).update_all(is_non_oda: true) unless ispf.blank?
+  end
+
+  def down
+    remove_column :reports, :is_non_oda
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_07_102933) do
+ActiveRecord::Schema.define(version: 2023_10_30_124418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -310,6 +310,7 @@ ActiveRecord::Schema.define(version: 2023_03_07_102933) do
     t.integer "financial_year"
     t.string "export_filename"
     t.datetime "approved_at"
+    t.boolean "is_non_oda"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"


### PR DESCRIPTION
Reports for ISPF need to be marked as ODA or non_ODA, to allow us to have two simultaneous open reports for ISPF.

## Changes in this PR

In this PR, an is_non_oda boolean is added to the report model. Additionally, having verified with DSIT that all existing ISPF reports are non-ODA, the migration sets the is_non_oda value for existing ISPF reports to true.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
