### PR TITLE
(2929) Published to IATI value in report csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Update documentation to reflect various new processes on the new DSIT AWS infrastructure
 - The report export now includes a column for the Original Commitment value of
   the activity, if one is available
+- The report export now includes a column for the Published to IATI value, which
+  will either be yes or no
 
 ## Release 139 - 2023-11-14
 

--- a/app/models/export/activity_iati_column.rb
+++ b/app/models/export/activity_iati_column.rb
@@ -1,0 +1,20 @@
+class Export::ActivityIatiColumn
+  def initialize(activities:)
+    @activities = activities
+  end
+
+  def headers
+    ["Published on IATI"]
+  end
+
+  def rows
+    return {} if @activities.empty?
+
+    @activities.map { |activity|
+      [
+        activity.id,
+        I18n.t("summary.label.activity.publish_to_iati.#{activity.publish_to_iati}")
+      ]
+    }.to_h
+  end
+end

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -33,6 +33,7 @@ class Export::Report
       )
     @tags_column = Export::ActivityTagsColumn.new(activities: activities) if @report.for_ispf?
     @link_column = Export::ActivityLinkColumn.new(activities: activities)
+    @iati_column = Export::ActivityIatiColumn.new(activities: activities)
   end
 
   def headers
@@ -48,6 +49,7 @@ class Export::Report
     headers << @comments_column.headers
     headers << @tags_column.headers if @report.for_ispf?
     headers << @link_column.headers
+    headers << @iati_column.headers
     headers.flatten
   end
 
@@ -65,6 +67,7 @@ class Export::Report
       row << comment_rows.fetch(activity.id, nil)
       row << tags_rows.fetch(activity.id, nil) if @report.for_ispf?
       row << link_rows.fetch(activity.id, nil)
+      row << iati_rows.fetch(activity.id, nil)
       row.flatten
     end
   end
@@ -122,6 +125,10 @@ class Export::Report
 
   def link_rows
     @_link_rows ||= @link_column.rows
+  end
+
+  def iati_rows
+    @_iati_rows ||= @iati_column.rows
   end
 
   def activities

--- a/spec/models/export/activity_iati_column_spec.rb
+++ b/spec/models/export/activity_iati_column_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Export::ActivityIatiColumn do
+  describe "#headers" do
+    it "returns an array that contains the header name of the column" do
+      activities = []
+
+      column = described_class.new(activities: activities)
+
+      expect(column.headers).to eql ["Published on IATI"]
+    end
+  end
+
+  describe "#rows" do
+    context "when there are no activities" do
+      it "returns an empty hash" do
+        activities = []
+
+        column = described_class.new(activities: activities)
+
+        expect(column.rows).to be {}
+      end
+    end
+
+    context "when there are activities" do
+      context "when the activity is publishable to IATI" do
+        it "returns the activity ID and yes" do
+          activity = double(Activity, publish_to_iati: true, id: "ACTIVITY_ID")
+          activities = [activity]
+
+          column = described_class.new(activities: activities)
+
+          expect(column.rows.count).to eql 1
+          expect(column.rows.first[0]).to eql "ACTIVITY_ID"
+          expect(column.rows.first[1]).to eql "Yes"
+        end
+      end
+
+      context "when the activity is not publishable to IATI" do
+        it "returns the activity ID and no" do
+          activity = double(Activity, publish_to_iati: false, id: "ACTIVITY_ID")
+          activities = [activity]
+
+          column = described_class.new(activities: activities)
+
+          expect(column.rows.count).to eql 1
+          expect(column.rows.first[0]).to eql "ACTIVITY_ID"
+          expect(column.rows.first[1]).to eql "No"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Export::Report do
         expect(headers.to_s).to_not include("Forecast")
         expect(headers).to include("Comments in report")
         expect(headers).to include("Link to activity")
+        expect(headers).to include("Published on IATI")
       end
     end
 
@@ -153,6 +154,8 @@ RSpec.describe Export::Report do
           .to eql @actual_spend_for_report_without_forecasts.value
         expect(value_for_column("Total Actuals", row))
           .to eql @actual_spend_for_report_without_forecasts.value
+        expect(value_for_column("Published on IATI", row))
+          .to eql "Yes"
       end
     end
   end
@@ -214,6 +217,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Forecast #{@report_without_actuals.own_financial_quarter}")
         expect(headers).to include("Comments in report")
         expect(headers).to include("Link to activity")
+        expect(headers).to include("Published on IATI")
       end
     end
 
@@ -235,6 +239,8 @@ RSpec.describe Export::Report do
           .to eql @forecast.value
         expect(value_for_column("Comments in report", row))
           .to eql @comment.body
+        expect(value_for_column("Published on IATI", row))
+          .to eql "Yes"
       end
     end
   end
@@ -270,6 +276,7 @@ RSpec.describe Export::Report do
         expect(headers).to include("Comments in report")
         expect(headers).not_to include("Tags")
         expect(headers).to include("Link to activity")
+        expect(headers).to include("Published on IATI")
       end
 
       context "when the report is for ISPF" do
@@ -324,6 +331,8 @@ RSpec.describe Export::Report do
           .to eql @comment.body
         expect(value_for_column("Link to activity", row))
           .to include(@project.id)
+        expect(value_for_column("Published on IATI", row))
+          .to eql "Yes"
       end
 
       context "when the report is for ISPF" do


### PR DESCRIPTION
## Changes in this PR

This work adds the `publish_to_iati` from `Activity` value in the report csv export.

- The value is true by default 
- The value is shown as one of 'Yes' or 'No'
- The column comes at the very end of the columns in the csv table

https://trello.com/c/c4GFG0UW