### PR TITLE
(2974) Show ODA state on ISPF reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Validate that the value of `is_oda` is set for ISPF reports
 - Reorder the fields on the new report form per design
 - Show if a report for ISPF is ODA or non-ODA on the report show view
+- Show if a report for ISPF is ODA or non-ODA on the report edit form
 
 ## Release 139 - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
 - Validate that the value of `is_oda` is set for ISPF reports
 - Reorder the fields on the new report form per design
+- Show if a report for ISPF is ODA or non-ODA on the report show view
 
 ## Release 139 - 2023-11-14
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -16,6 +16,12 @@ class ReportPresenter < SimpleDelegator
     I18n.l(super)
   end
 
+  def oda_type_summary
+    return if is_oda.nil?
+
+    I18n.t("is_oda_summary.#{is_oda}")
+  end
+
   def fund_and_oda_type
     return fund.source_fund.short_name if is_oda.nil?
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -28,7 +28,7 @@ class ReportPresenter < SimpleDelegator
     is_oda ? "#{fund.source_fund.name} (ODA)" : "#{fund.source_fund.name} (non-ODA)"
   end
 
-  def fund_and_oda_type
+  def short_fund_name_and_oda_type
     return fund.source_fund.short_name if is_oda.nil?
 
     is_oda ? "#{fund.source_fund.short_name} (ODA)" : "#{fund.source_fund.short_name} (non-ODA)"

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -22,6 +22,12 @@ class ReportPresenter < SimpleDelegator
     I18n.t("is_oda_summary.#{is_oda}")
   end
 
+  def fund_name_and_oda_type
+    return fund.source_fund.name if is_oda.nil?
+
+    is_oda ? "#{fund.source_fund.name} (ODA)" : "#{fund.source_fund.name} (non-ODA)"
+  end
+
   def fund_and_oda_type
     return fund.source_fund.short_name if is_oda.nil?
 

--- a/app/views/reports/_form.html.haml
+++ b/app/views/reports/_form.html.haml
@@ -9,7 +9,7 @@
 
 .govuk-form-group
   = label_tag "level-a-activity", t("form.label.report.level_a_activity"), class: "govuk-label"
-  = content_tag :p, report_presenter.fund.title, class: "govuk-body", id: "level-a-activity"
+  = content_tag :p, report_presenter.fund_name_and_oda_type, class: "govuk-body", id: "level-a-activity"
 
 = f.govuk_text_field :description
 = f.govuk_date_field :deadline, legend: {  size: "s" }

--- a/app/views/reports/_summary.html.haml
+++ b/app/views/reports/_summary.html.haml
@@ -13,6 +13,13 @@
       %dd.govuk-summary-list__value
         = @report_presenter.description
 
+  - unless @report_presenter.is_oda.nil?
+    .govuk-summary-list__row#is-oda
+      %dt.govuk-summary-list__key
+        = t("form.label.report.is_oda")
+      %dd.govuk-summary-list__value
+        = @report_presenter.oda_type_summary
+
   .govuk-summary-list__row
     %dt.govuk-summary-list__key
       = t("form.label.report.deadline")

--- a/app/views/shared/reports/_table_row.html.haml
+++ b/app/views/shared/reports/_table_row.html.haml
@@ -6,7 +6,7 @@
   - if type == "current"
     %td.govuk-table__cell= report.deadline
     %td.govuk-table__cell= report.state
-  %td.govuk-table__cell= report.fund_and_oda_type
+  %td.govuk-table__cell= report.short_fund_name_and_oda_type
   %td.govuk-table__cell= report.description
   - if type == "current" && current_user.partner_organisation?
     %td.govuk-table__cell= report.can_edit_message

--- a/config/locales/default.en.yml
+++ b/config/locales/default.en.yml
@@ -15,6 +15,9 @@ en:
     formats:
       default: "%Y-%m-%d"
       detailed: "%Y-%m-%d %H:%M"
+  is_oda_summary:
+    "true": ODA
+    "false": Non-ODA
   default:
     button:
       download_as_xml: Download as XML

--- a/config/locales/models/report.en.yml
+++ b/config/locales/models/report.en.yml
@@ -123,6 +123,7 @@ en:
         level_a_activity: Fund (level A)
         financial_quarter_and_year: Financial quarter
         uploaded_at: Uploaded at
+        is_oda: ODA or Non-ODA
     legend:
       report:
         description: Reporting period

--- a/spec/features/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/beis_users_can_edit_a_report_spec.rb
@@ -128,8 +128,17 @@ RSpec.feature "BEIS users can edit a report" do
       visit edit_report_path(report)
 
       expect(page).to have_content report_presenter.organisation.name
-      expect(page).to have_content report_presenter.fund.title
+      expect(page).to have_content report_presenter.fund.source_fund.name
       expect(page).to have_content report_presenter.financial_quarter_and_year
+    end
+
+    scenario "when the report is for the ISPF fund, they also see the ODA Type" do
+      authenticate!(user: beis_user)
+      report = create(:report, :for_ispf, is_oda: true)
+
+      visit edit_report_path(report)
+
+      expect(page).to have_content "International Science Partnerships Fund (ODA)"
     end
   end
 

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe ReportPresenter do
     end
   end
 
+  describe "#oda_type_summary" do
+    it "returns nil when the value is nil" do
+      report = build(:report, :for_gcrf, is_oda: nil)
+      result = described_class.new(report).oda_type_summary
+      expect(result).to eql nil
+    end
+
+    it "returns ODA when the value is true" do
+      report = build(:report, :for_ispf, is_oda: true)
+      result = described_class.new(report).oda_type_summary
+      expect(result).to eql "ODA"
+    end
+
+    it "returns Non-ODA when the value is false" do
+      report = build(:report, :for_ispf, is_oda: false)
+      result = described_class.new(report).oda_type_summary
+      expect(result).to eql "Non-ODA"
+    end
+  end
+
   describe "#fund_and_oda_type" do
     context "for a non-ISPF fund" do
       it "returns the short name of the fund" do

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe ReportPresenter do
     end
   end
 
-  describe "#fund_and_oda_type" do
+  describe "#short_fund_name_and_oda_type" do
     context "for a non-ISPF fund" do
       it "returns the short name of the fund" do
         report = build(:report, :for_gcrf)
-        result = described_class.new(report).fund_and_oda_type
+        result = described_class.new(report).short_fund_name_and_oda_type
         expect(result).to eql("GCRF")
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe ReportPresenter do
     context "for ISPF" do
       it "returns the short name of the fund and the ODA type in brackets" do
         report = build(:report, :for_ispf, is_oda: false)
-        result = described_class.new(report).fund_and_oda_type
+        result = described_class.new(report).short_fund_name_and_oda_type
         expect(result).to eql("ISPF (non-ODA)")
       end
     end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe ReportPresenter do
     end
   end
 
+  describe "#fund_name_and_oda_type" do
+    it "returns the full fund name only when is_oda is nil" do
+      report = build(:report, :for_gcrf, is_oda: nil)
+      result = described_class.new(report).fund_name_and_oda_type
+      expect(result).to eql "Global Challenges Research Fund"
+    end
+
+    it "returns the full fund name with '(ODA)' appended when is_oda is true" do
+      report = build(:report, :for_ispf, is_oda: true)
+      result = described_class.new(report).fund_name_and_oda_type
+      expect(result).to eql "International Science Partnerships Fund (ODA)"
+    end
+
+    it "returns the full fund name with '(non-ODA)' appended when is_oda is false" do
+      report = build(:report, :for_ispf, is_oda: false)
+      result = described_class.new(report).fund_name_and_oda_type
+      expect(result).to eql "International Science Partnerships Fund (non-ODA)"
+    end
+  end
+
   describe "#fund_and_oda_type" do
     context "for a non-ISPF fund" do
       it "returns the short name of the fund" do


### PR DESCRIPTION
## Changes in this PR

The introduction of the International Science Partnership Fund led to a state where reports contain either ODA activities or non-ODA activities - an important distinction for users.

This works displays the 'ODA state' on the report show view and report edit form.

The decisions was made for two versions of this:

- on the show page, for the ISPF fund reports, the ODA state is shown, for all other funds the row is not shown in the summary
- on the edit page, for the ISPF fund reports, the ODA state is appended to the fund name, for all other funds nothing is shown

(See screenshots below)

As we already have a way to present the fund short name with the ODA state appended, we followed this pattern and then renamed the original method to be clear about the behaviour of each.

We are currently in the position where the application will assume that for all funds except ISPF, `is_oda` MUST be nil, for this reason we guard against a nil value and take the appropriate action to try to prevent the nil value being interpreted as falsey when that would be the exact opposite of the desired state.

https://trello.com/c/q3CLtXRQ

## Screenshots of UI changes

![image](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/480578/d586567b-decb-44d6-999c-94370879b00a)

![image](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/480578/882f517f-96e9-4595-8138-cecd7f1246b0)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
