### PR TITLE
Changes to how benefitting countries are displayed in IATI XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Update IATI XML export benefitting countries into single region
+
 ## Release 168 - 2025-02-10
 
 [Full changelog][168]

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -50,18 +50,6 @@ module ActivityHelper
     Activity::DESERTIFICATION_POLICY_MARKER_CODES.key(code.to_i)
   end
 
-  def benefitting_countries_with_percentages(benefitting_countries)
-    return [] if benefitting_countries.blank?
-
-    benefitting_countries.map do |country|
-      OpenStruct.new(
-        code: country,
-        name: country_name_from_code(country),
-        percentage: 100 / benefitting_countries.count.to_f
-      )
-    end
-  end
-
   def edit_comment_path_for(commentable, comment)
     case commentable.class.name
     when "Activity"

--- a/app/views/shared/xml/_activity.xml.haml
+++ b/app/views/shared/xml/_activity.xml.haml
@@ -48,9 +48,9 @@
   - if activity.iati_scope
     %activity-scope{"code" => activity.iati_scope}/
   - if activity.benefitting_countries.present?
-    - benefitting_countries_with_percentages(activity.benefitting_countries).each do |country|
-      %recipient-country{"code" => country.code, "percentage" => country.percentage}
-        %narrative= country.name
+    - region = activity.benefitting_region
+    %recipient-region{code: region.code, percentage: "100.0", vocabulary: "1"}
+      %narrative= region.name
   - elsif activity.recipient_country?
     %recipient-country{"code" => activity.recipient_country}
       %narrative= country_name_from_code(activity.recipient_country)

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -200,44 +200,6 @@ RSpec.describe ActivityHelper, type: :helper do
     end
   end
 
-  describe "#benefitting_countries_with_percentages" do
-    it "returns an array of structs with country name, code and percentage" do
-      codes = ["AG", "LC"]
-      countries = benefitting_countries_with_percentages(codes)
-
-      expect(countries.count).to eql(2)
-
-      expect(countries.first.code).to eq("AG")
-      expect(countries.first.name).to eq("Antigua and Barbuda")
-      expect(countries.first.percentage).to eq(50.0)
-
-      expect(countries.last.code).to eq("LC")
-      expect(countries.last.name).to eq("Saint Lucia")
-      expect(countries.last.percentage).to eq(50.0)
-    end
-
-    it "handles the case when all countries are selected" do
-      codes = Codelist.new(type: "benefitting_countries", source: "beis").map { |c| c["code"] }
-      countries = benefitting_countries_with_percentages(codes)
-
-      expect(countries.first.percentage).to eq 100 / countries.count.to_f
-      expect(countries.last.percentage).to eq 100 / countries.count.to_f
-    end
-
-    it "handles the case when three coutries are selected" do
-      codes = ["AG", "LC", "BZ"]
-      countries = benefitting_countries_with_percentages(codes)
-
-      expect(countries.first.percentage).to eq 100 / countries.count.to_f
-      expect(countries.last.percentage).to eq 100 / countries.count.to_f
-    end
-
-    it "returns an empty array if the codes are nil or empty" do
-      expect(benefitting_countries_with_percentages(nil)).to eq([])
-      expect(benefitting_countries_with_percentages([])).to eq([])
-    end
-  end
-
   describe "#edit_comment_path_for" do
     let(:activity) { create(:project_activity) }
     let(:comment) { create(:comment, commentable: commentable) }


### PR DESCRIPTION
Due to a change in DSIT policy, activities where multiple benefiting countries have been reported should only display the associated region of those countries. We use the existing `Activity#benefitting_region` method in the IATI XML now rather than iterating over the benefitting countries and assigning percentages.

We also patch up the specs where previously we were expecting multiple countries to be shown in the XML.

## Changes in this PR

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [x] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
