### PR TITLE
Turn off Rails 7.1 callback checks in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,12 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Raise error when a before_action's only/except options reference missing actions.
-  config.action_controller.raise_on_missing_callback_actions = true
+  # We *should* do this in dev, but can't at present because of
+  # AbstractController::ActionNotFound at /home
+  # The index action could not be found for the :verify_policy_scoped
+  # callback on HomeController, but it is listed in the controller's
+  # :only option.
+  config.action_controller.raise_on_missing_callback_actions = false
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true


### PR DESCRIPTION
We *should* do this in dev, but can't at present because of

```
AbstractController::ActionNotFound at /home
The index action could not be found for the :verify_policy_scoped
callback on HomeController, but it is listed in the controller's
:only option.
```

In order to turn it on in dev, we need to do a bit of review/refactoring around when callbacks are called. At present, we allow them to fail silently when not applicable. This isn't a behaviour Rails 7.1 and up encourages, but we're on our last day of our last sprint and can't fix this now.

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
