### PR TITLE
Download a list of non-continuing ODA activities

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -88,4 +88,18 @@ class ExportsController < BaseController
       end
     end
   end
+
+  def non_continuing_activities
+    authorize :export, :show_continuing_activities?
+
+    respond_to do |format|
+      format.csv do
+        export = Export::ContinuingActivities.new
+
+        stream_csv_download(filename: export.non_continuing_filename, headers: export.non_continuing_headers) do |csv|
+          export.non_continuing_rows.each { |row| csv << row }
+        end
+      end
+    end
+  end
 end

--- a/app/services/export/continuing_activities.rb
+++ b/app/services/export/continuing_activities.rb
@@ -3,6 +3,10 @@ class Export::ContinuingActivities
     "continuing_activities.csv"
   end
 
+  def non_continuing_filename
+    "non_continuing_activities.csv"
+  end
+
   def headers
     [
       "Partner Organisation name",
@@ -15,6 +19,22 @@ class Export::ContinuingActivities
       "Future Transparency identifier",
       "Current Previous identifier",
       "Future Previous identifier",
+      "Partner Organisation ID",
+      "Status",
+      "Level"
+    ]
+  end
+
+  def non_continuing_headers
+    [
+      "Partner Organisation name",
+      "Activity title",
+      "Activity RODA ID",
+      "Fund (level A)",
+      "Parent level B RODA ID",
+      "Parent level B title",
+      "Transparency identifier",
+      "Previous identifier",
       "Partner Organisation ID",
       "Status",
       "Level"
@@ -70,39 +90,89 @@ class Export::ContinuingActivities
   end
 
   def activities
-    # active statuses, regardless of any associated actual spend
-    definitely_active = Activity
-      .joins(:organisation)
-      .includes(:organisation, :parent)
-      .where.not(level: "fund")
-      .where(is_oda: [nil, true])
-      .where.not(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
-      .order("organisations.name, activities.roda_identifier")
+    @_activities ||= begin
+      # active statuses, regardless of any associated actual spend
+      definitely_active = Activity
+        .joins(:organisation)
+        .includes(:organisation, :parent)
+        .where.not(level: "fund")
+        .where(is_oda: [nil, true])
+        .where.not(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
+        .order("organisations.name, activities.roda_identifier")
 
-    cut_off_quarter = FinancialQuarter.new(2022, 4)
+      cut_off_quarter = FinancialQuarter.new(2022, 4)
 
-    # activities that MAY need to continue, IF they have actual spend more recent than FQ4 2022-2023
-    potentially_active_due_to_actuals = Activity
-      .joins(:organisation, :actuals)
-      .includes(:organisation, :parent)
-      .where.not(level: "fund")
-      .where(is_oda: [nil, true])
-      .where(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
-      .where("transactions.date > ?", cut_off_quarter.end_date)
-      .order("organisations.name, activities.roda_identifier")
+      # activities that MAY need to continue, IF they have actual spend more recent than FQ4 2022-2023
+      potentially_active_due_to_actuals = Activity
+        .joins(:organisation, :actuals)
+        .includes(:organisation, :parent)
+        .where.not(level: "fund")
+        .where(is_oda: [nil, true])
+        .where(programme_status: ["completed", "stopped", "cancelled", "finalisation", "paused"])
+        .where("transactions.date > ?", cut_off_quarter.end_date)
+        .order("organisations.name, activities.roda_identifier")
 
-    # activities that MAY need to continue, IF they have forecasts for quarters after FQ4 2022-2023
-    potentially_active_due_to_forecasts = Activity
-      .joins(:organisation)
-      .includes(:organisation, :parent)
-      .where.not(level: "fund")
-      .where(is_oda: [nil, true])
-      .where(programme_status: "paused")
-      .order("organisations.name, activities.roda_identifier")
-    potentially_active_due_to_forecasts = potentially_active_due_to_forecasts.select do |activity|
-      Forecast.unscoped.where(parent_activity_id: activity.id).where("period_start_date > ?", cut_off_quarter.end_date).any?
+      # activities that MAY need to continue, IF they have forecasts for quarters after FQ4 2022-2023
+      potentially_active_due_to_forecasts = Activity
+        .joins(:organisation)
+        .includes(:organisation, :parent)
+        .where.not(level: "fund")
+        .where(is_oda: [nil, true])
+        .where(programme_status: "paused")
+        .order("organisations.name, activities.roda_identifier")
+      potentially_active_due_to_forecasts = potentially_active_due_to_forecasts.select do |activity|
+        Forecast.unscoped.where(parent_activity_id: activity.id).where("period_start_date > ?", cut_off_quarter.end_date).any?
+      end
+
+      (definitely_active + potentially_active_due_to_actuals + potentially_active_due_to_forecasts).uniq
     end
+  end
 
-    (definitely_active + potentially_active_due_to_actuals + potentially_active_due_to_forecasts).uniq
+  def non_continuing_rows
+    non_continuing_activities = Activity
+      .where.not(level: "fund")
+      .where.not(id: activities.pluck(:id))
+      .where(is_oda: [true, nil])
+    non_continuing_activities.map do |activity|
+      partner_organisation_name = activity.organisation.name
+      activity_title = activity.title || "Untitled (#{activity.id})"
+      roda_identifier = activity.roda_identifier
+      fund = activity.associated_fund.roda_identifier
+      parent_level_b_roda_id = case activity.level
+      when "programme"
+        ""
+      when "project"
+        activity.parent&.roda_identifier
+      else
+        activity.parent&.parent&.roda_identifier
+      end
+      parent_level_b_title = case activity.level
+      when "programme"
+        ""
+      when "project"
+        activity.parent&.title
+      else
+        activity.parent&.parent&.title
+      end
+      transparency_identifier = activity.transparency_identifier
+      previous_identifier = activity.previous_identifier
+      partner_organisation_identifier = activity.partner_organisation_identifier
+      status = activity.programme_status ? I18n.t("activity.programme_status.#{activity.programme_status}") : ""
+      level = I18n.t("table.body.activity.level.#{activity.level}")
+
+      [
+        partner_organisation_name,
+        activity_title,
+        roda_identifier,
+        fund,
+        parent_level_b_roda_id,
+        parent_level_b_title,
+        transparency_identifier,
+        previous_identifier,
+        partner_organisation_identifier,
+        status,
+        level
+      ]
+    end
   end
 end

--- a/app/views/exports/index.html.haml
+++ b/app/views/exports/index.html.haml
@@ -70,6 +70,13 @@
               CSV
             %td.govuk-table__cell
               = a11y_action_link("Download", continuing_activities_exports_path(format: "csv"))
+          %tr.govuk-table__row
+            %td.govuk-table__cell
+              Activities not continuing under GB-GOV-26
+            %td.govuk-table__cell
+              CSV
+            %td.govuk-table__cell
+              = a11y_action_link("Download", non_continuing_activities_exports_path(format: "csv"))
 
       %h1.govuk-heading-m
         = t("page_content.export.organisations.title")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       get "spending_breakdown_download"
     end
     get "continuing_activities", on: :collection
+    get "non_continuing_activities", on: :collection
   end
 
   namespace :exports do


### PR DESCRIPTION
## Changes in this PR

To help DSIT with confirming the lists of activities that will and won't need to be updated with the new transparency identifier, allow them to export a list of the activities that are assumed to not continue under GB-GOV-26.

The reason we have used the criteria of elimination rather than a new standalone query is that this is how the migration is likely to look like in practice: activities that fulfill the continuation criteria will be updated, and all other activities will be left as they are.

Non-ODA activities are excluded from both, because they are not concerned with transparency reporting to begin with.

## Screenshots of UI changes

### Before

### After
![Screenshot 2024-01-15 at 15 58 41](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/3c996b4f-4859-400e-af72-39571bb45e2a)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
