### PR TITLE
Alter the maximum age of an activity start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full changelog][unreleased]
 
 - Remove the supporting code for the one-off data migration related to the new DSIT transparency identifier (rake task and continuing/non-continuing activities exports)
+- Alter date boundary to allow activity start dates 27 years in the past
 
 ## Release 173 - 2025-02-13
 

--- a/app/validators/date_within_boundaries_validator.rb
+++ b/app/validators/date_within_boundaries_validator.rb
@@ -1,5 +1,5 @@
 class DateWithinBoundariesValidator < ActiveModel::EachValidator
-  MIN = 17
+  MIN = 27
   MAX = 25
 
   def validate_each(record, attribute, value)

--- a/app/validators/date_within_boundaries_validator.rb
+++ b/app/validators/date_within_boundaries_validator.rb
@@ -1,14 +1,14 @@
 class DateWithinBoundariesValidator < ActiveModel::EachValidator
-  MIN = 27
-  MAX = 25
+  MAX_YEARS_AGO = 27
+  MAX_YEARS_IN_FUTURE = 25
 
   def validate_each(record, attribute, value)
     return unless value
 
-    unless value.between?(MIN.years.ago, MAX.years.from_now)
+    unless value.between?(MAX_YEARS_AGO.years.ago, MAX_YEARS_IN_FUTURE.years.from_now)
       record.errors.add(
         attribute,
-        I18n.t("activerecord.errors.models.#{record.class.name.underscore.downcase}.attributes.#{attribute}.between", min: MIN, max: MAX)
+        I18n.t("activerecord.errors.models.#{record.class.name.underscore.downcase}.attributes.#{attribute}.between", min: MAX_YEARS_AGO, max: MAX_YEARS_IN_FUTURE)
       )
     end
   end

--- a/spec/features/beis_users_can_edit_a_report_spec.rb
+++ b/spec/features/beis_users_can_edit_a_report_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "BEIS users can edit a report" do
 
     # TODO: Remove this test when historical activities migration is complete
     # The earliest date BEIS have provided is 2005 (17 years ago)
-    scenario "the deadline cannot be very far in the future or before 2005" do
+    scenario "the deadline cannot be very far in the future or before 1997" do
       authenticate!(user: beis_user)
       report = create(:report)
 
@@ -96,7 +96,7 @@ RSpec.feature "BEIS users can edit a report" do
       click_on t("default.button.submit")
 
       expect(page).to_not have_content t("action.report.update.success")
-      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 17, max: 25)
+      expect(page).to have_content t("activerecord.errors.models.report.attributes.deadline.between", min: 27, max: 25)
     end
 
     scenario "they can edit a Report to change the description (Reporting Period)" do

--- a/spec/validators/date_within_boundaries_validator_spec.rb
+++ b/spec/validators/date_within_boundaries_validator_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe DateWithinBoundariesValidator do
   end
 
   # TODO: Remove this test when historical activities migration is complete
-  # The earliest date BEIS have provided is 2005 (17 years ago)
-  describe "when date is more than 17 years ago" do
+  # The earliest date BEIS have provided is 1995 (27 years ago)
+  describe "when date is more than 27 years ago" do
     it "is not valid" do
-      subject.date = 18.years.ago
+      subject.date = 28.years.ago
       expect(subject.valid?).to be(false)
     end
   end


### PR DESCRIPTION
Ticket [20715](https://dxw.zendesk.com/agent/tickets/20715) flagged two activity start dates that did not pass validation as they were more than 17 years in the past. 

We agreed with the client to add 10 years to this validation range, ie. to allow planned and actual activity start dates up to 27 years in the past. This will allow the resolution of this ticket, and also help to support the service as it matures and is more likely to need historical activity records added that exceed the previous 17 year limit. 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
