### PR TITLE
2948 2946 add is oda to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
+- Add `is_oda` attribute to reports and populate it to `false` for all existing ISPF reports
 
 ## Release 138 - 2023-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove ispf_fund_in_stealth_mode that hides ISPF funds from users
 - Add `is_oda` attribute to reports and populate it to `false` for all existing ISPF reports
+- Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types
 
 ## Release 138 - 2023-10-27
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -91,7 +91,8 @@ class Report < ApplicationRecord
 
     unless Report.where(
       fund: fund,
-      organisation: organisation
+      organisation: organisation,
+      is_oda: is_oda
     ).all?(&:approved?)
       errors.add(:base, I18n.t("activerecord.errors.models.report.unapproved_reports_html"))
     end

--- a/db/migrate/20231107133740_add_is_oda_to_reports.rb
+++ b/db/migrate/20231107133740_add_is_oda_to_reports.rb
@@ -1,0 +1,12 @@
+class AddIsOdaToReports < ActiveRecord::Migration[6.1]
+  def up
+    add_column :reports, :is_oda, :boolean
+
+    ispf = Activity.by_roda_identifier("ISPF")
+    Report.where(fund_id: ispf.id).update_all(is_oda: false) if ispf
+  end
+
+  def down
+    remove_column :reports, :is_oda
+  end
+end

--- a/db/migrate/20231107141900_enforce_one_editable_report_per_series_by_oda_type.rb
+++ b/db/migrate/20231107141900_enforce_one_editable_report_per_series_by_oda_type.rb
@@ -1,0 +1,19 @@
+class EnforceOneEditableReportPerSeriesByOdaType < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :reports, name: "enforce_one_editable_report_per_series"
+
+    add_index :reports, [:fund_id, :organisation_id, :is_oda],
+      where: "state <> 'approved'",
+      unique: true,
+      name: "enforce_one_editable_report_per_series"
+  end
+
+  def down
+    remove_index :reports, name: "enforce_one_editable_report_per_series"
+
+    add_index :reports, [:fund_id, :organisation_id],
+      where: "state <> 'approved'",
+      unique: true,
+      name: "enforce_one_editable_report_per_series"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_07_102933) do
+ActiveRecord::Schema.define(version: 2023_11_07_133740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -310,6 +310,7 @@ ActiveRecord::Schema.define(version: 2023_03_07_102933) do
     t.integer "financial_year"
     t.string "export_filename"
     t.datetime "approved_at"
+    t.boolean "is_oda"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_07_133740) do
+ActiveRecord::Schema.define(version: 2023_11_07_141900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2023_11_07_133740) do
     t.string "export_filename"
     t.datetime "approved_at"
     t.boolean "is_oda"
-    t.index ["fund_id", "organisation_id"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
+    t.index ["fund_id", "organisation_id", "is_oda"], name: "enforce_one_editable_report_per_series", unique: true, where: "((state)::text <> 'approved'::text)"
     t.index ["fund_id", "organisation_id"], name: "enforce_one_historic_report_per_series", unique: true, where: "((financial_quarter IS NULL) OR (financial_year IS NULL))"
     t.index ["fund_id"], name: "index_reports_on_fund_id"
     t.index ["organisation_id"], name: "index_reports_on_organisation_id"

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -12,16 +12,33 @@ RSpec.describe Report, type: :model do
     end
 
     context "in the :new validation context" do
-      it "validates there are no unapproved reports for the organisation and fund" do
-        organisation = create(:partner_organisation)
-        existing_approved_report = create(:report, :approved, organisation: organisation)
-        existing_unapproved_report = create(:report, state: "awaiting_changes", organisation: organisation)
+      context "for an ODA-only fund" do
+        it "validates there are no unapproved reports for the organisation and fund" do
+          organisation = create(:partner_organisation)
+          existing_approved_report = create(:report, :approved, organisation: organisation)
+          existing_unapproved_report = create(:report, state: "awaiting_changes", organisation: organisation)
 
-        new_valid_report = build(:report, fund: existing_approved_report.fund, organisation: organisation)
-        new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
+          new_valid_report = build(:report, fund: existing_approved_report.fund, organisation: organisation)
+          new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
 
-        expect(new_invalid_report.valid?(:new)).to be(false)
-        expect(new_valid_report.valid?).to be(true)
+          expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_valid_report.valid?(:new)).to be(true)
+        end
+      end
+
+      context "for a hybrid ODA and non-ODA fund such as ISPF" do
+        it "validates there are no unapproved reports for the organisation, fund, and ODA type" do
+          organisation = create(:partner_organisation)
+          _existing_approved_oda_report = create(:report, :for_ispf, :approved, is_oda: true, organisation: organisation)
+          _existing_approved_non_oda_report = create(:report, :for_ispf, :approved, is_oda: false, organisation: organisation)
+          _existing_unapproved_oda_report = create(:report, :for_ispf, is_oda: true, state: "awaiting_changes", organisation: organisation)
+
+          new_valid_report = build(:report, :for_ispf, is_oda: false, organisation: organisation)
+          new_invalid_report = build(:report, :for_ispf, is_oda: true, organisation: organisation)
+
+          expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_valid_report.valid?(:new)).to be(true)
+        end
       end
 
       it "validates the presence of financial_quarter and financial_year" do


### PR DESCRIPTION
## Changes in this PR

Add is_oda attribute to reports and populate it to false for all existing ISPF reports
Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types

## Screenshots of UI changes

N/A 


- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
