### PR TITLE
(2952) New ISPF reports are created as ODA or non-ODA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update how Node and Yarn are installed inside the application container
 - Allow ISPF reports to be created as ODA or non-ODA
 - Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
+- Validate that the value of `is_oda` is set for ISPF reports
 
 ## Release 139 - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Remove the `oda_eligibility` criterion from `reportable` scope, and apply it on a report by report basis, so we don't exclude ISPF non-ODA activities from ISPF non-ODA reports
 - Update how Node and Yarn are installed inside the application container
+- Allow ISPF reports to be created as ODA or non-ODA
+- Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
 
 ## Release 139 - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow ISPF reports to be created as ODA or non-ODA
 - Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
 - Validate that the value of `is_oda` is set for ISPF reports
+- Reorder the fields on the new report form per design
 
 ## Release 139 - 2023-11-14
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -114,6 +114,7 @@ class ReportsController < BaseController
       :financial_quarter,
       :financial_year,
       :fund_id,
+      :is_oda,
       :organisation_id,
       :deadline,
       :description

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -71,6 +71,11 @@ class Report < ApplicationRecord
     editable.for_activity(activity).first
   end
 
+  def is_oda=(value)
+    value = nil unless fund.present? && for_ispf?
+    super(value)
+  end
+
   def editable?
     state.in?(EDITABLE_STATES)
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,6 +23,7 @@ class Report < ApplicationRecord
   validate :no_prexisting_later_report?, on: :new
   validate :no_unapproved_reports_per_series, on: :new
   validates :deadline, date_not_in_past: true, date_within_boundaries: true, on: :edit
+  validates :is_oda, inclusion: [true, false], if: proc { |r| r.fund && r.for_ispf? }
 
   enum state: {
     active: "active",

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -9,21 +9,24 @@
       = form_with model: @report do |f|
         = f.govuk_error_summary
 
-        = f.govuk_fieldset legend: { text: nil } do
-          .govuk-grid-row
-            .govuk-grid-column-two-thirds
-              = f.govuk_collection_radio_buttons :financial_quarter,
-                list_of_financial_quarters,
-                :id,
-                :name,
-                inline: true,
-                legend: { text: "Financial quarter" , tag: :h2 }
-            .govuk-grid-column-one-third
-              = f.govuk_collection_select :financial_year,
-                list_of_financial_years(FinancialYear.previous_ten),
-                :id,
-                :name,
-                label: { text: "Financial year", tag: :h2, size: "m" }
+        = f.govuk_collection_radio_buttons :financial_quarter,
+          list_of_financial_quarters,
+          :id,
+          :name,
+          legend: { text: "Financial quarter", tag: :h2 }
+
+        = f.govuk_collection_select :financial_year,
+          list_of_financial_years(FinancialYear.previous_ten),
+          :id,
+          :name,
+          label: { text: "Financial year", tag: :h2, size: "m" }
+
+        = f.govuk_collection_select :organisation_id,
+          list_of_partner_organisations,
+          :id,
+          :name,
+          label: { size: "m" },
+          options: { include_blank: true }
 
         = f.govuk_radio_buttons_fieldset :fund_id do
           - @funds.each do |fund|
@@ -33,13 +36,7 @@
                   = f.govuk_radio_button :is_oda, true, label: { text: "ODA" }, link_errors: true
                   = f.govuk_radio_button :is_oda, false, label: { text: "non-ODA" }
 
-        = f.govuk_collection_select :organisation_id,
-          list_of_partner_organisations,
-          :id,
-          :name,
-          options: { include_blank: true }
-
-        = f.govuk_text_field :description
+        = f.govuk_text_field :description, label: { size: "s" }
         = f.govuk_date_field :deadline, legend: { size: "s" }
 
         = f.govuk_submit t("default.button.submit")

--- a/app/views/reports/new.html.haml
+++ b/app/views/reports/new.html.haml
@@ -27,7 +27,11 @@
 
         = f.govuk_radio_buttons_fieldset :fund_id do
           - @funds.each do |fund|
-            = f.govuk_radio_button :fund_id, fund.id, label: { text: fund.title }
+            = f.govuk_radio_button :fund_id, fund.id, label: { text: fund.title } do
+              - if fund.source_fund.ispf?
+                = f.govuk_radio_buttons_fieldset :is_oda, legend: { text: "Fund Type", size: "s" } do
+                  = f.govuk_radio_button :is_oda, true, label: { text: "ODA" }, link_errors: true
+                  = f.govuk_radio_button :is_oda, false, label: { text: "non-ODA" }
 
         = f.govuk_collection_select :organisation_id,
           list_of_partner_organisations,
@@ -36,6 +40,6 @@
           options: { include_blank: true }
 
         = f.govuk_text_field :description
-        = f.govuk_date_field :deadline, legend: {  size: "s" }
+        = f.govuk_date_field :deadline, legend: { size: "s" }
 
         = f.govuk_submit t("default.button.submit")

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -252,4 +252,6 @@ en:
               between: Date must be between %{min} years ago and %{max} years in the future
             financial_quarter:
               inclusion: Enter a financial quarter between 1 and 4
+            is_oda:
+              inclusion: ISPF reports must be one of ODA or non-ODA
           unapproved_reports_html: "Cannot create new report: There is an unapproved%{oda_type} report for the same partner organisation and fund. Previous reports must be approved before creating a new report."

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Activities::UploadsController do
       end
 
       context "when the fund is ISPF" do
-        before { report.update(fund: create(:fund_activity, :ispf)) }
+        before { report.update(fund: create(:fund_activity, :ispf), is_oda: false) }
 
         it "shows the ISPF non-ODA download link" do
           get :new, params: {report_id: report.id}
@@ -86,7 +86,7 @@ RSpec.describe Activities::UploadsController do
   describe "#show" do
     context "when requesting the ISPF ODA template" do
       it "downloads the CSV template with the correct filename" do
-        report.update(fund: create(:fund_activity, :ispf))
+        report.update(fund: create(:fund_activity, :ispf), is_oda: true)
 
         get :show, params: {report_id: report.id, type: :ispf_oda}
 
@@ -99,7 +99,7 @@ RSpec.describe Activities::UploadsController do
 
     context "when requesting the ISPF non-ODA template" do
       it "downloads the CSV template with the correct filename" do
-        report.update(fund: create(:fund_activity, :ispf))
+        report.update(fund: create(:fund_activity, :ispf), is_oda: false)
 
         get :show, params: {report_id: report.id, type: :ispf_non_oda}
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     trait :with_report do
       after(:create) do |activity|
         fund = activity.associated_fund
-        create(:report, :active, fund: fund, organisation: activity.organisation)
+        create(:report, :active, fund: fund, is_oda: activity.is_oda, organisation: activity.organisation)
       end
     end
 

--- a/spec/features/beis_users_can_create_a_report_spec.rb
+++ b/spec/features/beis_users_can_create_a_report_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "BEIS users can create a report" do
   let(:beis_user) { create(:beis_user) }
   let!(:newton_fund) { create(:fund_activity, :newton) }
   let!(:gcrf_fund) { create(:fund_activity, :gcrf) }
+  let!(:ispf_fund) { create(:fund_activity, :ispf) }
   let!(:partner_organisation) { create(:partner_organisation, name: "ACME Ltd") }
 
   before { travel_to DateTime.parse("2021-01-01") }
@@ -17,6 +18,20 @@ RSpec.feature "BEIS users can create a report" do
     given_i_am_a_logged_in_beis_user
     when_i_am_on_the_reports_page
     then_i_can_create_a_new_report
+    and_the_report_is_active
+  end
+
+  scenario "they can create a new ISPF ODA report" do
+    given_i_am_a_logged_in_beis_user
+    when_i_am_on_the_reports_page
+    then_i_can_create_a_new_ispf_oda_report
+    and_the_report_is_active
+  end
+
+  scenario "they can create a new ISPF non-ODA report" do
+    given_i_am_a_logged_in_beis_user
+    when_i_am_on_the_reports_page
+    then_i_can_create_a_new_ispf_non_oda_report
     and_the_report_is_active
   end
 
@@ -37,6 +52,32 @@ RSpec.feature "BEIS users can create a report" do
     select "ACME Ltd", from: "Partner organisation"
     click_on "Submit"
     expect(page).to have_content("success")
+  end
+
+  def then_i_can_create_a_new_ispf_oda_report
+    click_on "Create a new report"
+
+    choose "Q3"
+    select "2018-2019", from: "Financial year"
+    choose "International Science Partnerships Fund"
+    choose "ODA"
+    select "ACME Ltd", from: "Partner organisation"
+    click_on "Submit"
+    expect(page).to have_content("success")
+    expect(page).to have_content("ISPF (ODA)")
+  end
+
+  def then_i_can_create_a_new_ispf_non_oda_report
+    click_on "Create a new report"
+
+    choose "Q3"
+    select "2018-2019", from: "Financial year"
+    choose "International Science Partnerships Fund"
+    choose "non-ODA"
+    select "ACME Ltd", from: "Partner organisation"
+    click_on "Submit"
+    expect(page).to have_content("success")
+    expect(page).to have_content("ISPF (non-ODA)")
   end
 
   def and_the_report_is_active

--- a/spec/features/users_can_create_a_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_project_level_activity_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "a new project can be added to an ISPF ODA programme" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation)
-        report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
+        report = create(:report, :active, :for_ispf, is_oda: programme.is_oda, organisation: user.organisation)
         activity = build(:project_activity,
           :with_commitment,
           parent: programme,
@@ -157,7 +157,7 @@ RSpec.feature "Users can create a project" do
 
       scenario "a new project can be added to an ISPF non-ODA programme" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation, is_oda: false)
-        report = create(:report, :active, organisation: user.organisation, fund: programme.associated_fund)
+        report = create(:report, :active, :for_ispf, is_oda: programme.is_oda, organisation: user.organisation)
         activity = build(:project_activity,
           :with_commitment,
           parent: programme,
@@ -234,8 +234,7 @@ RSpec.feature "Users can create a project" do
           oda_programme = create(:programme_activity, :ispf_funded,
             is_oda: true,
             extending_organisation: user.organisation)
-          _report = create(:report, :active, organisation: user.organisation, fund: oda_programme.associated_fund)
-          oda_project = create(:project_activity, :ispf_funded,
+          oda_project = create(:project_activity, :ispf_funded, :with_report,
             parent: oda_programme,
             is_oda: true,
             ispf_themes: [1],
@@ -244,6 +243,7 @@ RSpec.feature "Users can create a project" do
             is_oda: false,
             linked_activity: oda_programme,
             extending_organisation: user.organisation)
+          _report = create(:report, :for_ispf, is_oda: false, organisation: user.organisation)
           non_oda_project = build(:project_activity, :ispf_funded, :with_commitment,
             parent: non_oda_programme,
             is_oda: false,

--- a/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
+++ b/spec/features/users_can_create_a_third_party_project_level_activity_spec.rb
@@ -84,13 +84,11 @@ RSpec.feature "Users can create a third-party project" do
       scenario "a new third party project can be added to an ISPF ODA project" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation)
 
-        project = create(:project_activity, :ispf_funded,
+        project = create(:project_activity, :ispf_funded, :with_report,
           organisation: user.organisation,
           extending_organisation: user.organisation,
           parent: programme,
           is_oda: true)
-
-        _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
 
         implementing_organisation = create(:implementing_organisation)
 
@@ -168,13 +166,11 @@ RSpec.feature "Users can create a third-party project" do
       scenario "a new third party project can be added to an ISPF non-ODA project" do
         programme = create(:programme_activity, :ispf_funded, extending_organisation: user.organisation, is_oda: false)
 
-        project = create(:project_activity, :ispf_funded,
+        project = create(:project_activity, :ispf_funded, :with_report,
           organisation: user.organisation,
           extending_organisation: user.organisation,
           parent: programme,
           is_oda: false)
-
-        _report = create(:report, :active, organisation: user.organisation, fund: project.associated_fund)
 
         implementing_organisation = create(:implementing_organisation)
 
@@ -255,8 +251,7 @@ RSpec.feature "Users can create a third-party project" do
           non_oda_programme = create(:programme_activity, :ispf_funded,
             is_oda: false,
             extending_organisation: user.organisation)
-          _report = create(:report, :active, organisation: user.organisation, fund: non_oda_programme.associated_fund)
-          non_oda_project = create(:project_activity, :ispf_funded,
+          non_oda_project = create(:project_activity, :ispf_funded, :with_report,
             is_oda: false,
             parent: non_oda_programme,
             organisation: user.organisation,

--- a/spec/features/users_can_manage_implementing_organisations_spec.rb
+++ b/spec/features/users_can_manage_implementing_organisations_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Users can manage the implementing organisations" do
 
     context "when the activity is ISPF" do
       let(:project) { create(:project_activity, :ispf_funded, organisation: partner_organisation) }
-      let!(:report) { create(:report, :active, organisation: partner_organisation, fund: project.associated_fund) }
+      let!(:report) { create(:report, :active, :for_ispf, is_oda: project.is_oda, organisation: partner_organisation) }
 
       scenario "they cannot remove the last implementing organisation" do
         def given_the_project_has_one_implementing_org

--- a/spec/features/users_can_upload_activities_spec.rb
+++ b/spec/features/users_can_upload_activities_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature "users can upload activities" do
   let(:user) { create(:partner_organisation_user, organisation: organisation) }
 
   let!(:programme) { create(:programme_activity, :newton_funded, extending_organisation: organisation, roda_identifier: "AFUND-B-PROG", parent: create(:fund_activity, roda_identifier: "AFUND")) }
-  let!(:report) { create(:report, fund: programme.associated_fund, organisation: organisation) }
+  let!(:report) { create(:report, fund: programme.associated_fund, is_oda: programme.is_oda, organisation: organisation) }
 
   let!(:oda_programme) {
     create(:programme_activity,
@@ -202,7 +202,7 @@ RSpec.feature "users can upload activities" do
   end
 
   context "uploading a valid template in the wrong form" do
-    let(:report) { create(:report, fund: non_oda_programme.associated_fund, organisation: organisation) }
+    let(:report) { create(:report, :for_ispf, is_oda: false, organisation: organisation) }
 
     scenario "uploading a template with ODA-specific fields via the non-ODA form" do
       old_count = Activity.count
@@ -305,7 +305,7 @@ RSpec.feature "users can upload activities" do
         parent: non_oda_programme)
     }
 
-    let(:report) { create(:report, fund: oda_programme.associated_fund, organisation: organisation) }
+    let(:report) { create(:report, :for_ispf, is_oda: true, organisation: organisation) }
 
     scenario "downloading the CSV template" do
       click_link t("action.activity.download.link", type: t("action.activity.type.ispf_oda"))
@@ -429,7 +429,7 @@ RSpec.feature "users can upload activities" do
         parent: oda_programme)
     }
 
-    let(:report) { create(:report, fund: non_oda_programme.associated_fund, organisation: organisation) }
+    let(:report) { create(:report, :for_ispf, is_oda: false, organisation: organisation) }
 
     scenario "downloading the CSV template" do
       click_link t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda"))

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe Report, type: :model do
     end
   end
 
+  describe "#is_oda=" do
+    it "does not persist a value for non-ISPF reports" do
+      report = build(:report, :for_gcrf)
+      report.is_oda = true
+      report.save
+
+      expect(report.reload.is_oda).to be_nil
+    end
+  end
+
   describe "associations" do
     it { should belong_to(:fund).class_name("Activity") }
     it { should belong_to(:organisation) }
@@ -261,7 +271,7 @@ RSpec.describe Report, type: :model do
 
     context "for an ISPF non-ODA report" do
       it "invokes the finder with the reportable activities scope" do
-        report.update(is_oda: false)
+        report.update(fund: create(:fund_activity, :ispf), is_oda: false)
         report.reportable_activities
 
         expect(Activity::ProjectsForReportFinder).to have_received(:new).with(report: report, scope: Activity.reportable)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe Report, type: :model do
       should validate_inclusion_of(:financial_quarter).in_array((1..4).to_a)
     end
 
+    context "for ISPF" do
+      before { subject.fund = build(:fund_activity, :ispf) }
+
+      it "should validate that is_oda is not nil" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.full_messages.join).to match("ISPF reports must be one of ODA or non-ODA")
+      end
+    end
+
     context "in the :new validation context" do
       context "for an ODA-only fund" do
         it "validates there are no unapproved reports for the organisation and fund" do

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ActivityPolicy do
-  let!(:report) { create(:report, :approved, organisation: user.organisation, fund: activity.associated_fund) }
+  let!(:report) { create(:report, :approved, is_oda: activity.is_oda, organisation: user.organisation, fund: activity.associated_fund) }
   let(:user) { build_stubbed(:beis_user) }
 
   subject { described_class.new(user, activity) }

--- a/spec/requests/activity_forms_spec.rb
+++ b/spec/requests/activity_forms_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Activity forms", type: :request do
   after { logout }
 
   let(:activity) { create(:project_activity, organisation: user.organisation, extending_organisation: user.organisation) }
-  let!(:fund) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
+  let!(:report) { create(:report, :active, organisation: user.organisation, fund: activity.associated_fund) }
 
   context "aid types" do
     let(:step) { :aid_type }

--- a/spec/services/activity/import_spec.rb
+++ b/spec/services/activity/import_spec.rb
@@ -1232,6 +1232,7 @@ RSpec.describe Activity::Import do
       subject { described_class.new(uploader: uploader, partner_organisation: organisation, report: nil, is_oda: true) }
 
       let(:fund_activity) { create(:fund_activity, :ispf) }
+      let!(:report) { create(:report, :for_ispf, is_oda: true) }
 
       let(:existing_oda_programme) {
         create(
@@ -1316,8 +1317,8 @@ RSpec.describe Activity::Import do
     context "when it's a non-ODA programme" do
       subject { described_class.new(uploader: uploader, partner_organisation: organisation, report: nil, is_oda: false) }
 
-      let(:fund_activity) { create(:fund_activity, :ispf) }
       let(:ispf) { create(:fund_activity, :ispf) }
+      let!(:report) { create(:report, :for_ispf, is_oda: false) }
       let(:new_non_oda_programme_attributes) {
         {
           "RODA ID" => new_activity_attributes["RODA ID"],

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe Export::Report do
       :report,
       financial_quarter: financial_quarter.to_i,
       financial_year: financial_year.to_i,
-      fund: @ispf_activity.associated_fund
+      fund: @ispf_activity.associated_fund,
+      is_oda: @ispf_activity.is_oda
     )
   end
 

--- a/spec/views/shared/activities/activity_spec.rb
+++ b/spec/views/shared/activities/activity_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe "shared/activities/_activity" do
           activity.parent.linked_activity = non_oda_activity.parent
           activity.parent.save
 
-          create(:report, :active, fund: activity.associated_fund, organisation: user.organisation)
+          create(:report, :active, fund: activity.associated_fund, is_oda: activity.is_oda, organisation: user.organisation)
         end
 
         context "when the activity is ODA" do


### PR DESCRIPTION
## Changes in this PR
- Allow ISPF reports to be created as ODA or non-ODA
- Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
- Validate that the value of `is_oda` is set for ISPF reports
- Reorder the fields on the new report form per design

## Screenshots of UI changes

### Before
![Screenshot 2023-11-16 at 17 46 19](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/558a7a13-da66-456e-8fa0-968ff95c1337)

### After
![Screenshot 2023-11-16 at 17 45 46](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/df3c79f5-0c46-4a68-934b-9d9992261008)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
