### PR TITLE
(3023) View updates for new importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)
 - Add a rake task to change the transparency identifier for activities that will continue under DSIT, and the providing org reference for their actual spend and forecasts
+- model a simple imported row so that users can see which row in the csv import
+  were skipped
 
 ## Release 143 - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add a rake task to change the transparency identifier for activities that will continue under DSIT, and the providing org reference for their actual spend and forecasts
 - model a simple imported row so that users can see which row in the csv import
   were skipped
+- the Activity actual, refund and comment upload success view now shows the
+  imported actuals, refunds, activity comments and skipped rows
 
 ## Release 143 - 2024-01-23
 

--- a/app/controllers/actuals/uploads_controller.rb
+++ b/app/controllers/actuals/uploads_controller.rb
@@ -47,13 +47,16 @@ class Actuals::UploadsController < BaseController
         @errors = importer.errors
 
         if import_result
-          # the old import and the UI combine Actuals and Refunds, so we have to do the same
-          # once we have tested the import, we will come back and make the UI improvements
-          # to make the most of the new importer
-          imported_actuals_and_refunds = importer.imported_actuals + importer.imported_refunds
+          @total_actuals = total_transactions(importer.imported_actuals)
+          @grouped_actuals = grouped_transactions(importer.imported_actuals)
 
-          @total_actuals = total_transactions(imported_actuals_and_refunds)
-          @grouped_actuals = grouped_transactions(imported_actuals_and_refunds)
+          @total_refunds = total_transactions(importer.imported_refunds)
+          @grouped_refunds = grouped_transactions(importer.imported_refunds)
+
+          @imported_activity_comments = importer.imported_comments
+
+          @skipped_rows = importer.skipped_rows
+
           @success = true
 
           flash.now[:notice] = t("action.actual.upload.success")

--- a/app/models/import/csv/imported_row.rb
+++ b/app/models/import/csv/imported_row.rb
@@ -1,0 +1,8 @@
+class Import::Csv::ImportedRow
+  attr_reader :csv_row_number, :object
+
+  def initialize(index, object)
+    @csv_row_number = index + 2
+    @object = object
+  end
+end

--- a/app/services/import/csv/activity_actual_refund_comment/file_service.rb
+++ b/app/services/import/csv/activity_actual_refund_comment/file_service.rb
@@ -29,7 +29,7 @@ class Import::Csv::ActivityActualRefundComment::FileService
 
         collate_errors_from_row_importer(index, row_importer) if row_importer.errors.any?
 
-        imported_row
+        Import::Csv::ImportedRow.new(index, imported_row)
       end
 
       unless @errors.empty?
@@ -41,26 +41,26 @@ class Import::Csv::ActivityActualRefundComment::FileService
   end
 
   def imported_actuals
-    @imported_rows.select do |row|
-      row.is_a?(Actual)
+    @imported_rows.filter_map do |row|
+      row.object if row.object.is_a?(Actual)
     end
   end
 
   def imported_refunds
-    @imported_rows.select do |row|
-      row.is_a?(Refund)
+    @imported_rows.filter_map do |row|
+      row.object if row.object.is_a?(Refund)
     end
   end
 
   def imported_comments
-    @imported_rows.select do |row|
-      row.is_a?(Comment)
+    @imported_rows.filter_map do |row|
+      row.object if row.object.is_a?(Comment)
     end
   end
 
   def skipped_rows
     @imported_rows.select do |row|
-      row.is_a?(Import::Csv::ActivityActualRefundComment::SkippedRow)
+      row.object.is_a?(Import::Csv::ActivityActualRefundComment::SkippedRow)
     end
   end
 

--- a/app/views/actuals/uploads/_actuals.html.haml
+++ b/app/views/actuals/uploads/_actuals.html.haml
@@ -1,0 +1,36 @@
+%table.govuk-table#actuals
+  %caption.govuk-table__caption.govuk-table__caption--m
+    Actuals
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} RODA Identifier
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Value
+  %tbody.govuk-table__body
+
+    - @grouped_actuals.each do |activity, actuals|
+
+      %tr.govuk-table__row{ id: "activity_actuals_#{activity.id}" }
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.title
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.roda_identifier
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          %table.govuk-table.actuals
+            - actuals.each do |actual|
+              %tr.govuk-table__row
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
+                  = actual.financial_quarter_and_year
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
+                  = actual.value
+                  - if actual.comment
+                    %tr.govuk-table__row
+                      %td.govuk-table__cell--numeric{class: "govuk-!-width-full", scope: "col", colspan: 2}
+                        = actual.comment.body
+
+
+    %tr.govuk-table__row.totals
+      %td.govuk-table__cell Total
+      %td.govuk-table__cell
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @total_actuals

--- a/app/views/actuals/uploads/_comments.html.haml
+++ b/app/views/actuals/uploads/_comments.html.haml
@@ -1,0 +1,19 @@
+%table.govuk-table#comments
+  %caption.govuk-table__caption.govuk-table__caption--m
+    Activity Comments
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} RODA Identifier
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Comment
+  %tbody.govuk-table__body
+
+    - @imported_activity_comments.each do |comment|
+
+      %tr.govuk-table__row{ id: "activity_comment_#{comment.id}" }
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = comment.associated_activity.title
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = comment.associated_activity.roda_identifier
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = comment.body

--- a/app/views/actuals/uploads/_refunds.html.haml
+++ b/app/views/actuals/uploads/_refunds.html.haml
@@ -1,0 +1,35 @@
+%table.govuk-table#refunds
+  %caption.govuk-table__caption.govuk-table__caption--m
+    Refunds
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Activity
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} RODA Identifier
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Value
+  %tbody.govuk-table__body
+
+    - @grouped_refunds.each do |activity, refunds|
+
+      %tr.govuk-table__row{ id: "activity_actuals_#{activity.id}" }
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.title
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = activity.roda_identifier
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          %table.govuk-table.actuals
+            - refunds.each do |refund|
+              %tr.govuk-table__row
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
+                  = refund.financial_quarter_and_year
+                %td.govuk-table__cell--numeric{class: "govuk-!-width-one-half", scope: "col"}
+                  = refund.value
+                  - if refund.comment
+                    %tr.govuk-table__row
+                      %td.govuk-table__cell--numeric{class: "govuk-!-width-full", scope: "col", colspan: 2}
+                        = refund.comment.body
+
+    %tr.govuk-table__row.totals
+      %td.govuk-table__cell Total
+      %td.govuk-table__cell
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @total_refunds

--- a/app/views/actuals/uploads/_skipped.html.haml
+++ b/app/views/actuals/uploads/_skipped.html.haml
@@ -1,0 +1,15 @@
+%table.govuk-table#skipped
+  %caption.govuk-table__caption.govuk-table__caption--m
+    Skipped rows
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{class: "govuk-!-width-one-third", scope: "col"} Row number
+      %th.govuk-table__header{class: "govuk-!-width-two-thirds", scope: "col"} RODA Identifier
+  %tbody.govuk-table__body
+    - @skipped_rows.each do |row|
+
+      %tr.govuk-table__row{ id: "skipped-row-#{row.csv_row_number}" }
+        %td.govuk-table__cell{class: "govuk-!-width-one-third"}
+          = row.csv_row_number
+        %td.govuk-table__cell{class: "govuk-!-width-two-thirds"}
+          = row.object.roda_identifier

--- a/app/views/actuals/uploads/update.html.haml
+++ b/app/views/actuals/uploads/update.html.haml
@@ -26,9 +26,27 @@
         %h1.govuk-heading-xl
           = t("page_title.actual.upload_success")
 
-    .govuk-grid-row
-      .govuk-grid-column-full
-        = render partial: "shared/actuals/actuals_by_activity"
+    - if ROLLOUT.active?(:use_new_activity_actual_refund_comment_importer)
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "actuals"
+
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "refunds"
+
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "comments"
+
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "skipped"
+
+    - else
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = render partial: "shared/actuals/actuals_by_activity"
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/spec/controllers/actuals/uploads_controller_spec.rb
+++ b/spec/controllers/actuals/uploads_controller_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe Actuals::UploadsController do
         allow(fake_import_file).to receive(:valid?).and_return(true)
         allow(CsvFileUpload).to receive(:new).and_return(fake_import_file)
 
-        importer = instance_double(Actual::Import, import: true)
+        importer = instance_double(Actual::Import)
+        allow(importer).to receive(:import).and_return(true)
         allow(importer).to receive(:errors).and_return([])
         allow(importer).to receive(:imported_actuals).and_return([])
         allow(importer).to receive(:invalid_with_comment).and_return(false)
@@ -152,10 +153,13 @@ RSpec.describe Actuals::UploadsController do
         allow(fake_import_file).to receive(:valid?).and_return(true)
         allow(CsvFileUpload).to receive(:new).and_return(fake_import_file)
 
-        importer = instance_double(Import::Csv::ActivityActualRefundComment::FileService, import!: true)
+        importer = instance_double(Import::Csv::ActivityActualRefundComment::FileService)
+        allow(importer).to receive(:import!).and_return(true)
         allow(importer).to receive(:errors).and_return([])
         allow(importer).to receive(:imported_actuals).and_return([])
         allow(importer).to receive(:imported_refunds).and_return([])
+        allow(importer).to receive(:imported_comments).and_return([])
+        allow(importer).to receive(:skipped_rows).and_return([])
         allow(Import::Csv::ActivityActualRefundComment::FileService).to receive(:new).and_return(importer)
 
         allow(Actual::Import).to receive(:new)

--- a/spec/features/import/users_can_upload_actuals_refunds_and_activity_comments_spec.rb
+++ b/spec/features/import/users_can_upload_actuals_refunds_and_activity_comments_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "users can upload actuals, refunds and activity comments" do
         #{project.roda_identifier}              | 1                 | 2020           | 20000        | 0            |
         #{another_project.roda_identifier}      | 1                 | 2020           | 0            | 30000        | Refund comment
         #{yet_another_project.roda_identifier}  | 1                 | 2020           | 0            | 0            | Activity comment
+        #{project.roda_identifier}              | 1                 | 2020           | 0            | 0            |
       CSV
       upload_csv(csv_data)
     end
@@ -36,11 +37,25 @@ RSpec.feature "users can upload actuals, refunds and activity comments" do
 
       expect(page).to have_text(t("action.actual.upload.success"))
 
-      expect(page).to have_content(project.roda_identifier)
-      expect(page).to have_content("£20,000.00")
+      within("#actuals") do
+        expect(page).to have_content(project.roda_identifier)
+        expect(page).to have_content("£20,000.00")
+      end
 
-      expect(page).to have_content(another_project.roda_identifier)
-      expect(page).to have_content("-£30,000.00")
+      within("#refunds") do
+        expect(page).to have_content(another_project.roda_identifier)
+        expect(page).to have_content("-£30,000.00")
+      end
+
+      within("#comments") do
+        expect(page).to have_content(yet_another_project.roda_identifier)
+        expect(page).to have_content("Activity comment")
+      end
+
+      within("#skipped") do
+        expect(page).to have_content("5")
+        expect(page).to have_content(project.roda_identifier)
+      end
     end
 
     it "allows the user to see the activity comment" do

--- a/spec/models/import/csv/imported_row_spec.rb
+++ b/spec/models/import/csv/imported_row_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Import::Csv::ImportedRow do
+  describe "#csv_row_number" do
+    it "returns the row number of the imported item from the source file" do
+      result = described_class.new(0, nil)
+
+      expect(result.csv_row_number).to be 2
+    end
+  end
+
+  describe "#object" do
+    it "returns the object that the imported row result in" do
+      imported_object = double("Imported Object")
+      result = described_class.new(0, imported_object)
+
+      expect(result.object).to be imported_object
+    end
+  end
+end

--- a/spec/services/import/csv/activity_actual_refund_comment/file_service_spec.rb
+++ b/spec/services/import/csv/activity_actual_refund_comment/file_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::FileService, type: :imp
 
         it "creates the Actual and returns true" do
           result = subject.import!
-          actual = subject.imported_rows.first
+          actual = subject.imported_rows.first.object
 
           expect(actual.parent_activity).to be activity
           expect(actual.value).to eql BigDecimal("10000")
@@ -73,7 +73,7 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::FileService, type: :imp
 
         it "creates the Refund and returns true" do
           result = subject.import!
-          refund = subject.imported_rows.first
+          refund = subject.imported_rows.first.object
 
           expect(refund.parent_activity).to eql activity
           expect(refund.comment.body).to eql "This is a refund comment."
@@ -112,7 +112,7 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::FileService, type: :imp
 
         it "creates the Comment and returns true" do
           result = subject.import!
-          imported_comment = subject.imported_rows.first
+          imported_comment = subject.imported_rows.first.object
 
           expect(result).to be true
 
@@ -157,7 +157,7 @@ RSpec.describe Import::Csv::ActivityActualRefundComment::FileService, type: :imp
 
         it "records the details of the skipped row" do
           subject.import!
-          skipped = subject.skipped_rows.first
+          skipped = subject.skipped_rows.first.object
 
           expect(skipped.roda_identifier).to eql "RODA-ID"
           expect(skipped.financial_quarter).to eql "2"


### PR DESCRIPTION
## Changes in this PR

Now that we have done some testing on the new importer with the DSIT team, we can be more confident to update the view. Whilst the existing view shows a combination of imported Actuals and Refunds, the new view split each type into it's own table:

- Actuals
- Refunds
- Activity comments
- Skipped rows

Skipped rows have quite a different shape to the other types, to help users identify which rows in their file were skipped we introduce the concept of a `ImportedRow`. This lets us store the resulting object along with the row number that sourced it, this is very much the same approach we take for any errrors.

https://trello.com/c/a6CvTA01

![image](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/480578/b7505c2c-62ff-4bd3-8c32-7cd9927feb30)
