### PR TITLE
Change deactivate/reactivate interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 [Full changelog][unreleased]
 
+- Split out deactivate/reactivate functionality into separate pages with confirmatory text
 - Upgrade the remaining 11 config options to Rails 7.0 defaults
 
 ## Release 160 - 2025-01-08

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -32,13 +32,6 @@ module FormHelper
       }
   end
 
-  def user_active_options
-    [
-      OpenStruct.new(id: "true", name: t("form.user.active.active")),
-      OpenStruct.new(id: "false", name: t("form.user.active.inactive"))
-    ]
-  end
-
   def organisation_active_options
     [
       OpenStruct.new(id: "true", name: t("form.label.organisation.active.true")),

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -18,4 +18,12 @@ class UserPolicy < ApplicationPolicy
   def destroy?
     beis_user?
   end
+
+  def deactivate?
+    beis_user?
+  end
+
+  def reactivate?
+    beis_user?
+  end
 end

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -26,10 +26,10 @@
     - @partner_organisations.each do |dp|
       = f.govuk_check_box :additional_organisations, dp.id, label: { text: dp.name }, checked: @user.additional_organisations.include?(dp)
 
-  = f.govuk_collection_radio_buttons :active,
-      user_active_options,
-      :id,
-      :name,
-      legend: { tag: :h2 }
-
-  = f.govuk_submit t("form.button.user.submit")
+  .govuk-button-group
+    = f.govuk_submit t("form.button.user.submit")
+    - if !@user.new_record?
+      - if @user.active?
+        = link_to t("form.button.user.deactivate"), deactivate_user_path, class: "govuk-button govuk-button--secondary"
+      - else
+        = link_to t("form.button.user.reactivate"), reactivate_user_path, class: "govuk-button govuk-button--secondary"

--- a/app/views/users/deactivate.html.haml
+++ b/app/views/users/deactivate.html.haml
@@ -1,0 +1,16 @@
+=content_for :page_title_prefix, t("page_title.users.deactivate")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_content.users.deactivate.title")
+
+      = t("page_content.users.deactivate.content_html", email: @user.email)
+
+      = form_with model: @user do |f|
+        = f.hidden_field :active, value: false
+
+        .govuk-button-group
+          = f.govuk_submit t("page_content.users.button.continue")
+          = link_to t("page_content.users.button.cancel"), edit_user_path, class: "govuk-button govuk-button--secondary"

--- a/app/views/users/reactivate.html.haml
+++ b/app/views/users/reactivate.html.haml
@@ -1,0 +1,16 @@
+=content_for :page_title_prefix, t("page_title.users.reactivate")
+
+%main.govuk-main-wrapper#main-content{ role: "main" }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl
+        = t("page_content.users.reactivate.title")
+
+      = t("page_content.users.reactivate.content_html", email: @user.email)
+
+      = form_with model: @user do |f|
+        = f.hidden_field :active, value: true
+
+        .govuk-button-group
+          = f.govuk_submit t("page_content.users.button.continue")
+          = link_to t("page_content.users.button.cancel"), edit_user_path, class: "govuk-button govuk-button--secondary"

--- a/config/locales/models/user.en.yml
+++ b/config/locales/models/user.en.yml
@@ -8,10 +8,14 @@ en:
       update:
         failed: The service is experiencing issues updating users and the team has been alerted to the problem.
         success: User successfully updated
+        success_deactivated: User successfully deactivated
+        success_reactivated: User successfully reactivated
   form:
     button:
       user:
         submit: Submit
+        deactivate: Deactivate user
+        reactivate: Reactivate user
     label:
       user:
         email: Email address
@@ -62,22 +66,51 @@ en:
     users:
       button:
         create: Add user
+        continue: Continue
+        cancel: Cancel
       new:
         no_organisations:
           cta: There are no organisations yet,
           link: you can make one now
+      deactivate:
+        title: Deactivate user?
+        content_html: |
+          <p class="govuk-body">
+            You are about to deactivate the user %{email}
+          </p>
+          <p class="govuk-body">
+            Doing so will:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>prevent the user from signing in to the application;</li>
+            <li>retain the changes the user has made in the history;</li>
+            <li>allow the user to be reactivated at any time.</li>
+          </ul>
+      reactivate:
+        title: Reactivate user?
+        content_html: |
+          <p class="govuk-body">
+            You are about to reactivate the user %{email}
+          </p>
+          <p class="govuk-body">
+            Doing so will allow them to sign in to the application.
+          </p>
   page_title:
     users:
       edit: Edit user
       index: Users
       new: Create user
       show: User
+      deactivate: Deactivate user
+      reactivate: Reactivate user
   breadcrumb:
     users:
       edit: Edit user
       index: Users
       new: Create user
       show: User
+      deactivate: Deactivate user
+      reactivate: Reactivate user
   tabs:
     users:
       active: Active

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,12 @@ Rails.application.routes.draw do
 
   get "/users", to: redirect("/users/active")
   get "/users/:user_state" => "users#index", :constraints => {user_state: /(in)?active/}, :as => "users_index"
-  resources :users, except: [:index]
+  resources :users, except: [:index] do
+    member do
+      get :deactivate
+      get :reactivate
+    end
+  end
   resources :activities, only: [:index]
 
   namespace :users do

--- a/spec/features/beis_users_can_edit_a_user_spec.rb
+++ b/spec/features/beis_users_can_edit_a_user_spec.rb
@@ -77,10 +77,10 @@ RSpec.feature "BEIS users can edit other users" do
 
     find("tr", text: user.name).click_link("Edit")
 
-    choose "Deactivate"
-    click_on t("default.button.submit")
+    click_on t("form.button.user.deactivate")
+    click_on t("page_content.users.button.continue")
 
-    expect(page).to have_content("User successfully updated")
+    expect(page).to have_content(t("action.user.update.success_deactivated"))
     expect(user.reload.active).to be(false)
   end
 
@@ -94,10 +94,10 @@ RSpec.feature "BEIS users can edit other users" do
 
     find("tr", text: user.name).click_link("Edit")
 
-    choose "Activate"
-    click_on t("default.button.submit")
+    click_on t("form.button.user.reactivate")
+    click_on t("page_content.users.button.continue")
 
-    expect(page).to have_content("User successfully updated")
+    expect(page).to have_content(t("action.user.update.success_reactivated"))
     expect(user.reload.active).to be(true)
   end
 


### PR DESCRIPTION
Here we move the deactivate/reactivate a user functionality into a separate pair of pages, with explanatory and confirmatory text on each page. We continue using the same `update` method on the Users controller and just pass the active state through.

## Changes in this PR

## Screenshots of UI changes

### Before

![activate_before](https://github.com/user-attachments/assets/a40a517b-eb2f-43eb-8a01-1cc1a150ff13)

### After

![activate_after](https://github.com/user-attachments/assets/53a51d42-c4e6-4192-99e4-ab60fb3c8b4d)

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
