### PR TITLE
Fix: Test coverage sent to Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         if: steps.cache-docker.outputs.cache-hit == 'true'
       - name: Run tests
         run: script/cibuild
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ./coverage/lcov.info
+          fail-on-error: false
       - name: Prepare Docker cache
         run: mkdir -p /tmp/docker-save && docker save beis-report-official-development-assistance_test:latest -o /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
         if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Create coverage directory
+        run: mkdir -p ./coverage
       - id: cache-docker
         uses: actions/cache@v3
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,8 @@ end
 group :test do
   gem "capybara", ">= 2.15"
   gem "climate_control"
-  gem "coveralls", require: false
+  gem "simplecov", "~> 0.21.2", require: false
+  gem "simplecov-lcov", "~> 0.8.0", require: false
   gem "database_cleaner"
   gem "fakeredis", require: false
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,12 +124,6 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -442,11 +436,13 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     sinatra (2.2.4)
       mustermann (~> 2.0)
       rack (~> 2.2)
@@ -489,17 +485,12 @@ GEM
       rubocop-performance (~> 1.18.0)
     strip_attributes (1.13.0)
       activemodel (>= 3.0, < 8.0)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
     tilt (2.0.11)
     timeout (0.4.1)
-    tins (1.31.0)
-      sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -545,7 +536,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   climate_control
-  coveralls
   cssbundling-rails (~> 1.3)
   csv-safe
   database_cleaner
@@ -594,6 +584,8 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   sidekiq (~> 6.5.10)
+  simplecov (~> 0.21.2)
+  simplecov-lcov (~> 0.8.0)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.1.0)
@@ -608,4 +600,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.3.9
+   2.4.22

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,10 @@ services:
       target: test
       args:
         RAILS_ENV: test
+    volumes:
+      - type: bind
+        source: ./coverage
+        target: /app/coverage
     depends_on:
       - db
     environment:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
-require "simplecov"
-require "coveralls"
 require "audited-rspec"
+require "simplecov"
+require "simplecov-lcov"
+
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = "coverage/lcov.info"
+end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+  SimpleCov::Formatter::LcovFormatter
 ])
 
 SimpleCov.minimum_coverage 98
+
 SimpleCov.start "rails" do
   # If we explicitly choose to not include code in the coverage calculation we
   # should leave a comment why


### PR DESCRIPTION
Our Coveralls reports have not worked for some time:

https://coveralls.io/jobs/132270209

This work fixes that by updating how we send the data to Coveralls. In summary:

- drop the coveralls gem
- update simplecov gem
- add a new formatter
- expose the coverage report in the GitHub action runner
- run the Coveralls GitHub action
