### PR TITLE
Add an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file (prevents GitHub red warnings)
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
A lot of editors support https://editorconfig.org out of the box. Some, like VS Code, require a plugin. But the main benefit of this little dotfile is that at its most basic it tells your editor to insert a newline at the end of the file when you've forgotten, thereby preventing the nasty little red circle of doom on GitHub when you forgot to add one yourself (and potentially causing a `standardrb` error requiring faff and a wasted build to fix).

## Changes in this PR

A dev-only affordance

## Screenshots of UI changes

### Before

<img width="267" alt="image" src="https://github.com/user-attachments/assets/e925a268-65be-4d9e-9842-53cd3e965467" />

### After

The above circle no longer appears when you forget to add a newline

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
