### PR TITLE
Level B export: fix partner org name

### DIFF
--- a/app/services/export/activities_level_b.rb
+++ b/app/services/export/activities_level_b.rb
@@ -9,7 +9,7 @@ class Export::ActivitiesLevelB
   #     there are many common fields
   # standard:disable Layout/ExtraSpacing
   FIELDS = [
-    Field.new("Partner Organisation",                      "ALL",  -> { activity.organisation.name }),
+    Field.new("Partner Organisation",                      "ALL",  -> { activity.extending_organisation.name }),
     Field.new("Activity level",                            "ALL",  -> { activity.level }),
     Field.new("Parent activity",                           "ALL",  -> { activity.source_fund.name }),
     Field.new("ODA or Non-ODA",                            "ISPF", -> { activity.is_oda }),
@@ -102,6 +102,6 @@ class Export::ActivitiesLevelB
 
   def activities
     @activities ||= @fund.activity.child_activities
-      .includes(:organisation, :commitment, :budgets, :linked_activity, :comments)
+      .includes(:organisation, :extending_organisation, :commitment, :budgets, :linked_activity, :comments)
   end
 end

--- a/spec/features/beis_users_can_download_exports_spec.rb
+++ b/spec/features/beis_users_can_download_exports_spec.rb
@@ -325,7 +325,7 @@ RSpec.feature "BEIS users can download exports" do
 
       # And each row should have the columns requested in our Example XLSX
       expect(document.first).to match(a_hash_including({
-        "Partner Organisation" => "Department for Business, Energy and Industrial Strategy",
+        "Partner Organisation" => programme_1.extending_organisation.name,
         "Activity level" => "Programme (level B)",
         "Parent activity" => "International Science Partnerships Fund",
         "ODA or Non-ODA" => "ODA",

--- a/spec/services/export/activities_level_b_spec.rb
+++ b/spec/services/export/activities_level_b_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Export::ActivitiesLevelB do
     let(:first_row) { export.headers.zip(export.rows.first).to_h } # express the first row as a hash of k/v
     let(:common_expected_values) do
       {
-        "Partner Organisation" => "Department for Business, Energy and Industrial Strategy",
+        "Partner Organisation" => programme_activity.extending_organisation.name,
         "Activity level" => "Programme (level B)",
         "Partner organisation identifier" => a_string_starting_with("GCRF-"),
         "RODA identifier" => a_string_starting_with("#{fund.short_name}-"),


### PR DESCRIPTION
This was always set to DSIT, because we'd been choosing

`activity.organisation.name`

instead of

`activity.extending_organisation.name`.

"Extending" here is a synonym for "partner"!

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
