### PR TITLE
Show environment banner and email prefix for the newly added dev domain

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -10,7 +10,7 @@ if defined?(Rails)
   when "www"
     environment_colour = ANSI_FG_RED
     environment_name = "production"
-  when "staging", "sandbox", "training", "pentest"
+  when "dev", "sandbox", "staging", "training"
     environment_colour = ANSI_FG_YELLOW
     environment_name = hostname
   else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Error message shown when attempting to create a report while an unapproved one for the same fund, org, and ODA type exists includes the ODA type where relevant
 - Show ODA/non-ODA alongside the fund short name on the reports table for ISPF
 - Fix the logic that generates actuals and variance rows for reports, to avoid inserting a spurious column for reports that have forecasts but no actuals
+- Show environment banner and email prefix on the `dev` domain
 
 ## Release 138 - 2023-10-27
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,17 +45,15 @@ module ApplicationHelper
     case hostname
     when "www"
       "production"
-    when "staging", "sandbox", "training"
+    when "dev", "sandbox", "staging", "training"
       hostname
-    when "pentest"
-      "training"
     else
       Rails.env
     end
   end
 
   def display_env_name?
-    environment_name.in? %w[training staging sandbox development]
+    environment_name.in? %w[dev development sandbox staging training]
   end
 
   def environment_mailer_prefix

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -76,23 +76,15 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       context "when the domain is 'https://training'" do
-        it "returns 'training" do
+        it "returns 'training'" do
           ClimateControl.modify DOMAIN: "https://training.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("training")
           end
         end
       end
 
-      context "when the domain is 'https://pentest'" do
-        it "returns 'training" do
-          ClimateControl.modify DOMAIN: "https://pentest.report-official-development-assistance.service.gov.uk" do
-            expect(helper.environment_name).to eql("training")
-          end
-        end
-      end
-
       context "when the domain is 'https://sandbox'" do
-        it "returns 'sandbox" do
+        it "returns 'sandbox'" do
           ClimateControl.modify DOMAIN: "sandbox.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("sandbox")
           end
@@ -100,9 +92,17 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       context "when the domain is 'https://staging'" do
-        it "returns 'staging" do
+        it "returns 'staging'" do
           ClimateControl.modify DOMAIN: "https://staging.report-official-development-assistance.service.gov.uk" do
             expect(helper.environment_name).to eql("staging")
+          end
+        end
+      end
+
+      context "when the domain is 'https://dev'" do
+        it "returns 'dev'" do
+          ClimateControl.modify DOMAIN: "https://dev.report-official-development-assistance.service.gov.uk" do
+            expect(helper.environment_name).to eql("dev")
           end
         end
       end
@@ -126,9 +126,9 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#display_env_name?" do
-    context "when the environment_name is one of training, staging, sandbox, or development" do
+    context "when the environment_name is one of dev, development, sandbox, staging, or training" do
       it "returns true" do
-        %w[training staging sandbox development].each do |env_name|
+        %w[dev development sandbox staging training].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
           expect(helper.display_env_name?).to be(true)
         end
@@ -146,9 +146,9 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#environment_mailer_prefix" do
-    context "when the environment_name is one of training, staging, sandbox, or development" do
+    context "when the environment_name is one of dev, development, sandbox, staging, or training" do
       it "returns the titleised environment name enclosed in square brackets and with a trailing space" do
-        %w[training staging sandbox development].each do |env_name|
+        %w[dev development sandbox staging training].each do |env_name|
           allow(helper).to receive(:environment_name).and_return(env_name)
           expect(helper.environment_mailer_prefix).to eql("[#{env_name.titleize}] ")
         end


### PR DESCRIPTION
## Changes in this PR
- Show environment banner and email prefix on the `dev` domain

## Screenshots of UI changes

### After
The banner will look similar to the development banner, but saying "dev" instead of "development".
![Screenshot 2023-11-09 at 18 50 24](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/79729a84-dce9-4bf6-bf18-7a36a0d6db2f)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
