### PR TITLE
Refactor DownloadLinkMailer

### DIFF
--- a/app/jobs/spending_breakdown_job.rb
+++ b/app/jobs/spending_breakdown_job.rb
@@ -13,12 +13,12 @@ class SpendingBreakdownJob < ApplicationJob
     fund_activity.save!
 
     DownloadLinkMailer.send_link(
-      recipient: requester,
-      file_name: upload.timestamped_filename
+      requester,
+      upload.timestamped_filename
     ).deliver
   rescue => error
     log_error(error, requester)
-    DownloadLinkMailer.send_failure_notification(recipient: requester).deliver
+    DownloadLinkMailer.send_failure_notification(requester).deliver
   end
 
   def save_tempfile(export)

--- a/app/mailers/download_link_mailer.rb
+++ b/app/mailers/download_link_mailer.rb
@@ -1,5 +1,5 @@
 class DownloadLinkMailer < ApplicationMailer
-  def send_link(recipient:, file_name:)
+  def send_link(recipient, file_name)
     @file_name = file_name
     @file_url = exports_url
 
@@ -15,7 +15,7 @@ class DownloadLinkMailer < ApplicationMailer
     )
   end
 
-  def send_failure_notification(recipient:)
+  def send_failure_notification(recipient)
     view_mail(
       ENV["NOTIFY_VIEW_TEMPLATE"],
       to: recipient.email,

--- a/spec/jobs/spending_breakdown_job_spec.rb
+++ b/spec/jobs/spending_breakdown_job_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe SpendingBreakdownJob, type: :job do
 
         expect(DownloadLinkMailer)
           .to have_received(:send_failure_notification)
-          .with(recipient: requester)
+          .with(requester)
         expect(email).to have_received(:deliver)
       end
     end
@@ -136,8 +136,8 @@ RSpec.describe SpendingBreakdownJob, type: :job do
       SpendingBreakdownJob.perform_now(requester_id: double, fund_id: double)
 
       expect(DownloadLinkMailer).to have_received(:send_link).with(
-        recipient: requester,
-        file_name: "timestamped_filename.csv"
+        requester,
+        "timestamped_filename.csv"
       )
       expect(email).to have_received(:deliver)
     end

--- a/spec/mailers/download_link_mailer_spec.rb
+++ b/spec/mailers/download_link_mailer_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
   describe "#send_link(recipient:, file_url:, file_name:)" do
     let(:mail) do
       DownloadLinkMailer.send_link(
-        recipient: user,
-        file_name: "spending_breakdown.csv"
+        user,
+        "spending_breakdown.csv"
       )
     end
 
@@ -72,7 +72,7 @@ RSpec.describe DownloadLinkMailer, type: :mailer do
 
   describe "#send_failure_notification(recipient:)" do
     let(:mail) do
-      DownloadLinkMailer.send_failure_notification(recipient: user)
+      DownloadLinkMailer.send_failure_notification(user)
     end
 
     it "sends the email to the given recipient" do


### PR DESCRIPTION
When we attempted to update to a new version of Ruby, this Mailer
stopped working.

We are not sure why, but switching to positional arguments resolves the
issue, UserMailer uses positional arguments so we assume that this is
acceptable.

Making this refactor opens the door to update Ruby.

