### PR TITLE
(3005) Update service owner organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)
+
 ## Release 143 - 2024-01-23
 
 [Full changelog][143]

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,5 @@
 class Organisation < ApplicationRecord
-  SERVICE_OWNER_IATI_REFERENCE = "GB-GOV-13"
+  SERVICE_OWNER_IATI_REFERENCE = "GB-GOV-26"
 
   strip_attributes only: [:iati_reference]
   has_many :users

--- a/config/locales/models/actual.en.yml
+++ b/config/locales/models/actual.en.yml
@@ -46,7 +46,7 @@ en:
         description: For example, 2020 quarter one spend on the Early Career Research Network project.
         disbursement_channel: The channel through which the funds will flow for this actual.
         providing_organisation: The organisation where this actual is coming from.
-        providing_organisation_reference_html: For example, GB-GOV-13. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
+        providing_organisation_reference_html: For example, GB-GOV-26. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
         receiving_organisation: The organisation receiving the money from this actual spend.
         receiving_organisation_reference_html: For example, GB-COH-12345. To lookup codes or for more information see <a href="http://org-id.guide/" target="_blank" class="govuk-link">the organisation finder service (Opens in new window)</a>.
   table:

--- a/config/locales/models/organisation.en.yml
+++ b/config/locales/models/organisation.en.yml
@@ -123,7 +123,7 @@ en:
         organisation:
           attributes:
             iati_reference:
-              format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-13
+              format: Identifiers must start with a country code and company type separated by a dash, eg. GB-GOV-26
               blank: Enter an IATI reference
             default_currency:
               blank: Enter a default currency

--- a/db/data/20240123152048_change_beis_to_dsit.rb
+++ b/db/data/20240123152048_change_beis_to_dsit.rb
@@ -1,0 +1,28 @@
+# Run me with `rails runner db/data/20240123152048_change_beis_to_dsit.rb`
+
+service_owner = Organisation.where(iati_reference: ["GB-GOV-13", "GB-GOV-26"]).first
+if service_owner
+  service_owner.iati_reference = "GB-GOV-26"
+  service_owner.name = "DEPARTMENT FOR SCIENCE, INNOVATION AND TECHNOLOGY"
+  service_owner.beis_organisation_reference = "DSIT"
+  service_owner.alternate_names = [
+    "DEPARTMENT FOR SCIENCE, INNOVATION & TECHNOLOGY",
+    "Department for Science, Innovation and Technology",
+    "Department for Science, Innovation & Technology"
+  ]
+
+  unless service_owner.save
+    puts "Failed to save the changes to #{service_owner.name}: #{service_owner.errors.messages.inspect}"
+  end
+end
+
+finance = Organisation.where(iati_reference: "GB-GOV-13-OPERATIONS").first
+if finance
+  finance.iati_reference = "GB-GOV-26-OPERATIONS"
+  finance.name = "DSIT FINANCE"
+  finance.beis_organisation_reference = "DF"
+
+  unless finance.save
+    puts "Failed to save the changes to #{finance.name}: #{finance.errors.messages.inspect}"
+  end
+end

--- a/db/seeds/organisations.yml
+++ b/db/seeds/organisations.yml
@@ -1,6 +1,6 @@
 - name: Department for Business, Energy and Industrial Strategy
   short_name: BEIS
-  reference: GB-GOV-13
+  reference: GB-GOV-26
   type: 10
   role: service_owner
 - name: UK Space Agency

--- a/doc/activity-identifiers.md
+++ b/doc/activity-identifiers.md
@@ -112,7 +112,7 @@ end users.
 This identifier is a transformed version of the RODA Identifier that's
 compatible with the IATI rules. Any string of characters in the RODA Identifier
 that are not letters, digits, or `-` are replaced with `-`, and the
-organisational prefix `GB-GOV-13-` is prepended to the result.
+organisational prefix `GB-GOV-26-` is prepended to the result.
 
 This identifier is not set by the ingest process _or_ assigned directly by end
 users; it is derived from the RODA Identifier when that is set.

--- a/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
+++ b/spec/features/beis_users_can_create_a_programme_level_activity_spec.rb
@@ -58,10 +58,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
 
       expect_implementing_organisation_to_be_the_partner_organisation(
         activity: created_activity,
@@ -116,10 +116,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
       expect(created_activity.publish_to_iati).to be(true)
@@ -167,10 +167,10 @@ RSpec.feature "BEIS users can create a programme level activity" do
       expect(created_activity.oda_eligibility).to eq(activity.oda_eligibility)
 
       expect(created_activity.accountable_organisation_name).to eq("Department for Business, Energy and Industrial Strategy")
-      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-13")
+      expect(created_activity.accountable_organisation_reference).to eq("GB-GOV-26")
       expect(created_activity.accountable_organisation_type).to eq("10")
 
-      expect(created_activity.transparency_identifier).to eql("GB-GOV-13-#{created_activity.roda_identifier}")
+      expect(created_activity.transparency_identifier).to eql("GB-GOV-26-#{created_activity.roda_identifier}")
       expect(created_activity.commitment.value).to eq(activity.commitment.value)
 
       expect(created_activity.publish_to_iati).to be(true)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Organisation, type: :model do
 
     describe "#iati_reference" do
       it "returns true if it does matches a known structure XX-XXX-" do
-        organisation = build(:partner_organisation, iati_reference: "GB-GOV-13")
+        organisation = build(:partner_organisation, iati_reference: "GB-GOV-44")
         result = organisation.valid?
         expect(result).to be(true)
       end


### PR DESCRIPTION
## Changes in this PR
- Change the transparency identifier and names for the DSIT organisations (DSIT and DSIT Finance)

## Screenshots of UI changes

### Before
![Screenshot 2024-01-19 at 11 57 48](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/77110a1d-a598-4a0c-ad7c-263be3c18a15)
![Screenshot 2024-01-19 at 11 57 55](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/2528e7d9-4de2-47a8-a737-59d78bdbc71a)

### After
![Screenshot 2024-01-19 at 12 14 54](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/1222ce6d-dabd-43f3-a034-eab8e60f6b69)
![Screenshot 2024-01-19 at 12 14 44](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/assets/579522/8597ff3f-75ad-4509-bb81-b29817e91a14)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
