### PR TITLE
Amend editable report finders acknowledge ODA-ness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
 - Add migration to add is_non_oda column to reports
 - Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types
+- Amend editable report finders to take into account ODA-ness
 
 ## Release 138 - 2023-10-27
 

--- a/app/services/activity/projects_for_report_finder.rb
+++ b/app/services/activity/projects_for_report_finder.rb
@@ -9,7 +9,8 @@ class Activity
       scope.where(
         level: [:project, :third_party_project],
         organisation_id: report.organisation_id,
-        source_fund_code: report.fund.source_fund_code
+        source_fund_code: report.fund.source_fund_code,
+        is_oda: !report.is_non_oda
       )
     end
 

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Activities::UploadsController do
     context "when requesting the ISPF ODA template" do
       it "downloads the CSV template with the correct filename" do
         report.update(fund: create(:fund_activity, :ispf))
+        report.update(is_non_oda: false)
 
         get :show, params: {report_id: report.id, type: :ispf_oda}
 
@@ -100,6 +101,7 @@ RSpec.describe Activities::UploadsController do
     context "when requesting the ISPF non-ODA template" do
       it "downloads the CSV template with the correct filename" do
         report.update(fund: create(:fund_activity, :ispf))
+        report.update(is_non_oda: true)
 
         get :show, params: {report_id: report.id, type: :ispf_non_oda}
 

--- a/spec/controllers/actuals/uploads_controller_spec.rb
+++ b/spec/controllers/actuals/uploads_controller_spec.rb
@@ -73,15 +73,15 @@ RSpec.describe Actuals::UploadsController do
   end
 
   describe "#show" do
-    let(:report) { create(:report, :active, organisation: organisation, fund: fund) }
+    let(:report) { create(:report, :active, organisation: organisation, fund: fund, is_non_oda: false) }
 
-    let!(:fund) { create(:fund_activity, roda_identifier: "A") }
-    let!(:programme_a) { create(:programme_activity, parent: fund, roda_identifier: "A-A", created_at: rand(0..60).minutes.ago) }
-    let!(:programme_b) { create(:programme_activity, parent: fund, roda_identifier: "A-B", created_at: rand(0..60).minutes.ago) }
-    let!(:project_c) { create(:project_activity, parent: programme_a, organisation: report.organisation, roda_identifier: "A-A-C", created_at: rand(0..60).minutes.ago) }
-    let!(:project_d) { create(:project_activity, parent: programme_b, organisation: report.organisation, roda_identifier: "A-B-D", created_at: rand(0..60).minutes.ago) }
-    let!(:third_party_project_e) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier: "A-A-C-E", created_at: rand(0..60).minutes.ago) }
-    let!(:third_party_project_f) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier: "A-B-D-F", created_at: rand(0..60).minutes.ago) }
+    let!(:fund) { create(:fund_activity, roda_identifier: "A", is_oda: true) }
+    let!(:programme_a) { create(:programme_activity, parent: fund, roda_identifier: "A-A", created_at: rand(0..60).minutes.ago, is_oda: true) }
+    let!(:programme_b) { create(:programme_activity, parent: fund, roda_identifier: "A-B", created_at: rand(0..60).minutes.ago, is_oda: true) }
+    let!(:project_c) { create(:project_activity, parent: programme_a, organisation: report.organisation, roda_identifier: "A-A-C", created_at: rand(0..60).minutes.ago, is_oda: true) }
+    let!(:project_d) { create(:project_activity, parent: programme_b, organisation: report.organisation, roda_identifier: "A-B-D", created_at: rand(0..60).minutes.ago, is_oda: true) }
+    let!(:third_party_project_e) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier: "A-A-C-E", created_at: rand(0..60).minutes.ago, is_oda: true) }
+    let!(:third_party_project_f) { create(:third_party_project_activity, parent: project_c, organisation: report.organisation, roda_identifier: "A-B-D-F", created_at: rand(0..60).minutes.ago, is_oda: true) }
 
     let!(:stopped_project) { create(:project_activity, parent: programme_a, organisation: report.organisation, programme_status: "stopped") }
     let!(:cancelled_project) { create(:project_activity, parent: programme_b, organisation: report.organisation, programme_status: "cancelled") }

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -2,15 +2,16 @@ RSpec.feature "users can upload actuals" do
   let(:organisation) { create(:partner_organisation) }
   let(:user) { create(:partner_organisation_user, organisation: organisation) }
 
-  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation) }
-  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
-  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation) }
+  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation, is_oda: true) }
+  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent, is_oda: true) }
+  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation, is_oda: true) }
 
   let! :report do
     create(:report,
       :active,
       fund: project.associated_fund,
-      organisation: organisation)
+      organisation: organisation,
+      is_non_oda: false)
   end
 
   before do

--- a/spec/features/users_can_upload_forecasts_spec.rb
+++ b/spec/features/users_can_upload_forecasts_spec.rb
@@ -2,9 +2,9 @@ RSpec.feature "users can upload forecasts" do
   let(:organisation) { create(:partner_organisation) }
   let(:user) { create(:partner_organisation_user, organisation: organisation) }
 
-  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation) }
-  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
-  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation) }
+  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation, is_oda: true) }
+  let!(:sibling_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent, is_oda: true) }
+  let!(:cousin_project) { create(:project_activity, :gcrf_funded, organisation: organisation, is_oda: true) }
 
   let! :report do
     create(:report,
@@ -12,7 +12,8 @@ RSpec.feature "users can upload forecasts" do
       fund: project.associated_fund,
       organisation: organisation,
       financial_year: 2021,
-      financial_quarter: 1)
+      financial_quarter: 1,
+      is_non_oda: false)
   end
 
   before do

--- a/spec/features/users_can_view_forecasts_within_report_spec.rb
+++ b/spec/features/users_can_view_forecasts_within_report_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Users can view forecasts in tab within a report" do
     scenario "the report contains a _forecasts_ tab" do
       programme = create(:programme_activity)
 
-      project = create(:project_activity, organisation: organisation, parent: programme)
+      project = create(:project_activity, organisation: organisation, parent: programme, is_oda: true)
 
       report = create(
         :report,
@@ -59,12 +59,14 @@ RSpec.feature "Users can view forecasts in tab within a report" do
         organisation: organisation,
         fund: programme.parent,
         financial_quarter: 3,
-        financial_year: 2020
+        financial_year: 2020,
+        is_non_oda: false
       )
 
       activities = 2.times.map {
         create(
           :third_party_project_activity,
+          is_oda: true,
           organisation: organisation,
           parent: project
         ).tap do |activity|

--- a/spec/features/users_can_view_reports_spec.rb
+++ b/spec/features/users_can_view_reports_spec.rb
@@ -398,7 +398,7 @@ RSpec.feature "Users can view reports" do
       scenario "the report shows the total forecasted and actual spend and the variance" do
         quarter_two_2019 = Date.parse("2019-7-1")
 
-        activity = create(:project_activity, organisation: partner_org_user.organisation)
+        activity = create(:project_activity, organisation: partner_org_user.organisation, is_oda: true)
         reporting_cycle = ReportingCycle.new(activity, 4, 2018)
         forecast = ForecastHistory.new(activity, financial_quarter: 1, financial_year: 2019)
 

--- a/spec/services/activity/projects_for_report_finder_spec.rb
+++ b/spec/services/activity/projects_for_report_finder_spec.rb
@@ -1,14 +1,41 @@
 require "rails_helper"
 
 RSpec.describe Activity::ProjectsForReportFinder do
-  it "only returns projects and third party projects that are for the report's organisation and fund" do
+  it "only returns projects and third party projects that are for the report's organisation, fund and oda-ness" do
     organisation = create(:partner_organisation)
     newton_fund = create(:fund_activity, :newton)
-    report = create(:report, organisation: organisation, fund: newton_fund)
+    report = create(:report, organisation: organisation, fund: newton_fund, is_non_oda: true)
 
     programme = create(:programme_activity, :newton_funded, parent: newton_fund)
-    project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
-    third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
+    project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme, is_oda: false)
+    third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project, is_oda: false)
+
+    gcrf_fund = create(:fund_activity, :gcrf)
+    another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
+    another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
+    another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
+
+    result = Activity::ProjectsForReportFinder.new(report: report).call
+
+    expect(result).to include third_party_project
+    expect(result).to include project
+
+    expect(result).not_to include newton_fund
+    expect(result).not_to include programme
+    expect(result).not_to include gcrf_fund
+    expect(result).not_to include another_programme
+    expect(result).not_to include another_project
+    expect(result).not_to include another_third_party_project
+  end
+
+  it "only returns projects and third party projects that are for the report's organisation, fund and oda-ness" do
+    organisation = create(:partner_organisation)
+    newton_fund = create(:fund_activity, :newton)
+    report = create(:report, organisation: organisation, fund: newton_fund, is_non_oda: false)
+
+    programme = create(:programme_activity, :newton_funded, parent: newton_fund)
+    project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme, is_oda: true)
+    third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project, is_oda: true)
 
     gcrf_fund = create(:fund_activity, :gcrf)
     another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)


### PR DESCRIPTION
We need to be able to distinguish between two different open reports on ISPF - ODA or non-ODA. Currently the code finds an editable report with a finder system that matches reports to activities by organisation, and by fund. 

## Changes in this PR
This PR changes the finders for editable reports to now use the 'ODA status' (is_oda; is_non_oda) of the report and activity as well - when an editable report is fetched, it must have the same ODA status as the activity. 

Where necessary, tests have been updated to ensure that reports and activities can be matched by ODA status. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
