### PR TITLE
Fix sidekiq deprecation warnings

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,17 +6,17 @@ options = {
 
 Sidekiq.configure_server do |config|
   config.logger.level = Logger::WARN if Rails.env.production?
-  config.options.merge!(options)
+  config.merge!(options)
   config.redis = {
     url: redis_url,
-    size: config.options[:concurrency] + 5
+    size: config[:concurrency] + 5
   }
 end
 
 Sidekiq.configure_client do |config|
-  config.options.merge!(options)
+  config.merge!(options)
   config.redis = {
     url: redis_url,
-    size: config.options[:concurrency] + 5
+    size: config[:concurrency] + 5
   }
 end


### PR DESCRIPTION
## Changes in this PR

WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
