### PR TITLE
(2985) Order activity comments exported in budget CSV

### DIFF
--- a/app/services/budget/export.rb
+++ b/app/services/budget/export.rb
@@ -56,7 +56,7 @@ class Budget
         activity.extending_organisation&.name,
         I18n.t("table.body.activity.level.#{activity.level}"),
         activity.title,
-        activity.programme? ? comments_formatted_for_csv(activity.comments) : ""
+        activity.programme? ? comments_formatted_for_csv(activity.comments.order(:created_at)) : ""
       ]
     end
 


### PR DESCRIPTION
## Changes in this PR

PostgreSQL doesn't guarantee an order for records unless we specify an ordering criterion ourselves. It is *likely* that the records will be returned with the most recently updated last, which is why the spec only fails occasionally.

This is potentially the cause of the budget spec failing sometimes.

Specifying the order in which the comments are returned will fix the intermittent failures, if they were caused by the unpredictable ordering coming from the database.

If, on the other hand, the intermittent errors are caused by some randomness in how the test objects are created[1], we may see failures again sometimes.

[1] `programme_activity_comment_1` should be created before `programme_activity_comment_2`. If *this* ordering is not guaranteed, and `programme_activity_comment_2` ends up with a `created_at` older than `programme_activity_comment_1`'s created_at, then the fix may not make a difference.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
