### PR TITLE
(2967) Generate unique references in organisation factory

### DIFF
--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :__organisation do
     sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
-    beis_organisation_reference { Faker::Alphanumeric.alpha(number: 5).upcase! }
-    iati_reference { "GB-GOV-#{Faker::Alphanumeric.alpha(number: 5).upcase!}" }
+    beis_organisation_reference { Faker::Alphanumeric.unique.alpha(number: 5).upcase! }
+    iati_reference { "GB-GOV-#{Faker::Alphanumeric.unique.alpha(number: 5).upcase!}" }
     organisation_type { "10" }
     default_currency { "GBP" }
     language_code { "en" }

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    Faker::Alphanumeric.unique.clear
+  end
+end


### PR DESCRIPTION
## Changes in this PR
- Use Faker's `unique` feature to guarantee unique strings for the `iati_reference` and `beis_organisation_reference` in the organisation factory.

We have seen the test suite fail with an intermittent failure, unrelated to actual code failure, caused by the organisation created failing the uniqueness check for its `iati_reference`:

```
ActiveRecord::RecordInvalid:
Validation failed: Iati reference Iati reference has already been taken
```

E.g. https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/actions/runs/6978961311/job/18991313569

We suspect this intermittent failure is caused by Faker's pseudo-random generator accidentally producing the same string within the same spec. The IATI reference and BEIS organisation reference are more susceptible to this, because the randomly generated sequences are only 5 characters long.

Using Faker's [unique feature](https://github.com/faker-ruby/faker#ensuring-unique-values) means it's also a good idea to clear the record of unique values that have been returned between each spec, to avoid running out of combinations. (Not statistically likely, but why take chances?)

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
