### PR TITLE
Fix: Asset compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,13 @@ COPY . ${APP_HOME}
 RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
 RUN cp -R $DEPS_HOME/node_modules/govuk-frontend/govuk/assets $APP_HOME/app/assets
 
+# We need a secret key, database url and Redis url to compile assets, these are
+# not used in the running application
 RUN if [ ${RAILS_ENV} = "production" ]; then \
+  DOMAIN="stand-in.local" \
+  SECRET_KEY_BASE="super secret" \
+  DATABASE_URL="postgres://stand-in:5432" \
+  REDIS_URL="redis://stand-in.local:6379" \
   bundle exec rake assets:precompile --quiet; \
   fi
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ documentation](/doc/getting-started.md) for instructions.
 
 ## Errors and monitoring
 
-TBC
+### Errors
+
+We send errors to a dxw owned [Rollbar
+project](https://rollbar.com/dxw/dsit-roda/), contact dxw support to get access.
 
 ## Architecture decision records We use ADRs to document architectural decisions
 We use ADRs to document architectural decisions that we make. They can be found


### PR DESCRIPTION
We recently switched off asset compilation in environments other than
production.

In production, we thought the environment variables required for asset
compilation would be present, when we deployed the change to the
development environment, it turned out that was not the case (we have
no direct control over how the infrastructure is configured).

Returning these stand in variables allows the assets to be compiled, the
variables are not used in the running container and this is how we
approached this issue before the change.