### PR TITLE
HOTFIX: Add new activity tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- add a new Activity tag, Strategic Allocation Pot (SAP), code 8
+
 ## Release 141 - 2023-12-04
 
 [Full changelog][141]

--- a/spec/helpers/codelist_helper_spec.rb
+++ b/spec/helpers/codelist_helper_spec.rb
@@ -240,11 +240,11 @@ RSpec.describe CodelistHelper, type: :helper do
       it "returns the BEIS codes and descriptions" do
         options = helper.tags_options
 
-        expect(options.length).to eq 7
+        expect(options.length).to eq 8
         expect(options.first.code).to eq 1
         expect(options.first.description).to eq "Ayrton Fund"
-        expect(options.last.code).to eq 7
-        expect(options.last.description).to eq "Previously reported under Newton Fund"
+        expect(options.last.code).to eq 8
+        expect(options.last.description).to eq "Strategic Allocation Pot (SAP)"
       end
     end
   end

--- a/vendor/data/codelists/BEIS/tags.yml
+++ b/vendor/data/codelists/BEIS/tags.yml
@@ -13,3 +13,5 @@ data:
     description: Previously reported under GCRF
   - code: 7
     description: Previously reported under Newton Fund
+  - code: 8
+    description: Strategic Allocation Pot (SAP)


### PR DESCRIPTION
This PR picks the relevant commit from [PR 2289](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2289) and applies them straight to main. 

We are doing this to be able to release this work quickly for the client, without releasing other commits currently sitting in develop.

-------

DSIT asked to have the following activity tag added:

code: 8
description: Strategic Allocation Pot (SAP)

This was on dxw support ticket #19080

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
