### PR TITLE
(2947) (2966) Update report - activity finders

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,7 +62,7 @@ class Report < ApplicationRecord
   end
 
   scope :for_activity, ->(activity) do
-    where(fund_id: activity.associated_fund.id, organisation_id: activity.organisation_id)
+    where(fund_id: activity.associated_fund.id, organisation_id: activity.organisation_id, is_oda: activity.is_oda)
   end
 
   scope :not_ispf, -> { where.not(fund_id: Activity.by_roda_identifier("ISPF").id) }

--- a/app/services/activity/projects_for_report_finder.rb
+++ b/app/services/activity/projects_for_report_finder.rb
@@ -9,7 +9,8 @@ class Activity
       scope.where(
         level: [:project, :third_party_project],
         organisation_id: report.organisation_id,
-        source_fund_code: report.fund.source_fund_code
+        source_fund_code: report.fund.source_fund_code,
+        is_oda: report.is_oda
       )
     end
 

--- a/spec/services/activity/projects_for_report_finder_spec.rb
+++ b/spec/services/activity/projects_for_report_finder_spec.rb
@@ -13,18 +13,10 @@ RSpec.describe Activity::ProjectsForReportFinder do
     gcrf_fund = create(:fund_activity, :gcrf)
     another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
     another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
-    another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
+    _another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
 
     result = Activity::ProjectsForReportFinder.new(report: report).call
 
-    expect(result).to include third_party_project
-    expect(result).to include project
-
-    expect(result).not_to include newton_fund
-    expect(result).not_to include programme
-    expect(result).not_to include gcrf_fund
-    expect(result).not_to include another_programme
-    expect(result).not_to include another_project
-    expect(result).not_to include another_third_party_project
+    expect(result).to contain_exactly project, third_party_project
   end
 end

--- a/spec/services/activity/projects_for_report_finder_spec.rb
+++ b/spec/services/activity/projects_for_report_finder_spec.rb
@@ -1,22 +1,43 @@
 require "rails_helper"
 
 RSpec.describe Activity::ProjectsForReportFinder do
-  it "only returns projects and third party projects that are for the report's organisation and fund" do
-    organisation = create(:partner_organisation)
-    newton_fund = create(:fund_activity, :newton)
-    report = create(:report, organisation: organisation, fund: newton_fund)
+  context "for an ODA-only fund" do
+    it "only returns projects and third party projects that are for the report's organisation and fund" do
+      organisation = create(:partner_organisation)
+      newton_fund = create(:fund_activity, :newton)
+      report = create(:report, organisation: organisation, fund: newton_fund)
 
-    programme = create(:programme_activity, :newton_funded, parent: newton_fund)
-    project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
-    third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
+      programme = create(:programme_activity, :newton_funded, parent: newton_fund)
+      project = create(:project_activity, :newton_funded, organisation: organisation, parent: programme)
+      third_party_project = create(:third_party_project_activity, :newton_funded, organisation: organisation, parent: project)
 
-    gcrf_fund = create(:fund_activity, :gcrf)
-    another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
-    another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
-    _another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
+      gcrf_fund = create(:fund_activity, :gcrf)
+      another_programme = create(:programme_activity, :gcrf_funded, parent: gcrf_fund)
+      another_project = create(:project_activity, :gcrf_funded, organisation: organisation, parent: another_programme)
+      _another_third_party_project = create(:third_party_project_activity, :gcrf_funded, organisation: organisation, parent: another_project)
 
-    result = Activity::ProjectsForReportFinder.new(report: report).call
+      result = Activity::ProjectsForReportFinder.new(report: report).call
 
-    expect(result).to contain_exactly project, third_party_project
+      expect(result).to contain_exactly project, third_party_project
+    end
+  end
+
+  context "for a hybrid fund such as ISPF" do
+    it "only returns projects and third party projects that are for the report's organisation, fund, and ODA type" do
+      organisation = create(:partner_organisation)
+      oda_report = create(:report, :for_ispf, is_oda: true, organisation: organisation)
+
+      oda_programme = create(:programme_activity, :ispf_funded, is_oda: true)
+      oda_project = create(:project_activity, :ispf_funded, organisation: organisation, parent: oda_programme)
+      oda_third_party_project = create(:third_party_project_activity, :ispf_funded, organisation: organisation, parent: oda_project)
+
+      non_oda_programme = create(:programme_activity, :ispf_funded, is_oda: false)
+      non_oda_project = create(:project_activity, :ispf_funded, organisation: organisation, parent: non_oda_programme, is_oda: false)
+      _non_oda_third_party_project = create(:third_party_project_activity, :ispf_funded, organisation: organisation, parent: non_oda_project, is_oda: false)
+
+      result = Activity::ProjectsForReportFinder.new(report: oda_report).call
+
+      expect(result).to contain_exactly oda_project, oda_third_party_project
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR
- Update the query that retrieves the report to take into account the ODA type (`is_oda`) of the activity.
- Update projects for report finder to filter activities by ODA type.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
