### PR TITLE
(2928) Outgoing commitment value in report csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   Actuals net values for all financial quarters in the report
 - Fix originating report finder in ActivityDefaults to take into account the ODA type of the activity
 - Update documentation to reflect various new processes on the new DSIT AWS infrastructure
+- The report export now includes a column for the Original Commitment value of
+  the activity, if one is available
 
 ## Release 139 - 2023-11-14
 

--- a/app/models/export/activity_commitment_column.rb
+++ b/app/models/export/activity_commitment_column.rb
@@ -1,0 +1,17 @@
+class Export::ActivityCommitmentColumn
+  def initialize(activities:)
+    @activities = activities
+  end
+
+  def headers
+    ["Original Commitment"]
+  end
+
+  def rows
+    return {} if @activities.empty?
+
+    @activities.map { |activity|
+      [activity.id, activity.commitment&.value]
+    }.to_h
+  end
+end

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -108,10 +108,6 @@ class Export::Report
     @_forecast_rows ||= @forecast_columns.rows
   end
 
-  def has_forecast_rows?
-    forecast_rows.values.flatten.any?
-  end
-
   def variance_rows
     @_variance_rows ||= @variance_column.rows
   end

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -13,6 +13,8 @@ class Export::Report
       Export::ActivityPartnerOrganisationColumn.new(activities_relation: activities)
     @change_state_column =
       Export::ActivityChangeStateColumn.new(activities: activities, report: @report)
+    @commitment_column =
+      Export::ActivityCommitmentColumn.new(activities: activities.includes([:commitment]))
     @actuals_columns =
       Export::ActivityActualsColumns.new(activities: activities, report: @report)
     @forecast_columns =
@@ -39,6 +41,7 @@ class Export::Report
     headers << @implementing_organisations.headers
     headers << @partner_organisations.headers
     headers << @change_state_column.headers
+    headers << @commitment_column.headers
     headers << @actuals_columns.headers if @actuals_columns.headers.any?
     headers << @variance_column.headers if @actuals_columns.headers.any? && @forecast_columns.headers.any?
     headers << @forecast_columns.headers if @forecast_columns.headers.any?
@@ -55,6 +58,7 @@ class Export::Report
       row << implementing_organisations_rows.fetch(activity.id, nil)
       row << partner_organisation_rows.fetch(activity.id, nil)
       row << change_state_rows.fetch(activity.id, nil)
+      row << commitment_rows.fetch(activity.id, nil)
       row << actuals_rows.fetch(activity.id, nil) if @actuals_columns.headers.any?
       row << variance_rows.fetch(activity.id, nil) if @actuals_columns.headers.any? && @forecast_columns.headers.any?
       row << forecast_rows.fetch(activity.id, nil) if @forecast_columns.headers.any?
@@ -90,6 +94,10 @@ class Export::Report
 
   def change_state_rows
     @_change_state_rows ||= @change_state_column.rows
+  end
+
+  def commitment_rows
+    @_commitment_rows ||= @commitment_column.rows
   end
 
   def actuals_rows

--- a/spec/models/export/activity_commitment_column_spec.rb
+++ b/spec/models/export/activity_commitment_column_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Export::ActivityCommitmentColumn do
+  describe "#headers" do
+    it "returns an array that contains the header name of the column" do
+      activities = []
+
+      column = described_class.new(activities: activities)
+
+      expect(column.headers).to eql ["Original Commitment"]
+    end
+  end
+
+  describe "#rows" do
+    context "when there are no activities" do
+      it "returns an empty hash" do
+        activities = []
+
+        column = described_class.new(activities: activities)
+
+        expect(column.rows).to be {}
+      end
+    end
+
+    context "when there are activities" do
+      context "when the activity has a commitment" do
+        it "returns the activity ID and the value of the commitment" do
+          commitment = double(Commitment, value: 100000.00)
+          activity = double(Activity, commitment: commitment, id: "ACTIVITY_ID")
+          activities = [activity]
+
+          column = described_class.new(activities: activities)
+
+          expect(column.rows.count).to eql 1
+          expect(column.rows.first[0]).to eql "ACTIVITY_ID"
+          expect(column.rows.first[1]).to eql 100000.00
+        end
+      end
+
+      context "when the activity has no commitment" do
+        it "returns the value as nil" do
+          activity = double(Activity, commitment: nil, id: "ACTIVITY_ID")
+          activities = [activity]
+
+          column = described_class.new(activities: activities)
+
+          expect(column.rows.count).to eql 1
+          expect(column.rows.first[0]).to eql "ACTIVITY_ID"
+          expect(column.rows.first[1]).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -139,19 +139,20 @@ RSpec.describe Export::Report do
 
     describe "#rows" do
       it "returns the rows correctly" do
-        first_row = subject.rows.first.to_a
+        row = subject.rows.first.to_a
 
-        expect(roda_identifier_value_for_row(first_row))
-          .to eq(@project_for_report_without_forecasts.roda_identifier)
-
-        expect(partner_organisation_value_for_row(first_row))
-          .to eq(@project_for_report_without_forecasts.organisation.name)
-        expect(change_state_value_for_row(first_row))
+        expect(value_for_column("RODA identifier", row))
+          .to eql @project_for_report_without_forecasts.roda_identifier
+        expect(value_for_column("Partner organisation", row))
+          .to eql @project_for_report_without_forecasts.organisation.name
+        expect(value_for_column("Change state", row))
           .to eq("Unchanged")
-        expect(original_commitment_value_for_row(first_row))
+        expect(value_for_column("Original Commitment", row))
           .to eql(@commitment.value)
-        expect(actual_spend_for_row(first_row))
-          .to eq(@actual_spend_for_report_without_forecasts.value)
+        expect(value_for_column("Actual net #{@actual_spend_for_report_without_forecasts.own_financial_quarter}", row))
+          .to eql @actual_spend_for_report_without_forecasts.value
+        expect(value_for_column("Total Actuals", row))
+          .to eql @actual_spend_for_report_without_forecasts.value
       end
     end
   end
@@ -218,26 +219,22 @@ RSpec.describe Export::Report do
 
     describe "#rows" do
       it "returns the rows correctly" do
-        first_row = subject.rows.first.to_a
+        row = subject.rows.first.to_a
 
-        expect(roda_identifier_value_for_row(first_row))
-          .to eq(@project_for_report_without_actuals.roda_identifier)
-
-        expect(partner_organisation_value_for_row(first_row))
-          .to eq(@project_for_report_without_actuals.organisation.name)
-        expect(change_state_value_for_row(first_row))
-          .to eq("Unchanged")
-        expect(original_commitment_value_for_row(first_row))
-          .to eq(@commitment.value)
-        # forecast for the report's own financial quarter
-        expect(first_row[@headers_for_report.length + 4])
-          .to eq(0)
-        # forecast for the next financial quarter
-        expect(first_row[@headers_for_report.length + 5])
-          .to eq(@forecast.value)
-        # comments
-        expect(first_row[@headers_for_report.length + 6])
-          .to eq(@comment.body)
+        expect(value_for_column("RODA identifier", row))
+          .to eql @project_for_report_without_actuals.roda_identifier
+        expect(value_for_column("Partner organisation", row))
+          .to eql @project_for_report_without_actuals.organisation.name
+        expect(value_for_column("Change state", row))
+          .to eql "Unchanged"
+        expect(value_for_column("Original Commitment", row))
+          .to eql @commitment.value
+        expect(value_for_column("Forecast #{@report_without_actuals.own_financial_quarter}", row))
+          .to be_zero
+        expect(value_for_column("Forecast #{@forecast.own_financial_quarter}", row))
+          .to eql @forecast.value
+        expect(value_for_column("Comments in report", row))
+          .to eql @comment.body
       end
     end
   end
@@ -301,34 +298,31 @@ RSpec.describe Export::Report do
       end
 
       it "returns the rows correctly" do
-        first_row = subject.rows.first.to_a
+        row = subject.rows.first.to_a
 
-        expect(roda_identifier_value_for_row(first_row))
-          .to eq(@project.roda_identifier)
-
-        # includes names of both implementing organisations
-        expect(implementing_organisation_value_for_row(first_row))
-          .to match(@project.implementing_organisations.first.name)
-        expect(implementing_organisation_value_for_row(first_row))
-          .to match(@project.implementing_organisations.second.name)
-
-        expect(partner_organisation_value_for_row(first_row))
-          .to eq(@project.organisation.name)
-        expect(change_state_value_for_row(first_row))
-          .to eq("Unchanged")
-        expect(original_commitment_value_for_row(first_row))
-          .to eq(@commitment.value)
-        expect(actual_spend_for_row(first_row))
-          .to eq(@actual_spend.value)
-        expect(total_actuals_for_row(first_row))
-          .to eq(@actual_spend.value)
-        expect(variance_for_row(first_row))
-          .to eq(@forecast.value - @actual_spend.value)
-        expect(forecast_for_row(first_row))
-          .to eq(@forecast.value)
-        expect(comments_for_row(first_row))
-          .to eq(@comment.body)
-        expect(link_for_row(first_row))
+        expect(value_for_column("RODA identifier", row))
+          .to eql @project.roda_identifier
+        expect(value_for_column("Implementing organisations", row))
+          .to include @project.implementing_organisations.first.name
+        expect(value_for_column("Implementing organisations", row))
+          .to include @project.implementing_organisations.second.name
+        expect(value_for_column("Partner organisation", row))
+          .to eql @project.organisation.name
+        expect(value_for_column("Change state", row))
+          .to eql "Unchanged"
+        expect(value_for_column("Original Commitment", row))
+          .to eql @commitment.value
+        expect(value_for_column("Actual net #{@actual_spend.own_financial_quarter}", row))
+          .to eql @actual_spend.value
+        expect(value_for_column("Total Actuals", row))
+          .to eql @actual_spend.value
+        expect(value_for_column("Variance #{@actual_spend.own_financial_quarter}", row))
+          .to eql @forecast.value - @actual_spend.value
+        expect(value_for_column("Forecast #{@forecast.own_financial_quarter}", row))
+          .to eql @forecast.value
+        expect(value_for_column("Comments in report", row))
+          .to eql @comment.body
+        expect(value_for_column("Link to activity", row))
           .to include(@project.id)
       end
 
@@ -343,9 +337,9 @@ RSpec.describe Export::Report do
 
         it "returns the rows with the correct tags" do
           first_row = subject.rows.first.to_a
-          tags_index = 56
+          tags = value_for_column("Tags", first_row)
 
-          expect(first_row[tags_index]).to eq("Ayrton Fund|Double-badged for ICF")
+          expect(tags).to eq("Ayrton Fund|Double-badged for ICF")
         end
       end
     end
@@ -505,43 +499,10 @@ RSpec.describe Export::Report do
     end
   end
 
-  def roda_identifier_value_for_row(row)
-    row[0]
-  end
+  def value_for_column(column_header, row)
+    index = subject.headers.index(column_header)
+    raise "Could not locate the column #{column_header}, check your expectation" if index.nil?
 
-  def implementing_organisation_value_for_row(row)
-    row[@headers_for_report.length]
-  end
-
-  def partner_organisation_value_for_row(row)
-    row[@headers_for_report.length + 1]
-  end
-
-  def change_state_value_for_row(row)
-    row[@headers_for_report.length + 2]
-  end
-
-  def original_commitment_value_for_row(row)
-    row[@headers_for_report.length + 3]
-  end
-
-  def actual_spend_for_row(row)
-    row[@headers_for_report.length + 4]
-  end
-
-  def variance_for_row(row)
-    row[@headers_for_report.length + 5]
-  end
-
-  def forecast_for_row(row)
-    row[@headers_for_report.length + 6]
-  end
-
-  def comments_for_row(row)
-    row[@headers_for_report.length + 7]
-  end
-
-  def link_for_row(row)
-    row[@headers_for_report.length + 8]
+    row[subject.headers.index(column_header)]
   end
 end

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Original Commitment")
         expect(headers.to_s).to_not include("Actual net")
         expect(headers.to_s).to_not include("Variance")
+        expect(headers).not_to include("Total Actuals")
         expect(headers).to include("Forecast #{@forecast.own_financial_quarter}")
         expect(headers).to include("Forecast #{@report_without_actuals.own_financial_quarter}")
         expect(headers).to include("Comments in report")

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe Export::Report do
       financial_year: financial_year.to_i
     )
 
+    @commitment = create(:commitment, value: 50000)
     @project = create(
       :project_activity_with_implementing_organisations,
-      implementing_organisations_count: 2
+      implementing_organisations_count: 2,
+      commitment: @commitment
     )
 
     @implementing_organisation =
@@ -88,9 +90,12 @@ RSpec.describe Export::Report do
         financial_year: financial_year.to_i
       )
 
+      @commitment = create(:commitment, value: 120000)
+
       @project_for_report_without_forecasts = create(
         :project_activity_with_implementing_organisations,
-        implementing_organisations_count: 2
+        implementing_organisations_count: 2,
+        commitment: @commitment
       )
 
       @actual_spend_for_report_without_forecasts =
@@ -122,6 +127,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Implementing organisations")
         expect(headers).to include("Partner organisation")
         expect(headers).to include("Change state")
+        expect(headers).to include("Original Commitment")
         expect(headers).to include("Actual net #{@actual_spend_for_report_without_forecasts.own_financial_quarter}")
         expect(headers).to include("Total Actuals")
         expect(headers.to_s).to_not include("Variance")
@@ -142,6 +148,8 @@ RSpec.describe Export::Report do
           .to eq(@project_for_report_without_forecasts.organisation.name)
         expect(change_state_value_for_row(first_row))
           .to eq("Unchanged")
+        expect(original_commitment_value_for_row(first_row))
+          .to eql(@commitment.value)
         expect(actual_spend_for_row(first_row))
           .to eq(@actual_spend_for_report_without_forecasts.value)
       end
@@ -159,9 +167,12 @@ RSpec.describe Export::Report do
         financial_year: financial_year.to_i
       )
 
+      @commitment = create(:commitment, value: 150000)
+
       @project_for_report_without_actuals = create(
         :project_activity_with_implementing_organisations,
-        implementing_organisations_count: 2
+        implementing_organisations_count: 2,
+        commitment: @commitment
       )
 
       @forecast =
@@ -194,6 +205,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Implementing organisations")
         expect(headers).to include("Partner organisation")
         expect(headers).to include("Change state")
+        expect(headers).to include("Original Commitment")
         expect(headers.to_s).to_not include("Actual net")
         expect(headers.to_s).to_not include("Variance")
         expect(headers).to include("Forecast #{@forecast.own_financial_quarter}")
@@ -214,14 +226,16 @@ RSpec.describe Export::Report do
           .to eq(@project_for_report_without_actuals.organisation.name)
         expect(change_state_value_for_row(first_row))
           .to eq("Unchanged")
+        expect(original_commitment_value_for_row(first_row))
+          .to eq(@commitment.value)
         # forecast for the report's own financial quarter
-        expect(first_row[@headers_for_report.length + 3])
+        expect(first_row[@headers_for_report.length + 4])
           .to eq(0)
         # forecast for the next financial quarter
-        expect(first_row[@headers_for_report.length + 4])
+        expect(first_row[@headers_for_report.length + 5])
           .to eq(@forecast.value)
         # comments
-        expect(first_row[@headers_for_report.length + 5])
+        expect(first_row[@headers_for_report.length + 6])
           .to eq(@comment.body)
       end
     end
@@ -250,6 +264,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Implementing organisations")
         expect(headers).to include("Partner organisation")
         expect(headers).to include("Change state")
+        expect(headers).to include("Original Commitment")
         expect(headers).to include("Actual net #{@actual_spend.own_financial_quarter}")
         expect(headers).to include("Total Actuals")
         expect(headers).to include("Variance #{@actual_spend.own_financial_quarter}")
@@ -300,6 +315,8 @@ RSpec.describe Export::Report do
           .to eq(@project.organisation.name)
         expect(change_state_value_for_row(first_row))
           .to eq("Unchanged")
+        expect(original_commitment_value_for_row(first_row))
+          .to eq(@commitment.value)
         expect(actual_spend_for_row(first_row))
           .to eq(@actual_spend.value)
         expect(total_actuals_for_row(first_row))
@@ -325,7 +342,7 @@ RSpec.describe Export::Report do
 
         it "returns the rows with the correct tags" do
           first_row = subject.rows.first.to_a
-          tags_index = 55
+          tags_index = 56
 
           expect(first_row[tags_index]).to eq("Ayrton Fund|Double-badged for ICF")
         end
@@ -503,11 +520,11 @@ RSpec.describe Export::Report do
     row[@headers_for_report.length + 2]
   end
 
-  def actual_spend_for_row(row)
+  def original_commitment_value_for_row(row)
     row[@headers_for_report.length + 3]
   end
 
-  def total_actuals_for_row(row)
+  def actual_spend_for_row(row)
     row[@headers_for_report.length + 4]
   end
 


### PR DESCRIPTION
## Changes in this PR

We want to show the original commitment value for an activity in the report csv export.

The value is entered by a user and is optional, when there is no value we show a blank value as zero could imply there was explicitally £0 of commitment, which may be missleading.

After spending time in the spec for the report export, we refactored the helpers to make the spec more approachable.

We also came across a redundant method, which we removed.

https://trello.com/c/7TbEQrNO



