### PR TITLE
Fix flaky healthcheck spec

### DIFF
--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe "Health Check", type: :request do
     ClimateControl.modify CURRENT_SHA: "b9c73f88", TIME_OF_BUILD: "2020-01-01T00:00:00Z" do
       get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eql(
-        "rails" => "OK",
-        "git_sha" => "b9c73f88",
-        "built_at" => "2020-01-01T00:00:00Z",
-        "sidekiq" => {
-          "enqueued" => 0,
-          "retry_size" => 0
-        }
+      expect(JSON.parse(response.body)).to match(
+        a_hash_including(
+          "rails" => "OK",
+          "git_sha" => "b9c73f88",
+          "built_at" => "2020-01-01T00:00:00Z",
+          "sidekiq" => anything
+        )
       )
     end
   end


### PR DESCRIPTION
## Changes in this PR

Mild fix for a spec that would fail in dev if you had any unprocessed Sidekiq detritus from other projects. Benefit for devs only, no need for CHANGELOG stuff

## Screenshots of UI changes

None

### Before

Sometimes specs would fail if you had unprocessed enqueued sidekiq stuffs

### After

They no longer fail

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
