### PR TITLE
Administrative interface for user additional organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Admin interface to enable additional organisations
+
 ## Release 159 - 2024-12-19
 
 [Full changelog][159]

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,7 @@ import "./src/cookie-consent";
 import initTableTreeView from "./src/table-tree-view";
 import "./src/toggle-providing-org-fields";
 import "./src/region-countries-checkbox";
+import "./src/edit-user-additional-organisations";
 import * as GOVUKFrontend from "govuk-frontend";
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/app/javascript/src/edit-user-additional-organisations.js
+++ b/app/javascript/src/edit-user-additional-organisations.js
@@ -1,0 +1,23 @@
+/*
+  This progressively enhances the "Create/Edit user" form such that a primary
+  organisation will be hidden from the list of additional organisations (and
+  also unchecked), because a user's primary organisation can never be a member
+  of that user's additional organisations.
+*/
+document.addEventListener("DOMContentLoaded", function() {
+  const primaryOrgSelect = document.querySelector("#user_organisation_id");
+
+  if (!primaryOrgSelect) return;
+
+  const handleCheckboxes = () => {
+    const val = primaryOrgSelect.querySelector("option:checked").value;
+
+    document.querySelectorAll(".additional-organisations .govuk-checkboxes__item").forEach((checkboxItem) => {
+      const match = checkboxItem.querySelector(`input[value="${val}"`);
+      checkboxItem.style.display = match ? (match.checked = false, "none") : "block";
+    });
+  }
+
+  primaryOrgSelect.addEventListener("change", handleCheckboxes);
+  handleCheckboxes();
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :historical_events
   validates_presence_of :name, :email
   validates :email, with: :email_cannot_be_changed_after_create, on: :update
+  validates :organisation_id, exclusion: {in: ->(user) { user.additional_organisations.map(&:id) }}
 
   before_save :ensure_otp_secret!, if: -> { otp_required_for_login && otp_secret.nil? }
 
@@ -39,7 +40,7 @@ class User < ApplicationRecord
   end
 
   def primary_organisation
-    Organisation.find(organisation_id)
+    Organisation.find_by_id(organisation_id)
   end
 
   def all_organisations

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -1,15 +1,17 @@
 class CreateUser
-  attr_accessor :user, :organisation
+  attr_accessor :user, :organisation, :additional_organisations
 
-  def initialize(user:, organisation:)
+  def initialize(user:, organisation:, additional_organisations: [])
     self.user = user
     self.organisation = organisation
+    self.additional_organisations = additional_organisations
   end
 
   def call
     result = Result.new(true)
 
     user.organisation = organisation
+    user.additional_organisations = additional_organisations
     # This password will never be used: the user must set a new password upon first login
     # but it must fulfill the password_complexity requirements we set in
     # config/initializers/devise_security

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,10 +1,11 @@
 class UpdateUser
-  attr_accessor :user, :organisation, :reset_mfa
+  attr_accessor :user, :organisation, :reset_mfa, :additional_organisations
 
-  def initialize(user:, organisation:, active: true, reset_mfa: false)
+  def initialize(user:, organisation:, active: true, reset_mfa: false, additional_organisations: [])
     self.user = user
     self.organisation = organisation
     self.reset_mfa = reset_mfa
+    self.additional_organisations = additional_organisations
     @active = active
   end
 
@@ -13,6 +14,7 @@ class UpdateUser
 
     User.transaction do
       user.organisation = organisation
+      user.additional_organisations = additional_organisations
 
       if reset_mfa
         user.mobile_number = nil

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -9,17 +9,22 @@
       = f.govuk_check_box :reset_mfa, true, multiple: false, label: { text: t("form.label.user.reset_mfa") }
 
   - if @service_owner.present?
-    = f.govuk_radio_buttons_fieldset :organisation, class: "user-organisations" do
-      = f.govuk_radio_button :organisation_id, @service_owner.id, label: { text: @service_owner.name }, link_errors: true
-      - if @partner_organisations.any?
-        = f.govuk_radio_divider
-        - @partner_organisations.each do |dp|
-          = f.govuk_radio_button :organisation_id, dp.id, label: { text: dp.name }
+    .govuk-form-group
+      = f.govuk_fieldset legend: {text: t("form.legend.user.primary_organisation")}, class: "user-organisations" do
+        %span.govuk-hint=t("form.hint.user.primary_organisation")
+
+        - opts = [[@service_owner.name, @service_owner.id]] + @partner_organisations.pluck(:name, :id)
+        =f.select :organisation_id, options_for_select(opts, @user.primary_organisation.try(:id)), {}, class: "govuk-select"
+
   - else
     .govuk-inset-text
       = succeed "." do
         = t("page_content.users.new.no_organisations.cta")
         = link_to t("page_content.users.new.no_organisations.link"), new_organisation_path, class: "govuk-link"
+
+  = f.govuk_check_boxes_fieldset :additional_organisations, legend: {text: "Additional organisations"}, class: "additional-organisations", hint: {text: t("form.hint.user.additional_organisations")} do
+    - @partner_organisations.each do |dp|
+      = f.govuk_check_box :additional_organisations, dp.id, label: { text: dp.name }, checked: @user.additional_organisations.include?(dp)
 
   = f.govuk_collection_radio_buttons :active,
       user_active_options,

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -25,6 +25,12 @@
             = t("summary.label.user.organisation")
           %dd.govuk-summary-list__value
             = @user.organisation.name
+        - if @user.additional_organisations?
+          .govuk-summary-list__row
+            %dt.govuk-summary-list__key
+              = t("summary.label.user.additional_organisations")
+            %dd.govuk-summary-list__value
+              = @user.additional_organisations.map(&:name).to_sentence 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
             = t("summary.label.user.active")

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -22,11 +22,14 @@ en:
         active: What is the user's status?
         organisation_id: What organisation does this user belong to?
         reset_mfa: Reset the user's mobile number?
+        primary_organisation: Primary organisation
     hint:
       user:
         active: Deactivated users cannot log in
         new_password: Minimum 15 characters; must contain at least one digit, one lowercase letter, one uppercase letter, and one punctuation mark or symbol
         reset_mfa: The user will have to provide their mobile number on their next log in attempt
+        primary_organisation: This is the main organisation the user belongs to
+        additional_organisations: Select one or more additional organisations that this user can supply data on behalf of. They will not receive notifications for these organisations
     user:
       active:
         active: Activate
@@ -48,6 +51,7 @@ en:
         name: Full name
         email: Email address
         organisation: Organisation
+        additional_organisations: Additional organisations
         active: Active?
         confirmed_for_mfa:
           label: Mobile number confirmed for authentication?
@@ -88,6 +92,8 @@ en:
           attributes:
             organisation:
               required: Select the user's organisation
+            organisation_id:
+              exclusion: Additional organisations cannot include the primary organisation.
             name:
               blank: Enter a full name
             email:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe User, type: :model do
 
       expect(user).to be_valid
     end
+
+    it "won't allow a user to have its primary organisation also as an additional organisation" do
+      user = create(:administrator)
+      org = user.organisation
+      user.organisation = org
+      user.additional_organisations << org
+      expect(user).to be_invalid
+    end
   end
 
   describe "associations" do

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -33,5 +33,21 @@ RSpec.describe CreateUser do
         expect(user.reload.organisation).to eql(organisation)
       end
     end
+
+    context "when additional organisations are provided" do
+      it "associates the additional organsations to it" do
+        organisation = create(:partner_organisation)
+        org1 = create(:partner_organisation)
+        org2 = create(:partner_organisation)
+
+        described_class.new(
+          user: user,
+          organisation: organisation,
+          additional_organisations: [org1, org2]
+        ).call
+
+        expect(user.reload.additional_organisations).to include(org1, org2)
+      end
+    end
   end
 end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe UpdateUser do
       end
     end
 
+    context "when additional organisations are provided" do
+      it "associates the additional organsations to it" do
+        organisation = create(:partner_organisation)
+        org1 = create(:partner_organisation)
+        org2 = create(:partner_organisation)
+
+        described_class.new(
+          user: user,
+          organisation: organisation,
+          additional_organisations: [org1, org2]
+        ).call
+
+        expect(user.reload.additional_organisations).to include(org1, org2)
+      end
+    end
+
     context "when reset MFA is requested" do
       it "resets the user's mobile number and its confirmation time" do
         described_class.new(


### PR DESCRIPTION
We now have the ability to add additional organisations from the app itself via the create/edit user forms.

This replaces the radio list of BEIS + partner organisations with a dropdown, for the primary organisation, and also adds a checkbox list of partner organisations for the additional organisations. Appropriate explanatory hint text is also provided.

We also have a sprinkling of JavaScript to enhance the form such that a user's additional organisation selections cannot include their primary organisation. As a safeguard for users who do not have JavaScript enabled, we have validation in the model for this too.

## Screenshots of UI changes

### Before

<img width="1857" alt="before" src="https://github.com/user-attachments/assets/ae32ff34-b0ab-40bc-86c1-10a502815dd1" />

### After

<img width="1857" alt="after" src="https://github.com/user-attachments/assets/115606a2-7efa-4258-9d2f-8b407f1455dc" />


- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
