### PR TITLE
Decouples published to IATI status between parent and child activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 [Full changelog][unreleased]
-
 - Decouples the publish to IATI status of parent and child activities
 ## Release 176 - 2025-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full changelog][unreleased]
 
+- Decouples the publish to IATI status of parent and child activities
+## Release 176 - 2025-04-14
+
+[Full changelog][176]
+
+- Fix a bug with deleting acutals
+
 ## Release 175 - 2025-04-01
 
 [Full changelog][175]
@@ -1869,7 +1876,8 @@
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-175...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-176...HEAD
+[176]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-175...release-176
 [175]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-173...release-175
 [174]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-173...release-174
 [173]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-172...release-173

--- a/app/controllers/activity_redactions_controller.rb
+++ b/app/controllers/activity_redactions_controller.rb
@@ -13,11 +13,6 @@ class ActivityRedactionsController < BaseController
     @activity.update(publish_to_iati: activity_params["publish_to_iati"])
     record_historical_event(@activity)
 
-    @activity.child_activities.each do |child_activity|
-      child_activity.update(publish_to_iati: activity_params["publish_to_iati"])
-      record_historical_event(child_activity)
-    end
-
     redirect_to organisation_activity_path(@activity.organisation, @activity)
   end
 

--- a/spec/features/users_can_edit_an_activity_spec.rb
+++ b/spec/features/users_can_edit_an_activity_spec.rb
@@ -27,11 +27,18 @@ RSpec.feature "Users can edit an activity" do
         expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
       end
 
-      visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
+      visit organisation_activity_path(project_activity.organisation, project_activity)
       click_on t("tabs.activity.details")
 
       within ".publish_to_iati" do
         expect(page).to have_content(t("summary.label.activity.publish_to_iati.false"))
+      end
+
+      visit organisation_activity_path(third_party_project_activity.organisation, third_party_project_activity)
+      click_on t("tabs.activity.details")
+
+      within ".publish_to_iati" do
+        expect(page).to have_content(t("summary.label.activity.publish_to_iati.true"))
       end
 
       expect_change_to_be_recorded_as_historical_event(
@@ -40,14 +47,6 @@ RSpec.feature "Users can edit an activity" do
         new_value: false,
         reference: "Activity redacted from IATI",
         activity: project_activity,
-        report: nil
-      )
-      expect_change_to_be_recorded_as_historical_event(
-        field: "publish_to_iati",
-        previous_value: true,
-        new_value: false,
-        reference: "Activity redacted from IATI",
-        activity: third_party_project_activity,
         report: nil
       )
     end


### PR DESCRIPTION
Changing the publish to IATI status of an activity now no longer also changes the status of the child activity

Ticket [20719](https://dxw.zendesk.com/agent/tickets/20719) requested that Level C and D activities have their 'publish to IATI' status decoupled. That is, if a parent activity is set to 'publish: yes', this should _not_ automatically also publish its child activities. This change was requested as it is not always desirable for every child activity of a parent to be published, or to be published at the same time as the parent. 

## Changes in this PR

Previously, the update function of the activity_redactions_controller bundled two updates together, an update to the activity, and to any child activities found for that activity. This PR removes the references to child activities, updating the publish to IATI status of the (parent) activity only. As each child activity is also an activity, its publishing status can be individually updated in the same way. 

## Screenshots of UI changes

For example, if the publish to IATI status of the parent activity is set to 'No', the status of the child activities is now not affected by this change.

<img width="1181" alt="Screenshot 2025-04-15 at 12 04 46" src="https://github.com/user-attachments/assets/3a89bc30-8659-475f-ae90-10b62b047f0c" />
<img width="1133" alt="Screenshot 2025-04-15 at 12 04 33" src="https://github.com/user-attachments/assets/6b65b365-7537-491b-8ceb-81cf4a6f3550" />

The status of these child activities can then be individually changed as needed.

<img width="1163" alt="Screenshot 2025-04-15 at 12 05 35" src="https://github.com/user-attachments/assets/3c9d2131-f14d-4aad-be0c-08c2d0d1c902" />
 

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
