### PR TITLE
(3007) Change transparency identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Exclude health check requests from host authorisation
 - Remove the feature flag for ODA bulk upload
 - Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)
+- Update the transparency identifier of activities that are continuing under DSIT, and the providing org reference of their actuals and forecasts
 
 ## Release 142 - 2024-01-16
 

--- a/db/migrate/20240115183402_change_transparency_identifier.rb
+++ b/db/migrate/20240115183402_change_transparency_identifier.rb
@@ -1,0 +1,70 @@
+class ChangeTransparencyIdentifier < ActiveRecord::Migration[6.1]
+  def up
+    continuing_activities = Export::ContinuingActivities.new.activities
+
+    continuing_activities.each do |activity|
+      original_previous_identifier = activity.previous_identifier.to_s
+      original_transparency_identifier = activity.transparency_identifier.to_s
+      updated_previous_identifier = original_transparency_identifier
+      updated_transparency_identifier = original_transparency_identifier.sub(/\AGB-GOV-13/, "GB-GOV-26")
+
+      if original_transparency_identifier == updated_transparency_identifier
+        Rails.logger.info("Activity #{activity.roda_identifier} NO CHANGE: transparency_identifier=#{original_transparency_identifier}")
+      elsif activity.update(
+        previous_identifier: updated_previous_identifier,
+        transparency_identifier: updated_transparency_identifier
+      )
+        message = "Activity #{activity.roda_identifier} UPDATED: previous_identifier=#{updated_previous_identifier} transparency_identifier=#{updated_transparency_identifier}"
+        if original_previous_identifier
+          message += " original previous_identifier=#{original_previous_identifier}"
+        end
+        Rails.logger.info(message)
+      else
+        Rails.logger.error("Activity #{activity.roda_identifier} UPDATE FAILED")
+      end
+
+      activity_actuals = activity.actuals.where(providing_organisation_reference: "GB-GOV-13")
+      if activity_actuals.any?
+        Rails.logger.info("Activity #{activity.roda_identifier}: Updating #{activity_actuals.count} actuals")
+
+        activity_actuals.each do |actual|
+          unless actual.update(providing_organisation_reference: "GB-GOV-26")
+            Rails.logger.error("Activity #{activity.roda_identifier}: FAILED to update an actual: #{actual.id}")
+          end
+        end
+      end
+
+      activity_forecasts = Forecast.unscoped.where(parent_activity_id: activity.id, providing_organisation_reference: "GB-GOV-13")
+      if activity_forecasts.any?
+        Rails.logger.info("Activity #{activity.roda_identifier}: Updating #{activity_forecasts.count} forecasts")
+
+        activity_forecasts.each do |forecast|
+          unless forecast.update(providing_organisation_reference: "GB-GOV-26")
+            Rails.logger.error("Activity #{activity.roda_identifier}: FAILED to update a forecast: #{forecast.id}")
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    activities_to_restore = Export::ContinuingActivities.new.activities
+
+    activities_to_restore.each do |activity|
+      if activity.transparency_identifier
+        activity.update(
+          previous_identifier: nil,
+          transparency_identifier: activity.transparency_identifier.sub(/\AGB-GOV-26/, "GB-GOV-13")
+        )
+      end
+
+      activity.actuals.where(providing_organisation_reference: "GB-GOV-26").each do |actual|
+        actual.update(providing_organisation_reference: "GB-GOV-13")
+      end
+
+      Forecast.unscoped.where(parent_activity_id: activity.id, providing_organisation_reference: "GB-GOV-26").each do |forecast|
+        forecast.update(providing_organisation_reference: "GB-GOV-13")
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_11_133813) do
+ActiveRecord::Schema.define(version: 2024_01_15_183402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Changes in this PR

For activities that will be continuing under DSIT:
- change their transparency identifier to replace the string "GB-GOV-13" with "GB-GOV-26"; e.g. `GB-GOV-13-ISPF-UKSA-AH2TS7K-SPB9U87` becomes `GB-GOV-26-ISPF-UKSA-AH2TS7K-SPB9U87`
- change the `providing_organisation_reference` for all their actuals, from "GB-GOV-13" to "GB-GOV-26"
- change the `providing_organisation_reference` for all their forecasts, from "GB-GOV-13" to "GB-GOV-26"

This type of data change would be better suited for a data migration or a rake task, but both of those would require access to the application console in the production environment.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
