### PR TITLE
(2931/5) Feature flag for new import service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - update Import Row Error to expose csv row number as expected by the user
 - add a service that can import a file of multiple rows of csv that contain either an Actual,
   Refund, or Activity Comment
+- support both the new and the old actual importer, allowing switching between
+  them with a feature flag
 
 ## Release 141 - 2023-12-04
 

--- a/app/models/import/row_error.rb
+++ b/app/models/import/row_error.rb
@@ -1,11 +1,13 @@
 class Import::RowError < StandardError
-  attr_reader :row_number, :column, :value, :csv_row_number
+  attr_reader :row_number, :column, :value, :csv_row_number, :csv_row
 
   def initialize(column:, row_number:, value:, message:)
     @row_number = row_number
     @column = column
     @value = value
     @csv_row_number = row_number + 2
+    # csv_row to stay compatible with the current importer UI so we can switch between the two
+    @csv_row = @csv_row_number
     super(message)
   end
 end

--- a/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
+++ b/config/locales/import/csv/actiity_actual_refund_comment/errors.en.yml
@@ -7,6 +7,7 @@ en:
           default:
             required: Is required
             negative: Cannot be negative
+          headers: Invalid headers in the csv file, check the template for the correct headers
           financial_quarter: Must be 1, 2, 3 or 4
           financial_year: Must be a four digit year
           financial_value: Must be a financial value

--- a/spec/features/import/users_can_upload_actuals_refunds_and_actvitiy_comments_spec.rb
+++ b/spec/features/import/users_can_upload_actuals_refunds_and_actvitiy_comments_spec.rb
@@ -1,0 +1,103 @@
+RSpec.feature "users can upload actuals, refunds and activity comments" do
+  let(:organisation) { create(:partner_organisation) }
+  let(:user) { create(:partner_organisation_user, organisation: organisation) }
+
+  let!(:project) { create(:project_activity, :newton_funded, organisation: organisation) }
+  let!(:another_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
+  let!(:yet_another_project) { create(:project_activity, :newton_funded, organisation: organisation, parent: project.parent) }
+
+  let!(:report) { create(:report, :active, fund: project.associated_fund, organisation: organisation) }
+
+  before do
+    authenticate!(user: user)
+    visit report_actuals_path(report)
+    click_link t("page_content.actuals.button.upload")
+
+    allow(ROLLOUT).to receive(:active?).with(:use_new_activity_actual_refund_comment_importer).and_return(true)
+  end
+
+  context "when the import is successful" do
+    let(:uploaded_csv) do
+      csv_data = <<~CSV
+        Activity RODA Identifier                | Financial Quarter | Financial Year | Actual Value | Refund Value | Comment
+        #{project.roda_identifier}              | 1                 | 2020           | 20000        | 0            |
+        #{another_project.roda_identifier}      | 1                 | 2020           | 0            | 30000        | Refund comment
+        #{yet_another_project.roda_identifier}  | 1                 | 2020           | 0            | 0            | Activity comment
+      CSV
+      upload_csv(csv_data)
+    end
+
+    it "shows the actuals and refunds that were imported" do
+      attach_file "report[actual_csv]", uploaded_csv.path
+      click_button t("action.actual.upload.button")
+
+      expect(Actual.count).to be 1
+      expect(Refund.count).to be 1
+
+      expect(page).to have_text(t("action.actual.upload.success"))
+
+      expect(page).to have_content(project.roda_identifier)
+      expect(page).to have_content("£20,000.00")
+
+      expect(page).to have_content(another_project.roda_identifier)
+      expect(page).to have_content("-£30,000.00")
+    end
+
+    it "allows the user to see the activity comment" do
+      attach_file "report[actual_csv]", uploaded_csv.path
+      click_button t("action.actual.upload.button")
+      visit report_comments_path(report)
+
+      expect(page).to have_content("Activity comment")
+      expect(page).to have_content(yet_another_project.roda_identifier)
+    end
+  end
+
+  context "when the import is unsuccessful" do
+    it "shows an error when the uploaded file does not contain the required headers" do
+      csv_data = <<~CSV
+        Incorrect Header           | Not correct header |
+        #{project.roda_identifier} | 1                  |
+      CSV
+      uploaded_csv = upload_csv(csv_data)
+
+      attach_file "report[actual_csv]", uploaded_csv.path
+      click_button t("action.actual.upload.button")
+
+      expect(page).to have_content("Invalid headers in the csv file")
+    end
+
+    it "shows the error when the uploaded actual is not valid" do
+      csv_data = <<~CSV
+        Activity RODA Identifier                | Financial Quarter | Financial Year | Actual Value | Refund Value | Comment
+        #{project.roda_identifier}              | 1                 | 2020           | -20000        | 0            |
+      CSV
+      uploaded_csv = upload_csv(csv_data)
+
+      attach_file "report[actual_csv]", uploaded_csv.path
+      click_button t("action.actual.upload.button")
+
+      expect(page).to have_content("Cannot be negative")
+    end
+
+    it "shows the error when the uploaded refund is not valid" do
+      csv_data = <<~CSV
+        Activity RODA Identifier                | Financial Quarter | Financial Year | Actual Value | Refund Value | Comment
+        #{project.roda_identifier}              | 1                 | 2020           | 0            | -30000       |
+      CSV
+      uploaded_csv = upload_csv(csv_data)
+
+      attach_file "report[actual_csv]", uploaded_csv.path
+      click_button t("action.actual.upload.button")
+
+      expect(page).to have_content("Refund must have a comment")
+    end
+  end
+
+  def upload_csv(content)
+    file = Tempfile.new("test.csv")
+    file.write(content.gsub(/ *\| */, ","))
+    file.close
+    file
+  end
+end

--- a/spec/models/import/row_error_spec.rb
+++ b/spec/models/import/row_error_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Import::RowError do
     end
   end
 
+  describe "#csv_row" do
+    it "returns csv_row_number to maintain compatibility with the existing importer" do
+      expect(subject.csv_row).to eql subject.csv_row_number
+    end
+  end
+
   describe "#message" do
     it "returns the supplied message" do
       expect(subject.message).to eql "The message"


### PR DESCRIPTION
This work allows us to switch between the old Actual and Refund importer (`Actual::Import`) and the new Acutal, Refund and Activity comment importer.

The goal here is to test the importer with DSIT in development or staging so they are confident it does everything they want.

Once we are happy, we will come back and update the UI to make the most of the new importer.