### PR TITLE
(3005) Change DSIT organisations' IATI references and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Exclude health check requests from host authorisation
 - Remove the feature flag for ODA bulk upload
+- Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)
 
 ## Release 142 - 2024-01-16
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,5 @@
 class Organisation < ApplicationRecord
-  SERVICE_OWNER_IATI_REFERENCE = "GB-GOV-13"
+  SERVICE_OWNER_IATI_REFERENCE = "GB-GOV-26"
 
   strip_attributes only: [:iati_reference]
   has_many :users

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -46,7 +46,7 @@ en:
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
         disbursement_channel: The channel through which the funds will flow for this actual.
         providing_organisation: The organisation where this actual is coming from.
-        providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        providing_organisation_reference_html: For example, GB-GOV-26. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
         receiving_organisation: The organisation receiving the money from this actual spend.
         receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
   table:

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -123,7 +123,7 @@ en:
         organisation:
           attributes:
             iati_reference:
-              format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
+              format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-26
               blank: Enter an IATI reference
             default_currency:
               blank: Enter a default currency

--- a/db/migrate/20240111133813_change_beis_to_dsit.rb
+++ b/db/migrate/20240111133813_change_beis_to_dsit.rb
@@ -1,0 +1,49 @@
+class ChangeBeisToDsit < ActiveRecord::Migration[6.1]
+  def up
+    service_owner = Organisation.where(iati_reference: "GB-GOV-13").first
+    if service_owner
+      service_owner.iati_reference = "GB-GOV-26"
+      service_owner.name = "DEPARTMENT FOR SCIENCE, INNOVATION AND TECHNOLOGY"
+      service_owner.beis_organisation_reference = "DSIT"
+
+      unless service_owner.save
+        Rails.logger.error("Failed to save the changes to #{service_owner.name}: #{service_owner.errors.messages.inspect}")
+      end
+    end
+
+    finance = Organisation.where(iati_reference: "GB-GOV-13-OPERATIONS").first
+    if finance
+      finance.iati_reference = "GB-GOV-26-OPERATIONS"
+      finance.name = "DSIT FINANCE"
+      finance.beis_organisation_reference = "DF"
+
+      unless finance.save
+        Rails.logger.error("Failed to save the changes to #{finance.name}: #{finance.errors.messages.inspect}")
+      end
+    end
+  end
+
+  def down
+    service_owner = Organisation.where(iati_reference: "GB-GOV-26").first
+    if service_owner
+      service_owner.iati_reference = "GB-GOV-13"
+      service_owner.name = "DEPARTMENT FOR BUSINESS, ENERGY & INDUSTRIAL STRATEGY"
+      service_owner.beis_organisation_reference = "BEIS"
+
+      unless service_owner.save
+        Rails.logger.error("Failed to save the changes to #{service_owner.name}: #{service_owner.errors.messages.inspect}")
+      end
+    end
+
+    finance = Organisation.where(iati_reference: "GB-GOV-26-OPERATIONS").first
+    if finance
+      finance.iati_reference = "GB-GOV-13-OPERATIONS"
+      finance.name = "BEIS FINANCE"
+      finance.beis_organisation_reference = "BF"
+
+      unless finance.save
+        Rails.logger.error("Failed to save the changes to #{finance.name}: #{finance.errors.messages.inspect}")
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_07_141900) do
+ActiveRecord::Schema.define(version: 2024_01_11_133813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -1,6 +1,6 @@
 - name: Department for Business, Energy and Industrial Strategy
   short_name: BEIS
-  reference: GB-GOV-13
+  reference: GB-GOV-26
   type: 10
   role: service_owner
 - name: UK Space Agency

--- a/doc/activity-identifiers.md
+++ b/doc/activity-identifiers.md
@@ -112,7 +112,7 @@ end users.
 This identifier is a transformed version of the RODA Identifier that's
 compatible with the IATI rules. Any string of characters in the RODA Identifier
 that are not letters, digits, or `-` are replaced with `-`, and the
-organisational prefix `GB-GOV-13-` is prepended to the result.
+organisational prefix `GB-GOV-26-` is prepended to the result.
 
 This identifier is not set by the ingest process _or_ assigned directly by end
 users; it is derived from the RODA Identifier when that is set.

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -58,10 +58,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
 
       expect_implementing_organisation_to_be_the_partner_organisation(
         activity: created_activity,
@@ -116,10 +116,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
       expect(created_activity.publish_to_iati).to be(true)
@@ -167,10 +167,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
       expect(created_activity.publish_to_iati).to be(true)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Organisation, type: :model do
 
     describe "#iati_reference" do
       it "returns true if it does matches a known structure XX-XXX-" do
-        organisation = build(:partner_organisation, iati_reference: "GB-GOV-13")
+        organisation = build(:partner_organisation, iati_reference: "GB-GOV-44")
         result = organisation.valid?
         expect(result).to be(true)
       end


### PR DESCRIPTION
## Changes in this PR
- Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
