### PR TITLE
Add activities.id to select list

### DIFF
--- a/lib/tasks/annual_fund_impact_metrics_activities.rake
+++ b/lib/tasks/annual_fund_impact_metrics_activities.rake
@@ -49,7 +49,8 @@ namespace :activities do
         "activities.programme_status",
         "activities.level",
         "activities.source_fund_code",
-        "organisations.name AS organisation_name"
+        "organisations.name AS organisation_name",
+        "activities.id"
       ).order("organisations.name")
 
     headers = [


### PR DESCRIPTION
We recently ran the annual fund metric impacts for activities rake task, and were informed by DSIT that all ISPF related data was missing. Testing and investigation has found a fix for this that will allow us to deliver the KPI data as requested by deadline.
## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
