### PR TITLE
Export a CSV of all continuing activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   comments
 - the new actual, refund and activity importer no longer accepts negative actual
   values
+- Provide a CSV download of all activities that are likely to continue under DSIT and will need the new DSIT transparency identifier
 
 ## Release 141 - 2023-12-04
 

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -74,4 +74,18 @@ class ExportsController < BaseController
     response.stream.write(spending_breakdown_csv)
     response.stream.close
   end
+
+  def continuing_activities
+    authorize :export, :show_continuing_activities?
+
+    respond_to do |format|
+      format.csv do
+        export = Export::ContinuingActivities.new
+
+        stream_csv_download(filename: export.filename, headers: export.headers) do |csv|
+          export.rows.each { |row| csv << row }
+        end
+      end
+    end
+  end
 end

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -14,4 +14,8 @@ class ExportPolicy < ApplicationPolicy
   def show_spending_breakdown?
     user.service_owner?
   end
+
+  def show_continuing_activities?
+    user.service_owner?
+  end
 end

--- a/app/services/export/continuing_activities.rb
+++ b/app/services/export/continuing_activities.rb
@@ -1,0 +1,85 @@
+class Export::ContinuingActivities
+  def filename
+    "continuing_activities.csv"
+  end
+
+  def headers
+    [
+      "Partner Organisation name",
+      "Activity name",
+      "RODA ID",
+      "Current Transparency identifier",
+      "Future Transparency identifier",
+      "Current Previous identifier",
+      "Future Previous identifier",
+      "Partner Organisation ID",
+      "Status",
+      "Level"
+    ]
+  end
+
+  def rows
+    activities.map do |activity|
+      partner_organisation_name = activity.organisation.name
+      activity_title = activity.title
+      roda_identifier = activity.roda_identifier
+      current_transparency_identifier = activity.transparency_identifier
+      future_transparency_identifier = current_transparency_identifier&.sub(/\AGB-GOV-13/, "GB-GOV-26")
+      current_previous_identifier = activity.previous_identifier
+      future_previous_identifier = current_transparency_identifier
+      partner_organisation_identifier = activity.partner_organisation_identifier
+      status = I18n.t("activity.programme_status.#{activity.programme_status}")
+      level = I18n.t("table.body.activity.level.#{activity.level}")
+
+      [
+        partner_organisation_name,
+        activity_title,
+        roda_identifier,
+        current_transparency_identifier,
+        future_transparency_identifier,
+        current_previous_identifier,
+        future_previous_identifier,
+        partner_organisation_identifier,
+        status,
+        level
+      ]
+    end
+  end
+
+  def activities
+    # active statuses, regardless of any associated actual spend
+    definitely_active = Activity
+      .joins(:organisation)
+      .includes(:organisation)
+      .where.not(level: "fund")
+      .where(is_oda: [nil, true])
+      .where.not(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
+      .order("organisations.name, programme_status")
+
+    cut_off_quarter = FinancialQuarter.new(2022, 4)
+
+    # activities that MAY need to continue, IF they have actual spend more recent than FQ4 2022-2023
+    potentially_active_due_to_actuals = Activity
+      .joins(:organisation, :actuals)
+      .includes(:organisation)
+      .where.not(level: "fund")
+      .where(is_oda: [nil, true])
+      .where(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
+      .where("transactions.date > ?", cut_off_quarter.end_date)
+      .order("organisations.name, programme_status")
+
+    # activities that MAY need to continue, IF they have forecasts for quarters after FQ4 2022-2023
+    potentially_active_due_to_forecasts = Activity
+      .joins(:organisation)
+      .includes(:organisation)
+      .where.not(level: "fund")
+      .where(is_oda: [nil, true])
+      .where(programme_status: "paused")
+      .order("organisations.name, programme_status")
+    potentially_active_due_to_forecasts = potentially_active_due_to_forecasts.select do |activity|
+      Forecast.unscoped.where(parent_activity_id: activity.id).where("period_start_date > ?", cut_off_quarter.end_date).any?
+    end
+
+    (definitely_active + potentially_active_due_to_actuals + potentially_active_due_to_forecasts).uniq
+  end
+end

--- a/app/views/exports/index.html.haml
+++ b/app/views/exports/index.html.haml
@@ -49,6 +49,28 @@
                   = a11y_action_link("Request new", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
                 - else
                   = a11y_action_link("Request", spending_breakdown_exports_path(fund_id: fund.id), t("table.export.spending_breakdown.name", fund: fund.name), ["govuk-link--no-visited-state"])
+
+      %h1.govuk-heading-m
+        Ad-hoc exports
+
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: "col"}
+              Purpose
+            %th.govuk-table__header{scope: "col"}
+              = t("table.export.header.format")
+            %th.govuk-table__header{scope: "col"}
+              = t("table.header.default.actions")
+        %tbody.govuk-table__body
+          %tr.govuk-table__row
+            %td.govuk-table__cell
+              Activities continuing under GB-GOV-26
+            %td.govuk-table__cell
+              CSV
+            %td.govuk-table__cell
+              = a11y_action_link("Download", continuing_activities_exports_path(format: "csv"))
+
       %h1.govuk-heading-m
         = t("page_content.export.organisations.title")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     member do
       get "spending_breakdown_download"
     end
+    get "continuing_activities", on: :collection
   end
 
   namespace :exports do

--- a/spec/services/export/continuing_activities_spec.rb
+++ b/spec/services/export/continuing_activities_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe Export::ContinuingActivities do
+  let(:export) { Export::ContinuingActivities.new }
+
+  describe "#activities" do
+    context "a completed activity" do
+      let!(:project) { create(:project_activity, programme_status: "completed") }
+
+      context "without actual spend" do
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+
+      context "with actual spend before or including in FQ4 2022-2023" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2022, 4).end_date) }
+
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+
+      context "with actual spend after FQ4 2022-2023" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2023, 1).start_date) }
+
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+    end
+
+    context "a spend_in_progress activity" do
+      let!(:project) { create(:project_activity, programme_status: "spend_in_progress") }
+
+      context "without actual spend" do
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+
+      context "with actual spend before or including in FQ4 2022-2023" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2022, 4).end_date) }
+
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+
+      context "with actual spend after FQ4 2022-2023" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2023, 1).start_date) }
+
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+
+      context "for ISPF non-ODA" do
+        before { project.update(is_oda: false) }
+
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+    end
+
+    context "a paused activity" do
+      let!(:project) { create(:project_activity, programme_status: "paused") }
+
+      context "with neither actual spend nor forecasts" do
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+
+      context "with actual spend before or including in FQ4 2022-2023 and no forecasts" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2022, 4).end_date) }
+
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+
+      context "with actual spend after FQ4 2022-2023 and no forecasts" do
+        before { create(:actual, parent_activity: project, date: FinancialQuarter.new(2023, 1).start_date) }
+
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+
+      context "with forecasts before or including in FQ4 2022-2023 and no actual spend" do
+        before do
+          ReportingCycle.new(project, 2, 2022).tick
+          # initialising a reporting cycle like that and "tick"ing over the report cycle
+          # gives us a report for FQ3 2022-2023, in which we can report a forecast for FQ4 2022-2023
+          forecast_history = ForecastHistory.new(project, financial_quarter: 4, financial_year: 2022)
+          forecast_history.set_value(1000)
+        end
+
+        it "is not included" do
+          expect(export.activities).to_not include(project)
+        end
+      end
+
+      context "with forecasts after FQ4 2022-2023 and no actual spend" do
+        before do
+          ReportingCycle.new(project, 3, 2022).tick
+          # initialising a reporting cycle like that and "tick"ing over the report cycle
+          # gives us a report for FQ4 2022-2023, in which we can report a forecast for FQ1 2023-2024
+          forecast_history = ForecastHistory.new(project, financial_quarter: 1, financial_year: 2023)
+          forecast_history.set_value(1000)
+        end
+
+        it "is included" do
+          expect(export.activities).to include(project)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

The first step in updating activities with the new transparency identifier: producing a list of activities that fulfill the conditions to continue, from the old GB-GOV-13 identifier corresponding to BEIS, to the new GB-GOV-26 identifier corresponding to DSIT.

The list will need to be signed off by DSIT.

If the synchronous request proves to be too much with production amounts of data, we'll go back to the more complex async option drafted in https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2301

## Screenshots of UI changes

### Before

### After
![Screenshot 2024-01-09 at 18 43 31](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/de5c8efc-1f64-476e-a432-c3b81107431f)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
