### PR TITLE
Refactor user scopes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,10 @@ class UsersController < BaseController
   def index
     authorize :user, :index?
     @user_state = params[:user_state]
-    @users = policy_scope(User).includes(:organisation).joins(:organisation).order("organisations.name ASC, users.name ASC")
     @users = if @user_state == "active"
-      @users.active
+      policy_scope(User).all_active
     else
-      @users.deactivated
+      policy_scope(User).all_deactivated
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,14 @@ class User < ApplicationRecord
   }.freeze
 
   scope :active, -> { where(deactivated_at: nil) }
-  scope :deactivated, -> { where.not(deactivated_at: nil).order(deactivated_at: :asc) }
+  scope :deactivated, -> { where.not(deactivated_at: nil) }
+
+  scope :all_active, -> {
+    active.includes(:organisation).joins(:organisation).order("organisations.name ASC, users.name ASC")
+  }
+  scope :all_deactivated, -> {
+    deactivated.includes(:organisation).joins(:organisation).order("users.deactivated_at ASC, organisations.name ASC, users.name ASC")
+  }
 
   delegate :service_owner?, :partner_organisation?, to: :organisation
 

--- a/spec/features/beis_users_can_view_other_users_spec.rb
+++ b/spec/features/beis_users_can_view_other_users_spec.rb
@@ -45,30 +45,6 @@ RSpec.feature "BEIS users can can view other users" do
       expect(page).to have_content("Mobile number confirmed for authentication? Yes")
     end
 
-    scenario "users are grouped by their organisation name in alphabetical order" do
-      a_organisation = create(:partner_organisation, name: "A Organisation")
-      b_organisation = create(:partner_organisation, name: "B Organisation")
-
-      a1_user = create(:administrator, organisation: a_organisation)
-      a2_user = create(:administrator, organisation: a_organisation)
-      b1_user = create(:administrator, organisation: b_organisation)
-      b2_user = create(:administrator, organisation: b_organisation)
-
-      # Navigate from the landing page
-      visit organisation_path(user.organisation)
-      click_on(t("page_title.users.index"))
-
-      expected_array = [
-        a1_user.organisation.name,
-        a2_user.organisation.name,
-        b1_user.organisation.name,
-        b2_user.organisation.name,
-        user.organisation.name
-      ].sort
-
-      expect(page.all("td.organisation").collect(&:text)).to match_array(expected_array)
-    end
-
     scenario "an inactive user can be viewed" do
       another_user = create(:inactive_user, deactivated_at: DateTime.now - 1.hour)
 


### PR DESCRIPTION
We recently added the length of time a user has been deactivated for on
the deactivated user index, the ordering on this did not work as
expected, this work fixes that and takes the time to refactor how we
approach this.

We create two scopes for use in the views, we've gone for scopes as we
can test those in isolation.

As we have the ordering tested on the scopes, we deleted the old feature
spec that tested the order of the user list.

We kept the call to `policy_scope(User)` although we think it is just
equivalent to `all` as there is no scope so it is inherited.

