### PR TITLE
CSV import actuals cannot be negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - add a new Activity tag, Strategic Allocation Pot (SAP), code 8
 - model a single row of csv data that contains actual, refund and activity
   comments
+- the new actual, refund and activity importer no longer accepts negative actual
+  values
 
 ## Release 141 - 2023-12-04
 

--- a/app/models/import/csv/activity_actual_refund_comment/row.rb
+++ b/app/models/import/csv/activity_actual_refund_comment/row.rb
@@ -135,6 +135,12 @@ class Import::Csv::ActivityActualRefundComment::Row
       @errors["Actual Value"] = [original_actual_value, I18n.t("import.csv.activity_actual_refund_comment.errors.financial_value")]
       return false
     end
+
+    if actual_value.negative?
+      @errors["Actual Value"] = [original_actual_value, I18n.t("import.csv.activity_actual_refund_comment.errors.default.negative")]
+      return false
+    end
+
     true
   end
 

--- a/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
+++ b/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
@@ -6,6 +6,7 @@ en:
         errors:
           default:
             required: Is required
+            negative: Cannot be negative
           financial_quarter: Must be 1, 2, 3 or 4
           financial_year: Must be a four digit year
           financial_value: Must be a financial value

--- a/spec/models/import/csv/activity_actual_refund_comment/row_spec.rb
+++ b/spec/models/import/csv/activity_actual_refund_comment/row_spec.rb
@@ -297,6 +297,16 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::Row do
     end
 
     context "when the actual value is a number" do
+      context "and the number is negative" do
+        let(:csv_row) { valid_csv_row(actual: "-10000", refund: "0", comment: "") }
+
+        it "is invaid with an error message and the original value" do
+          expect(subject).to be_invalid
+          expect(error_for_column("Actual Value").message).to eql "Cannot be negative"
+          expect(error_for_column("Actual Value").value).to eql "-10000"
+        end
+      end
+
       context "and the refund value is zero" do
         context "and there is no comment" do
           let(:csv_row) { valid_csv_row(actual: "10000", refund: "0", comment: "") }


### PR DESCRIPTION
## Changes in this PR

Actuals value must never be negative, here we add the validation to
the `Import::Csv::ActivityActualRefundComment::Row`.

https://trello.com/c/lBZkYq5c
