### PR TITLE
(3009) Budgets as "Activity budgets" for levels C and D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Display the budgets headings as "Activity budgets" for level C and D activities on the Financials tab
+
 ## Release 141 - 2023-12-04
 
 [Full changelog][141]

--- a/app/views/shared/activities/_budgets.html.haml
+++ b/app/views/shared/activities/_budgets.html.haml
@@ -1,7 +1,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m
-      = t("page_content.activity.budgets")
+      = t("page_content.activity.budgets.#{activity.to_model.level}")
 
     - if policy(activity).create?
       = link_to(t("page_content.budgets.button.create"), new_activity_budget_path(activity), class: "govuk-button")

--- a/config/locales/models/activity.en.yml
+++ b/config/locales/models/activity.en.yml
@@ -264,7 +264,11 @@ en:
     activity:
       unknown_country: Unknown country code (%{code})
       benefitting_region_check_box: Select or deselect all countries in %{region}
-      budgets: Budgets
+      budgets:
+        fund: Budgets
+        programme: Budgets
+        project: Activity budgets
+        third_party_project: Activity budgets
       button:
         create: Add activity
       implementing_organisation:

--- a/spec/features/users_can_create_a_budget_spec.rb
+++ b/spec/features/users_can_create_a_budget_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Users can create a budget" do
       scenario "they can view but not create budgets" do
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
-        expect(page).to have_content(t("page_content.activity.budgets"))
+        expect(page).to have_content(t("page_content.activity.budgets.programme"))
         expect(page).not_to have_content(t("page_content.budgets.button.create"))
       end
     end

--- a/spec/features/users_can_view_budgets_on_an_activity_page_spec.rb
+++ b/spec/features/users_can_view_budgets_on_an_activity_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can view budgets on an activity page" do
   context "when the user belongs to BEIS" do
     let(:user) { create(:beis_user) }
 
-    context "when the activity is fund_level" do
+    context "when the activity is a fund" do
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         create(:programme_activity, parent: fund_activity)
@@ -16,6 +16,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit organisation_activity_path(fund_activity.organisation, fund_activity)
 
+        expect(page).to have_content(t("page_content.activity.budgets.fund"))
         budget_information_is_shown_on_page(budget_presenter)
       end
 
@@ -34,7 +35,7 @@ RSpec.feature "Users can view budgets on an activity page" do
       end
     end
 
-    context "when the activity is programme level" do
+    context "when the activity is a programme" do
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
@@ -44,12 +45,14 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit organisation_activity_path(programme_activity.organisation, programme_activity)
 
+        expect(page).to have_content(t("page_content.activity.budgets.programme"))
         budget_information_is_shown_on_page(budget_presenter)
       end
     end
 
-    context "when the activity is project level" do
+    context "when the activity is a project" do
       let(:partner_org_user) { create(:partner_organisation_user) }
+
       scenario "budget information is shown on the page" do
         fund_activity = create(:fund_activity, organisation: user.organisation)
         programme_activity = create(:programme_activity, parent: fund_activity, organisation: user.organisation)
@@ -60,6 +63,7 @@ RSpec.feature "Users can view budgets on an activity page" do
 
         visit organisation_activity_path(project_activity.organisation, project_activity)
 
+        expect(page).to have_content(t("page_content.activity.budgets.project"))
         budget_information_is_shown_on_page(budget_presenter)
       end
 
@@ -99,6 +103,7 @@ RSpec.feature "Users can view budgets on an activity page" do
           click_link programme_activity.title
         end
 
+        expect(page).to have_content(t("page_content.activity.budgets.programme"))
         budget_information_is_shown_on_page(budget_presenter)
       end
 
@@ -115,7 +120,7 @@ RSpec.feature "Users can view budgets on an activity page" do
       end
     end
 
-    context "when the activity is project level" do
+    context "when the activity is a project" do
       scenario "budget information is shown on the page" do
         programme_activity = create(:programme_activity, extending_organisation: user.organisation)
         project_activity = create(:project_activity, parent: programme_activity, organisation: user.organisation)
@@ -129,6 +134,7 @@ RSpec.feature "Users can view budgets on an activity page" do
         click_on t("tabs.activity.children")
         click_link project_activity.title
 
+        expect(page).to have_content(t("page_content.activity.budgets.project"))
         budget_information_is_shown_on_page(budget_presenter)
       end
 


### PR DESCRIPTION
## Changes in this PR
- Display the budgets headings as "Activity budgets" for level C and D activities on the Financials tab

## Screenshots of UI changes

### Before

#### Service owner view:
<img width="1109" alt="Screenshot 2023-12-19 at 13 20 59" src="https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/aa79bb58-69dd-43ae-9a0d-9bd9f756404d">

#### Partner organisation view:
<img width="1110" alt="Screenshot 2023-12-19 at 13 21 16" src="https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/0c2e19f9-b0d8-4f46-bdeb-ab9e4cc96846">

### After

#### Service owner view:
<img width="1099" alt="Screenshot 2023-12-19 at 12 50 29" src="https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/e73ed0d2-9c2a-48ef-89d2-cc7bb375da6b">

#### Partner organisation view:
<img width="1125" alt="Screenshot 2023-12-19 at 12 50 15" src="https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/96fa5907-2b7d-4ef3-8b81-479377bb83f8">

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
