### PR TITLE
Fix IATI XML country export where there is only one benefitting country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full changelog][unreleased]
 
+- Fix IATI XML export countries where there is only one benefitting country
+
 ## Release 169 - 2025-02-10
 
 [Full changelog][169]

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -50,6 +50,10 @@ module ActivityHelper
     Activity::DESERTIFICATION_POLICY_MARKER_CODES.key(code.to_i)
   end
 
+  def first_benefitting_country(benefitting_countries)
+    BenefittingCountry.find_by_code(benefitting_countries.first)
+  end
+
   def edit_comment_path_for(commentable, comment)
     case commentable.class.name
     when "Activity"

--- a/app/views/shared/xml/_activity.xml.haml
+++ b/app/views/shared/xml/_activity.xml.haml
@@ -48,9 +48,14 @@
   - if activity.iati_scope
     %activity-scope{"code" => activity.iati_scope}/
   - if activity.benefitting_countries.present?
-    - region = activity.benefitting_region
-    %recipient-region{code: region.code, percentage: "100.0", vocabulary: "1"}
-      %narrative= region.name
+    - if activity.benefitting_countries.size > 1
+      - region = activity.benefitting_region
+      %recipient-region{code: region.code, percentage: "100.0", vocabulary: "1"}
+        %narrative= region.name
+    - else
+      - country = first_benefitting_country(activity.benefitting_countries)
+      %recipient-country{"code" => country.code, percentage: "100.0"}
+        %narrative= country.name
   - elsif activity.recipient_country?
     %recipient-country{"code" => activity.recipient_country}
       %narrative= country_name_from_code(activity.recipient_country)

--- a/spec/features/beis_users_can_view_an_activity_as_xml_spec.rb
+++ b/spec/features/beis_users_can_view_an_activity_as_xml_spec.rb
@@ -40,12 +40,18 @@ RSpec.feature "BEIS users can view project activities as XML" do
   context "when the activity has one benefitting country" do
     before { activity.update(benefitting_countries: ["CV"]) }
 
-    it "contains data about the recipient country's region" do
+    it "contains data about the recipient country" do
       visit organisation_activity_path(organisation, activity, format: :xml)
 
-      expect(xml.at("iati-activity/recipient-region/@code").text).to eq("1030")
-      expect(xml.at("iati-activity/recipient-region/narrative").text).to eq("Western Africa, regional")
-      expect(xml.at("iati-activity/recipient-region/@percentage").text).to eq("100.0")
+      expect(xml.at("iati-activity/recipient-country/@code").text).to eq("CV")
+      expect(xml.at("iati-activity/recipient-country/narrative").text).to eq("Cabo Verde")
+      expect(xml.at("iati-activity/recipient-country/@percentage").text).to eq("100.0")
+    end
+
+    it "contains nothing about the benefitting region" do
+      visit organisation_activity_path(organisation, activity, format: :xml)
+
+      expect(xml.at("iati-activity/recipient-region")).to be_nil
     end
 
     it "contains the IATI scope element" do
@@ -125,10 +131,11 @@ RSpec.feature "BEIS users can view project activities as XML" do
   context "when the activity has a legacy recipient_region and at least one benefitting country" do
     before { activity.update(recipient_region: "489", benefitting_countries: ["CV"]) }
 
-    it "contains appropriate data about the benefitting region" do
+    it "contains appropriate data about the recipient region" do
       visit organisation_activity_path(organisation, activity, format: :xml)
 
-      expect(xml.at("iati-activity/recipient-region/@code").text).to eq(activity.benefitting_region.code)
+      expect(xml.at("iati-activity/recipient-country/@code").text).to eq(activity.benefitting_countries.first)
+      expect(xml.at("iati-activity/recipient-region")).to be_nil
     end
   end
 

--- a/spec/helpers/activity_helper_spec.rb
+++ b/spec/helpers/activity_helper_spec.rb
@@ -200,6 +200,18 @@ RSpec.describe ActivityHelper, type: :helper do
     end
   end
 
+  describe "first_benefitting_countries" do
+    let(:activity) { create(:project_activity, benefitting_countries: ["DZ"]) }
+
+    it "returns the first benefitting country as a `BenefittingCountry` from an Activity's benefitting countries" do
+      benefitting_country = first_benefitting_country(activity.benefitting_countries)
+
+      expect(benefitting_country.code).to eq("DZ")
+      expect(benefitting_country.name).to eq("Algeria")
+      expect(benefitting_country).to be_a(BenefittingCountry)
+    end
+  end
+
   describe "#edit_comment_path_for" do
     let(:activity) { create(:project_activity) }
     let(:comment) { create(:comment, commentable: commentable) }


### PR DESCRIPTION
This fix slightly undoes the previous work on IATI XML country export where we merged `benefitting_countries` into one region; we were overzealous in that work, in that cases where there was only one benefitting country should have remained as they were previously, ie. rendered in the XML as a single country rather than a region.

## Changes in this PR

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
