### PR TITLE
(2949) Expose the ODA/non-ODA type of reports in the report views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Amend report validation to permit two editable reports per fund and organisation, as long as they have different ODA types
 - Amend the check for a pre-existing later report to take ODA type into account
 - Error message shown when attempting to create a report while an unapproved one for the same fund, org, and ODA type exists includes the ODA type where relevant
+- Show ODA/non-ODA alongside the fund short name on the reports table for ISPF
 
 ## Release 138 - 2023-10-27
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -16,6 +16,12 @@ class ReportPresenter < SimpleDelegator
     I18n.l(super)
   end
 
+  def fund_and_oda_type
+    return fund.source_fund.short_name if is_oda.nil?
+
+    is_oda ? "#{fund.source_fund.short_name} (ODA)" : "#{fund.source_fund.short_name} (non-ODA)"
+  end
+
   def approved_at
     return if super.blank?
     I18n.l(super, format: :detailed)

--- a/app/services/report/grouped_reports_fetcher.rb
+++ b/app/services/report/grouped_reports_fetcher.rb
@@ -11,7 +11,7 @@ class Report
     private def fetch(relation)
       relation
         .includes([:organisation, :fund])
-        .order("organisations.name ASC, financial_year, financial_quarter DESC")
+        .order("organisations.name ASC, activities.created_at ASC, reports.is_oda DESC, financial_year DESC, financial_quarter DESC")
         .map { |report| ReportPresenter.new(report) }
         .group_by(&:organisation)
     end

--- a/app/services/report/organisation_reports_fetcher.rb
+++ b/app/services/report/organisation_reports_fetcher.rb
@@ -21,7 +21,7 @@ class Report
     private def fetch(relation)
       relation
         .includes([:organisation, :fund])
-        .order("financial_year, financial_quarter DESC")
+        .order("activities.created_at, reports.is_oda DESC, financial_year DESC, financial_quarter DESC")
         .map { |report| ReportPresenter.new(report) }
     end
 

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -19,4 +19,3 @@
       = render partial: "shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.current, type: "current" }
     .govuk-tabs__panel{ id: "approved" }
       = render partial: "shared/reports/grouped_table", locals: { grouped_reports: @grouped_reports.approved, type: "approved" }
-

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -10,7 +10,7 @@
     .govuk-grid-row
       .govuk-grid-column-full
         .govuk-body
-          = link_to "Create a new report", new_report_path, class: "govuk-link"
+          = link_to t("action.report.create.new"), new_report_path, class: "govuk-link"
 
   .govuk-tabs{ data: { module: "govuk-tabs" } }
     = render partial: "shared/reports/tabs"

--- a/app/views/shared/reports/_table_row.html.haml
+++ b/app/views/shared/reports/_table_row.html.haml
@@ -6,7 +6,7 @@
   - if type == "current"
     %td.govuk-table__cell= report.deadline
     %td.govuk-table__cell= report.state
-  %td.govuk-table__cell= report.fund.source_fund.short_name
+  %td.govuk-table__cell= report.fund_and_oda_type
   %td.govuk-table__cell= report.description
   - if type == "current" && current_user.partner_organisation?
     %td.govuk-table__cell= report.can_edit_message

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -203,6 +203,7 @@ en:
       review:
         failure: Report could not be moved to in review
       create:
+        new: Create a new report
         success: Report successfully created
       update:
         success: Report successfully updated

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe ReportPresenter do
     end
   end
 
+  describe "#fund_and_oda_type" do
+    context "for a non-ISPF fund" do
+      it "returns the short name of the fund" do
+        report = build(:report, :for_gcrf)
+        result = described_class.new(report).fund_and_oda_type
+        expect(result).to eql("GCRF")
+      end
+    end
+
+    context "for ISPF" do
+      it "returns the short name of the fund and the ODA type in brackets" do
+        report = build(:report, :for_ispf, is_oda: false)
+        result = described_class.new(report).fund_and_oda_type
+        expect(result).to eql("ISPF (non-ODA)")
+      end
+    end
+  end
+
   describe "#approved_at" do
     it "returns the formatted datetime for the Report's approval date" do
       now = Time.current

--- a/spec/services/report/grouped_reports_fetcher_spec.rb
+++ b/spec/services/report/grouped_reports_fetcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Report::GroupedReportsFetcher do
   let(:subject) { described_class.new }
 
   describe "#approved" do
-    it "returns approved reports grouped by organisation and sorted by organisation name" do
+    it "returns approved reports grouped by organisation and sorted by organisation name, fund, and financial quarter" do
       organisation1_approved_reports = build_list(:report, 3, organisation: organisation1)
       organisation2_approved_reports = build_list(:report, 2, organisation: organisation2)
 
@@ -15,7 +15,7 @@ RSpec.describe Report::GroupedReportsFetcher do
 
       expect(Report).to receive(:approved).and_return(approved_relation_double)
       expect(approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(approved_relation_double)
-      expect(approved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(approved_reports)
+      expect(approved_relation_double).to receive(:order).with("organisations.name ASC, activities.created_at ASC, reports.is_oda DESC, financial_year DESC, financial_quarter DESC").and_return(approved_reports)
 
       expect(subject.approved).to eq({
         organisation1 => organisation1_approved_reports,
@@ -34,7 +34,7 @@ RSpec.describe Report::GroupedReportsFetcher do
 
       expect(Report).to receive(:not_approved).and_return(unapproved_relation_double)
       expect(unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(unapproved_relation_double)
-      expect(unapproved_relation_double).to receive(:order).with("organisations.name ASC, financial_year, financial_quarter DESC").and_return(unapproved_reports)
+      expect(unapproved_relation_double).to receive(:order).with("organisations.name ASC, activities.created_at ASC, reports.is_oda DESC, financial_year DESC, financial_quarter DESC").and_return(unapproved_reports)
 
       expect(subject.current).to eq({
         organisation1 => organisation1_unapproved_reports,

--- a/spec/services/report/organisation_reports_fetcher_spec.rb
+++ b/spec/services/report/organisation_reports_fetcher_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(approved_relation_double).to receive(:approved).and_return(approved_relation_double)
 
       expect(approved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(approved_relation_double)
-      expect(approved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(approved_reports)
+      expect(approved_relation_double).to receive(:order).with("activities.created_at, reports.is_oda DESC, financial_year DESC, financial_quarter DESC").and_return(approved_reports)
 
       expect(subject).to eq(approved_reports)
     end
@@ -35,7 +35,7 @@ RSpec.describe Report::OrganisationReportsFetcher do
       expect(unapproved_relation_double).to receive(:not_approved).and_return(unapproved_relation_double)
 
       expect(unapproved_relation_double).to receive(:includes).with([:organisation, :fund]).and_return(unapproved_relation_double)
-      expect(unapproved_relation_double).to receive(:order).with("financial_year, financial_quarter DESC").and_return(unapproved_reports)
+      expect(unapproved_relation_double).to receive(:order).with("activities.created_at, reports.is_oda DESC, financial_year DESC, financial_quarter DESC").and_return(unapproved_reports)
 
       expect(subject).to eq(unapproved_reports)
     end


### PR DESCRIPTION
## Changes in this PR
- Show ODA/non-ODA alongside the fund short name on the reports table for ISPF
- Order the reports by fund, ODA type, and financial period

## Screenshots of UI changes

### Before

### After
#### All reports table
![Screenshot 2023-11-09 at 18 08 57](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/fddde67f-f01f-4d11-81c8-823ba9d260f2)

#### Organisation reports table
![Screenshot 2023-11-09 at 18 24 30](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/a14804ef-3f1c-4d2d-94dc-c25451402892)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
