### PR TITLE
Handle case insensitivity in kpi script

### DIFF
--- a/lib/tasks/annual_fund_impact_metrics_activities.rake
+++ b/lib/tasks/annual_fund_impact_metrics_activities.rake
@@ -33,9 +33,9 @@ namespace :activities do
     activities = Activity
       .joins(:organisation)
       .where(
-        "(organisations.name IN (:level_c_orgs) AND activities.level = 'project') OR " \
-          "(organisations.name NOT IN (:level_c_orgs) AND activities.level = 'third_party_project')",
-        level_c_orgs: level_c_orgs
+        "(LOWER(organisations.name) IN (:level_c_orgs) AND activities.level = 'project') OR " \
+          "(LOWER(organisations.name) NOT IN (:level_c_orgs) AND activities.level = 'third_party_project')",
+        level_c_orgs: level_c_orgs.map(&:downcase)
       )
       .where(id: Actual
         .where(financial_year: financial_years)
@@ -73,7 +73,7 @@ namespace :activities do
         csv << headers
 
         org_activities.each do |activity|
-          partner_organisation_name = activity.organisation_name
+          partner_organisation_name = activity.organisation_name.titleize
           activity_title = activity.title
           roda_identifier = activity.roda_identifier
           partner_organisation_identifier = activity.partner_organisation_identifier

--- a/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
+++ b/spec/lib/tasks/annual_fund_impact_metrics_activities_spec.rb
@@ -105,6 +105,39 @@ RSpec.describe "rake activities:annual_fund_impact_metrics", type: :task do
         end
         expect(no_level_d_activities_present).to eq(true)
       end
+
+      it "finds the Organisations case-insensitively" do
+        upper_case_org = create(:partner_organisation, name: "CONNECTED PLACES CATAPULT")
+        create(
+          :project_activity,
+          :with_actual,
+          programme_status: "completed",
+          organisation: upper_case_org,
+          actual_attributes: {financial_year: 2021}
+        )
+        lower_case_org = create(:partner_organisation, name: "energy systems catapult")
+        create(
+          :project_activity,
+          :with_actual,
+          programme_status: "completed",
+          organisation: lower_case_org,
+          actual_attributes: {financial_year: 2021}
+        )
+
+        task.invoke([2021, 2022, 2023, 2024])
+
+        cpc_file = File.join(output_dir, "connected-places-catapult_2021-2022-2023-2024.csv")
+        expect(file_contains_activity_with_value(
+          cpc_file,
+          "Connected Places Catapult"
+        )).to eq(true)
+
+        esc_file = File.join(output_dir, "energy-systems-catapult_2021-2022-2023-2024.csv")
+        expect(file_contains_activity_with_value(
+          esc_file,
+          "Energy Systems Catapult"
+        )).to eq(true)
+      end
     end
 
     context "when selecting activities from any other organisation" do


### PR DESCRIPTION
## Changes in this PR

Ignores case when looking up Level C-reporting orgs in KPI script.

This rake task was failing to produce the expected output on production as some Organisations have upper case names.

Alternatively, we could resolve this with an ID, but we're unsure whether identifiers are consistent across environments.

In a perfect world, we'd allow users at DSIT to specify in the UI whether or not an Organisation reports at Level C or D e.g. with a checkbox, but this is a larger piece of work.

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [ ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
