### PR TITLE
Allow users to have additional organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Migration (and logic) to allow users to belong to multiple organisations
+
 ## Release 154 - 2024-12-05
 
 [Full changelog][154]

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user_organisation
+end

--- a/db/migrate/20241204220209_create_join_table_organisations_users.rb
+++ b/db/migrate/20241204220209_create_join_table_organisations_users.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableOrganisationsUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_join_table :organisations, :users, column_options: {type: :uuid} do |t|
+      t.index [:organisation_id, :user_id]
+      t.index [:user_id, :organisation_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_14_114012) do
+ActiveRecord::Schema.define(version: 2024_12_04_220209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -284,6 +284,13 @@ ActiveRecord::Schema.define(version: 2024_11_14_114012) do
     t.boolean "active", default: true
     t.string "alternate_names", array: true
     t.index ["iati_reference"], name: "index_organisations_on_iati_reference", unique: true
+  end
+
+  create_table "organisations_users", id: false, force: :cascade do |t|
+    t.uuid "organisation_id", null: false
+    t.uuid "user_id", null: false
+    t.index ["organisation_id", "user_id"], name: "index_organisations_users_on_organisation_id_and_user_id"
+    t.index ["user_id", "organisation_id"], name: "index_organisations_users_on_user_id_and_organisation_id"
   end
 
   create_table "outgoing_transfers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/doc/architecture/decisions/0038-users-may-belong-to-multiple-organisations.md
+++ b/doc/architecture/decisions/0038-users-may-belong-to-multiple-organisations.md
@@ -1,0 +1,39 @@
+# 38. Users may belong to multiple organisations
+
+Date: 2024-12-05
+
+## Status
+
+Accepted
+
+## Context
+
+Some RODA users wish to have the ability to view reports, activities, etc from
+other organisations. Currently these users have to have their organisation
+changed for them so that they can do this, which requires manual intervention
+by an administrator.
+
+## Decision
+
+Much of the logic in RODA is predicated on the idea that one user belongs to
+one organisation; changing the relationship to one where a user has many
+organisations would require a very large engineering effort.
+
+We believe the easiest way to allow a RODA user belonging to one organisation
+to be able to view data belonging to other organisations is to maintain its
+existing relationship where it belongs to one organisation, but to add an
+additional relationship where a user has and belongs to many organisations,
+which we are calling "additional organisations". This way, all the existing
+logic and tests still work, but we can augment the functionality to allow a
+user to switch their current organisation to be a different one from an
+"additional organisations" list (the contents of which would be set by an
+administrator for a given user).
+
+## Consequences
+
+It will be easier for users who need to see data from other organisations to be
+able to do this without requiring manual intervention.
+
+The relationship between a user and its organisation is critical functionality
+and so we must tread carefully. Our proposed solution does not require any
+changes to the existing policy logic.


### PR DESCRIPTION
This creates a `has_and_belongs_to_many` join table relationship between organisations and users, allowing a user to belong to `additional_organisations` and paves the way to allowing a user to set their `organisation` to be a `Current.user_organisation` and thus view data for that organisation instead of their own "real" organisation.

This should change nothing about the existing functionality of the site and will be entirely invisible to end users. (The next phase will include front-end changes which *will* allow selected users to switch their current organisation.)

Helper methods on the `User` model to navigate this relationship include `primary_organisation` (to retrieve the user's actual `organisation`, which is necessarily overwritten), `all_organisations` (the union of `primary_organisation` and `additional_organisations`) and `additional_organisations?` (to determine whether a user has a non-zero number of `additional_organisations`).

## Next steps

- [x] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
