### PR TITLE
Alias health_check so it responds to health-check

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   scope module: "public" do
     get "health_check" => "base#health_check"
+    match "health-check" => "base#health_check", :via => :get
     root to: "visitors#index"
   end
 

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe "Health Check", type: :request do
     end
   end
 
+  it "responds to health-check" do
+    get "/health-check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+    expect(response).to have_http_status(:ok)
+  end
+
   context "when enqueued is 20" do
     it "returns the correct size" do
       stats_double = double(Sidekiq::Stats, enqueued: 20, retry_size: 0)


### PR DESCRIPTION
## Changes in this PR

The AWS health check endpoint has been configured to look for the route `health-check` instead of `health_check`.

Rather than asking them to reconfigure it, we will accept that both versions (with dash and with underscore) are common, and provide an alias for the route, so that it responds to both requests.

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
