### PR TITLE
(3006) Order non-continuing activities by org and RODA ID

### DIFF
--- a/app/services/export/continuing_activities.rb
+++ b/app/services/export/continuing_activities.rb
@@ -130,9 +130,13 @@ class Export::ContinuingActivities
 
   def non_continuing_rows
     non_continuing_activities = Activity
+      .joins(:organisation)
+      .includes(:organisation, :parent)
       .where.not(level: "fund")
       .where.not(id: activities.pluck(:id))
       .where(is_oda: [true, nil])
+      .order("organisations.name, activities.roda_identifier")
+
     non_continuing_activities.map do |activity|
       partner_organisation_name = activity.organisation.name
       activity_title = activity.title || "Untitled (#{activity.id})"


### PR DESCRIPTION
## Changes in this PR
In order to make the list usable for Dan, order the non-continuing activities by the same criteria as the continuing ones: partner org name and RODA identifier.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
