### PR TITLE
Allow service owner to be identified by both IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Exclude health check requests from host authorisation
 - Remove the feature flag for ODA bulk upload
+- Allow service owner to be identified by both IDs during the transition between BEIS and DSIT
 
 ## Release 142 - 2024-01-16
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -101,6 +101,6 @@ class Organisation < ApplicationRecord
   end
 
   def self.service_owner
-    find_by(iati_reference: SERVICE_OWNER_IATI_REFERENCE)
+    find_by(iati_reference: ["GB-GOV-13", "GB-GOV-26"])
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -205,8 +205,25 @@ RSpec.describe Organisation, type: :model do
 
   describe ".service_owner" do
     let!(:service_owner) { create(:beis_organisation) }
+
     it "returns the service owner" do
       expect(Organisation.service_owner).to eq(service_owner)
+    end
+
+    context "when the organisation's iati_reference is 'GB-GOV-13'" do
+      before { service_owner.update(iati_reference: "GB-GOV-13") }
+
+      it "identifies it as the service owner" do
+        expect(Organisation.service_owner).to eq(service_owner)
+      end
+    end
+
+    context "when the organisation's iati_reference is 'GB-GOV-26'" do
+      before { service_owner.update(iati_reference: "GB-GOV-26") }
+
+      it "identifies it as the service owner" do
+        expect(Organisation.service_owner).to eq(service_owner)
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

To facilitate the transition between the service owner being identified by the old IATI reference `GB-GOV-13` and being identified by the new IATI reference `GB-GOV-26`, allow both identifiers to be used.

This will prevent user permissions from being lost during the short interval between the code being deployed and the migration being run.

## Screenshots of UI changes

N/A
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
