### PR TITLE
Remove --no-lock from brew bundle command

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -18,7 +18,7 @@ if [ -z "$CI" ]; then
       echo "==> Installing Homebrew dependencies..."
       brew update
       brew upgrade ruby-build
-      brew bundle install --verbose --no-lock
+      brew bundle install --verbose
     fi
   fi
 


### PR DESCRIPTION
## Changes in this PR

### Remove --no-lock from brew bundle command

This flag was removed: https://github.com/Homebrew/homebrew-bundle/commit/f92c362bc7995f98061eb0736c19c60e39a40651

script/bootstrap exits here when using this flag

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
