### PR TITLE
Amend report validation to include is_non_oda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
 - Add migration to add is_non_oda column to reports
+- Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types
 
 ## Release 138 - 2023-10-27
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -91,7 +91,8 @@ class Report < ApplicationRecord
 
     unless Report.where(
       fund: fund,
-      organisation: organisation
+      organisation: organisation,
+      is_non_oda: is_non_oda
     ).all?(&:approved?)
       errors.add(:base, I18n.t("activerecord.errors.models.report.unapproved_reports_html"))
     end

--- a/db/migrate/20231030201831_enforce_one_editable_report_per_series_by_oda_type.rb
+++ b/db/migrate/20231030201831_enforce_one_editable_report_per_series_by_oda_type.rb
@@ -1,0 +1,12 @@
+class EnforceOneEditableReportPerSeriesByOdaType < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :reports,
+      column: [:fund_id, :organisation_id],
+      name: "enforce_one_editable_report_per_series"
+
+    add_index :reports, [:fund_id, :organisation_id, :is_non_oda],
+      where: "state <> 'approved'",
+      unique: true,
+      name: "enforce_one_editable_report_per_series"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_30_124418) do
+ActiveRecord::Schema.define(version: 2023_10_30_201831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2023_10_30_124418) do
     t.string "export_filename"
     t.datetime "approved_at"
     t.boolean "is_non_oda"
-    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
+    t.index ["fund_id", "organisation_id", "is_non_oda"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -12,16 +12,33 @@ RSpec.describe Report, type: :model do
     end
 
     context "in the :new validation context" do
-      it "validates there are no unapproved reports for the organisation and fund" do
-        organisation = create(:partner_organisation)
-        existing_approved_report = create(:report, :approved, organisation: organisation)
-        existing_unapproved_report = create(:report, state: "awaiting_changes", organisation: organisation)
+      context "for an ODA-only fund" do
+        it "validates there are no unapproved reports for the organisation and fund" do
+          organisation = create(:partner_organisation)
+          existing_approved_report = create(:report, :approved, organisation: organisation)
+          existing_unapproved_report = create(:report, state: "awaiting_changes", organisation: organisation)
 
-        new_valid_report = build(:report, fund: existing_approved_report.fund, organisation: organisation)
-        new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
+          new_valid_report = build(:report, fund: existing_approved_report.fund, organisation: organisation)
+          new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
 
-        expect(new_invalid_report.valid?(:new)).to be(false)
-        expect(new_valid_report.valid?).to be(true)
+          expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_valid_report.valid?(:new)).to be(true)
+        end
+      end
+
+      context "for a hybrid ODA and non-ODA fund such as ISPF" do
+        it "validates there are no unapproved reports for the organisation, fund, and ODA type" do
+          organisation = create(:partner_organisation)
+          _existing_approved_oda_report = create(:report, :for_ispf, :approved, is_non_oda: false, organisation: organisation)
+          _existing_approved_non_oda_report = create(:report, :for_ispf, :approved, is_non_oda: true, organisation: organisation)
+          _existing_unapproved_oda_report = create(:report, :for_ispf, is_non_oda: false, state: "awaiting_changes", organisation: organisation)
+
+          new_valid_report = build(:report, :for_ispf, is_non_oda: true, organisation: organisation)
+          new_invalid_report = build(:report, :for_ispf, is_non_oda: false, organisation: organisation)
+
+          expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_valid_report.valid?(:new)).to be(true)
+        end
       end
 
       it "validates the presence of financial_quarter and financial_year" do


### PR DESCRIPTION
## Changes in this PR

Amend the report validation (enforced as Rails model validation and as database unique index) to take into account the ODA type of the report.

This allows non-ISPF reports (whose `is_non_oda` value is `nil`) to function as usual, and it allows ISPF to have one ODA and one non-ODA report editable at the same time for each partner organisation.

One can't really "edit" an index, which is why we're removing it and recreating it with the desired columns and attributes. See prior art at https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/1416/files#diff-6b33599697c95e38ad112ef133d058e26095bf7c68334fd0cf433547bebd4317 and https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/768/files

The index should be created without errors, because all the existing reports already fulfill the criteria. (Otherwise we would have had to modify the existing data before being able to enforce database-level constraints.)

## Screenshots of UI changes
N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
