### PR TITLE
(2977) Fix: missing error summary on matched effort form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - The IATI activity scope is calculated based on the benefitting countries and
   included in the IATI XML download as applicable
+- The error summary is now shown correctly when adding new matched effort in the
+  application
 
 ## Release 140 - 2023-11-28
 

--- a/app/views/matched_efforts/_form.html.haml
+++ b/app/views/matched_efforts/_form.html.haml
@@ -1,4 +1,6 @@
 = form_with model: matched_effort, url: path do |f|
+  = f.govuk_error_summary
+
   = f.hidden_field :activity_id, value: @activity.id
   = f.govuk_collection_select :organisation_id,
                 list_of_matched_effort_providers,
@@ -30,4 +32,3 @@
     = link_to t("form.link.activity.back"), organisation_activity_other_funding_path(@activity.organisation, @activity), class: "govuk-button govuk-button--secondary", "data-module": "govuk-button", role: "button"
   - if action_name == "edit"
     = link_to t("default.button.delete"), activity_matched_effort_path(@activity, @matched_effort), method: "delete" , class: "govuk-button govuk-button--warning", "data-module": "govuk-button", role: "button", data: { confirm: "Are you sure you want to delete this matched effort?" }
-

--- a/spec/features/users_can_create_a_matched_effort_spec.rb
+++ b/spec/features/users_can_create_a_matched_effort_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Users can create a matched effort" do
       end
     end
 
-    scenario "they receive an error message when the category does not match the funding type" do
+    scenario "they see a summary and the  error message when the category does not match the funding type" do
       template = build(:matched_effort,
         funding_type: "reciprocal",
         category: "staff_time",
@@ -59,6 +59,7 @@ RSpec.describe "Users can create a matched effort" do
 
       fill_in_matched_effort_form(template)
 
+      expect(page).to have_selector(".govuk-error-summary")
       expect(page).to_not have_content(t("action.matched_effort.create.success"))
       expect(page).to have_content(
         t(
@@ -70,11 +71,12 @@ RSpec.describe "Users can create a matched effort" do
       expect(page.find(:xpath, "//input[@value='#{template.category}']").checked?).to be(false)
     end
 
-    scenario "they receive errors when required fields are left blank" do
+    scenario "they see a summary and the errors when required fields are left blank" do
       page.find(:xpath, "//input[@value='in_kind']").set(true)
 
       click_on t("default.button.submit")
 
+      expect(page).to have_selector(".govuk-error-summary")
       expect(page).to have_content("Organisation can't be blank")
       expect(page).to have_content("Category can't be blank")
     end

--- a/spec/features/users_can_edit_a_matched_effort_spec.rb
+++ b/spec/features/users_can_edit_a_matched_effort_spec.rb
@@ -31,12 +31,13 @@ RSpec.describe "Users can create a matched effort" do
       expect(matched_effort.notes).to eq("Here are some new notes")
     end
 
-    scenario "they see errors when a required field is missing" do
+    scenario "they see a sumamry and the errors when a required field is missing" do
       select("", from: "matched_effort[organisation_id]")
       click_on t("default.button.submit")
 
       expect(page).to_not have_content(t("action.matched_effort.update.success"))
 
+      expect(page).to have_selector(".govuk-error-summary")
       expect(page).to have_content("Organisation can't be blank")
     end
   end


### PR DESCRIPTION
## Changes in this PR

The new matched effort form was missing it's error summary:

https://design-system.service.gov.uk/components/error-summary/

This adds it in and confirms its presence in the specs.

## Screenshots of UI changes

![image](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/480578/1ab2abcc-0067-4d71-abf0-5fc3b7a51c80)

https://trello.com/c/GaiuFcnt