### PR TITLE
Fix admin user switching issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full changelog][unreleased]
 
+- Fixed: users list view shows correct organisation after admin user has
+  switched organisation
+
 ## Release 161 - 2025-01-14
 
 [Full changelog][161]

--- a/app/views/shared/users/_active_table.html.haml
+++ b/app/views/shared/users/_active_table.html.haml
@@ -17,7 +17,7 @@
         %tr.govuk-table__row
           %td.govuk-table__cell= user.name
           %td.govuk-table__cell= user.email
-          %td.govuk-table__cell.organisation= user.organisation.name
+          %td.govuk-table__cell.organisation= user.primary_organisation.name
           %td.govuk-table__cell
             = a11y_action_link(t("default.link.show"), user_path(user), user.name)
             = a11y_action_link(t("default.link.edit"), edit_user_path(user), user.name, ["govuk-!-margin-left-3"])

--- a/app/views/shared/users/_deactivated_table.html.haml
+++ b/app/views/shared/users/_deactivated_table.html.haml
@@ -19,7 +19,7 @@
         %tr.govuk-table__row
           %td.govuk-table__cell= user.name
           %td.govuk-table__cell= user.email
-          %td.govuk-table__cell.organisation= user.organisation.name
+          %td.govuk-table__cell.organisation= user.primary_organisation.name
           %td.govuk-table__cell= time_ago_in_words(user.deactivated_at)
           %td.govuk-table__cell
             = a11y_action_link(t("default.link.show"), user_path(user), user.name)


### PR DESCRIPTION
This fixes an issue where if an admin user switches their organisation, the user list view shows the switched organisation rather than each user's actual organisation. We include a test to reflect that this behaviour is now correct.

## Changes in this PR

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
