### PR TITLE
Release 185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Release 185 - 2026-04-14
+
+[Full changelog][185]
+
 - Fix: ensure a report's downloaded transactions match those shown in UI
 - Update database schema to Rails 8
 
@@ -1935,7 +1939,8 @@
 - Planned start and end dates are mandatory
 - Actual start and end dates must not be in the future
 
-[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-184...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-185...HEAD
+[185]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-184...release-185
 [184]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-183...release-184
 [183]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-182...release-183
 [182]: https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/compare/release-181...release-182


### PR DESCRIPTION
## Release 185

- Fix: ensure a report's downloaded transactions match those shown in UI
- Update database schema to Rails 8

---

See [Zendesk 21429](https://dxw.zendesk.com/agent/tickets/21429)

Now that parts 1 and 2 of this 3 part plan are done, we're ready to release part 3:

1. ✅ First release (https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2658): Ensure that a report's transactions have compatible Activity and Report associations
2.  ✅ Manually make corrections: to fix up historic errors in data
3. Second release: Ensure a report's downloaded transactions match those shown in UI. If this were released at the same time as (1) the misposted actuals will not be visible in the UI and that is likely to make the work of (2) more difficult and error prone (see https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/2659)


---

- [ ] Is an ADR required? An ADR should be added if this PR introduces a change to the architecture.
- [x] Is a changelog entry required? An entry should always be made in `CHANGELOG.md`, unless this PR is a small tweak which has no impact outside the development team.
- [ ] Do any environment variables need amending or adding?
- [ ] Have any changes to the XML been checked with the IATI validator? See [XML Validation](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/doc/xml-validation.md)
