### PR TITLE
(2945) Clean up project and third-party project policies

### DIFF
--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,4 +1,4 @@
-class ProjectPolicy < ApplicationPolicy
+class ProjectPolicy < ActivityPolicy
   def index?
     true
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -3,22 +3,6 @@ class ProjectPolicy < ActivityPolicy
     true
   end
 
-  def show?
-    true
-  end
-
-  def create?
-    partner_organisation_user?
-  end
-
-  def update?
-    partner_organisation_user?
-  end
-
-  def destroy?
-    false
-  end
-
   def redact_from_iati?
     beis_user?
   end

--- a/app/policies/third_party_project_policy.rb
+++ b/app/policies/third_party_project_policy.rb
@@ -1,11 +1,2 @@
 class ThirdPartyProjectPolicy < ProjectPolicy
-  def create?
-    partner_organisation_user? && editable_report?
-  end
-
-  private
-
-  def editable_report?
-    Report.editable.exists?(organisation: record.organisation, fund: record.associated_fund)
-  end
 end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -100,9 +100,8 @@ RSpec.describe ActivityPolicy do
         is_expected.to forbid_action(:create_refund)
         is_expected.to forbid_action(:create_adjustment)
 
-        is_expected.to forbid_action(:create)
-        is_expected.to forbid_action(:edit)
-        is_expected.to forbid_action(:update)
+        is_expected.to forbid_new_and_create_actions
+        is_expected.to forbid_edit_and_update_actions
         is_expected.to forbid_action(:destroy)
 
         is_expected.to forbid_action(:create_child)
@@ -154,7 +153,7 @@ RSpec.describe ActivityPolicy do
         is_expected.to permit_action(:redact_from_iati)
         is_expected.to permit_action(:show_xml)
 
-        is_expected.to forbid_action(:create)
+        is_expected.to forbid_new_and_create_actions
         is_expected.to forbid_action(:edit)
         is_expected.to forbid_action(:update)
         is_expected.to forbid_action(:destroy)
@@ -287,7 +286,7 @@ RSpec.describe ActivityPolicy do
       context "and the user's organisation is not the extending organisation" do
         it "forbids all actions" do
           is_expected.to forbid_action(:show)
-          is_expected.to forbid_action(:create)
+          is_expected.to forbid_new_and_create_actions
           is_expected.to forbid_action(:edit)
           is_expected.to forbid_action(:update)
           is_expected.to forbid_action(:destroy)
@@ -316,7 +315,7 @@ RSpec.describe ActivityPolicy do
           it "only permits show" do
             is_expected.to permit_action(:show)
 
-            is_expected.to forbid_action(:create)
+            is_expected.to forbid_new_and_create_actions
             is_expected.to forbid_action(:edit)
             is_expected.to forbid_action(:update)
             is_expected.to forbid_action(:destroy)
@@ -413,7 +412,7 @@ RSpec.describe ActivityPolicy do
           it "only permits show" do
             is_expected.to permit_action(:show)
 
-            is_expected.to forbid_action(:create)
+            is_expected.to forbid_new_and_create_actions
             is_expected.to forbid_action(:edit)
             is_expected.to forbid_action(:update)
             is_expected.to forbid_action(:show_xml)
@@ -435,7 +434,7 @@ RSpec.describe ActivityPolicy do
 
           it "only forbids show_xml, destroy, redact_from_iati, create_child, and update_linked_activity" do
             is_expected.to permit_action(:show)
-            is_expected.to permit_action(:create)
+            is_expected.to permit_new_and_create_actions
             is_expected.to permit_action(:edit)
             is_expected.to permit_action(:update)
 

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe ProjectPolicy do
       is_expected.to permit_action(:redact_from_iati)
     end
 
+    context "when invoked as a headless policy" do
+      subject { described_class.new(user, :project) }
+
+      it "permits redact_from_iati" do
+        is_expected.to permit_action(:redact_from_iati)
+      end
+    end
+
     it "includes all projects in the resolved scope" do
       resolved_scope = described_class::Scope.new(user, Activity.project).resolve
       expect(resolved_scope).to contain_exactly(project, another_project)

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProjectPolicy do
   let(:project) { create(:project_activity, organisation: organisation) }
   let(:another_project) { create(:project_activity) }
 
-  subject { described_class.new(user, Activity.project) }
+  subject { described_class.new(user, project) }
 
   context "as a user that belongs to BEIS" do
     let(:user) { build_stubbed(:beis_user) }

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe ProjectPolicy do
 
     it "controls actions as expected" do
       is_expected.to permit_action(:index)
-      is_expected.to permit_action(:show)
-      is_expected.to forbid_new_and_create_actions
-      is_expected.to forbid_edit_and_update_actions
-      is_expected.to forbid_action(:destroy)
-      is_expected.to permit_action(:redact_from_iati)
     end
 
     context "when invoked as a headless policy" do
@@ -38,11 +33,6 @@ RSpec.describe ProjectPolicy do
 
     it "controls actions as expected" do
       is_expected.to permit_action(:index)
-      is_expected.to permit_action(:show)
-      is_expected.to permit_new_and_create_actions
-      is_expected.to permit_edit_and_update_actions
-      is_expected.to forbid_action(:destroy)
-      is_expected.to forbid_action(:redact_from_iati)
     end
 
     it "includes only projects that the users organisation is reporting the project in the resolved scope" do

--- a/spec/policies/third_party_project_policy_spec.rb
+++ b/spec/policies/third_party_project_policy_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe ThirdPartyProjectPolicy do
 
     it "controls actions as expected" do
       is_expected.to permit_action(:index)
-      is_expected.to permit_action(:show)
-      is_expected.to forbid_new_and_create_actions
-      is_expected.to forbid_edit_and_update_actions
-      is_expected.to forbid_action(:destroy)
-      is_expected.to permit_action(:redact_from_iati)
     end
 
     it "includes all third party projects in the resolved scope" do
@@ -30,17 +25,6 @@ RSpec.describe ThirdPartyProjectPolicy do
 
     it "controls actions as expected" do
       is_expected.to permit_action(:index)
-      is_expected.to permit_action(:show)
-      is_expected.to forbid_new_and_create_actions
-      is_expected.to permit_edit_and_update_actions
-      is_expected.to forbid_action(:destroy)
-      is_expected.to forbid_action(:redact_from_iati)
-    end
-
-    context "with an editable report" do
-      let(:third_party_project) { create(:third_party_project_activity, :with_report, organisation: organisation) }
-
-      it { is_expected.to permit_new_and_create_actions }
     end
 
     it "includes only projects that the users organisation is reporting the project in the resolved scope" do


### PR DESCRIPTION
## Changes in this PR
- `ProjectPolicy` now inherits from `ActivityPolicy`
- project and 3rd party project specs do not test redundant scenarios that are already tested in activity policy spec
- misleading specs have been removed

This is a step towards unifying all the activity related policies. Activities do not use an inheritance model for the different levels (fund, programme, project, third-party project), so in time we have ended up defining the policies in the activity policy.

The separate policies are now mainly used for:
- scopes; it may be possible to gather them under the activity policy umbrella, but this is outside the scope (pun unintended) of the current work, unless we are going to be working on those areas;
- "headless" invocations (using the policy without a record, e.g. `policy(:project)`)

The direction of change we are thinking of is to have all activity related policies under `ActivityPolicy`, unless future requirements are going to go against this thinking.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
