### PR TITLE
(2927) Add total actuals to report export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Show if a report for ISPF is ODA or non-ODA on the report show view
 - Show if a report for ISPF is ODA or non-ODA on the report edit form
 - Upload templates for ISPF reports use the ODA type of the report
+- The report export now includes a column for Total Actuals, the sum on the
+  Actuals net values for all financial quarters in the report
 
 ## Release 139 - 2023-11-14
 

--- a/spec/models/export/activity_actuals_columns_spec.rb
+++ b/spec/models/export/activity_actuals_columns_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe Export::ActivityActualsColumns do
             "Actual net FQ1 2020-2021",
             "Actual net FQ2 2020-2021",
             "Actual net FQ3 2020-2021",
-            "Actual net FQ4 2020-2021"
+            "Actual net FQ4 2020-2021",
+            "Total Actuals"
           ]
         )
       end
@@ -75,6 +76,15 @@ RSpec.describe Export::ActivityActualsColumns do
         expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
       end
 
+      it "contains the value for the total actuals i.e the sum of the actual net values" do
+        expected_total = value_for_header("Actual net FQ1 2020-2021") +
+          value_for_header("Actual net FQ3 2020-2021") +
+          value_for_header("Actual net FQ4 2020-2021") +
+          value_for_header("Actual net FQ2 2020-2021")
+
+        expect(value_for_header("Total Actuals")).to eq BigDecimal(expected_total)
+      end
+
       it "includes a row for each activity" do
         expect(subject.rows.count).to eq(5)
       end
@@ -89,7 +99,8 @@ RSpec.describe Export::ActivityActualsColumns do
             [
               "Actual net FQ1 2020-2021",
               "Actual net FQ2 2020-2021",
-              "Actual net FQ3 2020-2021"
+              "Actual net FQ3 2020-2021",
+              "Total Actuals"
             ]
           )
         end
@@ -112,6 +123,19 @@ RSpec.describe Export::ActivityActualsColumns do
 
         it "contains zero values for the financial quarters inbetween" do
           expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
+        end
+
+        it "contains zero values for the financial quarters inbetween" do
+          expect(value_for_header("Actual net FQ2 2020-2021")).to eq 0
+        end
+
+        it "contains the total actuals" do
+          expected_total = value_for_header("Actual net FQ1 2020-2021") +
+            value_for_header("Actual net FQ3 2020-2021") +
+            value_for_header("Actual net FQ2 2020-2021") +
+            value_for_header("Actual net FQ2 2020-2021")
+
+          expect(value_for_header("Total Actuals")).to eql BigDecimal(expected_total)
         end
 
         it "includes a row for each activity" do
@@ -180,6 +204,12 @@ RSpec.describe Export::ActivityActualsColumns do
           "Actual spend FQ2 2020-2021",
           "Refund FQ2 2020-2021",
           "Actual net FQ2 2020-2021"
+        )
+      end
+
+      it "does not include the heading for the total actuals" do
+        expect(subject.headers).not_to include(
+          "Total Actuals"
         )
       end
     end

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Partner organisation")
         expect(headers).to include("Change state")
         expect(headers).to include("Actual net #{@actual_spend_for_report_without_forecasts.own_financial_quarter}")
+        expect(headers).to include("Total Actuals")
         expect(headers.to_s).to_not include("Variance")
         expect(headers.to_s).to_not include("Forecast")
         expect(headers).to include("Comments in report")
@@ -250,6 +251,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Partner organisation")
         expect(headers).to include("Change state")
         expect(headers).to include("Actual net #{@actual_spend.own_financial_quarter}")
+        expect(headers).to include("Total Actuals")
         expect(headers).to include("Variance #{@actual_spend.own_financial_quarter}")
         expect(headers).to include("Forecast #{@forecast.own_financial_quarter}")
         expect(headers).to include("Comments in report")
@@ -299,6 +301,8 @@ RSpec.describe Export::Report do
         expect(change_state_value_for_row(first_row))
           .to eq("Unchanged")
         expect(actual_spend_for_row(first_row))
+          .to eq(@actual_spend.value)
+        expect(total_actuals_for_row(first_row))
           .to eq(@actual_spend.value)
         expect(variance_for_row(first_row))
           .to eq(@forecast.value - @actual_spend.value)
@@ -503,19 +507,23 @@ RSpec.describe Export::Report do
     row[@headers_for_report.length + 3]
   end
 
-  def variance_for_row(row)
+  def total_actuals_for_row(row)
     row[@headers_for_report.length + 4]
   end
 
-  def forecast_for_row(row)
+  def variance_for_row(row)
     row[@headers_for_report.length + 5]
   end
 
-  def comments_for_row(row)
+  def forecast_for_row(row)
     row[@headers_for_report.length + 6]
   end
 
-  def link_for_row(row)
+  def comments_for_row(row)
     row[@headers_for_report.length + 7]
+  end
+
+  def link_for_row(row)
+    row[@headers_for_report.length + 8]
   end
 end


### PR DESCRIPTION
## Changes in this PR

The total actuals is the sum of the 'actuals net' columns in the report,
of which there can be multiple..

Here we keep a total of the actual net values as it is calculated for each
financial quarter and add it to the columns for the current row if
appropriate.

Because the ActivityActualsColumns class also provides data for the
'spending breakdown' we have to check that a report is being generated
and only include the total actuals column if that is the case.

Most changes here relate to the addition of the extra column, the
ActivityActualsColumns adds `n` number of financial quarters and then
adds the total actuals to the end, some of this code has to rely on the
position of the values i.e the column number which has been altered by
this work.

We could not see another approach for this other than a major refactor
of how the exports are put together, so we settled on making this work.

https://trello.com/c/VE5g5sJi