### PR TITLE
(2941) Update Node and Yarn installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Remove the `oda_eligibility` criterion from `reportable` scope, and apply it on a report by report basis, so we don't exclude ISPF non-ODA activities from ISPF non-ODA reports
+- Update how Node and Yarn are installed inside the application container
 
 ## Release 139 - 2023-11-14
 
@@ -331,7 +332,7 @@
 
 - Fix spending breakdown report by running asynchronously and emailing a download link
   to the requester.
-- Fix missing Q4 21/22 option in external income by including "previous" year  as well as
+- Fix missing Q4 21/22 option in external income by including "previous" year as well as
   the next ten.
 
 ## Release 107 - 2022-04-06
@@ -370,7 +371,7 @@
 
 - Add bulk uploading to Refunds via the Actual importer
 - Rename `activity.comments` association to better reflect its purpose of collecting all comments on an
-activity and on its child transactions (which can be actuals, refunds, and adjustments)
+  activity and on its child transactions (which can be actuals, refunds, and adjustments)
 - Remove Auth0 user identifier from user management
 - Add sector and sector category codes to radio button text when adding a new activity
 - Fix an error where a new refund creation would silently fail when the value was non-numeric

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,41 @@
 FROM ruby:3.0.5 AS base
 MAINTAINER dxw <rails@dxw.com>
 
-RUN apt-get update && apt-get install -qq -y \
-  build-essential \
-  libpq-dev \
-  --fix-missing --no-install-recommends
+ARG RAILS_ENV
+ARG NODE_MAJOR
 
 ENV APP_HOME /app
 ENV DEPS_HOME /deps
 
-ARG RAILS_ENV
+ENV NODE_MAJOR ${NODE_MAJOR:-16}
 ENV RAILS_ENV ${RAILS_ENV:-production}
 ENV NODE_ENV ${RAILS_ENV:-production}
+
+# Setup Node installation
+# https://github.com/nodesource/distributions#installation-instructions
+#
+# depdends on ca-certificates, curl and gnupg
+#
+
+RUN mkdir -p /etc/apt/keyrings/ && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+| tee /etc/apt/sources.list.d/nodesource.list
+
+# Setup Yarn installation
+# https://classic.yarnpkg.com/lang/en/docs/install/#debian-stable
+#
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Install system packages
+#
+RUN apt-get update && apt-get install -qq -y \
+  build-essential \
+  libpq-dev \
+  nodejs \
+  yarn \
+  --fix-missing --no-install-recommends
 
 RUN echo "\nexport PATH=/usr/local/bin:\$PATH\n\n# Stop here if non-interactive shell\n[[ \$- == *i* ]] || return\n\ncd /app" >> ~/.bashrc
 
@@ -28,9 +52,6 @@ RUN mkdir -p ${DEPS_HOME}
 WORKDIR ${DEPS_HOME}
 # End
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-  && apt-get install -y nodejs \
-  && npm install --global yarn
 
 # Install Ruby dependencies
 COPY .ruby-version ${DEPS_HOME}/.ruby-version


### PR DESCRIPTION
## Changes in this PR

The nodesource.com setup scripts are deprecated.

Here we update the Dockerfile to use the new recommended installation.

We've moved both Node and Yarn installation into APT as we consider
them 'system' layer tools which install the packages on which the
application depends.

We've exposed the `NODE_MAJOR` version as a build argument which
defaults to 16, the current version in use by the application.

https://trello.com/c/RaVyNflr

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
