### PR TITLE
(Fix 21429) pt 1 of 2: Ensure transaction activity and report compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix: ensure that a report's transactions have compatible Activity and Report
+  associations, "ODA-wise"
+
 ## Release 183 - 2025-08-21
 
 [Full changelog][183]

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -609,6 +609,10 @@ class Activity < ApplicationRecord
     !fund? && source_fund.present? && source_fund.ispf?
   end
 
+  def is_oda?
+    is_oda != false
+  end
+
   def is_non_oda?
     is_oda == false
   end

--- a/app/models/actual.rb
+++ b/app/models/actual.rb
@@ -10,4 +10,13 @@ class Actual < Transaction
   validates :value,
     numericality: {greater_than: 0},
     unless: proc { |actual| actual.validation_context == :history }
+
+  validate :compatibility_of_report_and_activity_oda_wise
+
+  def compatibility_of_report_and_activity_oda_wise
+    return unless report && parent_activity
+    return if report.is_oda? == parent_activity.is_oda?
+
+    errors.add(:base, "A non-ODA report can not include ODA actuals, and vice-versa")
+  end
 end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -7,6 +7,8 @@ class Refund < Transaction
 
   validates_associated :comment
 
+  validate :compatibility_of_report_and_activity_oda_wise
+
   def value=(amount)
     big_decimal = begin
       BigDecimal(amount)
@@ -14,5 +16,14 @@ class Refund < Transaction
       return
     end
     write_attribute(:value, -big_decimal.abs)
+  end
+
+  private
+
+  def compatibility_of_report_and_activity_oda_wise
+    return unless report && parent_activity
+    return if report.is_oda? == parent_activity.is_oda?
+
+    errors.add(:base, "A non-ODA report can not include ODA refunds, and vice-versa")
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -75,6 +75,10 @@ class Report < ApplicationRecord
     super
   end
 
+  def is_oda?
+    is_oda != false
+  end
+
   def editable?
     state.in?(EDITABLE_STATES)
   end

--- a/app/views/actuals/uploads/_error_table.html.haml
+++ b/app/views/actuals/uploads/_error_table.html.haml
@@ -1,4 +1,4 @@
-%table.govuk-table
+%table.govuk-table.errors
   %caption.govuk-table__caption List of errors in your uploaded CSV file
   %thead.govuk-table__head
     %tr.govuk-table__row

--- a/spec/factories/actual.rb
+++ b/spec/factories/actual.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     receiving_organisation_reference { "GB-COH-{#{Faker::Number.number(digits: 6)}}" }
     receiving_organisation_type { "70" }
 
-    association :parent_activity, factory: :project_activity
+    association :parent_activity, factory: :project_activity, is_oda: true
     association :report
 
     trait :with_comment do

--- a/spec/features/users_can_upload_actuals_spec.rb
+++ b/spec/features/users_can_upload_actuals_spec.rb
@@ -129,6 +129,47 @@ RSpec.feature "users can upload actuals" do
         }
       ])
     end
+
+    context "and we attempt to upload an actual associated with an ODA activity" do
+      let(:oda_project) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          organisation: report.organisation,
+          is_oda: true,
+          source_fund_code: Fund.by_short_name("ISPF").id,
+          title: "ODA activity"
+        )
+      end
+
+      let(:non_oda_project) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          organisation: report.organisation,
+          is_oda: false,
+          source_fund_code: Fund.by_short_name("ISPF").id,
+          title: "Non-ODA activity"
+        )
+      end
+
+      scenario "see an error explaining that ODA actuals can not be included in a non-ODA report" do
+        oda_project_id = oda_project.roda_identifier
+        non_oda_project_id = non_oda_project.roda_identifier
+
+        upload_csv <<~CSV
+          Activity RODA Identifier | Financial Quarter | Financial Year | Actual Value | Refund Value | Receiving Organisation Name | Receiving Organisation Type | Receiving Organisation IATI Reference | Comment
+          #{oda_project_id}        | 1                 | 2020           | 5            |              |                             |                             |                                       |
+          #{non_oda_project_id}    | 2                 | 2020           | 6            |              |                             |                             |                                       |
+        CSV
+
+        expect(page).to have_css("table.govuk-table.errors") do |errors|
+          expect(errors).to have_content(
+            "A non-ODA report can not include ODA actuals, and vice-versa"
+          )
+        end
+      end
+    end
   end
 
   scenario "not uploading a file" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -2430,6 +2430,35 @@ RSpec.describe Activity, type: :model do
     end
   end
 
+  describe "#is_oda? (it may not be obvious that only ISPF programme activities " \
+             "record their ODA-ness with a boolean value)" do
+    let(:activity) { Activity.new }
+
+    context "when the #is_oda attribute is nil" do
+      before { activity.is_oda = nil }
+
+      it "returns true" do
+        expect(activity.is_oda?).to be true
+      end
+    end
+
+    context "when the #is_oda attribute is false" do
+      before { activity.is_oda = false }
+
+      it "returns false" do
+        expect(activity.is_oda?).to be false
+      end
+    end
+
+    context "when the #is_oda attribute is true" do
+      before { activity.is_oda = true }
+
+      it "returns true" do
+        expect(activity.is_oda?).to be true
+      end
+    end
+  end
+
   describe "#is_non_oda?" do
     context "when activity is a fund" do
       let(:activity) { build(:fund_activity) }

--- a/spec/models/actual_spec.rb
+++ b/spec/models/actual_spec.rb
@@ -1,5 +1,103 @@
 RSpec.describe Actual do
   describe "validations" do
+    describe "compatibility of associated report and activity response to #is_oda?" do
+      let(:oda_report) do
+        create(
+          :report,
+          :active,
+          :for_gcrf,
+          description: "ODA report",
+          is_oda: true
+        ).tap { |report| allow(report).to receive(:is_oda?).and_return(true) }
+      end
+
+      let(:non_oda_report) do
+        create(
+          :report,
+          :active,
+          :for_ispf,
+          description: "Non-ODA report with mixed activities",
+          is_oda: false
+        ).tap { |report| allow(report).to receive(:is_oda?).and_return(false) }
+      end
+
+      let(:non_oda_activity) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          source_fund_code: Fund.by_short_name("ISPF").id,
+          title: "Non-ODA activity"
+        ).tap { |activity| allow(activity).to receive(:is_oda?).and_return(false) }
+      end
+
+      let(:oda_activity) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          source_fund_code: Fund.by_short_name("GCRF").id,
+          title: "ODA activity"
+        ).tap { |activity| allow(activity).to receive(:is_oda?).and_return(true) }
+      end
+
+      context "when the associated REPORT is non-ODA" do
+        let(:actual) do
+          build(
+            :actual,
+            report: non_oda_report
+          )
+        end
+
+        context "and the associated ACTIVITY is ODA" do
+          before { actual.parent_activity = oda_activity }
+
+          it "is not valid" do
+            actual.valid?
+
+            expect(actual.errors[:base]).to include(
+              "A non-ODA report can not include ODA actuals, and vice-versa"
+            )
+          end
+        end
+
+        context "and the associated ACTIVITY is non-ODA" do
+          before { actual.parent_activity = non_oda_activity }
+
+          it "is valid" do
+            expect(actual.valid?).to be true
+          end
+        end
+      end
+
+      context "when the associated REPORT is ODA" do
+        let(:actual) do
+          build(
+            :actual,
+            report: oda_report
+          )
+        end
+
+        context "and the associated ACTIVITY is ODA" do
+          before { actual.parent_activity = oda_activity }
+
+          it "is valid" do
+            expect(actual.valid?).to be true
+          end
+        end
+
+        context "and the associated ACTIVITY is non-ODA" do
+          before { actual.parent_activity = non_oda_activity }
+
+          it "is not valid" do
+            actual.valid?
+
+            expect(actual.errors[:base]).to include(
+              "A non-ODA report can not include ODA actuals, and vice-versa"
+            )
+          end
+        end
+      end
+    end
+
     context "with no validation context" do
       it "allows positive values" do
         actual = build(:actual, value: 10_000)

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -37,6 +37,104 @@ RSpec.describe Refund, type: :model do
     end
   end
 
+  describe "compatibility of associated report and activity response to #is_oda?" do
+    let(:oda_report) do
+      create(
+        :report,
+        :active,
+        :for_gcrf,
+        is_oda: true,
+        description: "ODA report"
+      ).tap { |report| allow(report).to receive(:is_oda?).and_return(true) }
+    end
+
+    let(:non_oda_report) do
+      create(
+        :report,
+        :active,
+        :for_ispf,
+        is_oda: false,
+        description: "Non-ODA report"
+      ).tap { |report| allow(report).to receive(:is_oda?).and_return(false) }
+    end
+
+    let(:non_oda_activity) do
+      create(
+        :project_activity,
+        :ispf_funded,
+        source_fund_code: Fund.by_short_name("ISPF").id,
+        title: "Non-ODA activity"
+      ).tap { |activity| allow(activity).to receive(:is_oda?).and_return(false) }
+    end
+
+    let(:oda_activity) do
+      create(
+        :project_activity,
+        :ispf_funded,
+        source_fund_code: Fund.by_short_name("GCRF").id,
+        title: "ODA activity"
+      ).tap { |activity| allow(activity).to receive(:is_oda?).and_return(true) }
+    end
+
+    context "when the associated REPORT is non-ODA" do
+      let(:refund) do
+        build(
+          :refund,
+          report: non_oda_report
+        )
+      end
+
+      context "and the associated ACTIVITY is ODA" do
+        before { refund.parent_activity = oda_activity }
+
+        it "is not valid" do
+          expect(refund.valid?).to be false
+
+          expect(refund.errors[:base]).to include(
+            "A non-ODA report can not include ODA refunds, and vice-versa"
+          )
+        end
+      end
+
+      context "and the associated ACTIVITY is non-ODA" do
+        before { refund.parent_activity = non_oda_activity }
+
+        it "is valid" do
+          expect(refund.valid?).to be true
+        end
+      end
+    end
+
+    context "when the associated REPORT is ODA" do
+      let(:refund) do
+        build(
+          :refund,
+          report: oda_report
+        )
+      end
+
+      context "and the associated ACTIVITY is ODA" do
+        before { refund.parent_activity = oda_activity }
+
+        it "is valid" do
+          expect(refund.valid?).to be true
+        end
+      end
+
+      context "and the associated ACTIVITY is non-ODA" do
+        before { refund.parent_activity = non_oda_activity }
+
+        it "is not valid" do
+          expect(refund.valid?).to be false
+
+          expect(refund.errors[:base]).to include(
+            "A non-ODA report can not include ODA refunds, and vice-versa"
+          )
+        end
+      end
+    end
+  end
+
   describe "associated comment" do
     let(:refund) { create(:refund) }
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -134,6 +134,36 @@ RSpec.describe Report, type: :model do
     end
   end
 
+  describe "#is_oda? (so that we account for the fact that it's nil for all " \
+             "funds except for ISPF). Note that we avoid using Report#is_oda= " \
+             "in these examples, as it has special behaviour" do
+    let(:report) { Report.new }
+
+    context "when the #is_oda attribute is nil" do
+      before { report.write_attribute(:is_oda, nil) }
+
+      it "returns true" do
+        expect(report.is_oda?).to be true
+      end
+    end
+
+    context "when the #is_oda attribute is false" do
+      before { report.write_attribute(:is_oda, false) }
+
+      it "returns false" do
+        expect(report.is_oda?).to be false
+      end
+    end
+
+    context "when the #is_oda attribute is true" do
+      before { report.write_attribute(:is_oda, true) }
+
+      it "returns true" do
+        expect(report.is_oda?).to be true
+      end
+    end
+  end
+
   describe "associations" do
     it { should belong_to(:fund).class_name("Activity") }
     it { should belong_to(:organisation) }

--- a/spec/services/create_refund_spec.rb
+++ b/spec/services/create_refund_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe CreateRefund do
       end
     end
 
-    context "when there is no editable report for the activity" do
+    context "when there is no editable report for the activity (this includes where " \
+              "there's a mismatch between the report and activity's #is_oda? response)" do
       before do
         allow(Report).to receive(:editable_for_activity) { nil }
       end


### PR DESCRIPTION
See [Zendesk 21429](https://dxw.zendesk.com/agent/tickets/21429)

This is part 1 of 2 PRs to address an issue with the handling of actuals/refunds in ISPF reports where there's a chance of transactions associated with an ODA activity being applied to a non-ODA report, and vice-versa.

Our plan for releasing fixes and making remediations is:

1. **First release** (this PR): Ensure that a report's transactions have compatible Activity and Report associations
2. **Manually make corrections** to fix up historic errors in data
3. **Second release** (https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2659): Ensure a report's downloaded transactions match those shown in UI. If this were released at the same time as (1) the misposted actuals will not be visible in the UI and that is likely to make the work of (2) more difficult and error prone

## Ensure that a report's transactions have compatible Activity and Report associations

An ODA report should only contain ODA actuals and ODA refunds and conversely a Non-ODA report should only contain non-ODA actuals and refunds.

There's a preliminary task for both `Activity` and `Refund` models of overriding the built-in `#is_oda?` predicate, which returns `false` when the attribute is `nil`. This isn't what we want, as:

- `Report#is_oda` is only set when the fund is ISPF. For reasons which are not clear to me.
- `Activity#is_oda` is not always set

In both cases:

- there may be historic activities and reports which lack this value as they were created before the column was introduced
- the only fund which has Non-ODA activities (and therefore reports) is ISPF, so a nil value indicates that the activity/report is ODA.

## Uploading an incompatible actual

<img width="1083" height="904" alt="roda_upload" src="https://github.com/user-attachments/assets/fdda5a6e-5d3f-4aff-a88c-2709a960ce20" />


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x ] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
