### PR TITLE
(2995) Fix: flaky sign in spec

### DIFF
--- a/doc/0_index_of_contents.md
+++ b/doc/0_index_of_contents.md
@@ -4,6 +4,8 @@
 
 - **[Glossary of terms (glossary)](./glossary.md)**
 
+- **[Authentication](Authentication.md)**: Details about authentication and 2FA.
+
 - **[Importing new partner organisation data
   (importing-new-partner-organisation-data.md)](./importing-new-partner-organisation-data.md)**: We need to import
   legacy data for partner organisations, so they don't have to manually re-key it

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,0 +1,30 @@
+Authentication
+
+The applications facilitates user management, authentication and
+authorisation itself.
+
+## Two factor authentication
+
+We rely on the following gems for our implementation of two factor
+authentication:
+
+- [Devise](https://github.com/heartcombo/devise)
+- [Devise-Two-Factor
+  Authentication](https://github.com/devise-two-factor/devise-two-factor)
+
+As there are a number of Devise 2FA gems, make sure you are referencing the
+correct documentation!
+
+Our one time passwords are time based. Generally speaking OTP have a concept of
+'drift' to allow for differences in the time on both the service and client.
+
+Whilst many 2FA Devise gems have separate setting for the expiry and drift,
+Devise-Two-Factor does not appear to, combining them into a single
+`[otp_allowed_drift](https://github.com/devise-two-factor/devise-two-factor#enabling-two-factor-authentication)` that we have set to 5 minutes in
+`[config/initializers/devise.rb](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/config/initializers/devise.rb)`.
+
+Something appears to introduce an additional 30 seconds on top of this which is
+documented in our
+`[spec/features/users_can_sign_in_spec.rb](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/spec/features/users_can_sign_in_spec.rb)`,
+at this point we can only assume this is part of the underlying
+[rotp](https://github.com/mdp/rotp) gem that is used.


### PR DESCRIPTION
There are two quite different changes here:

The first tightens the time control around the user signing in and the spec storing the OTP for comparing later.

The second makes the OTP always correct, decoupling the spec from the OTP entirely.

I've documented what I learnt along wth the changes to the acutal specs.

I found that the OTP seems to last 5 mintutes and 30 seconds, even though it is configured to 5 miniutes. I've added a spec that demonstrates the odd extra 30 seconds and encourage you to have a play with the specs and see what you think and let me know.

I am confident the end result here will stop the flaking, but other folks tastes may vary so I am leaving this draft for now.

Appreciate any other views on this spec flaking, there is an example CI run linked in the commit, but here it is again:

https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/actions/runs/7020362563/job/19099874908#step:6:9200

https://trello.com/c/AmrnslpW