### PR TITLE
(2991) Identify originating report by using is_oda value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Upload templates for ISPF reports use the ODA type of the report
 - The report export now includes a column for Total Actuals, the sum on the
   Actuals net values for all financial quarters in the report
+- Fix originating report finder in ActivityDefaults to take into account the ODA type of the activity
 
 ## Release 139 - 2023-11-14
 

--- a/app/services/activity_defaults.rb
+++ b/app/services/activity_defaults.rb
@@ -61,6 +61,7 @@ class ActivityDefaults
     Report.find_by(
       fund_id: parent_activity.associated_fund.id,
       organisation_id: organisation.id,
+      is_oda: is_oda?,
       state: Report::EDITABLE_STATES
     )
   end

--- a/spec/services/activity_defaults_spec.rb
+++ b/spec/services/activity_defaults_spec.rb
@@ -255,18 +255,30 @@ RSpec.describe ActivityDefaults do
       end
 
       context "when the parent is an ISPF ODA project" do
+        let!(:current_oda_report) { create(:report, :for_ispf, is_oda: true, organisation: partner_organisation) }
+        let!(:current_non_oda_report) { create(:report, :for_ispf, is_oda: false, organisation: partner_organisation) }
         let(:parent_activity) { ispf_oda_project }
 
         it "sets the is_oda attribute to true" do
           expect(subject[:is_oda]).to be(true)
         end
+
+        it "sets the originating_report id to the ODA report for the current financial period" do
+          expect(subject[:originating_report_id]).to eq(current_oda_report.id)
+        end
       end
 
       context "when the parent is an ISPF non-ODA project" do
+        let!(:current_oda_report) { create(:report, :for_ispf, is_oda: true, organisation: partner_organisation) }
+        let!(:current_non_oda_report) { create(:report, :for_ispf, is_oda: false, organisation: partner_organisation) }
         let(:parent_activity) { ispf_non_oda_project }
 
         it "sets the is_oda attribute to false" do
           expect(subject[:is_oda]).to be(false)
+        end
+
+        it "sets the originating_report id to the non-ODA report for the current financial period" do
+          expect(subject[:originating_report_id]).to eq(current_non_oda_report.id)
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR
- Fix originating report finder in ActivityDefaults to take into account the ODA type of the activity

ActivityDefaults is responsible for setting a number of attributes for an activity that can be inferred from data the app already has.

One of these is the originating report, which is the currently active report for the fund and organisation of the activity.

Now that ISPF reports are split between ODA and non-ODA, the originating report finder needs to take into account the ODA type of the activity, and correctly find the corresponding report.

We forgot to update this finder in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2203


## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
