### PR TITLE
Apply ODA eligibility criteria within report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Remove the `oda_eligibility` criterion from `reportable` scope, and apply it on a report by report basis, so we don't exclude ISPF non-ODA activities from ISPF non-ODA reports
+
 ## Release 139 - 2023-11-14
 
 [Full changelog][139]

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -268,7 +268,7 @@ class Activity < ApplicationRecord
                   }
 
   scope :reportable, -> {
-    where(oda_eligibility: "eligible").where.not(programme_status: UNREPORTABLE_PROGRAMME_STATUSES)
+    where.not(programme_status: UNREPORTABLE_PROGRAMME_STATUSES)
   }
 
   scope :historic, -> {

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -104,7 +104,9 @@ class Report < ApplicationRecord
   end
 
   def reportable_activities
-    Activity::ProjectsForReportFinder.new(report: self, scope: Activity.reportable).call.with_roda_identifier
+    activities_scope = Activity.reportable
+    activities_scope = activities_scope.eligible unless is_oda == false
+    Activity::ProjectsForReportFinder.new(report: self, scope: activities_scope).call.with_roda_identifier
   end
 
   def activities_updated

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -43,40 +43,92 @@ RSpec.feature "users can upload actuals" do
     expect(page.html).to include t("action.actual.upload.back_link")
   end
 
-  scenario "downloading a CSV template with activities for the current report" do
-    visit report_actuals_upload_path(report, format: :csv)
+  context "when the report is for ODA activities" do
+    let!(:sibling_project_no_longer_eligible) { create(:project_activity, :newton_funded, oda_eligibility: "no_longer_eligible", organisation: organisation, parent: project.parent) }
 
-    csv_data = page.body.delete_prefix("\uFEFF")
-    rows = CSV.parse(csv_data, headers: true).map(&:to_h)
+    scenario "the actuals template includes all the reportable activities for the current report" do
+      visit report_actuals_upload_path(report, format: :csv)
 
-    expect(rows).to match_array([
-      {
-        "Activity Name" => project.title,
-        "Activity Partner Organisation Identifier" => project.partner_organisation_identifier,
-        "Activity RODA Identifier" => project.roda_identifier,
-        "Financial Quarter" => report.financial_quarter.to_s,
-        "Financial Year" => report.financial_year.to_s,
-        "Actual Value" => "0.00",
-        "Refund Value" => nil,
-        "Receiving Organisation Name" => nil,
-        "Receiving Organisation Type" => nil,
-        "Receiving Organisation IATI Reference" => nil,
-        "Comment" => nil
-      },
-      {
-        "Activity Name" => sibling_project.title,
-        "Activity Partner Organisation Identifier" => sibling_project.partner_organisation_identifier,
-        "Activity RODA Identifier" => sibling_project.roda_identifier,
-        "Financial Quarter" => report.financial_quarter.to_s,
-        "Financial Year" => report.financial_year.to_s,
-        "Actual Value" => "0.00",
-        "Refund Value" => nil,
-        "Receiving Organisation Name" => nil,
-        "Receiving Organisation Type" => nil,
-        "Receiving Organisation IATI Reference" => nil,
-        "Comment" => nil
-      }
-    ])
+      csv_data = page.body.delete_prefix("\uFEFF")
+      rows = CSV.parse(csv_data, headers: true).map(&:to_h)
+
+      expect(rows).to match_array([
+        {
+          "Activity Name" => project.title,
+          "Activity Partner Organisation Identifier" => project.partner_organisation_identifier,
+          "Activity RODA Identifier" => project.roda_identifier,
+          "Financial Quarter" => report.financial_quarter.to_s,
+          "Financial Year" => report.financial_year.to_s,
+          "Actual Value" => "0.00",
+          "Refund Value" => nil,
+          "Receiving Organisation Name" => nil,
+          "Receiving Organisation Type" => nil,
+          "Receiving Organisation IATI Reference" => nil,
+          "Comment" => nil
+        },
+        {
+          "Activity Name" => sibling_project.title,
+          "Activity Partner Organisation Identifier" => sibling_project.partner_organisation_identifier,
+          "Activity RODA Identifier" => sibling_project.roda_identifier,
+          "Financial Quarter" => report.financial_quarter.to_s,
+          "Financial Year" => report.financial_year.to_s,
+          "Actual Value" => "0.00",
+          "Refund Value" => nil,
+          "Receiving Organisation Name" => nil,
+          "Receiving Organisation Type" => nil,
+          "Receiving Organisation IATI Reference" => nil,
+          "Comment" => nil
+        }
+      ])
+    end
+  end
+
+  context "when the report is for ISPF non-ODA activities" do
+    let!(:project) { create(:project_activity, :ispf_funded, is_oda: false, organisation: organisation) }
+    let!(:sibling_project) { create(:project_activity, :ispf_funded, is_oda: false, organisation: organisation, parent: project.parent) }
+    let! :report do
+      create(:report,
+        :active,
+        :for_ispf,
+        is_oda: false,
+        organisation: organisation)
+    end
+
+    scenario "the actuals template includes all the reportable activities for the current report" do
+      visit report_actuals_upload_path(report, format: :csv)
+
+      csv_data = page.body.delete_prefix("\uFEFF")
+      rows = CSV.parse(csv_data, headers: true).map(&:to_h)
+
+      expect(rows).to match_array([
+        {
+          "Activity Name" => project.title,
+          "Activity Partner Organisation Identifier" => project.partner_organisation_identifier,
+          "Activity RODA Identifier" => project.roda_identifier,
+          "Financial Quarter" => report.financial_quarter.to_s,
+          "Financial Year" => report.financial_year.to_s,
+          "Actual Value" => "0.00",
+          "Refund Value" => nil,
+          "Receiving Organisation Name" => nil,
+          "Receiving Organisation Type" => nil,
+          "Receiving Organisation IATI Reference" => nil,
+          "Comment" => nil
+        },
+        {
+          "Activity Name" => sibling_project.title,
+          "Activity Partner Organisation Identifier" => sibling_project.partner_organisation_identifier,
+          "Activity RODA Identifier" => sibling_project.roda_identifier,
+          "Financial Quarter" => report.financial_quarter.to_s,
+          "Financial Year" => report.financial_year.to_s,
+          "Actual Value" => "0.00",
+          "Refund Value" => nil,
+          "Receiving Organisation Name" => nil,
+          "Receiving Organisation Type" => nil,
+          "Receiving Organisation IATI Reference" => nil,
+          "Comment" => nil
+        }
+      ])
+    end
   end
 
   scenario "not uploading a file" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -146,24 +146,18 @@ RSpec.describe Activity, type: :model do
     end
 
     describe ".reportable" do
-      it "does not return any unreportable activities" do
-        completed_project = create(:project_activity, programme_status: "completed")
-        paused_project = create(:project_activity, programme_status: "paused")
-        ineligible_project = create(:project_activity, oda_eligibility: "never_eligible")
-
+      it "includes only activities that have a reportable status" do
         eligible_project = create(:project_activity, oda_eligibility: "eligible")
-        project_in_delivery = create(:project_activity, programme_status: "delivery")
-        project_spend_in_progress = create(:project_activity, programme_status: "spend_in_progress")
+        ineligible_project = create(:project_activity, oda_eligibility: "never_eligible", parent: eligible_project.parent)
+        project_in_delivery = create(:project_activity, programme_status: "delivery", parent: eligible_project.parent)
+        project_spend_in_progress = create(:project_activity, programme_status: "spend_in_progress", parent: eligible_project.parent)
+
+        _completed_project = create(:project_activity, programme_status: "completed", parent: eligible_project.parent)
+        _paused_project = create(:project_activity, programme_status: "paused", parent: eligible_project.parent)
 
         reportable_activities = Activity.reportable
 
-        expect(reportable_activities).to include(eligible_project)
-        expect(reportable_activities).to include(project_in_delivery)
-        expect(reportable_activities).to include(project_spend_in_progress)
-
-        expect(reportable_activities).to_not include(completed_project)
-        expect(reportable_activities).to_not include(paused_project)
-        expect(reportable_activities).to_not include(ineligible_project)
+        expect(reportable_activities).to contain_exactly(eligible_project.associated_fund, eligible_project.parent, eligible_project, ineligible_project, project_in_delivery, project_spend_in_progress)
       end
     end
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -258,6 +258,23 @@ RSpec.describe Report, type: :model do
     it "returns the active_relation" do
       expect(report.reportable_activities).to eq(active_relation)
     end
+
+    context "for an ISPF non-ODA report" do
+      it "invokes the finder with the reportable activities scope" do
+        report.update(is_oda: false)
+        report.reportable_activities
+
+        expect(Activity::ProjectsForReportFinder).to have_received(:new).with(report: report, scope: Activity.reportable)
+      end
+    end
+
+    context "for any type of report other than non-ODA" do
+      it "appends the eligible scope to the activities scope" do
+        report.reportable_activities
+
+        expect(Activity::ProjectsForReportFinder).to have_received(:new).with(report: report, scope: Activity.reportable.eligible)
+      end
+    end
   end
 
   describe "#forecasts_for_reportable_activities" do


### PR DESCRIPTION
## Changes in this PR
- Remove the `oda_eligibility` criterion from `reportable` scope

Applying the ODA eligibility criteria globally, by including it in the definition of `reportable` activities, is not correct in the global context: ISPF non-ODA activities are reportable, as long as they have the relevant `programme_status`.

Instead, we will apply the ODA eligibility criteria on a report basis, as the report defines what it means for activities to be reportable within its purview.

For example, only projects and third-party projects are currently relevant for reporting, and it is the report's responsiblity to invoke the service object that applies the activity level criteria.

(This is not to say that we couldn't rethink these responsibilities, but in the current state, it's not much of a stretch to move this criterion under the report.)

## Screenshots of UI changes

### Before
![Screenshot 2023-11-14 at 14 02 24](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/47874bc3-889e-4a51-a901-ffee7552d3e9)

### After
![Screenshot 2023-11-14 at 14 02 54](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/d75efca1-486a-41b4-886e-9be0e33f1f3c)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
