### PR TITLE
Update KPI-exporting script to meet new requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+[Full changelog][unreleased]
+
+- Update KPI exporting rake task with new requirements
+
 ## Release 180 - 2025-07-15
 
 [Full changelog][180]

--- a/doc/support/download_activities_for_annual_impact_metrics.md
+++ b/doc/support/download_activities_for_annual_impact_metrics.md
@@ -1,6 +1,3 @@
-NOTE:
-- This document is deprecated (RODA is not hosted on G-PaaS anymore)
-
 # Download activities for annual impact metrics
 
 Every July, support will need to generate a CSV of activities that will be used
@@ -12,20 +9,24 @@ to pre-populate an annual collaborative spreadsheet of fund impact metrics.
    cf ssh beis-roda-prod
    ```
 2. Run the [annual fund impact metrics Rails
-   task](/lib/tasks/annual_fund_impact_metrics_activities.rake). The resulting CSV
-   will be written to `tmp/annual_fund_impact_metrics.csv`. Note: if this task has
-   been run before, the previous CSV will be overwritten; you must make sure the
-   CSV you download is not a previous iteration.
+   task](/lib/tasks/annual_fund_impact_metrics_activities.rake). This will
+   generate a CSV file containing Level D activities (or C, for specified
+   organisations) for each Organisation, written to
+   `tmp/annual_fund_impact_metrics`. Note: if this task has
+   been run before, the previous CSVs will be overwritten; you must make sure
+   the CSV you download is not a previous iteration.
+
+   This takes an array of integer Financial Years to specify for which years the
+   Activities should be collected.
    ```shell
-   bin/rails activities:annual_fund_impact_metrics
+   bin/rails activities:annual_fund_impact_metrics[2021,2022,2023,2024]
    ```
 3. Wait for the Rails task to finish, then end the SSH session.
    ```shell
    exit
    ```
-4. Copy the file to your local machine.
+4. Copy the directory to your local machine.
    ```shell
-   cf ssh beis-roda-prod --command "cat /app/tmp/annual_fund_impact_metrics.csv" >
-   local_file.csv
+    cf ssh beis-roda-prod --command "tar czf - /app/tmp/annual_fund_impact_metrics" > annual_fund_impact_metrics.tar.gz
    ```
 

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -44,6 +44,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_actual do
+      transient do
+        actual_attributes { {} }
+      end
+
+      after(:create) do |activity, evaluator|
+        create(:actual, {parent_activity: activity}.merge(evaluator.actual_attributes))
+      end
+    end
+
     trait :with_report do
       after(:create) do |activity|
         fund = activity.associated_fund

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -1,34 +1,245 @@
 require "tempfile"
+require "fileutils"
 
 RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
-  let(:test_csv) { Tempfile.new(["fake", ".csv"]) }
+  subject { Rake::Task["activities:annual_fund_impact_metrics"] }
+
+  let(:output_dir) { FileUtils.mkdir_p("tmp/annual_fund_impact_metrics") }
+  let(:years) { [2021, 2022, 2023, 2024] }
 
   before { freeze_time }
 
   after do
+    FileUtils.rm_rf(output_dir)
     subject.reenable
-    test_csv.unlink
   end
 
-  subject { Rake::Task["activities:annual_fund_impact_metrics"] }
+  it "generates a CSV file of Level C and D activities for each organisation" do
+    create(
+      :project_activity,
+      :with_actual,
+      :newton_funded,
+      title: "Completed Activity",
+      roda_identifier: "ABC123",
+      partner_organisation_identifier: "PORG1",
+      programme_status: "completed",
+      organisation: create(:partner_organisation, name: "Connected Places Catapult"),
+      actual_attributes: {financial_year: 2024}
+    )
 
-  context "when the CSV path is not provided" do
-    before { allow(CSV).to receive(:open).and_return(nil) }
+    level_d_org = create(:partner_organisation, name: "Aardvark Org")
+    create(
+      :third_party_project_activity,
+      :with_actual,
+      :gcrf_funded,
+      title: "Decided Activity",
+      roda_identifier: "DEF123",
+      partner_organisation_identifier: "PORG2",
+      organisation: level_d_org,
+      programme_status: "decided",
+      actual_attributes: {financial_year: 2022}
+    )
+    create(
+      :third_party_project_activity,
+      :with_actual,
+      :gcrf_funded,
+      title: "Review Activity",
+      roda_identifier: "GHI123",
+      partner_organisation_identifier: "PORG3",
+      organisation: level_d_org,
+      programme_status: "review",
+      actual_attributes: {financial_year: 2021}
+    )
 
-    it "uses the default path" do
-      task.invoke
+    task.invoke([2021, 2022, 2023, 2024])
 
-      expect(CSV).to have_received(:open).with("tmp/annual_fund_impact_metrics.csv", "wb")
+    catapult_csv_path = File.join(output_dir, "connected-places-catapult_2021-2022-2023-2024.csv")
+    aardvark_csv_path = File.join(output_dir, "aardvark-org_2021-2022-2023-2024.csv")
+
+    expect(File.exist?(catapult_csv_path)).to be true
+    expect(File.exist?(aardvark_csv_path)).to be true
+
+    aardvark_csv_lines = File.readlines(aardvark_csv_path)
+    expect(aardvark_csv_lines.count).to be 3
+    expect(aardvark_csv_lines[0]).to eq "Partner Organisation name,Activity name,RODA ID,Partner Organisation ID,Fund,Status,Level\n"
+    expect(aardvark_csv_lines[1]).to eq "Aardvark Org,Decided Activity,DEF123,PORG2,Global Challenges Research Fund,Decided,Third-party project (level D)\n"
+    expect(aardvark_csv_lines[2]).to eq "Aardvark Org,Review Activity,GHI123,PORG3,Global Challenges Research Fund,Review,Third-party project (level D)\n"
+
+    catapult_csv_lines = File.readlines(catapult_csv_path)
+    expect(catapult_csv_lines.count).to be 2
+    expect(catapult_csv_lines[0]).to eq "Partner Organisation name,Activity name,RODA ID,Partner Organisation ID,Fund,Status,Level\n"
+    expect(catapult_csv_lines[1]).to eq "Connected Places Catapult,Completed Activity,ABC123,PORG1,Newton Fund,Completed,Project (level C)\n"
+  end
+
+  describe "selecting the right activity level" do
+    context "when selecting activities from the list of specified partner organisations" do
+      it "only selects Level C activities" do
+        level_c_orgs = [
+          "Connected Places Catapult",
+          "Energy Systems Catapult",
+          "Offshore Renewable Energy Catapult",
+          "National Physics Laboratory",
+          "UK Atomic Energy Authority"
+        ]
+
+        level_c_orgs.each do |partner_organisation|
+          organisation = create(:partner_organisation, name: partner_organisation)
+          level_c_completed_activity = create(:project_activity, programme_status: "completed", organisation:)
+          create(:actual, financial_year: 2024, parent_activity: level_c_completed_activity)
+          level_d_completed_activity = create(:third_party_project_activity, programme_status: "completed", organisation:)
+          create(:actual, financial_year: 2024, parent_activity: level_d_completed_activity)
+        end
+
+        task.invoke([2021, 2022, 2023, 2024])
+        files = level_c_orgs.map do |org|
+          File.join(output_dir, "#{org.parameterize}_2021-2022-2023-2024.csv")
+        end
+
+        all_level_c_activities_present = files.all? do |file|
+          file_contains_activity_with_value(file, "Project (level C)")
+        end
+        expect(all_level_c_activities_present).to be(true)
+
+        no_level_d_activities_present = files.none? do |file|
+          file_contains_activity_with_value(file, "Third-party project (level D)")
+        end
+        expect(no_level_d_activities_present).to eq(true)
+      end
+    end
+
+    context "when selecting activities from any other organisation" do
+      it "only selects Level D activities" do
+        partner_organisation = create(:partner_organisation, name: "My Org")
+        create(
+          :project_activity,
+          :with_actual,
+          programme_status: "completed",
+          organisation: partner_organisation,
+          actual_attributes: {financial_year: 2024}
+        )
+        create(
+          :third_party_project_activity,
+          :with_actual,
+          programme_status: "completed",
+          organisation: partner_organisation,
+          actual_attributes: {financial_year: 2024}
+        )
+
+        task.invoke([2021, 2022, 2023, 2024])
+        file = File.join(output_dir, "my-org_2021-2022-2023-2024.csv")
+
+        expect(
+          file_contains_activity_with_value(file, "Project (level C)")
+        ).to eq(false)
+
+        expect(
+          file_contains_activity_with_value(file, "Third-party project (level D)")
+        ).to eq(true)
+      end
+    end
+  end
+
+  describe "specifying financial years" do
+    context "when financial years are not provided" do
+      it "displays an error and aborts" do
+        expect {
+          task.invoke
+        }.to raise_error(
+          SystemExit,
+          "Please provide at least one financial year, e.g. rake 'activities:annual_fund_impact_metrics[2022,2023]'"
+        )
+      end
+    end
+
+    context "when financial years are provided" do
+      it "only includes projects with postive net spend in the specified financial years" do
+        partner_organisation = create(:partner_organisation, name: "My Org")
+        [2021, 2022, 2023, 2024].each do |fy|
+          create(
+            :third_party_project_activity,
+            :with_actual,
+            organisation: partner_organisation,
+            programme_status: "completed",
+            actual_attributes: {financial_year: fy}
+          )
+        end
+
+        activity_with_actual_from_2020 = create(
+          :third_party_project_activity,
+          :with_actual,
+          organisation: partner_organisation,
+          programme_status: "completed",
+          actual_attributes: {financial_year: 2020}
+        )
+
+        task.invoke([2021, 2022, 2023, 2024])
+
+        file = File.join(output_dir, "my-org_2021-2022-2023-2024.csv")
+
+        expect(File.readlines(file).length).to eq(5)
+        expect(file_contains_activity_with_value(
+          file,
+          activity_with_actual_from_2020.roda_identifier
+        )).to be(false)
+      end
     end
   end
 
   it "excludes Activities with `delivery`, `agreement_in_place`, `open_for_applications`, `stopped`, or `planned` statuses" do
-    completed_activity = create(:programme_activity, programme_status: "completed")
-    delivery_activity = create(:programme_activity, programme_status: "delivery")
-    agreement_in_place_activity = create(:programme_activity, programme_status: "agreement_in_place")
-    open_for_applications_activity = create(:programme_activity, programme_status: "open_for_applications")
-    stopped_activity = create(:programme_activity, programme_status: "stopped")
-    planned_activity = create(:programme_activity, programme_status: "planned")
+    partner_organisation = create(:partner_organisation, name: "My Org")
+    completed_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "completed",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+    delivery_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "delivery",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+    agreement_in_place_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "agreement_in_place",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+    open_for_applications_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "open_for_applications",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+    stopped_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "stopped",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+    planned_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "planned",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
+
+    task.invoke([2021, 2022, 2023, 2024])
+
+    file = File.join(output_dir, "my-org_2021-2022-2023-2024.csv")
+
+    expect(
+      file_contains_activity_with_value(
+        file,
+        completed_activity.roda_identifier
+      )
+    ).to eq(true)
 
     excluded_activities = [
       delivery_activity,
@@ -38,73 +249,49 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
       planned_activity
     ]
 
-    (excluded_activities + [completed_activity]).each do |activity|
-      create(:actual, parent_activity: activity)
-    end
-
-    task.invoke(test_csv.path)
-    result = test_csv.readlines
-
-    expect(result.second).to include(completed_activity.roda_identifier)
-
-    excluded_activities_present = result.any? do |activity|
-      excluded_activities.map(&:roda_identifier).any? { |id| activity.include?(id) }
-    end
+    excluded_activities_present = excluded_activities.map(&:roda_identifier).any? { |id|
+      file_contains_activity_with_value(file, id)
+    }
     expect(excluded_activities_present).to be(false)
   end
 
-  it "includes Activities with `completed` statuses if there are no Actuals reported in the last 2 years" do
-    completed_activity = create(:programme_activity, programme_status: "completed")
-    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
+  it "excludes Activities with no Actuals" do
+    partner_organisation = create(:partner_organisation, name: "My Org")
+    completed_activity = create(
+      :third_party_project_activity,
+      :with_actual,
+      programme_status: "completed",
+      organisation: partner_organisation,
+      actual_attributes: {financial_year: 2021}
+    )
 
-    completed_over_2_years_ago_activity = create(:programme_activity, programme_status: "completed")
-    create(:actual, date: 2.years.ago - 1.day, parent_activity: completed_over_2_years_ago_activity, report: nil)
+    completed_activity_with_no_actual = create(
+      :third_party_project_activity,
+      programme_status: "completed",
+      organisation: partner_organisation
+    )
 
-    task.invoke(test_csv.path)
-    result = test_csv.readlines
+    task.invoke(2021, 2022, 2023, 2024)
 
-    expect(result.second).to include(completed_activity.roda_identifier)
+    file = File.join(output_dir, "my-org_2021-2022-2023-2024.csv")
 
-    excluded_activities_present = result.any? do |activity|
-      activity.include?(completed_over_2_years_ago_activity.roda_identifier)
-    end
+    expect(
+      file_contains_activity_with_value(file, completed_activity.roda_identifier)
+    ).to eq(true)
 
-    expect(excluded_activities_present).to be(false)
+    expect(
+      file_contains_activity_with_value(
+        file,
+        completed_activity_with_no_actual.roda_identifier
+      )
+    ).to eq(false)
   end
 
-  it "excludes Activities with `completed` statuses if it has no Actuals" do
-    completed_activity = create(:programme_activity, programme_status: "completed")
-    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
+  def file_contains_activity_with_value(file_path, value)
+    csv_lines = File.readlines(file_path)
 
-    completed_activity_with_no_actual = create(:programme_activity, programme_status: "completed")
-
-    task.invoke(test_csv.path)
-    result = test_csv.readlines
-
-    expect(result.second).to include(completed_activity.roda_identifier)
-
-    excluded_activities_present = result.any? do |activity|
-      activity.include?(completed_activity_with_no_actual.roda_identifier)
+    csv_lines.any? do |activity|
+      activity.include?(value)
     end
-
-    expect(excluded_activities_present).to be(false)
-  end
-
-  it "generates a CSV file of Activities ordered by organisation name and status" do
-    completed_activity = create(:programme_activity, programme_status: "completed")
-    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
-    beis_organisation = completed_activity.organisation
-    aardvark_organisation = create(:beis_organisation, name: "Department for Aardvarks", iati_reference: "CZH-COH-111")
-    decided_activity = create(:programme_activity, organisation: aardvark_organisation, programme_status: "decided")
-    review_activity = create(:programme_activity, organisation: aardvark_organisation, programme_status: "review")
-
-    task.invoke(test_csv.path)
-    result = test_csv.readlines
-
-    expect(result.count).to be 4
-    expect(result[0]).to eq "Partner Organisation name,Activity name,RODA ID,Partner Organisation ID,Status,Level\n"
-    expect(result[1]).to eq "#{aardvark_organisation.name},#{review_activity.title},#{review_activity.roda_identifier},#{review_activity.partner_organisation_identifier},Review,Programme (level B)\n"
-    expect(result[2]).to eq "#{aardvark_organisation.name},#{decided_activity.title},#{decided_activity.roda_identifier},#{decided_activity.partner_organisation_identifier},Decided,Programme (level B)\n"
-    expect(result[3]).to eq "\"#{beis_organisation.name}\",#{completed_activity.title},#{completed_activity.roda_identifier},#{completed_activity.partner_organisation_identifier},Completed,Programme (level B)\n"
   end
 end

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -1,23 +1,6 @@
 require "tempfile"
 
 RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
-  let!(:completed_activity) { create(:programme_activity, programme_status: "completed") }
-  let!(:actual_2_years_ago) { create(:actual, date: 2.years.ago, parent_activity: completed_activity, report: nil) }
-  let!(:beis_organisation) { completed_activity.organisation }
-  let!(:completed_activity_no_actuals) { create(:programme_activity, programme_status: "completed") }
-  let!(:decided_activity) { create(:programme_activity, organisation: aardvark_organisation, programme_status: "decided") }
-  let!(:review_activity) { create(:programme_activity, organisation: aardvark_organisation, programme_status: "review") }
-  let!(:aardvark_organisation) { create(:beis_organisation, name: "Department for Aardvarks", iati_reference: "CZH-COH-111") }
-
-  let!(:delivery_activity) { create(:programme_activity, programme_status: "delivery") }
-  let!(:agreement_in_place_activity) { create(:programme_activity, programme_status: "agreement_in_place") }
-  let!(:open_for_applications_activity) { create(:programme_activity, programme_status: "open_for_applications") }
-  let!(:stopped_activity) { create(:programme_activity, programme_status: "stopped") }
-  let!(:planned_activity) { create(:programme_activity, programme_status: "planned") }
-
-  let!(:completed_over_2_years_ago_activity) { create(:programme_activity, programme_status: "completed") }
-  let!(:actual_over_2_years_ago) { create(:actual, date: 2.years.ago - 1.day, parent_activity: completed_over_2_years_ago_activity, report: nil) }
-
   let(:test_csv) { Tempfile.new(["fake", ".csv"]) }
 
   before { freeze_time }
@@ -40,51 +23,81 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
   end
 
   it "excludes Activities with `delivery`, `agreement_in_place`, `open_for_applications`, `stopped`, or `planned` statuses" do
-    excluded_activity_titles = [
-      delivery_activity.title,
-      agreement_in_place_activity.title,
-      open_for_applications_activity.title,
-      stopped_activity.title,
-      planned_activity.title
+    completed_activity = create(:programme_activity, programme_status: "completed")
+    delivery_activity = create(:programme_activity, programme_status: "delivery")
+    agreement_in_place_activity = create(:programme_activity, programme_status: "agreement_in_place")
+    open_for_applications_activity = create(:programme_activity, programme_status: "open_for_applications")
+    stopped_activity = create(:programme_activity, programme_status: "stopped")
+    planned_activity = create(:programme_activity, programme_status: "planned")
+
+    excluded_activities = [
+      delivery_activity,
+      agreement_in_place_activity,
+      open_for_applications_activity,
+      stopped_activity,
+      planned_activity
     ]
+
+    (excluded_activities + [completed_activity]).each do |activity|
+      create(:actual, parent_activity: activity)
+    end
 
     task.invoke(test_csv.path)
     result = test_csv.readlines
 
-    excluded_activities_present = result.any? do |activity|
-      excluded_activity_titles.any? { |title| activity.include?(title) }
-    end
+    expect(result.second).to include(completed_activity.roda_identifier)
 
+    excluded_activities_present = result.any? do |activity|
+      excluded_activities.map(&:roda_identifier).any? { |id| activity.include?(id) }
+    end
     expect(excluded_activities_present).to be(false)
   end
 
-  it "excludes Activities with `completed` statuses if there are no Actuals reported in the last 2 years" do
-    excluded_activity_titles = [completed_over_2_years_ago_activity.title]
+  it "includes Activities with `completed` statuses if there are no Actuals reported in the last 2 years" do
+    completed_activity = create(:programme_activity, programme_status: "completed")
+    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
+
+    completed_over_2_years_ago_activity = create(:programme_activity, programme_status: "completed")
+    create(:actual, date: 2.years.ago - 1.day, parent_activity: completed_over_2_years_ago_activity, report: nil)
 
     task.invoke(test_csv.path)
     result = test_csv.readlines
 
+    expect(result.second).to include(completed_activity.roda_identifier)
+
     excluded_activities_present = result.any? do |activity|
-      excluded_activity_titles.any? { |title| activity.include?(title) }
+      activity.include?(completed_over_2_years_ago_activity.roda_identifier)
     end
 
     expect(excluded_activities_present).to be(false)
   end
 
   it "excludes Activities with `completed` statuses if it has no Actuals" do
-    excluded_activity_titles = [completed_activity_no_actuals.title]
+    completed_activity = create(:programme_activity, programme_status: "completed")
+    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
+
+    completed_activity_with_no_actual = create(:programme_activity, programme_status: "completed")
 
     task.invoke(test_csv.path)
     result = test_csv.readlines
 
+    expect(result.second).to include(completed_activity.roda_identifier)
+
     excluded_activities_present = result.any? do |activity|
-      excluded_activity_titles.any? { |title| activity.include?(title) }
+      activity.include?(completed_activity_with_no_actual.roda_identifier)
     end
 
     expect(excluded_activities_present).to be(false)
   end
 
   it "generates a CSV file of Activities ordered by organisation name and status" do
+    completed_activity = create(:programme_activity, programme_status: "completed")
+    create(:actual, date: Date.today, parent_activity: completed_activity, report: nil)
+    beis_organisation = completed_activity.organisation
+    aardvark_organisation = create(:beis_organisation, name: "Department for Aardvarks", iati_reference: "CZH-COH-111")
+    decided_activity = create(:programme_activity, organisation: aardvark_organisation, programme_status: "decided")
+    review_activity = create(:programme_activity, organisation: aardvark_organisation, programme_status: "review")
+
     task.invoke(test_csv.path)
     result = test_csv.readlines
 


### PR DESCRIPTION
## Changes in this PR

This updates the KPI-exporting script with latest requirements
- Only select activities with actuals from 2021,2022,2023,2024
- Remove restriction for only including Actuals in past 2 years
- Add "Fund" column to specify which fund an activity belongs to
- Export Level C activities for specified organisations, otherwise only
  export Level D activities.
- Generate a CSV file for each organisation

It also refactors the tests slightly to make them (I hope) more readable.

## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
