### PR TITLE
Set theme colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Theme colour has changed from blue to a black
+
 ## Release 157 - 2024-12-16
 
 [Full changelog][157]

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,9 @@
     %meta{charset: "utf-8"}/
     %title #{content_for :page_title_prefix} - #{t('app.title')}
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
-    %meta{content: "blue", name: "theme-color"}/
+    %meta{content: "#0b0c0c", name: "theme-color"}/
     %link{href: asset_path("favicon.ico"), rel: "shortcut icon", type: "image/x-icon"}/
+
 
     /[if !IE 8]
     = stylesheet_link_tag 'application', media: 'all'


### PR DESCRIPTION
This meta tag is used to set the colour that you see when the browser
'bounces':

https://webkit.org/blog/11989/new-webkit-features-in-safari-15/

it is currently set to `blue` which is pretty distracting!

In the current GOV.UK front end it is set to `#0b0c0c` so we do the
same:

https://design-system.service.gov.uk/styles/page-template/
