### PR TITLE
Error message has ODA type of report when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `is_oda` attribute to reports and populate it to `false` for all existing ISPF reports
 - Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types
 - Amend the check for a pre-existing later report to take ODA type into account
+- Error message shown when attempting to create a report while an unapproved one for the same fund, org, and ODA type exists includes the ODA type where relevant
 
 ## Release 138 - 2023-10-27
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -94,7 +94,12 @@ class Report < ApplicationRecord
       organisation: organisation,
       is_oda: is_oda
     ).all?(&:approved?)
-      errors.add(:base, I18n.t("activerecord.errors.models.report.unapproved_reports_html"))
+      oda_type = if is_oda == true
+        " ODA"
+      elsif is_oda == false
+        " non-ODA"
+      end
+      errors.add(:base, I18n.t("activerecord.errors.models.report.unapproved_reports_html", oda_type: oda_type))
     end
   end
 

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -251,4 +251,4 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
             financial_quarter:
               inclusion: Enter a financial quarter between 1 and 4
-          unapproved_reports_html: "Cannot create new report: There is an unapproved report for the same partner organisation and fund. Previous reports must be approved before creating a new report."
+          unapproved_reports_html: "Cannot create new report: There is an unapproved%{oda_type} report for the same partner organisation and fund. Previous reports must be approved before creating a new report."

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Report, type: :model do
           new_invalid_report = build(:report, fund: existing_unapproved_report.fund, organisation: organisation)
 
           expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_invalid_report.errors.full_messages).to contain_exactly("Cannot create new report: There is an unapproved report for the same partner organisation and fund. Previous reports must be approved before creating a new report.")
           expect(new_valid_report.valid?(:new)).to be(true)
         end
       end
@@ -37,6 +38,7 @@ RSpec.describe Report, type: :model do
           new_invalid_report = build(:report, :for_ispf, is_oda: true, organisation: organisation)
 
           expect(new_invalid_report.valid?(:new)).to be(false)
+          expect(new_invalid_report.errors.full_messages).to contain_exactly("Cannot create new report: There is an unapproved ODA report for the same partner organisation and fund. Previous reports must be approved before creating a new report.")
           expect(new_valid_report.valid?(:new)).to be(true)
         end
       end


### PR DESCRIPTION
## Changes in this PR

For ISPF reports, the error message is now more specific about which type of report (ODA or non-ODA) already exists and is not approved.

No change for non-ISPF reports.

Note: there is no way to specify ODA/non-ODA through the UI at the moment. This functionality will be added in future PRs.

## Screenshots of UI changes

### Before
![Screenshot 2023-11-09 at 17 10 38](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/c9b37fe7-b431-4e18-89ee-23a76facedc1)

### After
![Screenshot 2023-11-09 at 17 14 28](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/d234fdcc-d2e0-475c-83d7-9488e320a9fa)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
