### PR TITLE
(2931/3) Actual, Refund or Comment row import service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - the new actual, refund and activity importer no longer accepts negative actual
   values
 - Provide a CSV download of all activities that are likely to continue under DSIT and will need the new DSIT transparency identifier
+- add a service that can import a single row of csv that contains either a
+  Actual, Refund or Activity Comment
 
 ## Release 141 - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Provide a CSV download of all activities that are likely to continue under DSIT and will need the new DSIT transparency identifier
 - add a service that can import a single row of csv that contains either a
   Actual, Refund or Activity Comment
+- when importing an Activity, Refund or Activity comment, the result can now be
+  a row that was skipped
 
 ## Release 141 - 2023-12-04
 

--- a/app/models/import/csv/activity_actual_refund_comment/skipped_row.rb
+++ b/app/models/import/csv/activity_actual_refund_comment/skipped_row.rb
@@ -1,0 +1,17 @@
+class Import::Csv::ActivityActualRefundComment::SkippedRow
+  def initialize(import_row)
+    @row = import_row
+  end
+
+  def roda_identifier
+    @row.roda_identifier
+  end
+
+  def financial_quarter
+    @row.financial_quarter
+  end
+
+  def financial_year
+    @row.financial_year
+  end
+end

--- a/app/services/import/csv/activity_actual_refund_comment/row_service.rb
+++ b/app/services/import/csv/activity_actual_refund_comment/row_service.rb
@@ -1,0 +1,135 @@
+class Import::Csv::ActivityActualRefundComment::RowService
+  attr_reader :errors
+
+  def initialize(report, user, row)
+    @report = report
+    @user = user
+    @activity = nil
+    @errors = {}
+    @row = Import::Csv::ActivityActualRefundComment::Row.new(row)
+  end
+
+  def import!
+    if @row.valid?
+      @activity = find_activity(@row.roda_identifier)
+
+      return false if @activity.nil?
+
+      return false if @row.empty?
+
+      return false unless authorise_activity(@activity)
+
+      create_record
+    else
+      @errors.update(@row.errors)
+      false
+    end
+  end
+
+  private def create_record
+    case type_of_row(@row)
+    when :actual
+      result = create_actual(@row, @activity)
+    when :refund
+      result = create_refund(@row, @activity)
+    when :comment
+      result = create_activity_comment(@row, @activity)
+    end
+
+    return false unless result
+
+    if result.failure?
+      result.object.errors.each do |error|
+        @errors[error.attribute] = [error.attribute, error.message]
+      end
+      false
+    else
+      result.object
+    end
+  end
+
+  private def find_activity(roda_identifier)
+    activity = Activity.find_by_roda_identifier(roda_identifier)
+
+    unless activity
+      @errors.update({"Activity RODA Identifier" => [
+        roda_identifier, I18n.t("import.csv.activity_actual_refund_comment.errors.activity_roda_identifier.not_found")
+      ]})
+    end
+
+    activity
+  end
+
+  private def authorise_activity(activity)
+    policy = ActivityPolicy.new(@user, activity)
+    if !policy.create?
+      @errors.update({"Activity RODA Identifier" => [
+        activity.roda_identifier,
+        I18n.t("import.csv.activity_actual_refund_comment.errors.activity_roda_identifier.not_authorised")
+      ]})
+      return false
+    elsif !reportable_activity?(activity)
+      @errors.update({"Activity RODA Identifier" => [
+        activity.roda_identifier,
+        I18n.t("import.csv.activity_actual_refund_comment.errors.activity_roda_identifier.not_reportable")
+      ]})
+      return false
+    end
+    true
+  end
+
+  private def reportable_activity?(activity)
+    activity.organisation == @report.organisation && activity.associated_fund == @report.fund
+  end
+
+  private def type_of_row(row)
+    return :actual if row.actual_value.positive? && row.refund_value.zero?
+    return :refund if row.refund_value.nonzero? && row.actual_value.zero?
+    return :comment if row.actual_value.zero? && row.refund_value.zero? && row.comment.present?
+  end
+
+  private def create_actual(row, activity)
+    creator = CreateActual.new(activity: activity, report: @report, user: @user)
+    financial_quarter = FinancialQuarter.new(row.financial_year, row.financial_quarter)
+
+    creator.call(attributes: {
+      value: row.actual_value,
+      financial_quarter: row.financial_quarter,
+      financial_year: row.financial_year,
+      comment: row.comment,
+      currency: activity.providing_organisation.default_currency,
+      description: "#{financial_quarter} spend on #{activity.title}",
+      receiving_organisation_name: row.receiving_organisation_name,
+      receiving_organisation_type: row.receiving_organisation_type,
+      receiving_organisation_reference: row.receiving_organisation_iati_reference
+    })
+  end
+
+  private def create_refund(row, activity)
+    creator = CreateRefund.new(activity: activity, report: @report, user: @user)
+    financial_quarter = FinancialQuarter.new(row.financial_year, row.financial_quarter)
+
+    creator.call(attributes: {
+      value: row.refund_value,
+      financial_quarter: row.financial_quarter,
+      financial_year: row.financial_year,
+      comment: row.comment,
+      currency: activity.providing_organisation.default_currency,
+      description: "#{financial_quarter} refund from #{activity.title}",
+      receiving_organisation_name: row.receiving_organisation_name,
+      receiving_organisation_type: row.receiving_organisation_type,
+      receiving_organisation_reference: row.receiving_organisation_iati_reference
+    })
+  end
+
+  private def create_activity_comment(row, activity)
+    comment = Comment.new(
+      body: row.comment,
+      commentable: activity,
+      owner: @user,
+      report: @report
+    )
+
+    Result.new(comment.save!, comment)
+  end
+end

--- a/app/services/import/csv/activity_actual_refund_comment/row_service.rb
+++ b/app/services/import/csv/activity_actual_refund_comment/row_service.rb
@@ -15,9 +15,9 @@ class Import::Csv::ActivityActualRefundComment::RowService
 
       return false if @activity.nil?
 
-      return false if @row.empty?
-
       return false unless authorise_activity(@activity)
+
+      return Import::Csv::ActivityActualRefundComment::SkippedRow.new(@row) if @row.empty?
 
       create_record
     else

--- a/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
+++ b/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
@@ -19,3 +19,7 @@ en:
           receiving_organisation_type:
             blank_name: Cannot be blank when Receiving Organisation Name is present
             invalid_code: Is not a valid receiving organisation type code
+          activity_roda_identifier:
+            not_found: Cannot be found
+            not_authorised: Not authorised
+            not_reportable: Cannot be included in this report

--- a/spec/models/import/csv/activity_actual_refund_comment/row_spec.rb
+++ b/spec/models/import/csv/activity_actual_refund_comment/row_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Import::Csv::ActivityActualRefundComment::Row do
+RSpec.describe Import::Csv::ActivityActualRefundComment::Row, type: :import_csv do
   subject { described_class.new(csv_row) }
 
   describe "#actual_value" do
@@ -603,21 +603,6 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::Row do
         end
       end
     end
-  end
-
-  def valid_csv_row(actual: "10000", refund: "0", comment: "This is a comment")
-    row = double(CSV::Row)
-    allow(row).to receive(:field).with("Activity RODA Identifier").and_return("GCRF-UKSA-DJ94DSK0-ID")
-    allow(row).to receive(:field).with("Financial Quarter").and_return("1")
-    allow(row).to receive(:field).with("Financial Year").and_return("2023")
-    allow(row).to receive(:field).with("Actual Value").and_return(actual)
-    allow(row).to receive(:field).with("Refund Value").and_return(refund)
-    allow(row).to receive(:field).with("Comment").and_return(comment)
-    allow(row).to receive(:field).with("Receiving Organisation Name").and_return(nil)
-    allow(row).to receive(:field).with("Receiving Organisation IATI Reference").and_return(nil)
-    allow(row).to receive(:field).with("Receiving Organisation Type").and_return(nil)
-
-    row
   end
 
   def error_for_column(column_header)

--- a/spec/models/import/csv/activity_actual_refund_comment/skipped_row_spec.rb
+++ b/spec/models/import/csv/activity_actual_refund_comment/skipped_row_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Import::Csv::ActivityActualRefundComment::SkippedRow do
+  subject do
+    described_class.new(
+      double(
+        roda_identifier: "VALID-RODA-IDENTIFIER",
+        financial_quarter: "2",
+        financial_year: "2023"
+      )
+    )
+  end
+
+  describe "#roda_identifier" do
+    it "returns the roda identifier from the row" do
+      expect(subject.roda_identifier).to eql "VALID-RODA-IDENTIFIER"
+    end
+  end
+
+  describe "#financial_quarter" do
+    it "returns the value from the row" do
+      expect(subject.financial_quarter).to eql "2"
+    end
+  end
+
+  describe "#financial_year" do
+    it "returns the value from the row" do
+      expect(subject.financial_year).to eql "2023"
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   config.include TransactionHelpers
   config.include ExportHelpers
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include CsvImportHelpers, type: :import_csv
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/import/csv/activity_actual_refund_comment/row_service_spec.rb
+++ b/spec/services/import/csv/activity_actual_refund_comment/row_service_spec.rb
@@ -1,0 +1,453 @@
+require "rails_helper"
+
+RSpec.describe Import::Csv::ActivityActualRefundComment::RowService, type: :import_csv do
+  let(:report) { double(Report) }
+  let(:user) { double(User) }
+  let(:organisation) { double(Organisation, default_currency: "GBP") }
+  let(:fund) { double(Fund) }
+  let(:activity) { double(Activity) }
+
+  let(:valid_actual) { double(Actual, errors: [], save!: true) }
+  let(:invalid_actual) { double(Actual, errors: [double(attribute: "value", message: "Value must not be zero")], save!: false) }
+
+  let(:valid_refund) { double(Refund, errors: [], save!: true) }
+  let(:invalid_refund) { double(Refund, errors: [double(attribute: "value", message: "Value must not be zero")], save!: false) }
+
+  let(:valid_comment) { double(Comment, errors: [], save!: true) }
+  let(:invalid_comment) { double(Comment, errors: [double(attribute: "body", message: "Cannot be blank")], save!: false) }
+
+  let(:authorised_policy) { double(ActivityPolicy, create?: true) }
+  let(:unauthorised_policy) { double(ActivityPolicy, create?: false) }
+
+  subject { described_class.new(report, user, csv_row) }
+
+  describe "#import!" do
+    context "when the row is for an actual" do
+      context "and the row is valid" do
+        let(:csv_row) { valid_csv_row(actual: "10000", refund: "0", comment: "") }
+
+        it "returns the actual record" do
+          allow(activity).to receive(:providing_organisation).and_return(organisation)
+          allow(activity).to receive(:title).and_return("A test activity")
+
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          creator = double(CreateActual)
+          allow(CreateActual).to receive(:new).and_return(creator)
+          allow(creator).to receive(:call).and_return(Result.new(true, valid_actual))
+
+          result = subject.import!
+
+          expect(result).to eql valid_actual
+        end
+
+        it "assigns the default values" do
+          allow(activity).to receive(:providing_organisation).and_return(organisation)
+          allow(activity).to receive(:title).and_return("A test activity")
+
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          creator = double(CreateActual)
+          allow(CreateActual).to receive(:new).and_return(creator)
+          allow(creator).to receive(:call).and_return(Result.new(true, valid_actual))
+
+          subject.import!
+
+          expected_attributes = {
+            comment: nil,
+            currency: "GBP",
+            description: "FQ1 2023-2024 spend on A test activity",
+            financial_quarter: "1",
+            financial_year: "2023",
+            value: BigDecimal("10000"),
+            receiving_organisation_name: nil,
+            receiving_organisation_type: nil,
+            receiving_organisation_reference: nil
+          }
+
+          expect(creator).to have_received(:call).with(attributes: expected_attributes)
+        end
+
+        context "and there is a receiving organisation" do
+          it "assigns the receiving organisation attributes" do
+            allow(csv_row).to receive(:field).with("Receiving Organisation Name").and_return("Receiving Organisation")
+            allow(csv_row).to receive(:field).with("Receiving Organisation Type").and_return("10")
+            allow(csv_row).to receive(:field).with("Receiving Organisation IATI Reference").and_return("IATI-RO-01")
+
+            allow(activity).to receive(:providing_organisation).and_return(organisation)
+            allow(activity).to receive(:title).and_return("A test activity")
+
+            allow(subject).to receive(:find_activity).and_return(activity)
+            allow(subject).to receive(:authorise_activity).and_return(true)
+
+            creator = double(CreateActual)
+            allow(CreateActual).to receive(:new).and_return(creator)
+            allow(creator).to receive(:call).and_return(Result.new(true, valid_actual))
+
+            subject.import!
+
+            expected_attributes = {
+              comment: nil,
+              currency: "GBP",
+              description: "FQ1 2023-2024 spend on A test activity",
+              financial_quarter: "1",
+              financial_year: "2023",
+              value: BigDecimal("10000"),
+              receiving_organisation_name: "Receiving Organisation",
+              receiving_organisation_type: "10",
+              receiving_organisation_reference: "IATI-RO-01"
+            }
+
+            expect(creator).to have_received(:call).with(attributes: expected_attributes)
+          end
+        end
+
+        context "and the actual cannot be saved" do
+          it "returns false with errors" do
+            allow(subject).to receive(:find_activity).and_return(activity)
+            allow(subject).to receive(:authorise_activity).and_return(true)
+            allow(subject).to receive(:type_of_row).and_return(:actual)
+            allow(subject).to receive(:create_actual).and_return(Result.new(false, invalid_actual))
+
+            result = subject.import!
+            errors = subject.errors
+
+            expect(result).to be false
+
+            expect(errors.count).to be 1
+            expect(error_for_attribute(errors, "value").attribute).to eql "value"
+            expect(error_for_attribute(errors, "value").message).to eql "Value must not be zero"
+          end
+        end
+      end
+
+      context "when the row is not valid" do
+        let(:csv_row) { valid_csv_row(actual: "10000", refund: "20000", comment: "") }
+
+        it "returns false with errors" do
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+
+          expect(errors.count).to be 2
+          expect(error_for_attribute(errors, "Actual Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Actual Value").value).to eql "10000"
+          expect(error_for_attribute(errors, "Refund Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Refund Value").value).to eql "20000"
+        end
+      end
+
+      context "when the type of row cannot be identified" do
+        let(:csv_row) { valid_csv_row }
+
+        it "returns false without errors" do
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+          allow(subject).to receive(:type_of_row).and_return(nil)
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+          expect(errors.count).to be_zero
+        end
+      end
+    end
+
+    context "when the row is for a refund" do
+      context "and the row is valid" do
+        let(:csv_row) { valid_csv_row(actual: "0", refund: "30000", comment: "This is a refund comment.") }
+
+        it "returns the refund" do
+          allow(activity).to receive(:providing_organisation).and_return(organisation)
+          allow(activity).to receive(:title).and_return("A test activity")
+
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          creator = double(CreateRefund)
+          allow(CreateRefund).to receive(:new).and_return(creator)
+          allow(creator).to receive(:call).and_return(Result.new(true, valid_refund))
+
+          result = subject.import!
+
+          expect(result).to eql valid_refund
+        end
+
+        it "assigns the default values" do
+          allow(activity).to receive(:providing_organisation).and_return(organisation)
+          allow(activity).to receive(:title).and_return("A test activity")
+
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          creator = double(CreateRefund)
+          allow(CreateRefund).to receive(:new).and_return(creator)
+          allow(creator).to receive(:call).and_return(Result.new(true, valid_refund))
+
+          subject.import!
+
+          expected_attributes = {
+            comment: "This is a refund comment.",
+            currency: "GBP",
+            description: "FQ1 2023-2024 refund from A test activity",
+            financial_quarter: "1",
+            financial_year: "2023",
+            value: BigDecimal("30000"),
+            receiving_organisation_name: nil,
+            receiving_organisation_type: nil,
+            receiving_organisation_reference: nil
+          }
+
+          expect(creator).to have_received(:call).with(attributes: expected_attributes)
+        end
+
+        context "and there is a receiving organisation" do
+          it "assigns the receiving organisation attributes" do
+            allow(csv_row).to receive(:field).with("Receiving Organisation Name").and_return("Receiving Organisation")
+            allow(csv_row).to receive(:field).with("Receiving Organisation Type").and_return("10")
+            allow(csv_row).to receive(:field).with("Receiving Organisation IATI Reference").and_return("IATI-RO-01")
+
+            allow(activity).to receive(:providing_organisation).and_return(organisation)
+            allow(activity).to receive(:title).and_return("A test activity")
+
+            allow(subject).to receive(:find_activity).and_return(activity)
+            allow(subject).to receive(:authorise_activity).and_return(true)
+
+            creator = double(CreateRefund)
+            allow(CreateRefund).to receive(:new).and_return(creator)
+            allow(creator).to receive(:call).and_return(Result.new(true, valid_refund))
+
+            subject.import!
+
+            expected_attributes = {
+              comment: "This is a refund comment.",
+              currency: "GBP",
+              description: "FQ1 2023-2024 refund from A test activity",
+              financial_quarter: "1",
+              financial_year: "2023",
+              value: BigDecimal("30000"),
+              receiving_organisation_name: "Receiving Organisation",
+              receiving_organisation_type: "10",
+              receiving_organisation_reference: "IATI-RO-01"
+            }
+
+            expect(creator).to have_received(:call).with(attributes: expected_attributes)
+          end
+        end
+
+        context "and the refund cannot be saved" do
+          it "returns false with the error" do
+            allow(subject).to receive(:find_activity).and_return(activity)
+            allow(subject).to receive(:authorise_activity).and_return(true)
+            allow(subject).to receive(:type_of_row).and_return(:refund)
+            allow(subject).to receive(:create_refund).and_return(Result.new(false, invalid_refund))
+
+            result = subject.import!
+            errors = subject.errors
+
+            expect(result).to be false
+
+            expect(errors.count).to be 1
+            expect(error_for_attribute(errors, "value").attribute).to eql "value"
+            expect(error_for_attribute(errors, "value").message).to eql "Value must not be zero"
+          end
+        end
+      end
+
+      context "when the row is not valid" do
+        let(:csv_row) { valid_csv_row(actual: "20000", refund: "30000", comment: "This is a refund comment.") }
+
+        it "returns false with errors" do
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+
+          expect(errors.count).to be 2
+          expect(error_for_attribute(errors, "Actual Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Actual Value").value).to eql "20000"
+          expect(error_for_attribute(errors, "Refund Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Refund Value").value).to eql "30000"
+        end
+      end
+    end
+
+    context "when the row is for an activity comment" do
+      context "and the row is valid" do
+        let(:csv_row) { valid_csv_row(actual: "0", refund: "0", comment: "This is a activity comment.") }
+
+        it "returns the comment record" do
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+
+          allow(Comment).to receive(:new).and_return(valid_comment)
+
+          result = subject.import!
+
+          expect(result).to eql valid_comment
+        end
+
+        context "and the activity comment cannot be saved" do
+          it "returns false with the error" do
+            allow(subject).to receive(:find_activity).and_return(activity)
+            allow(subject).to receive(:authorise_activity).and_return(true)
+            allow(subject).to receive(:type_of_row).and_return(:comment)
+            allow(subject).to receive(:create_activity_comment).and_return(Result.new(false, invalid_comment))
+
+            result = subject.import!
+            errors = subject.errors
+
+            expect(result).to be false
+
+            expect(errors.count).to be 1
+            expect(error_for_attribute(errors, "body").attribute).to eql "body"
+            expect(error_for_attribute(errors, "body").message).to eql "Cannot be blank"
+          end
+        end
+      end
+
+      context "when the row is not valid" do
+        let(:csv_row) { valid_csv_row(actual: "40000", refund: "50000", comment: "This is a activity comment.") }
+
+        it "returns false with errors" do
+          allow(subject).to receive(:find_activity).and_return(activity)
+          allow(subject).to receive(:authorise_activity).and_return(true)
+          allow(subject).to receive(:type_of_row).and_return(:comment)
+          allow(subject).to receive(:create_activity_comment).and_return(Result.new(false, valid_comment))
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+
+          expect(errors.count).to be 2
+          expect(error_for_attribute(errors, "Actual Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Actual Value").value).to eql "40000"
+          expect(error_for_attribute(errors, "Refund Value").message).to include "cannot be reported on the same row"
+          expect(error_for_attribute(errors, "Refund Value").value).to eql "50000"
+        end
+      end
+    end
+
+    context "when the activity cannot be found" do
+      let(:csv_row) { valid_csv_row }
+
+      it "returns false with an error" do
+        allow(Activity).to receive(:find_by_roda_identifier).and_return(nil)
+
+        result = subject.import!
+        errors = subject.errors
+
+        expect(result).to be false
+
+        expect(errors.count).to be 1
+        expect(error_for_attribute(errors, "Activity RODA Identifier").message).to eql "Cannot be found"
+      end
+    end
+
+    context "when the row is empty" do
+      let(:csv_row) { valid_csv_row(actual: "0", refund: "0", comment: "") }
+
+      it "returns false without an error" do
+        row = double(Import::Csv::ActivityActualRefundComment::Row, valid?: true, empty?: true)
+        allow(row).to receive(:roda_identifier)
+        allow(Import::Csv::ActivityActualRefundComment::Row).to receive(:new).and_return(row)
+
+        allow(subject).to receive(:find_activity).and_return(activity)
+
+        result = subject.import!
+        errors = subject.errors
+
+        expect(result).to be false
+
+        expect(errors.count).to be_zero
+      end
+    end
+
+    context "when the activity is authorised" do
+      let(:csv_row) { valid_csv_row(actual: "10000", refund: "0", comment: "") }
+
+      it "returns the new record with no errors" do
+        allow(ActivityPolicy).to receive(:new).and_return(authorised_policy)
+
+        allow(activity).to receive(:roda_identifier).and_return("VALID-RODA-IDENTIFIER")
+        allow(activity).to receive(:organisation).and_return(organisation)
+        allow(activity).to receive(:associated_fund).and_return(fund)
+
+        allow(report).to receive(:organisation).and_return(organisation)
+        allow(report).to receive(:fund).and_return(fund)
+
+        allow(subject).to receive(:find_activity).and_return(activity)
+        allow(subject).to receive(:type_of_row).and_return(:comment)
+        allow(subject).to receive(:create_activity_comment).and_return(Result.new(true, valid_comment))
+
+        result = subject.import!
+        errors = subject.errors
+
+        expect(result).to be valid_comment
+        expect(errors.count).to be_zero
+      end
+    end
+
+    context "when the activity is not authorised" do
+      let(:csv_row) { valid_csv_row(actual: "10000", refund: "0", comment: "") }
+
+      context "because the user cannot create" do
+        it "returns false with an error" do
+          allow(ActivityPolicy).to receive(:new).and_return(unauthorised_policy)
+
+          allow(activity).to receive(:roda_identifier).and_return("VALID-RODA-IDENTIFIER")
+
+          allow(subject).to receive(:find_activity).and_return(activity)
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+
+          expect(errors.count).to be 1
+          expect(error_for_attribute(errors, "Activity RODA Identifier").value).to eql "VALID-RODA-IDENTIFIER"
+          expect(error_for_attribute(errors, "Activity RODA Identifier").message).to eql "Not authorised"
+        end
+      end
+
+      context "when the activity is not reportable" do
+        let(:csv_row) { valid_csv_row(actual: "10000", refund: "0", comment: "") }
+
+        it "returns false with an error" do
+          allow(ActivityPolicy).to receive(:new).and_return(authorised_policy)
+
+          allow(activity).to receive(:roda_identifier).and_return("VALID-RODA-IDENTIFIER")
+
+          allow(subject).to receive(:reportable_activity?).and_return(false)
+          allow(subject).to receive(:find_activity).and_return(activity)
+
+          result = subject.import!
+          errors = subject.errors
+
+          expect(result).to be false
+          expect(errors.count).to be 1
+          expect(error_for_attribute(errors, "Activity RODA Identifier").value).to eql "VALID-RODA-IDENTIFIER"
+          expect(error_for_attribute(errors, "Activity RODA Identifier").message).to eql "Cannot be included in this report"
+        end
+      end
+    end
+  end
+
+  def error_for_attribute(errors, attribute)
+    value = errors[attribute][0]
+    message = errors[attribute][1]
+
+    OpenStruct.new(attribute: attribute, value: value, message: message)
+  end
+end

--- a/spec/support/csv_import_helpers.rb
+++ b/spec/support/csv_import_helpers.rb
@@ -1,0 +1,16 @@
+module CsvImportHelpers
+  def valid_csv_row(actual: "10000", refund: "0", comment: "This is a comment.")
+    row = double(CSV::Row)
+    allow(row).to receive(:field).with("Activity RODA Identifier").and_return("GCRF-UKSA-DJ94DSK0-ID")
+    allow(row).to receive(:field).with("Financial Quarter").and_return("1")
+    allow(row).to receive(:field).with("Financial Year").and_return("2023")
+    allow(row).to receive(:field).with("Actual Value").and_return(actual)
+    allow(row).to receive(:field).with("Refund Value").and_return(refund)
+    allow(row).to receive(:field).with("Comment").and_return(comment)
+    allow(row).to receive(:field).with("Receiving Organisation Name").and_return(nil)
+    allow(row).to receive(:field).with("Receiving Organisation IATI Reference").and_return(nil)
+    allow(row).to receive(:field).with("Receiving Organisation Type").and_return(nil)
+
+    row
+  end
+end


### PR DESCRIPTION
In #2293 we introduced a model of a row that contains Actual, Refund or Activity comment data for importing.

Here we add a service that can turn one of these row objects into actual objects in the application database.

Given a appropriate `CSV::Row` this service will with return the resulting object that was added or false, a row can be skipped, see below.

This is the point at which we will attempt to locate the `Activity` to associate the record with. We also check that the activity is authorised for the report and user.

In the current import implementation (that this work intends to replace) a row cannot be skipped i.e. a row cannot result in no data being created, this was seen by users as a drawback, they want to include rows that have no result. To support this change, we introduce a simple `SkippedRow` class that models just enough attributes to show the users which rows in their data were skipped - whilst there is no interface for this, we want to be able to support it later.

This work is the third in a series, next step: add a service that calls this service to import an entire file of rows.

If you want more context about the longer plan - just ask! :)

https://trello.com/c/lBZkYq5c