### PR TITLE
Fix rails ujs links not working

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,3 +12,5 @@ document.addEventListener("DOMContentLoaded", () => {
   GOVUKFrontend.initAll();
   initTableTreeView();
 });
+
+Rails.start()


### PR DESCRIPTION
## Changes in this PR

## Fix Rails UJS links not working

@rails/ujs is used to transform links to enable deletes. It creates a hidden
form and submits the request as a POST request with a hidden field
_method=delete.

A recent change means this is not working, users therefore cannot perform
important actions.

Calling `start` isn't supposed to be necessary, but seems to fix the issue.

We may need to do a review of these links to see if we can use an improved
method vs Rails UJS.


## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
