### PR TITLE
(2982) ISPF reports templates are split between ODA and non-ODA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Reorder the fields on the new report form per design
 - Show if a report for ISPF is ODA or non-ODA on the report show view
 - Show if a report for ISPF is ODA or non-ODA on the report edit form
+- Upload templates for ISPF reports use the ODA type of the report
 
 ## Release 139 - 2023-11-14
 

--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -11,7 +11,6 @@ class Activities::UploadsController < BaseController
     authorize report, :show?
 
     @report_presenter = ReportPresenter.new(report)
-    @is_ispf = report.for_ispf?
 
     prepare_default_report_trail(report)
     add_breadcrumb t("breadcrumb.report.upload_activities"), new_report_activities_upload_path(report)

--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -30,8 +30,7 @@ class Activities::UploadsController < BaseController
     authorize report, :upload?
 
     @report_presenter = ReportPresenter.new(report)
-    @type = params[:type].to_sym
-    upload = CsvFileUpload.new(params[:report], :"activity_csv_#{@type}")
+    upload = CsvFileUpload.new(params[:report], :"activity_csv_#{@report_presenter.oda_type}")
     @success = false
 
     prepare_default_report_trail(report)

--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -20,9 +20,8 @@ class Activities::UploadsController < BaseController
     authorize report, :show?
 
     @report_presenter = ReportPresenter.new(report)
-    type = params[:type].to_sym
-    headers = Activity::Import::Field.where_level_and_type(level: :level_c_d, type: type).map(&:heading)
     filename = @report_presenter.filename_for_activities_template
+    headers = Activity::Import::Field.where_level_and_type(level: :level_c_d, type: @report_presenter.oda_type).map(&:heading)
 
     stream_csv_download(filename: filename, headers: headers)
   end

--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -21,9 +21,8 @@ class Activities::UploadsController < BaseController
 
     @report_presenter = ReportPresenter.new(report)
     type = params[:type].to_sym
-    is_oda = Activity::Import.is_oda_by_type(type: type)
-    filename = @report_presenter.filename_for_activities_template(is_oda: is_oda)
     headers = Activity::Import::Field.where_level_and_type(level: :level_c_d, type: type).map(&:heading)
+    filename = @report_presenter.filename_for_activities_template
 
     stream_csv_download(filename: filename, headers: headers)
   end

--- a/app/controllers/activities/uploads_controller.rb
+++ b/app/controllers/activities/uploads_controller.rb
@@ -33,7 +33,6 @@ class Activities::UploadsController < BaseController
     @type = params[:type].to_sym
     upload = CsvFileUpload.new(params[:report], :"activity_csv_#{@type}")
     @success = false
-    is_oda = Activity::Import.is_oda_by_type(type: @type)
 
     prepare_default_report_trail(report)
     add_breadcrumb t("breadcrumb.report.upload_activities"), new_report_activities_upload_path(report)
@@ -43,7 +42,7 @@ class Activities::UploadsController < BaseController
         uploader: current_user,
         partner_organisation: current_user.organisation,
         report: report,
-        is_oda: is_oda
+        is_oda: report.is_oda
       )
       importer.import(upload.rows)
       @errors = importer.errors

--- a/app/models/csv_file_upload.rb
+++ b/app/models/csv_file_upload.rb
@@ -5,8 +5,8 @@ class CsvFileUpload
 
   attr_reader :file, :error
 
-  def initialize(params, atttibute_name)
-    @file = params&.fetch(atttibute_name, nil)
+  def initialize(params, attribute_name)
+    @file = params&.fetch(attribute_name, nil)
   end
 
   def rows

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -138,6 +138,17 @@ class Report < ApplicationRecord
     forecasts_for_reportable_activities.sum(&:value)
   end
 
+  def oda_type
+    case is_oda
+    when nil
+      :non_ispf
+    when true
+      :ispf_oda
+    when false
+      :ispf_non_oda
+    end
+  end
+
   def financial_quarter_is_not_in_the_future?
     return false unless financial_quarter && financial_year
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -52,15 +52,15 @@ class ReportPresenter < SimpleDelegator
   end
 
   def filename_for_activities_template
-    filename(purpose: "activities_upload", is_oda: is_oda)
+    filename(purpose: "activities_upload")
   end
 
   def filename_for_actuals_template
-    filename(purpose: "actuals_upload", is_oda: is_oda)
+    filename(purpose: "actuals_upload")
   end
 
   def filename_for_forecasts_template
-    filename(purpose: "forecasts_upload", is_oda: is_oda)
+    filename(purpose: "forecasts_upload")
   end
 
   def filename_for_all_reports_download
@@ -79,7 +79,7 @@ class ReportPresenter < SimpleDelegator
     TotalPresenter.new(super).value
   end
 
-  private def filename(purpose:, is_oda: nil)
+  private def filename(purpose:)
     oda = case is_oda
     when true
       "ODA"

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -60,7 +60,7 @@ class ReportPresenter < SimpleDelegator
   end
 
   def filename_for_forecasts_template
-    filename(purpose: "forecasts_upload")
+    filename(purpose: "forecasts_upload", is_oda: is_oda)
   end
 
   def filename_for_all_reports_download

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -51,7 +51,7 @@ class ReportPresenter < SimpleDelegator
     "#{financial_quarter_and_year} #{fund.roda_identifier} #{organisation.beis_organisation_reference}"
   end
 
-  def filename_for_activities_template(is_oda:)
+  def filename_for_activities_template
     filename(purpose: "activities_upload", is_oda: is_oda)
   end
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -56,7 +56,7 @@ class ReportPresenter < SimpleDelegator
   end
 
   def filename_for_actuals_template
-    filename(purpose: "actuals_upload")
+    filename(purpose: "actuals_upload", is_oda: is_oda)
   end
 
   def filename_for_forecasts_template

--- a/app/views/activities/uploads/_fund_section.html.haml
+++ b/app/views/activities/uploads/_fund_section.html.haml
@@ -3,7 +3,7 @@
 
 %p.govuk-body
   = link_to t("action.activity.download.link", type: t("action.activity.type")[type]),
-    report_activities_upload_path(@report_presenter, type: type, format: :csv),
+    report_activities_upload_path(@report_presenter, format: :csv),
     class: "govuk-link"
 
 - if policy(@report_presenter).upload?

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -10,10 +10,11 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      - if @is_ispf
-        - if ROLLOUT.active?(:oda_bulk_upload)
+      - if @report_presenter.for_ispf?
+        - if @report_presenter.is_oda && ROLLOUT.active?(:oda_bulk_upload)
           = render partial: "fund_section", locals: { type: :ispf_oda }
-        = render partial: "fund_section", locals: { type: :ispf_non_oda }
+        - elsif @report_presenter.is_oda == false
+          = render partial: "fund_section", locals: { type: :ispf_non_oda }
       - else
         = render partial: "fund_section", locals: { type: :non_ispf }
 

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -10,12 +10,7 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      - if @report_presenter.for_ispf?
-        - if @report_presenter.is_oda && ROLLOUT.active?(:oda_bulk_upload)
-          = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
-        - elsif @report_presenter.is_oda == false
-          = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
-      - else
+      - unless @report_presenter.is_oda && !ROLLOUT.active?(:oda_bulk_upload)
         = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
 
   .govuk-grid-row

--- a/app/views/activities/uploads/new.html.haml
+++ b/app/views/activities/uploads/new.html.haml
@@ -12,11 +12,11 @@
     .govuk-grid-column-two-thirds
       - if @report_presenter.for_ispf?
         - if @report_presenter.is_oda && ROLLOUT.active?(:oda_bulk_upload)
-          = render partial: "fund_section", locals: { type: :ispf_oda }
+          = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
         - elsif @report_presenter.is_oda == false
-          = render partial: "fund_section", locals: { type: :ispf_non_oda }
+          = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
       - else
-        = render partial: "fund_section", locals: { type: :non_ispf }
+        = render partial: "fund_section", locals: { type: @report_presenter.oda_type }
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/activities/uploads/update.html.haml
+++ b/app/views/activities/uploads/update.html.haml
@@ -21,7 +21,7 @@
   - else
     .govuk-grid-row
       .govuk-grid-column-two-thirds
-        = render partial: "shared/activities/uploads/upload_form", locals: { instance: @report_presenter, path_helper: "report_activities_upload_path", type: @type, recovered_from_error: true }
+        = render partial: "shared/activities/uploads/upload_form", locals: { instance: @report_presenter, path_helper: "report_activities_upload_path", type: @report_presenter.oda_type, recovered_from_error: true }
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -28,25 +28,31 @@ RSpec.describe Activities::UploadsController do
       end
 
       context "when the fund is ISPF" do
-        before { report.update(fund: create(:fund_activity, :ispf), is_oda: false) }
+        context "and the report is non-ODA" do
+          before { report.update(fund: create(:fund_activity, :ispf), is_oda: false) }
 
-        it "shows the ISPF non-ODA download link" do
-          get :new, params: {report_id: report.id}
-
-          expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
-          expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
-          expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
-        end
-
-        context "when the `oda_bulk_upload` feature flag is enabled" do
-          before { allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true) }
-
-          it "shows the ISPF ODA and non-ODA download links" do
+          it "shows the ISPF non-ODA download link" do
             get :new, params: {report_id: report.id}
 
-            expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
             expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
+            expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
             expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+          end
+        end
+
+        context "and the report is ODA" do
+          before { report.update(fund: create(:fund_activity, :ispf), is_oda: true) }
+
+          context "when the `oda_bulk_upload` feature flag is enabled" do
+            before { allow(ROLLOUT).to receive(:active?).with(:oda_bulk_upload).and_return(true) }
+
+            it "shows the ISPF ODA download link" do
+              get :new, params: {report_id: report.id}
+
+              expect(response.body).to include(t("action.activity.download.link", type: t("action.activity.type.ispf_oda")))
+              expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.ispf_non_oda")))
+              expect(response.body).not_to include(t("action.activity.download.link", type: t("action.activity.type.non_ispf")))
+            end
           end
         end
       end

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Activities::UploadsController do
 
       context "when uploading ISPF ODA activities" do
         it "asks Activity::Import to import the uploaded rows" do
-          report.update(fund: create(:fund_activity, :ispf))
+          report.update(fund: create(:fund_activity, :ispf), is_oda: true)
 
           put :update, params: {report_id: report.id, report: file_upload, type: "ispf_oda"}
 
@@ -176,7 +176,7 @@ RSpec.describe Activities::UploadsController do
 
       context "when uploading ISPF non-ODA activities" do
         it "asks Activity::Import to import the uploaded rows" do
-          report.update(fund: create(:fund_activity, :ispf))
+          report.update(fund: create(:fund_activity, :ispf), is_oda: false)
 
           put :update, params: {report_id: report.id, report: file_upload, type: "ispf_non_oda"}
 

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe Activities::UploadsController do
   end
 
   describe "#show" do
-    context "when requesting the ISPF ODA template" do
-      it "downloads the CSV template with the correct filename" do
+    context "when the report is ISPF ODA" do
+      it "downloads the ODA CSV template with the correct filename" do
         report.update(fund: create(:fund_activity, :ispf), is_oda: true)
 
-        get :show, params: {report_id: report.id, type: :ispf_oda}
+        get :show, params: {report_id: report.id}
 
         expect(response.headers.to_h).to include({
           "Content-Type" => "text/csv",
@@ -103,11 +103,11 @@ RSpec.describe Activities::UploadsController do
       end
     end
 
-    context "when requesting the ISPF non-ODA template" do
-      it "downloads the CSV template with the correct filename" do
+    context "when the report is ISPF non-ODA" do
+      it "downloads the non-ODA CSV template with the correct filename" do
         report.update(fund: create(:fund_activity, :ispf), is_oda: false)
 
-        get :show, params: {report_id: report.id, type: :ispf_non_oda}
+        get :show, params: {report_id: report.id}
 
         expect(response.headers.to_h).to include({
           "Content-Type" => "text/csv",
@@ -116,9 +116,9 @@ RSpec.describe Activities::UploadsController do
       end
     end
 
-    context "when requesting the non-ISPF template" do
+    context "when the report is non-ISPF" do
       it "downloads the CSV template with the correct filename" do
-        get :show, params: {report_id: report.id, type: :non_ispf}
+        get :show, params: {report_id: report.id}
 
         expect(response.headers.to_h).to include({
           "Content-Type" => "text/csv",

--- a/spec/controllers/activities/uploads_controller_spec.rb
+++ b/spec/controllers/activities/uploads_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Activities::UploadsController do
     end
 
     it "asks CsvFileUpload to prepare the uploaded activities" do
-      put :update, params: {report_id: report.id, report: file_upload, type: "non_ispf"}
+      put :update, params: {report_id: report.id, report: file_upload}
 
       expect(CsvFileUpload).to have_received(:new).with(file_upload, :activity_csv_non_ispf)
     end
@@ -161,7 +161,7 @@ RSpec.describe Activities::UploadsController do
         it "asks Activity::Import to import the uploaded rows" do
           report.update(fund: create(:fund_activity, :ispf), is_oda: true)
 
-          put :update, params: {report_id: report.id, report: file_upload, type: "ispf_oda"}
+          put :update, params: {report_id: report.id, report: file_upload}
 
           expect(Activity::Import).to have_received(:new).with(
             uploader: user,
@@ -178,7 +178,7 @@ RSpec.describe Activities::UploadsController do
         it "asks Activity::Import to import the uploaded rows" do
           report.update(fund: create(:fund_activity, :ispf), is_oda: false)
 
-          put :update, params: {report_id: report.id, report: file_upload, type: "ispf_non_oda"}
+          put :update, params: {report_id: report.id, report: file_upload}
 
           expect(Activity::Import).to have_received(:new).with(
             uploader: user,
@@ -193,7 +193,7 @@ RSpec.describe Activities::UploadsController do
 
       context "when uploading non-ISPF activities" do
         it "asks Activity::Import to import the uploaded rows" do
-          put :update, params: {report_id: report.id, report: file_upload, type: "non_ispf"}
+          put :update, params: {report_id: report.id, report: file_upload}
 
           expect(Activity::Import).to have_received(:new).with(
             uploader: user,
@@ -211,7 +211,7 @@ RSpec.describe Activities::UploadsController do
       before { allow(upload).to receive(:valid?).and_return(false) }
 
       it "does NOT ask Activity::Import to import the uploaded rows" do
-        put :update, params: {report_id: report.id, report: file_upload, type: "non_ispf"}
+        put :update, params: {report_id: report.id, report: file_upload}
 
         expect(Activity::Import).not_to have_received(:new)
       end

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -165,10 +165,32 @@ RSpec.describe ReportPresenter do
     end
 
     describe "#filename_for_actuals_template" do
-      it "returns the URL-encoded filename for the actuals template CSV download" do
-        result = described_class.new(report).filename_for_actuals_template
+      context "non-ISPF" do
+        it "returns the URL-encoded filename for the actuals template CSV download" do
+          result = described_class.new(report).filename_for_actuals_template
 
-        expect(result).to eql "FQ1 2020-2021-GCRF-BOR-actuals_upload.csv"
+          expect(result).to eql "FQ1 2020-2021-GCRF-BOR-actuals_upload.csv"
+        end
+      end
+
+      context "ISPF ODA" do
+        it "returns the URL-encoded filename for the actuals template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: true)
+
+          result = described_class.new(report).filename_for_actuals_template
+
+          expect(result).to eql "FQ1 2020-2021-ISPF-ODA-BOR-actuals_upload.csv"
+        end
+      end
+
+      context "ISPF non-ODA" do
+        it "returns the URL-encoded filename for the actuals template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: false)
+
+          result = described_class.new(report).filename_for_actuals_template
+
+          expect(result).to eql "FQ1 2020-2021-ISPF-non-ODA-BOR-actuals_upload.csv"
+        end
       end
     end
 

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -136,28 +136,28 @@ RSpec.describe ReportPresenter do
 
     describe "#filename_for_activities_template" do
       context "non-ISPF" do
-        it "returns the URL-encoded filename for the activities template CSV dowload" do
-          result = described_class.new(report).filename_for_activities_template(is_oda: nil)
+        it "returns the URL-encoded filename for the activities template CSV download" do
+          result = described_class.new(report).filename_for_activities_template
 
           expect(result).to eql "FQ1 2020-2021-GCRF-BOR-activities_upload.csv"
         end
       end
 
       context "ISPF ODA" do
-        it "returns the URL-encoded filename for the activities template CSV dowload" do
-          report.update(fund: create(:fund_activity, :ispf))
+        it "returns the URL-encoded filename for the activities template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: true)
 
-          result = described_class.new(report).filename_for_activities_template(is_oda: true)
+          result = described_class.new(report).filename_for_activities_template
 
           expect(result).to eql "FQ1 2020-2021-ISPF-ODA-BOR-activities_upload.csv"
         end
       end
 
       context "ISPF non-ODA" do
-        it "returns the URL-encoded filename for the activities template CSV dowload" do
-          report.update(fund: create(:fund_activity, :ispf))
+        it "returns the URL-encoded filename for the activities template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: false)
 
-          result = described_class.new(report).filename_for_activities_template(is_oda: false)
+          result = described_class.new(report).filename_for_activities_template
 
           expect(result).to eql "FQ1 2020-2021-ISPF-non-ODA-BOR-activities_upload.csv"
         end
@@ -165,7 +165,7 @@ RSpec.describe ReportPresenter do
     end
 
     describe "#filename_for_actuals_template" do
-      it "returns the URL-encoded filename for the actuals template CSV dowload" do
+      it "returns the URL-encoded filename for the actuals template CSV download" do
         result = described_class.new(report).filename_for_actuals_template
 
         expect(result).to eql "FQ1 2020-2021-GCRF-BOR-actuals_upload.csv"
@@ -173,7 +173,7 @@ RSpec.describe ReportPresenter do
     end
 
     describe "#filename_for_forecasts_template" do
-      it "returns the URL-encoded filename for the forecasts template CSV dowload" do
+      it "returns the URL-encoded filename for the forecasts template CSV download" do
         result = described_class.new(report).filename_for_forecasts_template
 
         expect(result).to eql "FQ1 2020-2021-GCRF-BOR-forecasts_upload.csv"

--- a/spec/presenters/report_presenter_spec.rb
+++ b/spec/presenters/report_presenter_spec.rb
@@ -195,10 +195,32 @@ RSpec.describe ReportPresenter do
     end
 
     describe "#filename_for_forecasts_template" do
-      it "returns the URL-encoded filename for the forecasts template CSV download" do
-        result = described_class.new(report).filename_for_forecasts_template
+      context "non-ISPF" do
+        it "returns the URL-encoded filename for the forecasts template CSV download" do
+          result = described_class.new(report).filename_for_forecasts_template
 
-        expect(result).to eql "FQ1 2020-2021-GCRF-BOR-forecasts_upload.csv"
+          expect(result).to eql "FQ1 2020-2021-GCRF-BOR-forecasts_upload.csv"
+        end
+      end
+
+      context "ISPF ODA" do
+        it "returns the URL-encoded filename for the forecasts template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: true)
+
+          result = described_class.new(report).filename_for_forecasts_template
+
+          expect(result).to eql "FQ1 2020-2021-ISPF-ODA-BOR-forecasts_upload.csv"
+        end
+      end
+
+      context "ISPF non-ODA" do
+        it "returns the URL-encoded filename for the forecasts template CSV download" do
+          report.update(fund: create(:fund_activity, :ispf), is_oda: false)
+
+          result = described_class.new(report).filename_for_forecasts_template
+
+          expect(result).to eql "FQ1 2020-2021-ISPF-non-ODA-BOR-forecasts_upload.csv"
+        end
       end
     end
 


### PR DESCRIPTION
## Changes in this PR
- Upload templates for ISPF reports use the ODA type of the report

## Screenshots of UI changes

### Before
![Screenshot 2023-11-22 at 14 10 09](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/02d4319b-2a17-41be-a5fe-0b51542bc82a)

### After
![Screenshot 2023-11-22 at 14 09 20](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/5394b1dc-2849-402c-b8f4-0288921a108a)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
