### PR TITLE
Remove 6 of 100 activities to have PO Org ID edited

### DIFF
--- a/db/data/20240919000000_change_partner_org_ids.rb
+++ b/db/data/20240919000000_change_partner_org_ids.rb
@@ -95,10 +95,6 @@ class PartnerOrgIdChanger
 
   def changes
     [
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-9TK4WUY",
-       existing_po_id: 'GCRF-BARAR-Fell22-RaR\100413',
-       new_po_id: 'RaR\100413'},
-
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-YLZDCUS",
        existing_po_id: 'GCRF-BARAR-Fell22-RaR\100415',
        new_po_id: 'RaR\100415'},
@@ -122,10 +118,6 @@ class PartnerOrgIdChanger
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-7ZX3M2M",
        existing_po_id: 'GCRF-BARAR-Fell22-RaR\100503',
        new_po_id: 'RaR\100503'},
-
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-Z3FC2LP",
-       existing_po_id: 'GCRF-BARAR-Fell22-RaR\100514',
-       new_po_id: 'RaR\100514'},
 
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-T3ZLGGN",
        existing_po_id: 'GCRF-BARAR-Fell22-RaR\100530',
@@ -154,10 +146,6 @@ class PartnerOrgIdChanger
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-JQHPTK3",
        existing_po_id: 'GCRF-BARAR-Fell22-RaR\100569',
        new_po_id: 'RaR\100569'},
-
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-RFPMJX3",
-       existing_po_id: 'GCRF-BARAR-Fell22-RaR\100570',
-       new_po_id: 'RaR\100570'},
 
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-ESQWRUS",
        existing_po_id: 'GCRF-BARAR-Fell22-RaR\100572',
@@ -198,10 +186,6 @@ class PartnerOrgIdChanger
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-476XY79",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100193",
        new_po_id: 'RaR\100193'},
-
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-6GG5YVE",
-       existing_po_id: "GCRF-BARAR-Fell22-RaR100197",
-       new_po_id: 'RaR\100197'},
 
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-7HXASCQ",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100207",
@@ -254,10 +238,6 @@ class PartnerOrgIdChanger
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-6B4N58F",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100281",
        new_po_id: 'RaR\100281'},
-
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-HXBLEK9",
-       existing_po_id: "GCRF-BARAR-Fell22-RaR100282",
-       new_po_id: 'RaR\100282'},
 
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-QRUNKKT",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100285",
@@ -358,10 +338,6 @@ class PartnerOrgIdChanger
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-ZME9AQ8",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100445",
        new_po_id: 'RaR\100445'},
-
-      {roda_id: "GCRF-BA-R5FBZXE-73R7B48-RM5XQA5",
-       existing_po_id: "GCRF-BARAR-Fell22-RaR100446",
-       new_po_id: 'RaR\100446'},
 
       {roda_id: "GCRF-BA-R5FBZXE-73R7B48-CRGCAC9",
        existing_po_id: "GCRF-BARAR-Fell22-RaR100451",


### PR DESCRIPTION
In this PR we tweak the data to be changed in `db/data/20240919000000_change_partner_org_ids.rb`

See https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2367

Following a review of validation errors identified when running the migration in `--dry-run` mode, 6 activities are to be excluded. Their RODA IDs:

- `GCRF-BA-R5FBZXE-73R7B48-9TK4WUY`
- `GCRF-BA-R5FBZXE-73R7B48-Z3FC2LP`
- `GCRF-BA-R5FBZXE-73R7B48-RFPMJX3`
- `GCRF-BA-R5FBZXE-73R7B48-6GG5YVE`
- `GCRF-BA-R5FBZXE-73R7B48-HXBLEK9`
- `GCRF-BA-R5FBZXE-73R7B48-RM5XQA5`

In the case of 6 of the 100 activites in the list of 100 for editing, it turned out that the change in
`Activity#partner_organisation_identifier` would violate a uniqueness control on this field. The validation rule specifies that two activities with the same "parent" activities can't share a Partner Organisation ID.

See [commit 3b60964][]

> Activity identifiers are only unique between sibling activities
>
> Activities can now have the same identifier, but only when they belong
> to different parent activities.
>
> We are loosening up the uniqueness validation on activity identifiers
> because we believe it is likely that the project and third-party project
> identifiers currently used by delivery partners have the possibility of
> being the same.
>
> When using this reference to publish to IATI we think this approach
> would continue to work. The fund, programme and project identifiers are
> all combined which should guarantee uniqueness across all activities.

[commit 3b60964]:
https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/commit/3b60964ef615de39d0dedf976d31b83d38af86dd
