### PR TITLE
(3021) Exclude health check requests from host auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Exclude health check requests from host authorisation
+
 ## Release 142 - 2024-01-16
 
 [Full changelog][142]

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,5 +74,7 @@ module Roda
 
     # Default headers
     config.action_dispatch.default_headers["X-XSS-Protection"] = "0"
+
+    config.host_authorization = {exclude: ->(request) { request.path =~ /health(_|-)check/ }}
   end
 end


### PR DESCRIPTION
## Changes in this PR

Exclude health check requests from host authorisation, to allow the AWS deploy pipeline to proceed faster. Currently health check requests are denied by the host auth process, because the IPs are not in the DOMAIN or ADDITIONAL_HOSTNAMES env vars.

We don't have a canonical list of the IPs, nor do we have easy access to the env vars (these particular env vars live in task definitions, not in ParameterStore).

https://api.rubyonrails.org/classes/ActionDispatch/HostAuthorization.html

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
