### PR TITLE
(3019) Change what identifier is used as iati-identifier in XMLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   were skipped
 - the Activity actual, refund and comment upload success view now shows the
   imported actuals, refunds, activity comments and skipped rows
+- Use an activity's `transparency_identifier` as `iati-identifier` in XML exports, and the `previous_identifier`, if it exists, as `other-identifier`
 
 ## Release 143 - 2024-01-23
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -511,14 +511,6 @@ class Activity < ApplicationRecord
     end
   end
 
-  def iati_identifier
-    if previous_identifier.present?
-      previous_identifier
-    else
-      transparency_identifier
-    end
-  end
-
   def iati_scope
     Iati::ActivityScopeService.new(benefitting_countries).call
   end

--- a/app/views/shared/xml/_activity.xml.haml
+++ b/app/views/shared/xml/_activity.xml.haml
@@ -1,5 +1,5 @@
 %iati-activity{"default-currency" => activity.default_currency, "xml:lang" => activity.organisation.language_code }
-  %iati-identifier= activity.iati_identifier
+  %iati-identifier= activity.transparency_identifier
   %reporting-org{"type" => reporting_organisation.organisation_type, "ref" => reporting_organisation.iati_reference }
     %narrative= reporting_organisation.name
   %title
@@ -22,7 +22,7 @@
       %participating-org{"ref" => organisation.iati_reference, "type" => organisation.organisation_type, "role" => 4}
         %narrative= organisation.name
   - if activity.previous_identifier?
-    %other-identifier{"ref" => activity.transparency_identifier, type: "A1"}
+    %other-identifier{"ref" => activity.previous_identifier, type: "A1"}
   %activity-status{"code" => activity.iati_status}/
   - if activity.planned_start_date?
     %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/

--- a/spec/features/beis_users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/beis_users_can_view_an_activity_as_xml_spec.rb
@@ -24,18 +24,16 @@ RSpec.feature "BEIS users can view project activities as XML" do
       )
     end
 
-    it "shows the previous identifier as the activity identifier" do
+    it "shows the activity transparency identifier as the iati identifier" do
       visit organisation_activity_path(organisation, activity, format: :xml)
 
-      expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.previous_identifier)
+      expect(xml.at("iati-activity/iati-identifier").text).to eq(activity.transparency_identifier)
     end
 
-    it "shows the activity transparency identifier as the other identifier" do
-      iati_identifier = activity.transparency_identifier
-
+    it "shows the previous identifier as the other identifier" do
       visit organisation_activity_path(organisation, activity, format: :xml)
 
-      expect(xml.at("iati-activity/other-identifier/@ref").text).to eq(iati_identifier)
+      expect(xml.at("iati-activity/other-identifier/@ref").text).to eq(activity.previous_identifier)
     end
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1338,18 +1338,6 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  describe "#iati_identifier" do
-    it "returns the previous_identifier if it exists" do
-      activity = create(:project_activity, previous_identifier: "previous-id", transparency_identifier: "transparency-id")
-      expect(activity.iati_identifier).to eq("previous-id")
-    end
-
-    it "returns the transparency_identifier if previous_identifier is not set" do
-      activity = create(:project_activity, previous_identifier: nil, transparency_identifier: "transparency-id")
-      expect(activity.iati_identifier).to eq("transparency-id")
-    end
-  end
-
   describe "#actual_total_for_report_financial_quarter" do
     let(:project) { create(:project_activity) }
 


### PR DESCRIPTION
## Changes in this PR
- Use an activity's `transparency_identifier` as `iati-identifier` in XML exports, and the `previous_identifier`, if it exists, as `other-identifier`

## Screenshots of UI changes

N/A

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
