### PR TITLE
Revert "Move build-time packages to devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,21 +2,19 @@
   "name": "beis-report-official-development-assistance",
   "private": true,
   "dependencies": {
-    "@rails/ujs": "^7.1.3-4",
-    "accessible-autocomplete": "^2.0.2",
-    "core-js": "^3.27.1",
-    "govuk-frontend": "^3.11.0"
-  },
-  "devDependencies": {
     "@babel/core": "^7.26.9",
     "@babel/plugin-transform-runtime": "^7.26.9",
     "@babel/preset-env": "^7.26.9",
     "@babel/runtime": "^7.26.9",
+    "@rails/ujs": "^7.1.3-4",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
+    "accessible-autocomplete": "^2.0.2",
     "babel": "^6.23.0",
+    "core-js": "^3.27.1",
+    "govuk-frontend": "^3.11.0",
     "rollup": "^3.29.5",
     "sass": "^1.57.0"
   },


### PR DESCRIPTION
This reverts commit 4d564a91a28a2ca8825594149b72210413be9961.

We have identified this commit as causing problems with yarn installing sass at build time

[Release 174 ](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/releases/tag/release-174)is currently failing to deploy in production. The build step of the AWS pipeline that manages the deployment of new changes is failing, meaning the deploy step is never triggered. The docker build is failing because yarn is unable to install sass. 

Our investigation of the causes of this failure has identified this previously unreleased commit as causing the problem with the sass installation. At this time we do not know what aspect of the changes introduced here has caused the problem. We have unreleased code that must be deployed before the new RODA reporting window opens this week. We are therefore reverting this commit (that does not have dependent commits) so that we can make the release. 


- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
