### PR TITLE
Update iati xml details for DSIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Bump Ruby version from 3.0.6 to 3.1.2
+- Update details in IATI xml yaml to reflect switch from BEIS to DSIT
 
 ## Release 145 - 2024-01-25
 

--- a/config/locales/views/iati_xml.en.yml
+++ b/config/locales/views/iati_xml.en.yml
@@ -1,8 +1,8 @@
 ---
 en:
   contact_info:
-    organisation: Department of Business Energy and Industrial Strategy
+    organisation: DEPARTMENT FOR SCIENCE, INNOVATION AND TECHNOLOGY
     department: General enquiries
     email: enquiries@odamanagement.org
-    website: https://www.gov.uk/government/publications/beis-official-development-assistance-research-and-innovation
-    mailing_address: Department of Business, Energy and Industrial Strategy, 4th Floor, 1 Victoria Street, SW1H 0ET
+    website: https://www.gov.uk/government/publications/international-science-partnerships-fund-ispf
+    mailing_address: Department for Science, Innovation and Technology, 22-26 Whitehall, London, SW1A 2EG


### PR DESCRIPTION
## Changes in this PR

Certain details (organisation name, email, address) have not been updated in the config for IATI xml since the switch from BEIS to DSIT. 

This PR updates the required fields with the new details, as per [this](https://dxw.zendesk.com/agent/tickets/19873) support ticket. 

**NOTE:** this PR depends on [PR 2363](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2363). 2363 bumps the Ruby version being used from 3.0.6 to 3.1.2. The commits in this PR are rebased over 2363, and should probably again be rebased over develop once 2363 is merged. **HOLD MERGE** of this PR until 2363 is merged.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
