### PR TITLE
Brakeman is complaining about our EOL version of Rails 7.0.8.7.

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,13 +1,32 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
+      "file": "Gemfile.lock",
+      "line": 345,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "c9d687a2c77044d660ae16e064dd263b7353c4446090ec5dfe867226a88ec066",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/organisations_controller.rb",
-      "line": 78,
+      "line": 86,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:organisation).permit(:name, :organisation_type, :default_currency, :language_code, :iati_reference, :beis_organisation_reference, :role, :active)",
       "render_path": null,
@@ -24,6 +43,5 @@
       "note": ""
     }
   ],
-  "updated": "2023-02-07 15:40:36 +0000",
-  "brakeman_version": "5.4.0"
+  "brakeman_version": "7.0.0"
 }


### PR DESCRIPTION
We'll be upgrading Rails to 7.1.x shortly so let's temporarily disable the EOLRails warning in Brakeman, and re-enable it when we're updating to Rails 7.1.x.