### PR TITLE
(Fix 21429) pt 2 of 2: Ensure downloaded report matches UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: ensure a report's downloaded transactions match those shown in UI
+
 ## Release 184 - 2026-03-18
 
 [Full changelog][184]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -129,11 +129,15 @@ class Report < ApplicationRecord
   end
 
   def summed_actuals
-    actuals.sum(&:value)
+    actuals.joins(:parent_activity)
+      .where("activities.id": reportable_activities.pluck(:id))
+      .sum(&:value)
   end
 
   def summed_refunds
-    refunds.sum(&:value)
+    refunds.joins(:parent_activity)
+      .where("activities.id": reportable_activities.pluck(:id))
+      .sum(&:value)
   end
 
   def summed_forecasts_for_reportable_activities

--- a/app/services/transaction/grouped_actuals_fetcher.rb
+++ b/app/services/transaction/grouped_actuals_fetcher.rb
@@ -6,7 +6,9 @@ class Transaction
 
     def call
       report.actuals
+        .joins(:parent_activity)
         .includes([:parent_activity, :comment])
+        .where("activities.id": report.reportable_activities.pluck(:id))
         .map { |actual| TransactionPresenter.new(actual) }
         .group_by { |actual| ActivityPresenter.new(actual.parent_activity) }
     end

--- a/spec/features/beis_users_can_download_a_report_as_csv_spec.rb
+++ b/spec/features/beis_users_can_download_a_report_as_csv_spec.rb
@@ -1,0 +1,110 @@
+RSpec.feature "BEIS users can download a report as CSV" do
+  let(:beis_user) { create(:beis_user) }
+
+  before do
+    Fund.all.each { |fund| create(:fund_activity, source_fund_code: fund.id, roda_identifier: fund.short_name) }
+    authenticate! user: beis_user
+  end
+  after { logout }
+
+  context "when I have a non-ODA report" do
+    let(:report) do
+      create(
+        :report,
+        :active,
+        :for_ispf,
+        description: "Non-ODA report with mixed activities",
+        is_oda: false
+      )
+    end
+
+    context "and it includes actuals from both ODA and non-ODA activities" do
+      let(:non_oda_activity) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          organisation: report.organisation,
+          is_oda: false,
+          source_fund_code: Fund.by_short_name("ISPF").id,
+          title: "Non-ODA activity"
+        )
+      end
+
+      let(:oda_activity) do
+        create(
+          :project_activity,
+          :ispf_funded,
+          organisation: report.organisation,
+          is_oda: true,
+          source_fund_code: Fund.by_short_name("ISPF").id,
+          title: "ODA activity"
+        )
+      end
+
+      let(:non_oda_actual) do
+        build(
+          :actual,
+          parent_activity: non_oda_activity,
+          description: "Non-ODA actual",
+          report: report
+        )
+      end
+
+      let(:oda_actual) do
+        build(
+          :actual,
+          parent_activity: oda_activity,
+          description: "ODA actual",
+          report: report
+        ).tap do |invalid_actual|
+          invalid_actual.save(validate: false)
+        end
+      end
+
+      before do
+        report.actuals << non_oda_actual
+        report.actuals << oda_actual
+      end
+
+      context "and I view the actuals in the UI" do
+        scenario "then I see only non-ODA actuals in UI" do
+          visit reports_path
+
+          within "##{report.id}" do
+            click_on t("default.link.show")
+          end
+
+          within "ul[aria-label='Report subnavigation']" do
+            click_on "Actuals / Refunds"
+          end
+
+          within "table#actuals" do
+            expect(page).to have_content(non_oda_activity.roda_identifier)
+            expect(page).to have_no_content(oda_activity.roda_identifier)
+          end
+
+          within ".totals" do
+            expect(page).to have_content(non_oda_actual.value)
+          end
+        end
+      end
+
+      context "and download the report as a CSV" do
+        scenario "then I see only non-ODA actuals in CSV" do
+          visit reports_path
+
+          within "##{report.id}" do
+            click_on t("default.link.show")
+          end
+
+          click_on "Download report as CSV file"
+
+          downloaded_rows = CSV.parse(page.body.delete_prefix("\uFEFF"), headers: true).map(&:to_h)
+
+          expect(downloaded_rows.size).to eq(1)
+          expect(downloaded_rows.first.fetch("RODA identifier")).to eq(non_oda_activity.roda_identifier)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -432,11 +432,19 @@ RSpec.describe Report, type: :model do
 
   describe "#summed_actuals" do
     it "sums all of the actuals belonging to a report" do
-      report = create(:report)
+      report = create(:report, :for_gcrf, is_oda: nil)
 
-      create(:actual, report: report, value: 50)
-      create(:actual, report: report, value: 75)
-      create(:actual, report: report, value: 100)
+      project = create(
+        :project_activity,
+        :gcrf_funded,
+        organisation: report.organisation,
+        source_fund_code: Fund.by_short_name("GCRF").id,
+        title: "ODA activity"
+      )
+
+      create(:actual, report: report, parent_activity: project, value: 50)
+      create(:actual, report: report, parent_activity: project, value: 75)
+      create(:actual, report: report, parent_activity: project, value: 100)
 
       expect(report.summed_actuals).to eq(225)
     end
@@ -444,11 +452,19 @@ RSpec.describe Report, type: :model do
 
   describe "#summed_refunds" do
     it "sums all of the refunds belonging to a report (NB: negative values)" do
-      report = create(:report)
+      report = create(:report, :for_gcrf, is_oda: nil)
 
-      create(:refund, report: report, value: 25)
-      create(:refund, report: report, value: 75)
-      create(:refund, report: report, value: 100)
+      project = create(
+        :project_activity,
+        :gcrf_funded,
+        organisation: report.organisation,
+        source_fund_code: Fund.by_short_name("GCRF").id,
+        title: "ODA activity"
+      )
+
+      create(:refund, report: report, parent_activity: project, value: 25)
+      create(:refund, report: report, parent_activity: project, value: 75)
+      create(:refund, report: report, parent_activity: project, value: 100)
 
       expect(report.summed_refunds).to eq(-200)
     end

--- a/spec/services/transaction/grouped_actuals_fetcher_spec.rb
+++ b/spec/services/transaction/grouped_actuals_fetcher_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Transaction::GroupedActualsFetcher do
 
     before do
       allow(report).to receive(:actuals).and_return(actuals_stub)
-      allow(actuals_stub).to receive(:includes).with([:parent_activity, :comment]).and_return(actuals)
+      allow(actuals_stub).to receive(:joins).with(:parent_activity).and_return(actuals_stub)
+      allow(actuals_stub).to receive(:includes).with([:parent_activity, :comment]).and_return(actuals_stub)
+      allow(actuals_stub).to receive(:where).and_return(actuals)
     end
 
     it "returns actuals grouped by activity" do


### PR DESCRIPTION
See [Zendesk 21429](https://dxw.zendesk.com/agent/tickets/21429)

This is part 2 of 2 PRs to address an issue with the handling of actuals/refunds in ISPF reports where there's a chance of transactions associated with an ODA activity being applied to a non-ODA report, and vice-versa.

Our plan for releasing fixes and making remediations is:

1. First release (https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2658): Ensure that a report's transactions have compatible Activity and Report associations
2. Manually make corrections: to fix up historic errors in data
3. **Second release (this PR)**: Ensure a report's downloaded transactions match those shown in UI. If this were released at the same time as (1) the misposted actuals will not be visible in the UI and that is likely to make the work of (2) more difficult and error prone

## Ensure a report's downloaded transactions match those shown in UI

This work originates in ticket [Zendesk 21429](https://dxw.zendesk.com/agent/tickets/21429) in which it appeared that certain actuals had been lost because they were missing from the downloaded version of a report. In this case we had a non-ODA report which included ODA actuals:

- these ODA actuals were **shown** in the UI view of the report

- these ODA actuals were **omitted** from the CSV download of the report

In this PR we align the mechanisms used for the UI and download so that this would not happen in future. It should (since https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2658) be impossible for this mix of ODA and non-ODA transactions to occur. It's a worthwhile exercise in consistency in any case as this should reduce the chance of similar discrepancies in future.

### Viewing a report with mixed ODA and Non-ODA actuals (BEFORE)

<img width="1235" height="1255" alt="report_ui_before" src="https://github.com/user-attachments/assets/a8588b3e-e2e5-4a39-ad37-898e1c75c77e" />

### Viewing a report with mixed ODA and Non-ODA actuals (AFTER)

<img width="1208" height="1077" alt="report_ui_after" src="https://github.com/user-attachments/assets/d6e89ec3-fb19-4051-b470-ec2a1185f172" />


## Next steps

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
