### PR TITLE
Allow editing budgets with no associated report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   that report. This removes the second requirement, allowing budgets associated
   with previously-approved reports can still be edited provided they meet the
   first requirement.
+- In case an existing budget has no associated report, associate it with the
+  current editable report when attempting to update, making the budget valid
 
 ## Release 176 - 2025-04-15
 

--- a/app/services/update_budget.rb
+++ b/app/services/update_budget.rb
@@ -7,6 +7,7 @@ class UpdateBudget
   end
 
   def call(attributes: {})
+    attributes[:report] = report unless budget.report
     budget.assign_attributes(attributes)
 
     convert_and_assign_value(budget, attributes[:value])

--- a/spec/services/update_budget_spec.rb
+++ b/spec/services/update_budget_spec.rb
@@ -157,6 +157,33 @@ RSpec.describe UpdateBudget do
       end
     end
 
+    context "when the budget is missing a required report" do
+      let(:parent_activity) { create(:project_activity) }
+      let(:budget) {
+        budget = build(:budget, :direct, parent_activity:, report: nil)
+        budget.save(validate: false)
+        budget
+      }
+
+      context "but there's an editable report for the activity" do
+        it "assigns the report to the budget and returns a successful result" do
+          result = subject.call(attributes: {})
+
+          expect(result.success?).to be(true)
+        end
+      end
+
+      context "and there's no editable report for the activity" do
+        before { report.destroy! }
+
+        it "returns a failed result" do
+          result = subject.call(attributes: {})
+
+          expect(result.success?).to be(false)
+        end
+      end
+    end
+
     it_behaves_like "sanitises monetary field"
   end
 end


### PR DESCRIPTION
## Changes in this PR

This is a follow on from 1056fe40b0f95c102cc218c3d05c8d5d9d824146

We found that some budgets aren't associated with a report at all. This means they fail validation when attempting to update. They should still be updatable as long as there's a current editable report, so this associates that report with the budget in such cases

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
