### PR TITLE
Release 140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full changelog][unreleased]
 
+## Release 140 - 2023-11-28
+
+[Full changelog][140]
+
 - Remove the `oda_eligibility` criterion from `reportable` scope, and apply it on a report by report basis, so we don't exclude ISPF non-ODA activities from ISPF non-ODA reports
 - Update how Node and Yarn are installed inside the application container
 - Allow ISPF reports to be created as ODA or non-ODA
@@ -1603,7 +1607,8 @@
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-139...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-140...HEAD
+[140]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-139...release-140
 [139]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-138...release-139
 [138]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-137...release-138
 [137]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-136...release-137


### PR DESCRIPTION
2023-11-28

[Full changelog][140]

- Remove the `oda_eligibility` criterion from `reportable` scope, and apply it on a report by report basis, so we don't exclude ISPF non-ODA activities from ISPF non-ODA reports
- Update how Node and Yarn are installed inside the application container
- Allow ISPF reports to be created as ODA or non-ODA
- Ensure that non-ISPF reports do not get a value set for `is_oda` (for historical reasons, the app relies on non-ISPF reports and activities not having an `is_oda` value set)
- Validate that the value of `is_oda` is set for ISPF reports
- Reorder the fields on the new report form per design
- Show if a report for ISPF is ODA or non-ODA on the report show view
- Show if a report for ISPF is ODA or non-ODA on the report edit form
- Upload templates for ISPF reports use the ODA type of the report
- The report export now includes a column for Total Actuals, the sum on the
  Actuals net values for all financial quarters in the report
- Fix originating report finder in ActivityDefaults to take into account the ODA type of the activity
- Update documentation to reflect various new processes on the new DSIT AWS infrastructure
- The report export now includes a column for the Original Commitment value of
  the activity, if one is available
- The report export now includes a column for the Published to IATI value, which
  will either be yes or no

