### PR TITLE
Data migration for IATI and other identifiers

### DIFF
--- a/app/views/shared/xml/_activity.xml.haml
+++ b/app/views/shared/xml/_activity.xml.haml
@@ -23,6 +23,10 @@
         %narrative= organisation.name
   - if activity.previous_identifier?
     %other-identifier{"ref" => activity.previous_identifier, type: "A1"}
+  - if activity.hybrid_beis_dsit_activity?
+    %other-identifier{"ref" => "GB-GOV-13", type: "B1"}
+      %owner-org{"ref" => "GB-GOV-13"}
+        %narrative{"xml:lang" => activity.organisation.language_code}= "DSIT previous reporting-org identifier"
   %activity-status{"code" => activity.iati_status}/
   - if activity.planned_start_date?
     %activity-date{"iso-date" => activity.planned_start_date, type: "1"}/

--- a/db/data/20241114082139_fix_hybrid_beis_dsit_identifier.rb
+++ b/db/data/20241114082139_fix_hybrid_beis_dsit_identifier.rb
@@ -1,0 +1,65 @@
+# Require me in the console with `require Rails.root + "db/data/20241114082139_fix_hybrid_beis_dsit_identifier.rb"`
+# then run me with `FixHybridBeisDsitIdentifier.new.migrate!`
+#
+# Description:
+#
+# For every Activity where `previous_identifier` is NOT nil
+# When the `previous_identifier` starts "GB-GOV-13" AND `transparency_identifier` starts "GB-GOV-26"
+# Then set `transparency_identifier` to start "GB-GOV-13"
+# AND set `previous_identifier` to nil
+# AND set hybrid_beis_dsit_activity to true.
+#
+class FixHybridBeisDsitIdentifier
+  attr_reader :target, :updated
+
+  def initialize
+    @target = 0
+    @updated = 0
+  end
+
+  def migrate!
+    target_activities.each do |activity|
+      fix_activity(activity)
+    end
+
+    puts "Total target activities: #{@target}"
+    puts "Total updated activities: #{@updated}"
+
+    true
+  end
+
+  def target_activities
+    activities = Activity.where.not(previous_identifier: nil).select do |activity|
+      identifier_starts_with_beis(activity.previous_identifier) &&
+        identifier_starts_with_dsit(activity.transparency_identifier)
+    end
+
+    @target = activities.count
+    activities
+  end
+
+  def fix_activity(activity)
+    puts "Updating activity id #{activity.id} with IATI ID: #{activity.transparency_identifier} and Previous IATI ID: #{activity.previous_identifier}"
+
+    activity.update!(
+      transparency_identifier: activity.previous_identifier,
+      previous_identifier: nil,
+      hybrid_beis_dsit_activity: true
+    )
+
+    @updated += 1
+    puts "Activity Updated!"
+  end
+
+  def identifier_starts_with_beis(identifier)
+    return if identifier.nil?
+
+    identifier.slice(0, 9).eql?("GB-GOV-13")
+  end
+
+  def identifier_starts_with_dsit(identifier)
+    return if identifier.nil?
+
+    identifier.slice(0, 9).eql?("GB-GOV-26")
+  end
+end

--- a/db/migrate/20241114114012_add_hybrid_beis_dsit_activity.rb
+++ b/db/migrate/20241114114012_add_hybrid_beis_dsit_activity.rb
@@ -1,0 +1,5 @@
+class AddHybridBeisDsitActivity < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activities, :hybrid_beis_dsit_activity, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_15_183402) do
+ActiveRecord::Schema.define(version: 2024_11_14_114012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2024_01_15_183402) do
     t.string "ispf_oda_partner_countries", array: true
     t.string "ispf_non_oda_partner_countries", array: true
     t.string "spending_breakdown_filename"
+    t.boolean "hybrid_beis_dsit_activity", default: false
     t.index ["extending_organisation_id"], name: "index_activities_on_extending_organisation_id"
     t.index ["level"], name: "index_activities_on_level"
     t.index ["organisation_id"], name: "index_activities_on_organisation_id"

--- a/spec/db/data/20241114082139_fix_hybrid_beis_dsit_identifier_spec.rb
+++ b/spec/db/data/20241114082139_fix_hybrid_beis_dsit_identifier_spec.rb
@@ -1,0 +1,98 @@
+require Rails.root + "db/data/20241114082139_fix_hybrid_beis_dsit_identifier.rb"
+
+RSpec.describe FixHybridBeisDsitIdentifier do
+  describe "#migrate!" do
+    it "updates only the appropriate activities and includes a count" do
+      activity_to_update = create(
+        :programme_activity,
+        transparency_identifier: "GB-GOV-26-AAAA-BBBB-CCC-DDDDDDD",
+        previous_identifier: "GB-GOV-13-AAAA-BBBB-CCC-DDDDDDD",
+        hybrid_beis_dsit_activity: false
+      )
+      activity_to_ignore = create(
+        :programme_activity,
+        transparency_identifier: "GB-GOV-26-EEEE-FFFF-GGG-HHHHHHH",
+        previous_identifier: nil,
+        hybrid_beis_dsit_activity: false
+      )
+      other_activity_to_ignore = create(
+        :programme_activity,
+        transparency_identifier: "GB-GOV-13-EEEE-FFFF-GGG-HHHHHHH",
+        previous_identifier: "GB-GOV-13-IIII_JJJJ_KKK_LL",
+        hybrid_beis_dsit_activity: false
+      )
+
+      migration = described_class.new
+      migration.migrate!
+
+      expect(activity_to_update.reload.transparency_identifier).to eql "GB-GOV-13-AAAA-BBBB-CCC-DDDDDDD"
+      expect(activity_to_update.hybrid_beis_dsit_activity).to be true
+
+      expect(activity_to_ignore.reload.transparency_identifier).to eql "GB-GOV-26-EEEE-FFFF-GGG-HHHHHHH"
+      expect(activity_to_ignore.hybrid_beis_dsit_activity).to be false
+
+      expect(other_activity_to_ignore.reload.transparency_identifier).to eql "GB-GOV-13-EEEE-FFFF-GGG-HHHHHHH"
+      expect(other_activity_to_ignore.hybrid_beis_dsit_activity).to be false
+
+      expect(migration.target).to be 1
+      expect(migration.updated).to be 1
+    end
+  end
+
+  describe "#identifier_starts_with_beis" do
+    it "returns true for identifiers that start GB-GOV-13" do
+      valid_identifier = "GB-GOV-13-1234-5678-91011"
+
+      expect(described_class.new.identifier_starts_with_beis(valid_identifier)).to be true
+    end
+
+    it "returns false for identifiers that do not start GB-GOV-13" do
+      valid_identifier = "GB-GOV-10-1234-5678-91011"
+
+      expect(described_class.new.identifier_starts_with_beis(valid_identifier)).to be false
+    end
+  end
+
+  describe "#identifier_starts_with_dsit" do
+    it "returns true for identifiers that start GB-GOV-26" do
+      valid_identifier = "GB-GOV-26-1234-5678-91011"
+
+      expect(described_class.new.identifier_starts_with_dsit(valid_identifier)).to be true
+    end
+
+    it "returns false for identifiers that do not start GB-GOV-26" do
+      valid_identifier = "GB-GOV-10-1234-5678-91011"
+
+      expect(described_class.new.identifier_starts_with_dsit(valid_identifier)).to be false
+    end
+  end
+
+  describe "#fix_activity" do
+    let(:activity) do
+      create(
+        :programme_activity,
+        transparency_identifier: "GB-GOV-26-AAAA-BBBB-CCC-DDDDDDD",
+        previous_identifier: "GB-GOV-13-AAAA-BBBB-CCC-DDDDDDD",
+        hybrid_beis_dsit_activity: false
+      )
+    end
+
+    it "updates the transparency_identifier to the value of previous_identifier" do
+      described_class.new.fix_activity(activity)
+
+      expect(activity.transparency_identifier).to eql "GB-GOV-13-AAAA-BBBB-CCC-DDDDDDD"
+    end
+
+    it "updates the previous_identifier to nil" do
+      described_class.new.fix_activity(activity)
+
+      expect(activity.previous_identifier).to be_nil
+    end
+
+    it "updates the hybrid BEIS DSIT state to true" do
+      described_class.new.fix_activity(activity)
+
+      expect(activity.hybrid_beis_dsit_activity).to be true
+    end
+  end
+end

--- a/spec/views/shared/xml/activity_spec.rb
+++ b/spec/views/shared/xml/activity_spec.rb
@@ -30,6 +30,28 @@ RSpec.describe "shared/xml/activity" do
     end
   end
 
+  describe "Other identifier for BEIS to DSIT" do
+    context "when hybrid_beis_dsit_activity is true" do
+      let(:activity) { create(:programme_activity, hybrid_beis_dsit_activity: true) }
+      let!(:commitment) { nil }
+
+      it "includes the other-identifier element" do
+        expect(rendered).to include("<other-identifier ref='GB-GOV-13' type='B1'>")
+        expect(rendered).to include("<owner-org ref='GB-GOV-13'>")
+        expect(rendered).to include("<narrative xml:lang='en'>DSIT previous reporting-org identifier</narrative")
+      end
+    end
+
+    context "when hybrid_beis_dsit_activity is false" do
+      let(:activity) { create(:programme_activity, hybrid_beis_dsit_activity: false) }
+      let!(:commitment) { nil }
+
+      it "does not include the other-identifier element" do
+        expect(rendered).not_to include("<other-identifier ref='GB-GOV-13'type='B1'>")
+      end
+    end
+  end
+
   describe "activity-scope" do
     context "when there are benefitting countries" do
       let(:commitment) { nil }


### PR DESCRIPTION
This data migration fixes the data in the application that was
previously updated in error.

We previously updated the `transparency_identifier` which should be
immutable. This data migration reverts that change.

We then set the new `hybrid_beis_dsit_activity` which makes the
application display 'previous reporting organisation' info in the IATI
xml.

A 'hybrid activity' is one that was started under BEIS but continued
under DSIT and so has to show:

- the previous reporting organisation
- retain the old IATI identifier

There can never be new 'hybrid activities'.

Instructions for running this data migration are in the file.