### PR TITLE
(2999) Replace the deprecated call to `Redis.current`

### DIFF
--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -1,6 +1,9 @@
 require "redis"
 
-ROLLOUT = Rollout.new(Redis.current)
+REDIS.with do |connection|
+  connection.select(1)
+  ROLLOUT = Rollout.new(connection)
+end
 
 ROLLOUT.define_group(:beis_users) do |user|
   user.service_owner?

--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -1,9 +1,10 @@
 require "redis"
 
-REDIS.with do |connection|
-  connection.select(1)
-  ROLLOUT = Rollout.new(connection)
-end
+ROLLOUT = Rollout.new(Redis.new(url: ENV["REDIS_URL"]))
+# REDIS.with do |connection|
+#   connection.select(1)
+#   ROLLOUT = Rollout.new(connection)
+# end
 
 ROLLOUT.define_group(:beis_users) do |user|
   user.service_owner?

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: postgres://postgres:password@db:5432/roda_test
+      REDIS_URL: redis://localhost:6379
     env_file:
       - .env.test
   db:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,10 +14,10 @@ services:
         target: /app/coverage
     depends_on:
       - db
+      - redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: postgres://postgres:password@db:5432/roda_test
-      REDIS_URL: redis://localhost:6379
     env_file:
       - .env.test
   db:
@@ -26,5 +26,9 @@ services:
       - db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
 volumes:
   db-data:

--- a/spec/requests/rollout_spec.rb
+++ b/spec/requests/rollout_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Rollout UI", type: :request do
   end
 
   context "for a visitor" do
-    it "returns 404" do
+    it "returns 404", :use_original_rollout do
       expect { get "/rollout" }.to raise_error(ActionController::RoutingError)
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe "Rollout UI", type: :request do
     end
     after { logout }
 
-    it "returns 404" do
+    it "returns 404", :use_original_rollout do
       expect { get "/rollout" }.to raise_error(ActionController::RoutingError)
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe "Rollout UI", type: :request do
     end
     after { logout }
 
-    it "returns 200" do
+    it "returns 200", :use_original_rollout do
       get "/rollout"
       expect(response).to be_ok
     end


### PR DESCRIPTION
## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
