### PR TITLE
(2997) Include ODA type in ISPF report export filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   included in the IATI XML download as applicable
 - The error summary is now shown correctly when adding new matched effort in the
   application
+- The filenames for ISPF report CSVs now include the ODA type
 
 ## Release 140 - 2023-11-28
 

--- a/app/services/export/report.rb
+++ b/app/services/export/report.rb
@@ -76,6 +76,7 @@ class Export::Report
     [
       @report.own_financial_quarter,
       @report.fund.source_fund.short_name,
+      @report.is_oda.nil? ? nil : I18n.t(".is_oda_summary.#{@report.is_oda}"),
       @report.organisation.beis_organisation_reference,
       "report.csv"
     ].reject(&:blank?).join("_")

--- a/spec/services/export/report_spec.rb
+++ b/spec/services/export/report_spec.rb
@@ -472,11 +472,20 @@ RSpec.describe Export::Report do
 
   describe "#filename" do
     subject { described_class.new(report: @report) }
+
     it "creates the file name" do
       expect(subject.filename).to include(@report.own_financial_quarter.to_s)
       expect(subject.filename).to include(@report.fund.source_fund.short_name)
       expect(subject.filename).to include(@report.organisation.beis_organisation_reference)
       expect(subject.filename).to include("report.csv")
+    end
+
+    context "for an ISPF report" do
+      subject { described_class.new(report: build(:report, :for_ispf, is_oda: false)) }
+
+      it "includes the ODA/non-ODA type in the file name" do
+        expect(subject.filename).to include("ISPF_Non-ODA")
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR
- ISPF report CSVs now include the ODA type, to make it easier for users to distinguish between them.

## Screenshots of UI changes
N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
