### PR TITLE
Fix the mismatch between headers and rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Amend the check for a pre-existing later report to take ODA type into account
 - Error message shown when attempting to create a report while an unapproved one for the same fund, org, and ODA type exists includes the ODA type where relevant
 - Show ODA/non-ODA alongside the fund short name on the reports table for ISPF
+- Fix the logic that generates actuals and variance rows for reports, to avoid inserting a spurious column for reports that have forecasts but no actuals
 
 ## Release 138 - 2023-10-27
 

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -55,9 +55,9 @@ class Export::Report
       row << implementing_organisations_rows.fetch(activity.id, nil)
       row << partner_organisation_rows.fetch(activity.id, nil)
       row << change_state_rows.fetch(activity.id, nil)
-      row << actuals_rows.fetch(activity.id, nil) if actuals_rows.any?
-      row << variance_rows.fetch(activity.id, nil) if actuals_rows.any? && has_forecast_rows?
-      row << forecast_rows.fetch(activity.id, nil) if has_forecast_rows?
+      row << actuals_rows.fetch(activity.id, nil) if @actuals_columns.headers.any?
+      row << variance_rows.fetch(activity.id, nil) if @actuals_columns.headers.any? && @forecast_columns.headers.any?
+      row << forecast_rows.fetch(activity.id, nil) if @forecast_columns.headers.any?
       row << comment_rows.fetch(activity.id, nil)
       row << tags_rows.fetch(activity.id, nil) if @report.for_ispf?
       row << link_rows.fetch(activity.id, nil)


### PR DESCRIPTION
## Changes in this PR
- Fix the logic that generates actuals and variance rows for reports, to avoid inserting a spurious column for reports that have forecasts but no actuals

In certain circumstances, such as when a report has forecasts but no actual spend, there is an extra column for the data that is not matched to a header.

The reason the extra column shows up is due to the data structures used for the actuals and variance, which will always return a hash with keys and values, even if the values are not meaningful (empty arrays or zero values).

We cannot simply filter out empty arrays or zero values, because they can be meaningful in other contexts, such as when there are some nil or zero values in some quarters, but they are surrounded by quarters with non-zero values, so we have to include them.

The simplest solution is to trust the logic of the headers generation, and not attempt to compute actuals or variance for reports where the app has already determined there are no actuals or variance to display.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
