### PR TITLE
Add ODA vs non-ODA choice for ISPF funds when creating a report

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -7,3 +7,10 @@ table .totals td {
   padding-top: 1.5em;
   padding-bottom: 1.5em;
 }
+
+.buttons-inset {
+  padding-left: 4em;
+  padding-bottom: 2em;
+  border-left: 6px solid gray;
+  height: 100px;
+}

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -114,6 +114,7 @@ class ReportsController < BaseController
       :financial_quarter,
       :financial_year,
       :fund_id,
+      :is_oda,
       :organisation_id,
       :deadline,
       :description

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -24,10 +24,29 @@
                 :id,
                 :name,
                 label: { text: "Financial year", tag: :h2, size: "m" }
+          :javascript 
+            function odaToggle (fundTitle, div){
+              var titleString = "International Science Partnerships Fund"
+              var isIspf = fundTitle === titleString
+
+              if (isIspf){
+                document.querySelector('.oda-buttons').style.display = 'block';
+              }
+              if (!isIspf){
+                document.querySelector('.oda-buttons').style.display = 'none';
+              }
+            }
 
         = f.govuk_radio_buttons_fieldset :fund_id do
           - @funds.each do |fund|
-            = f.govuk_radio_button :fund_id, fund.id, label: { text: fund.title }
+            = f.govuk_radio_button :fund_id, fund.id, label: { text: fund.title }, :onclick => "odaToggle('#{fund.title}', '.oda-buttons')"
+            - if fund.title == "International Science Partnerships Fund"
+              .div.oda-buttons{ :style =>"display: none;" }
+                .buttons-inset
+                  %h1.govuk-heading-s
+                    = "Fund Type" 
+                  = f.govuk_radio_button :is_oda, true, label: { text: "ODA" }
+                  = f.govuk_radio_button :is_oda, false, label: { text: "non-ODA" }
 
         = f.govuk_collection_select :organisation_id,
           list_of_partner_organisations,


### PR DESCRIPTION
## This is a WIP PR for me to hand over in progress ticket work before taking annual leave

This code implements: https://trello.com/c/O0XfA5fc/2952-update-the-new-report-form-to-offer-enforce-a-choice-of-ispf-oda-and-ispf-non-oda-when-creating-an-ispf-report

### Complete:

- Selecting ISPF when creating a new report now reveals an additional two, nested, radio buttons for selecting 'ODA' or 'non-ODA'. This uses a small amount of custom JS in the new report haml file, and a very small amount of custom css in the reports stylesheet
- Selecting one of either button sets the relevant is_oda value on the report
- is_oda is now part of the parameters for report creation in reports.controller

### To Do:

- The selection of is_oda value as part of report parameters does not currently have any tests
- The change in front end appearance has not yet been reflected in the tests
- The grey 'connecting line' as specified by Beth in the designs is not sufficiently indented


