### PR TITLE
Prepare user model for anonymisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Theme colour has changed from blue to a black
+- The date and time a user is deactivated is now stored
 
 ## Release 157 - 2024-12-16
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < BaseController
   end
 
   def create
-    @user = User.new(user_params)
+    @user = User.new(user_params.except(:active))
     authorize @user
     @service_owner = service_owner
     @partner_organisations = partner_organisations
@@ -60,10 +60,11 @@ class UsersController < BaseController
     @partner_organisations = partner_organisations
 
     reset_mfa = user_params.delete(:reset_mfa)
-    @user.assign_attributes(user_params.except(:reset_mfa))
+    active = user_params[:active] == "true"
+    @user.assign_attributes(user_params.except(:reset_mfa, :active))
 
     if @user.valid?
-      result = UpdateUser.new(user: @user, organisation: organisation, reset_mfa: reset_mfa).call
+      result = UpdateUser.new(user: @user, active: active, organisation: organisation, reset_mfa: reset_mfa).call
 
       if result.success?
         flash[:notice] = t("action.user.update.success")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,10 +14,15 @@ class User < ApplicationRecord
     organisation_id: :organisation
   }.freeze
 
-  scope :active, -> { where(active: true) }
-  scope :inactive, -> { where(active: false) }
+  scope :active, -> { where(deactivated_at: nil) }
+  scope :inactive, -> { where.not(deactivated_at: nil) }
 
   delegate :service_owner?, :partner_organisation?, to: :organisation
+
+  def active
+    deactivated_at.blank?
+  end
+  alias_method :active?, :active
 
   def organisation
     if Current.user_organisation

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,10 +1,11 @@
 class UpdateUser
   attr_accessor :user, :organisation, :reset_mfa
 
-  def initialize(user:, organisation:, reset_mfa: false)
+  def initialize(user:, organisation:, active: true, reset_mfa: false)
     self.user = user
     self.organisation = organisation
     self.reset_mfa = reset_mfa
+    @active = active
   end
 
   def call
@@ -17,6 +18,8 @@ class UpdateUser
         user.mobile_number = nil
         user.mobile_number_confirmed_at = nil
       end
+
+      user.deactivated_at = @active ? nil : DateTime.now
 
       user.save
     end

--- a/db/migrate/20241212115356_add_user_anonymisation.rb
+++ b/db/migrate/20241212115356_add_user_anonymisation.rb
@@ -1,0 +1,23 @@
+class AddUserAnonymisation < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :deactivated_at, :datetime
+    add_column :users, :anonymised_at, :datetime
+
+    User.where(active: false).each do |user|
+      user.update_column(:deactivated_at, user.updated_at)
+    end
+
+    remove_column :users, :active
+  end
+
+  def down
+    add_column :users, :active, :boolean, default: true
+
+    User.where.not(deactivated_at: nil).each do |user|
+      user.update_column(:active, false)
+    end
+
+    remove_column :users, :deactivated_at, :datetime
+    remove_column :users, :anonymised_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_04_220209) do
+ActiveRecord::Schema.define(version: 2024_12_12_115356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -358,7 +358,6 @@ ActiveRecord::Schema.define(version: 2024_12_04_220209) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "organisation_id"
-    t.boolean "active", default: true
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -370,6 +369,8 @@ ActiveRecord::Schema.define(version: 2024_12_04_220209) do
     t.boolean "otp_required_for_login", default: true
     t.string "mobile_number"
     t.datetime "mobile_number_confirmed_at"
+    t.datetime "deactivated_at"
+    t.datetime "anonymised_at"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :administrator, class: "User" do
     name { Faker::Name.name }
     email { Faker::Internet.email }
-    active { true }
+    deactivated_at { nil }
+    anonymised_at { nil }
     password { "Ab1!#{SecureRandom.uuid}" }
     mobile_number { Faker::PhoneNumber.phone_number }
     mobile_number_confirmed_at { 1.day.ago }
@@ -19,7 +20,7 @@ FactoryBot.define do
     end
 
     factory :inactive_user do
-      active { false }
+      deactivated_at { Date.yesterday }
     end
 
     trait :new_user do

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -352,7 +352,7 @@ RSpec.feature "Users can sign in" do
 
   context "when the user has been deactivated" do
     scenario "the user cannot log in and sees an informative message" do
-      user = create(:partner_organisation_user, active: false)
+      user = create(:partner_organisation_user, deactivated_at: DateTime.yesterday)
 
       visit root_path
       log_in_via_form(user)
@@ -368,7 +368,7 @@ RSpec.feature "Users can sign in" do
 
       expect(page.current_path).to eql home_path
 
-      user.active = false
+      user.deactivated_at = DateTime.now
       user.save
 
       visit home_path

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the user is inactive" do
       before do
-        user.update!(active: false)
+        user.update!(deactivated_at: DateTime.yesterday)
       end
 
       it "should raise an error" do
@@ -136,7 +136,7 @@ RSpec.describe ReportMailer, type: :mailer do
     end
 
     context "when the user is inactive" do
-      let(:user) { create(:administrator, organisation: organisation, active: false) }
+      let(:user) { create(:administrator, organisation: organisation, deactivated_at: DateTime.yesterday) }
 
       it "should raise an error" do
         expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
@@ -166,7 +166,7 @@ RSpec.describe ReportMailer, type: :mailer do
     end
 
     context "when the user is inactive" do
-      before { user.update!(active: false) }
+      before { user.update!(deactivated_at: DateTime.yesterday) }
 
       it "should raise an error" do
         expect { mail.body }.to raise_error(ArgumentError, "User must be active to receive report-related emails")
@@ -239,7 +239,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
       context "when the user is inactive" do
         before do
-          user.update!(active: false)
+          user.update!(deactivated_at: DateTime.yesterday)
         end
 
         it "should raise an error" do
@@ -317,7 +317,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the user is inactive" do
       before do
-        user.update!(active: false)
+        user.update!(deactivated_at: DateTime.yesterday)
       end
 
       it "should raise an error" do
@@ -379,7 +379,7 @@ RSpec.describe ReportMailer, type: :mailer do
 
     context "when the user is inactive" do
       before do
-        user.update!(active: false)
+        user.update!(deactivated_at: DateTime.yesterday)
       end
 
       it "should raise an error" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,18 +112,18 @@ RSpec.describe User, type: :model do
 
   describe "scopes" do
     it "shows active users for active scope" do
-      create(:administrator, active: true)
-      create(:administrator, active: true)
-      create(:administrator, active: false)
+      create(:administrator, deactivated_at: nil)
+      create(:administrator, deactivated_at: nil)
+      create(:administrator, deactivated_at: DateTime.yesterday)
 
       expect(User.active.size).to eq(2)
       expect(User.active.last.active).to eq(true)
     end
 
     it "shows inactive users for inactive scope" do
-      create(:administrator, active: true)
-      create(:administrator, active: true)
-      create(:administrator, active: false)
+      create(:administrator, deactivated_at: nil)
+      create(:administrator, deactivated_at: nil)
+      create(:administrator, deactivated_at: DateTime.yesterday)
 
       expect(User.inactive.size).to eq(1)
       expect(User.inactive.last.active).to eq(false)
@@ -154,6 +154,30 @@ RSpec.describe User, type: :model do
       user.password = "AaBbCc123456789!"
 
       expect(user.valid?).to be_truthy
+    end
+  end
+
+  describe "#active" do
+    it "is aliased as active?" do
+      user = build(:partner_organisation_user)
+
+      expect(user.active?).to be true
+    end
+
+    context "when the user has no deactivated date" do
+      it "is active" do
+        user = build(:partner_organisation_user, deactivated_at: nil)
+
+        expect(user.active?).to be true
+      end
+    end
+
+    context "when the user has a deactivated date" do
+      it "is not active" do
+        user = build(:partner_organisation_user, deactivated_at: DateTime.yesterday)
+
+        expect(user.active?).to be false
+      end
     end
   end
 end

--- a/spec/services/report/send_state_change_emails_spec.rb
+++ b/spec/services/report/send_state_change_emails_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Report::SendStateChangeEmails do
 
   let!(:report) { create(:report, state: state) }
   let!(:partner_organisation_users) { create_list(:administrator, 5, organisation: report.organisation) }
-  let!(:inactive_po_user) { create(:administrator, organisation: report.organisation, active: false) }
+  let!(:inactive_po_user) { create(:administrator, organisation: report.organisation, deactivated_at: DateTime.yesterday) }
   let!(:service_owners) { create_list(:beis_user, 2) }
-  let!(:inactive_service_owner) { create(:beis_user, active: false) }
+  let!(:inactive_service_owner) { create(:beis_user, deactivated_at: DateTime.yesterday) }
 
   let(:recipients) { ActionMailer::Base.deliveries.map { |delivery| delivery.to }.flatten }
 


### PR DESCRIPTION
This is the work to start to allow us to anonymise users - our version of 'deletion'. We decided not to delete users as we want to retain the history of 'who did what when'. DSIT have decided  that a user who has been deactivated for 5 years can be anonymised, which will remove all personally identifiable information (PII) from a user in the application.

To do so we will need to store when a user was deactivated so we can either anonymise ourselves or let admin users do so.

This first step introduces two date and time fields to user:

- deactivated_at
- anonymised_at

We are taking the `updated_at` timestamp as our best guess at the deactivated_at date and time of existing users as we assume a deactivated user last activity will be the deactivation of their account.

As the state of the user is an important part of the application, I've made this work in three separate commits to keep it clear and have good commit messages, this means the application and test suite are broken until the final commit - we can squash these down if that is preferable (I like it this way).

First we alter the table and migrate the data, we've made the migration reversible just in case.

We then change the User model to use the deactivated_at date to determine is the user is active or not along with updates to spec setups.

Finally we temporarily change how the flow for admin users to deactivate and activate users works - this is temporary as we plan to change the UI for this next, that work is in scope and on our Trello board.