### PR TITLE
(2986) Fix the coverage calculation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,19 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 ])
 
 SimpleCov.minimum_coverage 98
+SimpleCov.start "rails" do
+  # If we explicitly choose to not include code in the coverage calculation we
+  # should leave a comment why
+  #
+  # TODO: not sure we can test initializers for Rails so ignore for now
+  add_filter "config/initializers"
+  # TODO: these files are at 0% and so we should deal with them
+  add_filter "lib/generators/data_migration_generator.rb"
+  add_filter "app/controllers/programmes_controller.rb"
+  # TODO: tasks have very low coverage, we should decide what our stance on this is and leave them here
+  # or add coverage
+  add_filter "/lib/tasks"
+end
 
 require "webmock/rspec"
 require "pundit/matchers"


### PR DESCRIPTION
## Changes in this PR

We use Simplecov as part of Coveralls to generate a code coverage
percentage and a bar which we hold ourselves to (98%).

https://coveralls.io/
https://github.com/simplecov-ruby/simplecov

Unfortunately, Simplecov looks to mis-configured so our coverage report
may not have been as accurate as we would have liked!

By configuring Simplecov explicitally for Rails, we get a more accurate
report (the spec files themselves for example are no longer included
which were heavily skewing our result).

In order to continue to reach our goal of 98% coverage we have more
work to do or some decisions to make:

For now we are ignoring low coverage in some specific files and all the
tasks, these are common items to skip, but we should make a decision
about where to take these.

We've heavily commented the filters to account for this.

With this work in place we can be more confident about out coverage and
so our test suite.

https://trello.com/c/CWbKd99V